### PR TITLE
[codex] add guarded workspace reset flow

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -5,11 +5,16 @@ This directory contains public, workspace-local reference material for agents wo
 - Canonical runtime root: `/vllm-workspace`
 - Primary command surface: `tools/vaws.py`
 - Compatibility entrypoints: `./setup` and `./sync`
+- Workflow skills live under `.agents/skills/`.
+- Bootstrap and repair procedure: `.agents/skills/workspace-bootstrap/`
+- For Codex bootstrap, start from natural language user input and route into the bootstrap skill.
+- Guarded reset and deinit procedure: `.agents/skills/workspace-reset/`
+- Session switching procedure: `.agents/skills/workspace-session-switch/`
+- Sync procedure: `.agents/skills/workspace-sync/`
 - Local overlay state: `.workspace.local/`
 - `.workspace.local/repos.yaml` stores local `origin`/`upstream` repo topology.
 - Tracked repo defaults stay on community `upstream` repositories; user forks are configured locally.
 - Current control-plane session manifests: `.workspace.local/sessions/<session>/manifest.yaml`
 - Target runtime session manifests: `/vllm-workspace/.vaws/sessions/<session>/manifest.yaml`
 - These files are reference material only.
-- For Codex bootstrap, the user should describe the setup in natural language and the agent should carry out the internal bootstrap flow.
 - Keep private tokens, private hosts, and legacy path references out of tracked files.

--- a/.agents/skills/workspace-bootstrap/SKILL.md
+++ b/.agents/skills/workspace-bootstrap/SKILL.md
@@ -17,5 +17,8 @@ Use this skill when initializing or repairing the local workspace overlay for a 
 - Keep tracked defaults on community `upstream` repositories and store user-specific `origin` topology in `.workspace.local/repos.yaml`.
 - Prefer `config/*.example.yaml` as the public template source.
 - Keep secrets, private hosts, and private paths out of tracked files.
+- Guarded reset is a two-step flow: `tools/vaws.py reset --prepare` first, then `tools/vaws.py reset --execute --confirmation-id ... --confirm ...`.
+- Agents must not skip prepare, reuse stale confirmation ids, or fabricate authorization.
+- After a successful reset, restore `origin` and `upstream` on `vllm/` and `vllm-ascend/` to the community URLs.
 
 This is workspace-local reference material only.

--- a/.agents/skills/workspace-reset/SKILL.md
+++ b/.agents/skills/workspace-reset/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: workspace-reset
+description: Use when resetting or deinitializing this workspace after an explicit user request, especially when the agent must clear local overlay identity and remote runtime state without skipping the guarded confirmation flow.
+---
+
+# Workspace Reset
+
+Use this skill when a user explicitly asks to reset, deinitialize, or return this workspace to a near post-clone state.
+
+- Keep the canonical runtime root at `/vllm-workspace`.
+- Treat reset as a guarded two-step flow: run `tools/vaws.py reset --prepare` first, then `tools/vaws.py reset --execute --confirmation-id ... --confirm ...`.
+- Show the destruction summary from `reset --prepare` before executing the destructive step.
+- Agents must not skip prepare, reuse stale confirmation ids, or fabricate authorization.
+- Reset is expected to clear local workspace identity and clean the approved remote runtime before local overlay cleanup.
+- After a successful reset, restore `origin` and `upstream` on `vllm/` and `vllm-ascend/` to the community URLs.
+- Keep private hosts, tokens, and user-specific paths out of tracked files.
+
+This is workspace-local reference material only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,29 +2,21 @@
 
 This repository is a public-facing control workspace for vLLM Ascend development workflows.
 
-## Canonical constants
+## Always-On Context
 
 - Runtime root: `/vllm-workspace`
 - Primary command surface: `tools/vaws.py`
 - Compatibility entrypoints: `./setup`, `./sync`
 - Source repos: `vllm/`, `vllm-ascend/` as submodules
 - Clone and refresh sources recursively: `git submodule update --init --recursive`
-- Tracked submodules default to community `upstream` repositories.
-- User-specific `origin` remotes are declared in `.workspace.local/repos.yaml`.
-- For Codex bootstrap, the user should provide natural language input and the agent should perform the internal bootstrap steps.
-
-## Commit hygiene
-
 - `config/*.example.yaml` are the only tracked config templates for bootstrap guidance.
 - `.workspace.local/` must stay local-only and is never committed.
-- `.workspace.local/repos.yaml` is local state for repo topology and remote roles.
 - Do not commit credentials, private hosts, private paths, tokens, or keys.
-- `.agents/skills/` contains workspace-local reference material, not global skill installers.
-- Guarded reset requires `tools/vaws.py reset --prepare` before `tools/vaws.py reset --execute --confirmation-id ... --confirm ...`.
-- Agents must not skip prepare, reuse stale confirmation ids, or fabricate authorization.
-- After a successful reset, restore `origin` and `upstream` on `vllm/` and `vllm-ascend/` back to the community URLs.
 
-## Environment assumptions
+## Workflow Routing
 
-- Do not hardcode environment-specific hostnames or paths.
-- Use placeholder/example values only in tracked files.
+- Keep detailed operational procedures in `.agents/skills/`, not in this file.
+- Use `.agents/skills/workspace-bootstrap/SKILL.md` for bootstrap and bootstrap repair.
+- Use `.agents/skills/workspace-reset/SKILL.md` for guarded reset / deinit.
+- Use `.agents/skills/workspace-session-switch/SKILL.md` for session changes.
+- Use `.agents/skills/workspace-sync/SKILL.md` for sync behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,9 @@ This repository is a public-facing control workspace for vLLM Ascend development
 - `.workspace.local/repos.yaml` is local state for repo topology and remote roles.
 - Do not commit credentials, private hosts, private paths, tokens, or keys.
 - `.agents/skills/` contains workspace-local reference material, not global skill installers.
