### PR TITLE
[codex] Bootstrap upstream defaults and local origins

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -6,7 +6,10 @@ This directory contains public, workspace-local reference material for agents wo
 - Primary command surface: `tools/vaws.py`
 - Compatibility entrypoints: `./setup` and `./sync`
 - Local overlay state: `.workspace.local/`
+- `.workspace.local/repos.yaml` stores local `origin`/`upstream` repo topology.
+- Tracked repo defaults stay on community `upstream` repositories; user forks are configured locally.
 - Current control-plane session manifests: `.workspace.local/sessions/<session>/manifest.yaml`
 - Target runtime session manifests: `/vllm-workspace/.vaws/sessions/<session>/manifest.yaml`
 - These files are reference material only.
+- For Codex bootstrap, the user should describe the setup in natural language and the agent should carry out the internal bootstrap flow.
 - Keep private tokens, private hosts, and legacy path references out of tracked files.

--- a/.agents/skills/workspace-bootstrap/SKILL.md
+++ b/.agents/skills/workspace-bootstrap/SKILL.md
@@ -1,15 +1,20 @@
 ---
 name: workspace-bootstrap
-description: Public workspace-local guidance for bootstrap and repair flows.
+description: Use when initializing or repairing this workspace from natural language user input, especially when the agent needs to gather server access details and vllm-ascend repo ownership before running internal bootstrap steps.
 ---
 
 # Workspace Bootstrap
 
-Use this skill when initializing or repairing the local workspace overlay.
+Use this skill when initializing or repairing the local workspace overlay for a real user.
 
 - Keep the canonical runtime root at `/vllm-workspace`.
-- Use `tools/vaws.py init` and `tools/vaws.py doctor` for bootstrap checks.
+- Start from natural language user input, not by telling the user to invoke internal tools.
+- Collect remote server connection details first.
+- Collect `vllm-ascend` repo path or fork URL and Git auth second.
+- Treat `vllm` fork configuration as optional.
+- Once enough information is available, the agent should run `tools/vaws.py init --bootstrap ...` and then use `tools/vaws.py doctor` for follow-up checks.
 - Treat `.workspace.local/` as local overlay state only.
+- Keep tracked defaults on community `upstream` repositories and store user-specific `origin` topology in `.workspace.local/repos.yaml`.
 - Prefer `config/*.example.yaml` as the public template source.
 - Keep secrets, private hosts, and private paths out of tracked files.
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "vllm-ascend"]
 	path = vllm-ascend
-	url = https://github.com/maoxx241/vllm-ascend.git
+	url = https://github.com/vllm-project/vllm-ascend.git
 	branch = main
 [submodule "vllm"]
 	path = vllm
-	url = https://github.com/maoxx241/vllm.git
+	url = https://github.com/vllm-project/vllm.git
 	branch = main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,11 +9,15 @@ This repository is a public-facing control workspace for vLLM Ascend development
 - Compatibility entrypoints: `./setup`, `./sync`
 - Source repos: `vllm/`, `vllm-ascend/` as submodules
 - Clone and refresh sources recursively: `git submodule update --init --recursive`
+- Tracked submodules default to community `upstream` repositories.
+- User-specific `origin` remotes are declared in `.workspace.local/repos.yaml`.
+- For Codex bootstrap, the user should provide natural language input and the agent should perform the internal bootstrap steps.
 
 ## Commit hygiene
 
 - `config/*.example.yaml` are the only tracked config templates for bootstrap guidance.
 - `.workspace.local/` must stay local-only and is never committed.
+- `.workspace.local/repos.yaml` is local state for repo topology and remote roles.
 - Do not commit credentials, private hosts, private paths, tokens, or keys.
 - `.agents/skills/` contains workspace-local reference material, not global skill installers.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Public workspace-local control repository for coordinating vLLM and vLLM-Ascend 
 - `tools/vaws.py` is the primary CLI.
 - `./setup` is the bootstrap compatibility entrypoint.
 - `./sync` is the compatibility sync entrypoint.
+- For Codex users, bootstrap should start from natural language requests and the agent should drive the internal command flow.
 
 ## Runtime root
 
@@ -16,6 +17,8 @@ Public workspace-local control repository for coordinating vLLM and vLLM-Ascend 
 
 - `vllm/` is tracked as a workspace submodule.
 - `vllm-ascend/` is tracked as a workspace submodule.
+- Tracked submodule defaults point at community `upstream` repositories.
+- User-owned `origin` remotes belong in `.workspace.local/repos.yaml`, not in tracked files.
 - Bootstrap the sources with `git clone --recursive` or `git submodule update --init --recursive`.
 - Recursive init matters because `vllm-ascend/` also carries nested submodules.
 - The control repo lives at `/vllm-workspace/workspace`.
@@ -24,4 +27,5 @@ Public workspace-local control repository for coordinating vLLM and vLLM-Ascend 
 
 - `.agents/skills/` contains public reference material for workspace-local agents.
 - `.workspace.local/` is local-only overlay state and stays untracked.
+- `.workspace.local/repos.yaml` is the local source of truth for `origin`/`upstream` repo topology.
 - Tracked files must not contain private tokens, private hosts, or legacy path references.

--- a/config/repos.example.yaml
+++ b/config/repos.example.yaml
@@ -11,8 +11,10 @@ submodules:
     default_branch: main
     push_remote: origin
     upstream_remote: upstream
+    upstream_url: https://github.com/vllm-project/vllm.git
   vllm-ascend:
     path: vllm-ascend
     default_branch: main
     push_remote: origin
     upstream_remote: upstream
+    upstream_url: https://github.com/vllm-project/vllm-ascend.git

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,21 +41,21 @@ def vaws_repo(tmp_path: Path) -> Path:
             [
                 '[submodule "vllm"]',
                 "\tpath = vllm",
-                "\turl = https://github.com/example/vllm.git",
+                "\turl = https://github.com/vllm-project/vllm.git",
                 "\tbranch = main",
                 '[submodule "vllm-ascend"]',
                 "\tpath = vllm-ascend",
-                "\turl = https://github.com/example/vllm-ascend.git",
+                "\turl = https://github.com/vllm-project/vllm-ascend.git",
                 "\tbranch = main",
                 "",
             ]
         ),
         encoding="utf-8",
     )