+- Guarded reset requires `tools/vaws.py reset --prepare` before `tools/vaws.py reset --execute --confirmation-id ... --confirm ...`.
+- Agents must not skip prepare, reuse stale confirmation ids, or fabricate authorization.
+- After a successful reset, restore `origin` and `upstream` on `vllm/` and `vllm-ascend/` back to the community URLs.
 
 ## Environment assumptions
 

--- a/README.md
+++ b/README.md
@@ -2,18 +2,17 @@
 
 Public workspace-local control repository for coordinating vLLM and vLLM-Ascend work.
 
-## Current entrypoints
+## Entry Points
 
 - `tools/vaws.py` is the primary CLI.
 - `./setup` is the bootstrap compatibility entrypoint.
 - `./sync` is the compatibility sync entrypoint.
-- For Codex users, bootstrap should start from natural language requests and the agent should drive the internal command flow.
 
-## Runtime root
+## Runtime Root
 
 - Canonical container/runtime path: `/vllm-workspace`
 
-## Source repos
+## Source Repos
 
 - `vllm/` is tracked as a workspace submodule.
 - `vllm-ascend/` is tracked as a workspace submodule.
@@ -23,12 +22,17 @@ Public workspace-local control repository for coordinating vLLM and vLLM-Ascend 
 - Recursive init matters because `vllm-ascend/` also carries nested submodules.
 - The control repo lives at `/vllm-workspace/workspace`.
 
-## Workspace-local reference
+## Local Overlay
 
-- `.agents/skills/` contains public reference material for workspace-local agents.
 - `.workspace.local/` is local-only overlay state and stays untracked.
 - `.workspace.local/repos.yaml` is the local source of truth for `origin`/`upstream` repo topology.
-- Guarded reset uses `tools/vaws.py reset --prepare` to mint a fresh confirmation id, then `tools/vaws.py reset --execute --confirmation-id ... --confirm ...` to perform the reset.
-- Agents must not skip prepare, reuse stale confirmation ids, or fabricate authorization.
-- A successful reset restores `origin` and `upstream` on `vllm/` and `vllm-ascend/` to the community URLs.
 - Tracked files must not contain private tokens, private hosts, or legacy path references.
+
+## Agent Workflows
+
+- `.agents/skills/` contains public reference material for workspace-local agents.
+- Bootstrap and workspace repair flow live in `.agents/skills/workspace-bootstrap/`.
+- For Codex bootstrap, the user should start from a natural language request and the agent should route into the bootstrap skill.
+- Guarded deinit/reset flow lives in `.agents/skills/workspace-reset/`.
+- Session switching flow lives in `.agents/skills/workspace-session-switch/`.
+- Sync flow lives in `.agents/skills/workspace-sync/`.

--- a/README.md
+++ b/README.md
@@ -28,4 +28,7 @@ Public workspace-local control repository for coordinating vLLM and vLLM-Ascend 
 - `.agents/skills/` contains public reference material for workspace-local agents.
 - `.workspace.local/` is local-only overlay state and stays untracked.
 - `.workspace.local/repos.yaml` is the local source of truth for `origin`/`upstream` repo topology.
+- Guarded reset uses `tools/vaws.py reset --prepare` to mint a fresh confirmation id, then `tools/vaws.py reset --execute --confirmation-id ... --confirm ...` to perform the reset.
+- Agents must not skip prepare, reuse stale confirmation ids, or fabricate authorization.
+- A successful reset restores `origin` and `upstream` on `vllm/` and `vllm-ascend/` to the community URLs.
 - Tracked files must not contain private tokens, private hosts, or legacy path references.

--- a/tests/test_repo_layout.py
+++ b/tests/test_repo_layout.py
@@ -31,29 +31,29 @@ def test_public_guidance_uses_current_entrypoints_and_canonical_root():
     repo = Path(__file__).resolve().parents[1]
     readme = (repo / "README.md").read_text(encoding="utf-8").lower()
     agents = (repo / "AGENTS.md").read_text(encoding="utf-8").lower()
+    agents_readme = (repo / ".agents" / "README.md").read_text(
+        encoding="utf-8"
+    ).lower()
     cursorrules = (repo / ".cursorrules").read_text(encoding="utf-8").lower()
 
-    for text in (readme, agents, cursorrules):
+    for text in (readme, agents, agents_readme, cursorrules):
         assert "/vllm-workspace" in text
         assert "tools/vaws.py" in text
-        assert "./setup" in text
-        assert "./sync" in text
         assert "/workspace/vllm_workspace" not in text
 
-    for text in (readme, agents, cursorrules):
+    for text in (readme, agents, agents_readme, cursorrules):
         assert "planned" not in text
         assert "process docs" not in text
         assert "process documentation" not in text
 
     assert ".agents/skills/" in readme
-    assert ".agents/skills/" in agents
+    assert ".agents/skills/" in agents_readme
     assert ".agents/skills/" in cursorrules
     assert "vllm/" in readme
     assert "vllm-ascend/" in readme
     assert "submodule" in readme
     assert "vllm/" in agents
     assert "vllm-ascend/" in agents
-    assert "submodule" in agents
 
 
 def test_workspace_submodules_are_declared():
@@ -91,32 +91,51 @@ def test_public_repo_topology_example_stays_public_and_upstream_oriented():
 def test_public_docs_explain_upstream_defaults_and_local_origin_bootstrap():
     repo = Path(__file__).resolve().parents[1]
     readme = (repo / "README.md").read_text(encoding="utf-8").lower()
-    agents = (repo / "AGENTS.md").read_text(encoding="utf-8").lower()
+    bootstrap_skill = (
+        repo / ".agents" / "skills" / "workspace-bootstrap" / "SKILL.md"
+    ).read_text(encoding="utf-8").lower()
     agents_readme = (repo / ".agents" / "README.md").read_text(
         encoding="utf-8"
     ).lower()
 