-    _init_git_repo(repo / "vllm", "https://github.com/example/vllm.git")
+    _init_git_repo(repo / "vllm", "https://github.com/vllm-project/vllm.git")
     _init_git_repo(
         repo / "vllm-ascend",
-        "https://github.com/example/vllm-ascend.git",
+        "https://github.com/vllm-project/vllm-ascend.git",
     )
     (repo / "vllm-ascend" / ".gitmodules").write_text(
         "\n".join(

--- a/tests/test_repo_layout.py
+++ b/tests/test_repo_layout.py
@@ -61,11 +61,10 @@ def test_workspace_submodules_are_declared():
     gitmodules = (repo / ".gitmodules").read_text(encoding="utf-8")
     assert 'submodule "vllm"' in gitmodules
     assert "path = vllm" in gitmodules
-    assert "https://github.com/" in gitmodules
-    assert "vllm.git" in gitmodules
+    assert "https://github.com/vllm-project/vllm.git" in gitmodules
     assert 'submodule "vllm-ascend"' in gitmodules
     assert "path = vllm-ascend" in gitmodules
-    assert "vllm-ascend.git" in gitmodules
+    assert "https://github.com/vllm-project/vllm-ascend.git" in gitmodules
     assert "git@github.com:" not in gitmodules
 
 
@@ -77,6 +76,31 @@ def test_public_docs_explain_recursive_submodule_bootstrap():
     for text in (readme, agents):
         assert "recursive" in text
         assert "submodule update --init --recursive" in text
+
+
+def test_public_repo_topology_example_stays_public_and_upstream_oriented():
+    repo = Path(__file__).resolve().parents[1]
+    repos_example = (repo / "config" / "repos.example.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "https://github.com/vllm-project/vllm.git" in repos_example
+    assert "https://github.com/vllm-project/vllm-ascend.git" in repos_example
+    assert "git@github.com:" not in repos_example
+
+
+def test_public_docs_explain_upstream_defaults_and_local_origin_bootstrap():
+    repo = Path(__file__).resolve().parents[1]
+    readme = (repo / "README.md").read_text(encoding="utf-8").lower()
+    agents = (repo / "AGENTS.md").read_text(encoding="utf-8").lower()
+    agents_readme = (repo / ".agents" / "README.md").read_text(
+        encoding="utf-8"
+    ).lower()
+
+    for text in (readme, agents, agents_readme):
+        assert "upstream" in text
+        assert "origin" in text
+        assert ".workspace.local/repos.yaml" in text
+        assert "natural language" in text or "conversational" in text
 
 
 def test_workspace_local_skill_skeletons_exist_and_stay_public():
@@ -95,8 +119,11 @@ def test_workspace_local_skill_skeletons_exist_and_stay_public():
     expected_skill_content = {
         "workspace-bootstrap": (
             "/vllm-workspace",
-            "tools/vaws.py init",
-            "tools/vaws.py doctor",
+            "natural language",
+            "server",
+            "vllm-ascend",
+            "optional",
+            "tools/vaws.py init --bootstrap",
         ),
         "workspace-session-switch": (
             ".workspace.local/state.json",

--- a/tests/test_vaws_init_bootstrap.py
+++ b/tests/test_vaws_init_bootstrap.py
@@ -1,0 +1,114 @@
+import subprocess
+
+import yaml
+
+from conftest import run_vaws
+
+
+def _remote_url(repo, relative_path, remote_name):
+    result = subprocess.run(
+        ["git", "remote", "get-url", remote_name],
+        cwd=repo / relative_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
+    result = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--server-host",
+        "173.125.1.2",
+        "--server-user",
+        "root",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+        "--vllm-origin-url",
+        "git@github.com:alice/vllm.git",
+        "--git-auth-mode",
+        "ssh-agent",
+    )
+
+    assert result.returncode == 0
+
+    repos = yaml.safe_load((vaws_repo / ".workspace.local" / "repos.yaml").read_text())
+    assert repos["submodules"]["vllm"]["upstream_url"] == "https://github.com/vllm-project/vllm.git"
+    assert repos["submodules"]["vllm"]["origin_url"] == "git@github.com:alice/vllm.git"
+    assert repos["submodules"]["vllm-ascend"]["upstream_url"] == "https://github.com/vllm-project/vllm-ascend.git"
+    assert repos["submodules"]["vllm-ascend"]["origin_url"] == "git@github.com:alice/vllm-ascend.git"
+
+    auth = yaml.safe_load((vaws_repo / ".workspace.local" / "auth.yaml").read_text())
+    assert auth["host_auth"]["mode"] == "ssh-key"
+    assert auth["git_auth"]["mode"] == "ssh-agent"
+
+    targets = yaml.safe_load(
+        (vaws_repo / ".workspace.local" / "targets.yaml").read_text()
+    )
+    assert targets["hosts"]["host-a"]["host"] == "173.125.1.2"
+    assert targets["targets"]["single-default"]["runtime"]["workspace_root"] == "/vllm-workspace"
+
+    assert _remote_url(vaws_repo, "vllm", "origin") == "git@github.com:alice/vllm.git"
+    assert _remote_url(vaws_repo, "vllm", "upstream") == "https://github.com/vllm-project/vllm.git"
+    assert _remote_url(vaws_repo, "vllm-ascend", "origin") == "git@github.com:alice/vllm-ascend.git"
+    assert _remote_url(vaws_repo, "vllm-ascend", "upstream") == "https://github.com/vllm-project/vllm-ascend.git"
+
+
+def test_init_bootstrap_allows_missing_vllm_origin_url(vaws_repo):
+    result = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--server-host",
+        "173.125.1.2",
+        "--server-user",
+        "root",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+
+    assert result.returncode == 0
+
+    repos = yaml.safe_load((vaws_repo / ".workspace.local" / "repos.yaml").read_text())
+    assert "origin_url" not in repos["submodules"]["vllm"]
+    assert repos["submodules"]["vllm-ascend"]["origin_url"] == "git@github.com:alice/vllm-ascend.git"
+    assert _remote_url(vaws_repo, "vllm", "origin") == "https://github.com/vllm-project/vllm.git"
+    assert _remote_url(vaws_repo, "vllm", "upstream") == "https://github.com/vllm-project/vllm.git"
+
+
+def test_init_bootstrap_requires_vllm_ascend_origin_url(vaws_repo):
+    result = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--server-host",
+        "173.125.1.2",
+        "--server-user",
+        "root",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "vllm-ascend" in output
+    assert "origin" in output
+
+
+def test_init_bootstrap_requires_server_host(vaws_repo):
+    result = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--server-user",
+        "root",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "server" in output
+    assert "host" in output

--- a/tools/lib/bootstrap.py
+++ b/tools/lib/bootstrap.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+from .config import RepoPaths
+
+COMMUNITY_UPSTREAM_URLS = {
+    "vllm": "https://github.com/vllm-project/vllm.git",
+    "vllm-ascend": "https://github.com/vllm-project/vllm-ascend.git",
+}
+
+DEFAULT_TARGET_NAME = "single-default"
+DEFAULT_HOST_NAME = "host-a"
+DEFAULT_RUNTIME_IMAGE = "quay.nju.edu.cn/ascend/vllm-ascend:latest"
+DEFAULT_RUNTIME_CONTAINER = "vaws-workspace"
+DEFAULT_RUNTIME_SSH_PORT = 63269
+DEFAULT_RUNTIME_WORKSPACE_ROOT = "/vllm-workspace"
+DEFAULT_RUNTIME_BOOTSTRAP_MODE = "host-then-container"
+DEFAULT_SERVER_PORT = 22
+
+OVERLAY_FILES = ("targets.yaml", "repos.yaml", "auth.yaml", "state.json")
+
+
+class BootstrapError(RuntimeError):
+    """Structured bootstrap input or remote-topology failure."""
+
+
+@dataclass(frozen=True)
+class BootstrapRequest:
+    server_host: str
+    server_user: str
+    vllm_ascend_origin_url: str
+    server_port: int = DEFAULT_SERVER_PORT
+    server_auth_mode: str = "ssh-key"
+    server_auth_group: str = "default"
+    server_password_env: Optional[str] = None
+    server_key_path: Optional[str] = None
+    target_name: str = DEFAULT_TARGET_NAME
+    host_name: str = DEFAULT_HOST_NAME
+    runtime_image: str = DEFAULT_RUNTIME_IMAGE
+    runtime_container: str = DEFAULT_RUNTIME_CONTAINER
+    runtime_ssh_port: int = DEFAULT_RUNTIME_SSH_PORT
+    runtime_workspace_root: str = DEFAULT_RUNTIME_WORKSPACE_ROOT
+    vllm_origin_url: Optional[str] = None
+    git_auth_mode: str = "ssh-key"
+    git_key_path: Optional[str] = None
+    git_token_env: Optional[str] = None
+
+
+def _require_non_empty(value: Optional[str], field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise BootstrapError(f"missing bootstrap field: {field_name}")
+    return value.strip()
+
+
+def _require_port(value: Any, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1 or value > 65535:
+        raise BootstrapError(f"invalid bootstrap field: {field_name}")
+    return value
+
+
+def bootstrap_request_from_args(args: Any) -> BootstrapRequest:
+    return BootstrapRequest(
+        server_host=_require_non_empty(args.server_host, "server host"),
+        server_user=_require_non_empty(args.server_user, "server user"),
+        vllm_ascend_origin_url=_require_non_empty(
+            args.vllm_ascend_origin_url,
+            "vllm-ascend origin url",
+        ),
+        server_port=_require_port(args.server_port, "server port"),
+        server_auth_mode=_require_non_empty(args.server_auth_mode, "server auth mode"),
+        server_auth_group=_require_non_empty(
+            args.server_auth_group,
+            "server auth group",
+        ),
+        server_password_env=args.server_password_env,
+        server_key_path=args.server_key_path,
+        target_name=_require_non_empty(args.target_name, "target name"),
+        host_name=_require_non_empty(args.host_name, "host name"),
+        runtime_image=_require_non_empty(args.runtime_image, "runtime image"),
+        runtime_container=_require_non_empty(args.runtime_container, "runtime container"),
+        runtime_ssh_port=_require_port(args.runtime_ssh_port, "runtime ssh port"),
+        runtime_workspace_root=_require_non_empty(
+            args.runtime_workspace_root,
+            "runtime workspace root",
+        ),
+        vllm_origin_url=args.vllm_origin_url,
+        git_auth_mode=_require_non_empty(args.git_auth_mode, "git auth mode"),
+        git_key_path=args.git_key_path,
+        git_token_env=args.git_token_env,
+    )
+
+
+def _ensure_overlay(paths: RepoPaths) -> None:
+    if paths.local_overlay.exists() and not paths.local_overlay.is_dir():
+        raise BootstrapError(
+            "invalid local overlay: .workspace.local/ exists but is not a directory"
+        )
+
+    paths.local_overlay.mkdir(parents=True, exist_ok=True)
+    for name in OVERLAY_FILES:
+        file_path = paths.local_overlay / name
+        if file_path.exists():
+            continue
+        if name == "state.json":
+            file_path.write_text("{}\n", encoding="utf-8")
+        else:
+            file_path.write_text("", encoding="utf-8")
+
+
+def _load_yaml_mapping(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
+        raise BootstrapError(f"invalid bootstrap file: {path.name}") from exc
+
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        raise BootstrapError(f"invalid bootstrap file: {path.name}")
+    return loaded
+
+
+def _write_yaml(path: Path, payload: Dict[str, Any]) -> None:
+    path.write_text(
+        yaml.safe_dump(payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _run_git(repo_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _ensure_git_remote(repo_path: Path, remote_name: str, url: str) -> None:
+    if not (repo_path / ".git").exists():
+        raise BootstrapError(f"invalid workspace repo: {repo_path}")
+
+    probe = _run_git(repo_path, "remote", "get-url", remote_name)
+    if probe.returncode == 0:
+        update = _run_git(repo_path, "remote", "set-url", remote_name, url)
+    else:
+        update = _run_git(repo_path, "remote", "add", remote_name, url)
+
+    if update.returncode != 0:
+        stderr = update.stderr.strip() or update.stdout.strip()
+        raise BootstrapError(
+            f"failed to configure remote '{remote_name}' for {repo_path.name}: {stderr}"
+        )
+
+
+def _write_repos_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
+    repos_path = paths.local_overlay / "repos.yaml"
+    config = _load_yaml_mapping(repos_path)
+
+    workspace = dict(config.get("workspace") or {})
+    workspace.update(
+        {
+            "path": ".",
+            "default_branch": "main",
+            "protected_branches": ["main"],
+            "push_remote": "origin",
+            "upstream_remote": "upstream",
+        }
+    )
+    config["workspace"] = workspace
+
+    submodules = dict(config.get("submodules") or {})
+    submodules["vllm"] = {
+        "path": "vllm",
+        "default_branch": "main",
+        "push_remote": "origin",
+        "upstream_remote": "upstream",
+        "upstream_url": COMMUNITY_UPSTREAM_URLS["vllm"],
+    }
+    if request.vllm_origin_url:
+        submodules["vllm"]["origin_url"] = request.vllm_origin_url
+
+    submodules["vllm-ascend"] = {
+        "path": "vllm-ascend",
+        "default_branch": "main",
+        "push_remote": "origin",
+        "upstream_remote": "upstream",
+        "upstream_url": COMMUNITY_UPSTREAM_URLS["vllm-ascend"],
+        "origin_url": request.vllm_ascend_origin_url,
+    }
+    config["submodules"] = submodules
+    _write_yaml(repos_path, config)
+
+
+def _write_targets_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
+    targets_path = paths.local_overlay / "targets.yaml"
+    config = _load_yaml_mapping(targets_path)
+    hosts = dict(config.get("hosts") or {})
+    hosts[request.host_name] = {
+        "host": request.server_host,
+        "port": request.server_port,
+        "login_user": request.server_user,
+        "auth_group": request.server_auth_group,
+    }
+    config["hosts"] = hosts
+
+    targets = dict(config.get("targets") or {})
+    targets[request.target_name] = {
+        "hosts": [request.host_name],
+        "runtime": {
+            "image_ref": request.runtime_image,
+            "container_name": request.runtime_container,
+            "ssh_port": request.runtime_ssh_port,
+            "workspace_root": request.runtime_workspace_root,
+            "bootstrap_mode": DEFAULT_RUNTIME_BOOTSTRAP_MODE,
+        },
+    }
+    config["targets"] = targets
+    _write_yaml(targets_path, config)
+
+
+def _write_auth_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
+    auth_path = paths.local_overlay / "auth.yaml"
+    config = _load_yaml_mapping(auth_path)
+
+    credential = {
+        "username": request.server_user,
+    }
+    if request.server_password_env:
+        credential["password_env"] = request.server_password_env
+    if request.server_key_path:
+        credential["key_path"] = request.server_key_path
+
+    config["host_auth"] = {
+        "mode": request.server_auth_mode,
+        "credential_groups": {
+            request.server_auth_group: credential,
+        },
+    }
+
+    git_auth = {
+        "mode": request.git_auth_mode,
+    }
+    if request.git_key_path:
+        git_auth["key_path"] = request.git_key_path
+    if request.git_token_env:
+        git_auth["token_env"] = request.git_token_env
+    config["git_auth"] = git_auth
+    _write_yaml(auth_path, config)
+
+
+def _ensure_state_json(paths: RepoPaths) -> None:
+    state_path = paths.local_overlay / "state.json"
+    try:
+        payload = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+    state_path.write_text(f"{json.dumps(payload, indent=2)}\n", encoding="utf-8")
+
+
+def _configure_repo_remotes(paths: RepoPaths, request: BootstrapRequest) -> None:
+    repo_targets = {
+        "vllm": {
+            "path": paths.root / "vllm",
+            "upstream": COMMUNITY_UPSTREAM_URLS["vllm"],
+            "origin": request.vllm_origin_url,
+        },
+        "vllm-ascend": {
+            "path": paths.root / "vllm-ascend",
+            "upstream": COMMUNITY_UPSTREAM_URLS["vllm-ascend"],
+            "origin": request.vllm_ascend_origin_url,
+        },
+    }
+
+    for repo_name, config in repo_targets.items():
+        repo_path = config["path"]
+        _ensure_git_remote(repo_path, "upstream", config["upstream"])
+        origin_url = config["origin"]
+        if origin_url:
+            _ensure_git_remote(repo_path, "origin", origin_url)
+        elif repo_name == "vllm":
+            _ensure_git_remote(repo_path, "origin", config["upstream"])
+
+
+def bootstrap_init(paths: RepoPaths, request: BootstrapRequest) -> int:
+    try:
+        _ensure_overlay(paths)
+        _write_repos_yaml(paths, request)
+        _write_targets_yaml(paths, request)
+        _write_auth_yaml(paths, request)
+        _ensure_state_json(paths)
+        _configure_repo_remotes(paths, request)
+    except BootstrapError as exc:
+        print(str(exc))
+        return 1
+
+    print("init: bootstrap ok")
+    return 0

--- a/tools/vaws.py
+++ b/tools/vaws.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from tools.lib.bootstrap import bootstrap_init, bootstrap_request_from_args
 from tools.lib.config import RepoPaths
 from tools.lib.doctor import doctor, init
 from tools.lib.gitflow import default_base_ref
@@ -17,7 +18,32 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="vaws")
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("doctor")
-    subparsers.add_parser("init")
+    init_parser = subparsers.add_parser("init")
+    init_parser.add_argument("--bootstrap", action="store_true")
+    init_parser.add_argument("--target-name", default="single-default")
+    init_parser.add_argument("--host-name", default="host-a")
+    init_parser.add_argument("--server-host")
+    init_parser.add_argument("--server-user", default="root")
+    init_parser.add_argument("--server-port", type=int, default=22)
+    init_parser.add_argument("--server-auth-mode", default="ssh-key")
+    init_parser.add_argument("--server-auth-group", default="default")
+    init_parser.add_argument("--server-password-env")
+    init_parser.add_argument("--server-key-path")
+    init_parser.add_argument(
+        "--runtime-image",
+        default="quay.nju.edu.cn/ascend/vllm-ascend:latest",
+    )
+    init_parser.add_argument("--runtime-container", default="vaws-workspace")
+    init_parser.add_argument("--runtime-ssh-port", type=int, default=63269)
+    init_parser.add_argument(
+        "--runtime-workspace-root",
+        default="/vllm-workspace",
+    )
+    init_parser.add_argument("--vllm-origin-url")
+    init_parser.add_argument("--vllm-ascend-origin-url")
+    init_parser.add_argument("--git-auth-mode", default="ssh-key")
+    init_parser.add_argument("--git-key-path")
+    init_parser.add_argument("--git-token-env")
     sync_parser = subparsers.add_parser("sync")
     sync_subparsers = sync_parser.add_subparsers(dest="sync_command")
     sync_start_parser = sync_subparsers.add_parser("start")
@@ -58,6 +84,13 @@ def main(argv: Optional[List[str]] = None) -> int:
     if args.command == "doctor":
         return doctor(paths)
     if args.command == "init":
+        if args.bootstrap:
+            try:
+                request = bootstrap_request_from_args(args)
+            except RuntimeError as exc:
+                print(str(exc))
+                return 1
+            return bootstrap_init(paths, request)
         return init(paths)
     if args.command == "sync":
         if args.sync_command in (None, "status"):


### PR DESCRIPTION
## Summary
- switch tracked submodule defaults and public repo templates to community upstream repositories
- add bootstrap initialization logic that writes local overlay target/auth/repo topology and configures submodule origin/upstream remotes
- update Codex bootstrap guidance and add regression coverage for required `vllm-ascend` origin and optional `vllm` origin handling

## Test Plan
- `pytest -q`