-    for text in (readme, agents, agents_readme):
+    for text in (readme, bootstrap_skill, agents_readme):
         assert "upstream" in text
         assert "origin" in text
         assert ".workspace.local/repos.yaml" in text
         assert "natural language" in text or "conversational" in text
 
 
-def test_public_guidance_mentions_guarded_reset_workflow():
+def test_agents_md_routes_bootstrap_and_reset_to_skills():
     repo = Path(__file__).resolve().parents[1]
-    readme = (repo / "README.md").read_text(encoding="utf-8").lower()
     agents = (repo / "AGENTS.md").read_text(encoding="utf-8").lower()
-    skill = (
-        repo / ".agents" / "skills" / "workspace-bootstrap" / "SKILL.md"
+    for skill_name in (
+        "workspace-bootstrap",
+        "workspace-reset",
+        "workspace-session-switch",
+        "workspace-sync",
+    ):
+        assert skill_name in agents
+
+    assert "reset --prepare" not in agents
+    assert "reset --execute" not in agents
+    assert "must not skip prepare" not in agents
+    assert "fabricate authorization" not in agents
+    assert "init --bootstrap" not in agents
+
+
+def test_workspace_reset_skill_owns_guarded_reset_procedure():
+    repo = Path(__file__).resolve().parents[1]
+    text = (
+        repo / ".agents" / "skills" / "workspace-reset" / "SKILL.md"
     ).read_text(encoding="utf-8").lower()
 
-    for text in (readme, agents, skill):
-        assert "reset --prepare" in text
-        assert "reset --execute" in text
-        assert "must not skip prepare" in text
-        assert "stale confirmation id" in text or "stale confirmation ids" in text
-        assert "fabricate authorization" in text
+    assert "workspace-local" in text
+    assert "reset --prepare" in text
+    assert "reset --execute" in text
+    assert "must not skip prepare" in text
+    assert "stale confirmation id" in text or "stale confirmation ids" in text
+    assert "fabricate authorization" in text
+    assert "community urls" in text or "community `origin` and `upstream`" in text
 
 
 def test_workspace_local_skill_skeletons_exist_and_stay_public():
@@ -140,6 +159,13 @@ def test_workspace_local_skill_skeletons_exist_and_stay_public():
             "vllm-ascend",
             "optional",
             "tools/vaws.py init --bootstrap",
+        ),
+        "workspace-reset": (
+            "/vllm-workspace",
+            "tools/vaws.py reset --prepare",
+            "tools/vaws.py reset --execute",
+            "stale confirmation id",
+            "community",
         ),
         "workspace-session-switch": (
             ".workspace.local/state.json",

--- a/tests/test_repo_layout.py
+++ b/tests/test_repo_layout.py
@@ -103,6 +103,22 @@ def test_public_docs_explain_upstream_defaults_and_local_origin_bootstrap():
         assert "natural language" in text or "conversational" in text
 
 
+def test_public_guidance_mentions_guarded_reset_workflow():
+    repo = Path(__file__).resolve().parents[1]
+    readme = (repo / "README.md").read_text(encoding="utf-8").lower()
+    agents = (repo / "AGENTS.md").read_text(encoding="utf-8").lower()
+    skill = (
+        repo / ".agents" / "skills" / "workspace-bootstrap" / "SKILL.md"
+    ).read_text(encoding="utf-8").lower()
+
+    for text in (readme, agents, skill):
+        assert "reset --prepare" in text
+        assert "reset --execute" in text
+        assert "must not skip prepare" in text
+        assert "stale confirmation id" in text or "stale confirmation ids" in text
+        assert "fabricate authorization" in text
+
+
 def test_workspace_local_skill_skeletons_exist_and_stay_public():
     repo = Path(__file__).resolve().parents[1]
     agents_root = repo / ".agents"

--- a/tests/test_vaws_reset.py
+++ b/tests/test_vaws_reset.py
@@ -1,0 +1,578 @@
+import json
+import subprocess
+import shutil
+import stat
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from conftest import run_vaws
+from tools.lib.remote import (
+    CredentialGroup,
+    HostSpec,
+    RuntimeSpec,
+    TargetContext,
+    destroy_runtime,
+)
+
+COMMUNITY_VLLM_URL = "https://github.com/vllm-project/vllm.git"
+COMMUNITY_VLLM_ASCEND_URL = "https://github.com/vllm-project/vllm-ascend.git"
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _remote_url(repo: Path, relative_path: str, remote_name: str) -> str:
+    result = subprocess.run(
+        ["git", "remote", "get-url", remote_name],
+        cwd=repo / relative_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def seed_reset_workspace(vaws_repo: Path, target_name: str = "single-default") -> Path:
+    simulation_root = vaws_repo.parent / "simulation-runtime"
+    overlay = vaws_repo / ".workspace.local"
+    overlay.mkdir(exist_ok=True)
+
+    (overlay / "auth.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "host_auth": {
+                    "mode": "local-simulation",
+                    "credential_groups": {
+                        "shared-lab-a": {
+                            "username": "root",
+                            "simulation_root": str(simulation_root),
+                        }
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (overlay / "repos.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "workspace": {
+                    "default_branch": "main",
+                    "push_remote": "origin",
+                    "upstream_remote": "upstream",
+                },
+                "submodules": {
+                    "vllm": {
+                        "default_branch": "main",
+                        "push_remote": "origin",
+                        "upstream_remote": "upstream",
+                        "origin_url": "git@github.com:alice/vllm.git",
+                        "upstream_url": "https://github.com/vllm-project/vllm.git",
+                    },
+                    "vllm-ascend": {
+                        "default_branch": "main",
+                        "push_remote": "origin",
+                        "upstream_remote": "upstream",
+                        "origin_url": "git@github.com:alice/vllm-ascend.git",
+                        "upstream_url": "https://github.com/vllm-project/vllm-ascend.git",
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (overlay / "targets.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "hosts": {
+                    "host-a": {
+                        "host": "127.0.0.1",
+                        "port": 22,
+                        "login_user": "root",
+                        "auth_group": "shared-lab-a",
+                    }
+                },
+                "targets": {
+                    target_name: {
+                        "hosts": ["host-a"],
+                        "runtime": {
+                            "image_ref": "registry.example.com/ascend/vllm-ascend:test",
+                            "container_name": "vaws-owner",
+                            "ssh_port": 63269,
+                            "workspace_root": "/vllm-workspace",
+                            "bootstrap_mode": "host-then-container",
+                        },
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (overlay / "state.json").write_text("{}\n", encoding="utf-8")
+
+    subprocess.run(
+        ["git", "remote", "set-url", "origin", "git@github.com:alice/vllm.git"],
+        cwd=vaws_repo / "vllm",
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "remote", "set-url", "upstream", "https://github.com/vllm-project/vllm.git"],
+        cwd=vaws_repo / "vllm",
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "remote", "set-url", "origin", "git@github.com:alice/vllm-ascend.git"],
+        cwd=vaws_repo / "vllm-ascend",
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "remote",
+            "set-url",
+            "upstream",
+            "https://github.com/vllm-project/vllm-ascend.git",
+        ],
+        cwd=vaws_repo / "vllm-ascend",
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    return simulation_root
+
+
+def add_competing_target(vaws_repo: Path, target_name: str = "single-backup") -> None:
+    targets_path = vaws_repo / ".workspace.local" / "targets.yaml"
+    targets_config = yaml.safe_load(targets_path.read_text(encoding="utf-8"))
+    targets_config["targets"][target_name] = {
+        "hosts": ["host-a"],
+        "runtime": {
+            "image_ref": "registry.example.com/ascend/vllm-ascend:test",
+            "container_name": "vaws-backup",
+            "ssh_port": 63270,
+            "workspace_root": "/vllm-workspace-backup",
+            "bootstrap_mode": "host-then-container",
+        },
+    }
+    targets_path.write_text(yaml.safe_dump(targets_config), encoding="utf-8")
+
+
+def prepare_reset_confirmation(vaws_repo: Path):
+    overlay = vaws_repo / ".workspace.local"
+    result = run_vaws(vaws_repo, "reset", "--prepare")
+    assert result.returncode == 0
+
+    output = result.stdout + result.stderr
+    lowered = output.lower()
+    assert "wipe local workspace identity" in lowered
+    assert "remote runtime context" in lowered
+    assert "overlay" in lowered
+    assert "I authorize wiping local workspace identity and remote runtime" in output
+
+    request_path = overlay / "reset-request.json"
+    assert request_path.exists()
+    request_data = json.loads(request_path.read_text(encoding="utf-8"))
+    confirmation_id = request_data.get("confirmation_id")
+    assert isinstance(confirmation_id, str) and confirmation_id.strip()
+    return confirmation_id, output
+
+
+def seed_initialized_reset_state(vaws_repo: Path) -> Path:
+    simulation_root = seed_reset_workspace(vaws_repo)
+
+    assert run_vaws(vaws_repo, "target", "ensure", "single-default").returncode == 0
+    assert run_vaws(vaws_repo, "session", "create", "feat_alpha").returncode == 0
+    assert run_vaws(vaws_repo, "session", "create", "feat_beta").returncode == 0
+    assert run_vaws(vaws_repo, "session", "switch", "feat_beta").returncode == 0
+    return simulation_root
+
+
+def seed_initialized_reset_state_with_competing_target(vaws_repo: Path) -> Path:
+    simulation_root = seed_reset_workspace(vaws_repo)
+    add_competing_target(vaws_repo)
+
+    assert run_vaws(vaws_repo, "target", "ensure", "single-default").returncode == 0
+    assert run_vaws(vaws_repo, "session", "create", "feat_alpha").returncode == 0
+    assert run_vaws(vaws_repo, "session", "create", "feat_beta").returncode == 0
+    assert run_vaws(vaws_repo, "session", "switch", "feat_beta").returncode == 0
+    return simulation_root
+
+
+def test_reset_prepare_prints_destruction_summary_and_creates_confirmation_record(
+    vaws_repo,
+):
+    seed_initialized_reset_state(vaws_repo)
+
+    confirmation_id, output = prepare_reset_confirmation(vaws_repo)
+    lowered = output.lower()
+    assert confirmation_id in output
+    assert "task 2" not in lowered
+    assert "only clear local overlay state" not in lowered
+    assert "wipe local workspace identity" in lowered
+    assert "remote runtime context" in lowered
+    assert (vaws_repo / ".workspace.local" / "reset-request.json").exists()
+
+
+def test_reset_prepare_records_approved_target_in_confirmation_record(vaws_repo):
+    seed_initialized_reset_state(vaws_repo)
+
+    prepare_reset_confirmation(vaws_repo)
+    request_data = read_json(vaws_repo / ".workspace.local" / "reset-request.json")
+
+    assert request_data["approved_target"] == "single-default"
+
+
+def test_reset_prepare_fails_closed_on_invalid_runtime_state(vaws_repo):
+    seed_initialized_reset_state(vaws_repo)
+
+    state_path = vaws_repo / ".workspace.local" / "state.json"
+    state_path.write_text("not valid json", encoding="utf-8")
+
+    result = run_vaws(vaws_repo, "reset", "--prepare")
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "invalid runtime state" in output
+    assert "state.json" in output
+    assert not (vaws_repo / ".workspace.local" / "reset-request.json").exists()
+
+
+def test_reset_execute_fails_without_valid_confirmation_id(vaws_repo):
+    seed_initialized_reset_state(vaws_repo)
+    confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
+
+    result = run_vaws(
+        vaws_repo,
+        "reset",
+        "--execute",
+        "--confirmation-id",
+        "bogus-confirmation-id",
+        "--confirm",
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "confirmation id" in output
+    assert "invalid" in output or "unknown" in output
+    assert confirmation_id not in output
+
+
+def test_reset_execute_fails_without_confirmation_input(vaws_repo):
+    seed_initialized_reset_state(vaws_repo)
+    prepare_reset_confirmation(vaws_repo)
+
+    result = run_vaws(vaws_repo, "reset", "--execute")
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "confirmation" in output
+    assert "missing" in output or "required" in output or "provide" in output
+
+
+def test_reset_execute_fails_without_pending_reset_request(vaws_repo):
+    seed_initialized_reset_state(vaws_repo)
+
+    result = run_vaws(
+        vaws_repo,
+        "reset",
+        "--execute",
+        "--confirmation-id",
+        "stale-confirmation-id",
+        "--confirm",
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "reset-request" in output or "pending" in output or "prepare" in output
+
+
+def test_reset_execute_fails_without_exact_confirmation_phrase(vaws_repo):
+    seed_initialized_reset_state(vaws_repo)
+    confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
+
+    result = run_vaws(
+        vaws_repo,
+        "reset",
+        "--execute",
+        "--confirmation-id",
+        confirmation_id,
+        "--confirm",
+        "this is not the exact phrase",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "confirmation phrase" in output
+    assert "exact" in output or "match" in output
+
+
+def test_reset_execute_fails_when_reset_request_status_is_not_pending(vaws_repo):
+    seed_initialized_reset_state(vaws_repo)
+    confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
+
+    request_path = vaws_repo / ".workspace.local" / "reset-request.json"
+    request_data = read_json(request_path)
+    request_data["status"] = "cancelled"
+    request_path.write_text(json.dumps(request_data, indent=2) + "\n", encoding="utf-8")
+
+    result = run_vaws(
+        vaws_repo,
+        "reset",
+        "--execute",
+        "--confirmation-id",
+        confirmation_id,
+        "--confirm",
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "status" in output
+    assert "pending" in output
+
+
+def test_reset_execute_rejects_confirmation_phrase_with_outer_whitespace(vaws_repo):
+    seed_initialized_reset_state(vaws_repo)
+    confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
+
+    result = run_vaws(
+        vaws_repo,
+        "reset",
+        "--execute",
+        "--confirmation-id",
+        confirmation_id,
+        "--confirm",
+        "  I authorize wiping local workspace identity and remote runtime  ",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "confirmation phrase" in output
+    assert "exact" in output or "match" in output
+
+
+def test_reset_execute_removes_local_and_remote_state(vaws_repo):
+    seed_initialized_reset_state(vaws_repo)
+    confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
+    simulation_root = vaws_repo.parent / "simulation-runtime"
+    runtime_root = simulation_root / "host-a" / "vllm-workspace"
+
+    result = run_vaws(
+        vaws_repo,
+        "reset",
+        "--execute",
+        "--confirmation-id",
+        confirmation_id,
+        "--confirm",
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+
+    assert result.returncode == 0
+    output = (result.stdout + result.stderr).lower()
+    assert "reset" in output
+    assert "ok" in output or "complete" in output
+
+    overlay = vaws_repo / ".workspace.local"
+    assert not (overlay / "reset-request.json").exists()
+    assert read_json(overlay / "state.json") == {}
+    assert not (overlay / "sessions").exists()
+    assert (overlay / "targets.yaml").read_text(encoding="utf-8") == ""
+    assert (overlay / "auth.yaml").read_text(encoding="utf-8") == ""
+    assert (overlay / "repos.yaml").read_text(encoding="utf-8") == ""
+    assert not runtime_root.exists()
+    assert not (runtime_root / ".vaws" / "current").exists()
+    assert not (runtime_root / ".vaws" / "runtime.json").exists()
+    assert _remote_url(vaws_repo, "vllm", "origin") == COMMUNITY_VLLM_URL
+    assert _remote_url(vaws_repo, "vllm", "upstream") == COMMUNITY_VLLM_URL
+    assert _remote_url(vaws_repo, "vllm-ascend", "origin") == COMMUNITY_VLLM_ASCEND_URL
+    assert _remote_url(vaws_repo, "vllm-ascend", "upstream") == COMMUNITY_VLLM_ASCEND_URL
+
+
+def test_reset_execute_keeps_cleanup_pinned_to_prepared_target_after_live_target_changes(
+    vaws_repo,
+):
+    simulation_root = seed_initialized_reset_state_with_competing_target(vaws_repo)
+    confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
+
+    assert run_vaws(vaws_repo, "target", "ensure", "single-backup").returncode == 0
+
+    result = run_vaws(
+        vaws_repo,
+        "reset",
+        "--execute",
+        "--confirmation-id",
+        confirmation_id,
+        "--confirm",
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+
+    assert result.returncode == 0
+    output = (result.stdout + result.stderr).lower()
+    assert "ok" in output or "complete" in output
+
+    prepared_runtime_root = simulation_root / "host-a" / "vllm-workspace"
+    competing_runtime_root = simulation_root / "host-a" / "vllm-workspace-backup"
+    assert not prepared_runtime_root.exists()
+    assert competing_runtime_root.exists()
+    assert not (vaws_repo / ".workspace.local" / "reset-request.json").exists()
+
+
+def test_reset_execute_ignores_corrupted_live_state_when_prepared_target_is_pinned(
+    vaws_repo,
+):
+    simulation_root = seed_initialized_reset_state(vaws_repo)
+    confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
+
+    (vaws_repo / ".workspace.local" / "state.json").write_text(
+        "not valid json",
+        encoding="utf-8",
+    )
+
+    result = run_vaws(
+        vaws_repo,
+        "reset",
+        "--execute",
+        "--confirmation-id",
+        confirmation_id,
+        "--confirm",
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+
+    assert result.returncode == 0
+    output = (result.stdout + result.stderr).lower()
+    assert "ok" in output or "complete" in output
+
+    runtime_root = simulation_root / "host-a" / "vllm-workspace"
+    assert not runtime_root.exists()
+    assert not (vaws_repo / ".workspace.local" / "reset-request.json").exists()
+
+
+def test_reset_execute_fails_and_preserves_request_when_sessions_cleanup_fails(
+    vaws_repo,
+):
+    seed_initialized_reset_state(vaws_repo)
+    confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
+
+    overlay = vaws_repo / ".workspace.local"
+    sessions_path = overlay / "sessions"
+    if sessions_path.exists():
+        if sessions_path.is_dir():
+            shutil.rmtree(sessions_path)
+        else:
+            sessions_path.unlink()
+    sessions_path.write_text("not-a-directory", encoding="utf-8")
+
+    result = run_vaws(
+        vaws_repo,
+        "reset",
+        "--execute",
+        "--confirmation-id",
+        confirmation_id,
+        "--confirm",
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "failed to clean local workspace" in output or "not a directory" in output
+    assert "traceback (most recent call last)" not in output
+    assert (overlay / "reset-request.json").exists()
+
+
+def test_reset_execute_stops_before_local_cleanup_when_remote_cleanup_fails(
+    vaws_repo,
+):
+    simulation_root = seed_reset_workspace(vaws_repo)
+    overlay = vaws_repo / ".workspace.local"
+    assert run_vaws(vaws_repo, "target", "ensure", "single-default").returncode == 0
+    assert run_vaws(vaws_repo, "session", "create", "feat_alpha").returncode == 0
+    assert run_vaws(vaws_repo, "session", "switch", "feat_alpha").returncode == 0
+
+    confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
+    runtime_root = simulation_root / "host-a" / "vllm-workspace"
+    runtime_parent = runtime_root.parent
+    original_mode = runtime_parent.stat().st_mode
+    runtime_parent.chmod(original_mode & ~stat.S_IWUSR & ~stat.S_IWGRP & ~stat.S_IWOTH)
+
+    try:
+        result = run_vaws(
+            vaws_repo,
+            "reset",
+            "--execute",
+            "--confirmation-id",
+            confirmation_id,
+            "--confirm",
+            "I authorize wiping local workspace identity and remote runtime",
+        )
+    finally:
+        runtime_parent.chmod(original_mode)
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "remote" in output or "cleanup" in output
+    assert "permission" in output or "failed" in output
+
+    assert read_json(overlay / "state.json")["current_session"] == "feat_alpha"
+    assert (overlay / "sessions" / "feat_alpha" / "manifest.yaml").exists()
+    assert (overlay / "reset-request.json").exists()
+    runtime_root = simulation_root / "host-a" / "vllm-workspace"
+    assert (runtime_root / ".vaws" / "current").exists()
+
+
+def test_destroy_runtime_dispatches_host_cleanup(monkeypatch):
+    calls = []
+
+    def fake_run_host_command(ctx, script):
+        calls.append(script)
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("tools.lib.remote._run_host_command", fake_run_host_command)
+
+    ctx = TargetContext(
+        name="single-default",
+        host=HostSpec(
+            name="host-a",
+            host="127.0.0.1",
+            port=22,
+            login_user="root",
+            auth_group="shared-lab-a",
+        ),
+        credential=CredentialGroup(mode="ssh-key", username="root"),
+        runtime=RuntimeSpec(
+            image_ref="registry.example.com/ascend/vllm-ascend:test",
+            container_name="vaws-owner",
+            ssh_port=63269,
+            workspace_root="/vllm-workspace",
+            bootstrap_mode="host-then-container",
+            host_workspace_path="/root/.vaws/targets/single-default/workspace",
+            docker_run_args=[],
+        ),
+    )
+
+    destroy_runtime(ctx)
+
+    assert len(calls) == 1
+    script = calls[0]
+    assert "docker container ls -a" in script
+    assert "|| exit 1" in script
+    assert "docker rm -f" in script
+    assert "grep -Fqx" in script or "grep -Fxq" in script
+    assert "vaws-owner" in script
+    assert "/root/.vaws/targets/single-default/workspace" in script

--- a/tools/lib/config.py
+++ b/tools/lib/config.py
@@ -9,3 +9,27 @@ class RepoPaths:
     @property
     def local_overlay(self) -> Path:
         return self.root / ".workspace.local"
+
+    @property
+    def local_state_file(self) -> Path:
+        return self.local_overlay / "state.json"
+
+    @property
+    def local_targets_file(self) -> Path:
+        return self.local_overlay / "targets.yaml"
+
+    @property
+    def local_auth_file(self) -> Path:
+        return self.local_overlay / "auth.yaml"
+
+    @property
+    def local_repos_file(self) -> Path:
+        return self.local_overlay / "repos.yaml"
+
+    @property
+    def local_sessions_dir(self) -> Path:
+        return self.local_overlay / "sessions"
+
+    @property
+    def reset_request_file(self) -> Path:
+        return self.local_overlay / "reset-request.json"

--- a/tools/lib/remote.py
+++ b/tools/lib/remote.py
@@ -4,6 +4,7 @@ import json
 import os
 import shlex
 import subprocess
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -904,3 +905,49 @@ def switch_remote_session(ctx: TargetContext, session_name: str, transport: str)
             f"failed to switch remote session '{session_name}': {(result.stderr or result.stdout).strip()}"
         )
     _write_host_runtime_state(ctx, transport, current_session=session_name)
+
+
+def _destroy_simulation_runtime(ctx: TargetContext) -> None:
+    runtime_root = _simulation_runtime_root(ctx)
+    if not runtime_root.exists():
+        return
+    try:
+        parent_dir = runtime_root.parent
+        if not os.access(parent_dir, os.W_OK | os.X_OK):
+            raise RemoteError(
+                f"failed to clean simulation runtime at {runtime_root}: permission denied"
+            )
+        if runtime_root.is_symlink():
+            runtime_root.unlink()
+        else:
+            shutil.rmtree(runtime_root)
+    except OSError as exc:
+        raise RemoteError(
+            f"failed to clean simulation runtime at {runtime_root}: {exc}"
+        ) from exc
+
+
+def _destroy_host_runtime(ctx: TargetContext) -> None:
+    script = "\n".join(
+        [
+            "set -e",
+            f"container_names=$(docker container ls -a --format '{{{{.Names}}}}') || exit 1",
+            f"if printf '%s\\n' \"$container_names\" | grep -Fqx {shlex.quote(ctx.runtime.container_name)}; then",
+            f"  docker rm -f {shlex.quote(ctx.runtime.container_name)} >/dev/null",
+            "fi",
+            f"rm -rf {shlex.quote(ctx.runtime.host_workspace_path)}",
+        ]
+    )
+    result = _run_host_command(ctx, script)
+    if result.returncode != 0:
+        raise RemoteError(
+            f"failed to clean remote runtime for target '{ctx.name}': "
+            f"{(result.stderr or result.stdout).strip()}"
+        )
+
+
+def destroy_runtime(ctx: TargetContext) -> None:
+    if ctx.credential.mode == "local-simulation":
+        _destroy_simulation_runtime(ctx)
+        return
+    _destroy_host_runtime(ctx)

--- a/tools/lib/reset.py
+++ b/tools/lib/reset.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import json
+import secrets
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .bootstrap import COMMUNITY_UPSTREAM_URLS
+from .config import RepoPaths
+from .remote import RemoteError, destroy_runtime, resolve_target_context
+from .runtime import read_state, write_state
+
+CONFIRMATION_PHRASE = "I authorize wiping local workspace identity and remote runtime"
+
+
+def _ensure_overlay(paths: RepoPaths) -> None:
+    if paths.local_overlay.exists() and not paths.local_overlay.is_dir():
+        raise RuntimeError("invalid local overlay: .workspace.local/ exists but is not a directory")
+    paths.local_overlay.mkdir(parents=True, exist_ok=True)
+
+
+def _load_reset_request(paths: RepoPaths) -> Dict[str, Any]:
+    request_path = paths.reset_request_file
+    if not request_path.is_file():
+        raise RuntimeError("missing pending reset request: run `vaws reset --prepare` first")
+
+    try:
+        request = json.loads(request_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("invalid pending reset request: .workspace.local/reset-request.json") from exc
+
+    if not isinstance(request, dict):
+        raise RuntimeError("invalid pending reset request: .workspace.local/reset-request.json")
+    return request
+
+
+def _write_reset_request(paths: RepoPaths, confirmation_id: str) -> None:
+    request = {
+        "confirmation_id": confirmation_id,
+        "status": "pending",
+        "confirmation_phrase": CONFIRMATION_PHRASE,
+    }
+    paths.reset_request_file.write_text(
+        json.dumps(request, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _current_target_from_state(paths: RepoPaths) -> Optional[str]:
+    state = read_state(paths)
+    current_target = state.get("current_target")
+    if isinstance(current_target, str) and current_target.strip():
+        return current_target.strip()
+    return None
+
+
+def _print_prepare_summary(confirmation_id: str) -> None:
+    print("reset prepare: this request records approval to wipe local workspace identity and remote runtime context")
+    print("reset prepare: reset execute will clean the active remote runtime first, then clear local overlay state")
+    print("reset prepare: local overlay state includes .workspace.local/state.json, .workspace.local/sessions/, .workspace.local/targets.yaml, .workspace.local/auth.yaml, and .workspace.local/repos.yaml")
+    print(f"reset prepare: confirmation id: {confirmation_id}")
+    print(f"reset prepare: confirm with: {CONFIRMATION_PHRASE}")
+
+
+def prepare_reset(paths: RepoPaths) -> int:
+    try:
+        _ensure_overlay(paths)
+        confirmation_id = f"reset-{secrets.token_urlsafe(16)}"
+        request = {
+            "confirmation_id": confirmation_id,
+            "status": "pending",
+            "confirmation_phrase": CONFIRMATION_PHRASE,
+        }
+        approved_target = _current_target_from_state(paths)
+        if approved_target:
+            request["approved_target"] = approved_target
+        paths.reset_request_file.write_text(
+            json.dumps(request, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    except RuntimeError as exc:
+        print(str(exc))
+        return 1
+    except OSError as exc:
+        print(f"reset prepare: failed to write reset request: {exc}")
+        return 1
+
+    _print_prepare_summary(confirmation_id)
+    return 0
+
+
+def _cleanup_local_state(paths: RepoPaths) -> None:
+    write_state(paths, {})
+    sessions_path = paths.local_sessions_dir
+    if sessions_path.exists():
+        if not sessions_path.is_dir():
+            raise RuntimeError("failed to clean local workspace: .workspace.local/sessions is not a directory")
+        shutil.rmtree(sessions_path)
+    paths.local_targets_file.write_text("", encoding="utf-8")
+    paths.local_auth_file.write_text("", encoding="utf-8")
+    paths.local_repos_file.write_text("", encoding="utf-8")
+
+
+def _cleanup_remote_state(request: Dict[str, Any], paths: RepoPaths) -> None:
+    approved_target = request.get("approved_target")
+    if not isinstance(approved_target, str) or not approved_target.strip():
+        return
+
+    context = resolve_target_context(paths, approved_target.strip())
+    destroy_runtime(context)
+
+
+def _run_git(repo_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _ensure_git_remote(repo_path: Path, remote_name: str, url: str) -> None:
+    if not (repo_path / ".git").exists():
+        raise RuntimeError(f"invalid workspace repo: {repo_path}")
+
+    probe = _run_git(repo_path, "remote", "get-url", remote_name)
+    if probe.returncode == 0:
+        update = _run_git(repo_path, "remote", "set-url", remote_name, url)
+    else:
+        update = _run_git(repo_path, "remote", "add", remote_name, url)
+
+    if update.returncode != 0:
+        stderr = update.stderr.strip() or update.stdout.strip()
+        raise RuntimeError(
+            f"failed to configure remote '{remote_name}' for {repo_path.name}: {stderr}"
+        )
+
+
+def _restore_public_repo_remotes(paths: RepoPaths) -> None:
+    repo_targets = {
+        "vllm": paths.root / "vllm",
+        "vllm-ascend": paths.root / "vllm-ascend",
+    }
+
+    for repo_name, repo_path in repo_targets.items():
+        url = COMMUNITY_UPSTREAM_URLS[repo_name]
+        _ensure_git_remote(repo_path, "origin", url)
+        _ensure_git_remote(repo_path, "upstream", url)
+
+
+def execute_reset(
+    paths: RepoPaths,
+    confirmation_id: Optional[str],
+    confirm: Optional[str],
+) -> int:
+    if not isinstance(confirmation_id, str) or not confirmation_id.strip():
+        print("reset execute: missing confirmation id; provide --confirmation-id")
+        return 1
+    if not isinstance(confirm, str) or not confirm.strip():
+        print("reset execute: missing confirmation phrase; provide --confirm")
+        return 1
+
+    confirmation_id = confirmation_id.strip()
+
+    try:
+        request = _load_reset_request(paths)
+    except RuntimeError as exc:
+        print(str(exc))
+        return 1
+
+    status = request.get("status")
+    if status != "pending":
+        print("reset execute: reset request status must be pending")
+        return 1
+
+    pending_confirmation_id = request.get("confirmation_id")
+    if not isinstance(pending_confirmation_id, str) or not pending_confirmation_id.strip():
+        print("reset execute: invalid pending reset request: missing confirmation id")
+        return 1
+    if pending_confirmation_id.strip() != confirmation_id:
+        print("reset execute: invalid confirmation id; prepare a new reset request and try again")
+        return 1
+    if confirm != CONFIRMATION_PHRASE:
+        print("reset execute: confirmation phrase must exactly match the approved phrase")
+        return 1
+
+    try:
+        _cleanup_remote_state(request, paths)
+    except RemoteError as exc:
+        print(f"reset execute: failed to clean remote runtime: {exc}")
+        return 1
+
+    try:
+        _cleanup_local_state(paths)
+    except (OSError, RuntimeError) as exc:
+        print(f"reset execute: failed to clean local workspace: {exc}")
+        return 1
+
+    try:
+        _restore_public_repo_remotes(paths)
+    except (OSError, RuntimeError) as exc:
+        print(f"reset execute: failed to restore public repo remotes: {exc}")
+        return 1
+
+    try:
+        if paths.reset_request_file.exists():
+            paths.reset_request_file.unlink()
+    except OSError as exc:
+        print(f"reset execute: failed to clean local workspace: {exc}")
+        return 1
+
+    print("reset execute: ok")
+    return 0

--- a/tools/vaws.py
+++ b/tools/vaws.py
@@ -10,6 +10,7 @@ from tools.lib.bootstrap import bootstrap_init, bootstrap_request_from_args
 from tools.lib.config import RepoPaths
 from tools.lib.doctor import doctor, init
 from tools.lib.gitflow import default_base_ref
+from tools.lib.reset import execute_reset, prepare_reset
 from tools.lib.session import create_session, status_session, switch_session
 from tools.lib.targets import ensure_target
 
@@ -57,6 +58,12 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
     )
     remotes_subparsers.add_parser("normalize")
+
+    reset_parser = subparsers.add_parser("reset")
+    reset_parser.add_argument("--prepare", action="store_true")
+    reset_parser.add_argument("--execute", action="store_true")
+    reset_parser.add_argument("--confirmation-id")
+    reset_parser.add_argument("--confirm")
 
     target_parser = subparsers.add_parser("target")
     target_subparsers = target_parser.add_subparsers(dest="target_command", required=True)
@@ -110,6 +117,16 @@ def main(argv: Optional[List[str]] = None) -> int:
             print(str(exc))
             return 1
         return 0
+    if args.command == "reset":
+        if args.prepare and args.execute:
+            print("reset: choose only one mode, --prepare or --execute")
+            return 1
+        if args.prepare:
+            return prepare_reset(paths)
+        if args.execute:
+            return execute_reset(paths, args.confirmation_id, args.confirm)
+        print("reset: missing mode, use --prepare or --execute")
+        return 1
     if args.command == "target" and args.target_command == "ensure":
         return ensure_target(paths, args.target_name)
     if args.command == "session" and args.session_command == "create":


### PR DESCRIPTION
## Summary
- add a guarded `tools/vaws.py reset` flow with prepare/execute authorization, fail-closed target pinning, and remote-before-local cleanup
- restore `vllm` and `vllm-ascend` remotes back to community `origin`/`upstream` on successful reset
- add reset regression coverage plus public guidance for the guarded reset workflow

## Why
This adds a repeatable way to return the workspace to a near post-clone, pre-bootstrap state for bootstrap testing without rewriting git history, while preventing agents from running the destructive reset path without an explicit two-step confirmation.

## Validation
- [x] `pytest -q tests/test_vaws_reset.py tests/test_repo_layout.py -q`
- [x] `pytest -q`
