### PR TITLE
[codex] migrate workspace control plane to bootstrap-fleet-reset model

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -6,9 +6,10 @@ This directory contains public, workspace-local reference material for agents wo
 - Primary command surface: `tools/vaws.py`
 - Compatibility entrypoints: `./setup` and `./sync`
 - Workflow skills live under `.agents/skills/`.
-- Bootstrap and repair procedure: `.agents/skills/workspace-bootstrap/`
+- Bootstrap and first-time baseline procedure: `.agents/skills/workspace-bootstrap/`
+- Fleet server maintenance procedure: `.agents/skills/workspace-fleet/`
 - For Codex bootstrap, start from natural language user input and route into the bootstrap skill.
-- Guarded reset and deinit procedure: `.agents/skills/workspace-reset/`
+- Guarded best-effort reset and deinit procedure: `.agents/skills/workspace-reset/`
 - Session switching procedure: `.agents/skills/workspace-session-switch/`
 - Sync procedure: `.agents/skills/workspace-sync/`
 - Local overlay state: `.workspace.local/`

--- a/.agents/skills/workspace-bootstrap/SKILL.md
+++ b/.agents/skills/workspace-bootstrap/SKILL.md
@@ -18,8 +18,7 @@ Use this skill when initializing or repairing the local workspace overlay for a 
 - Keep tracked defaults on community `upstream` repositories and store user-specific `origin` topology in `.workspace.local/repos.yaml`.
 - Prefer `config/*.example.yaml` as the public template source.
 - Keep secrets, private hosts, and private paths out of tracked files.
-- Guarded reset is a two-step flow: `tools/vaws.py reset --prepare` first, then `tools/vaws.py reset --execute --confirmation-id ... --confirm ...`.
-- Agents must not skip prepare, reuse stale confirmation ids, or fabricate authorization.
-- After a successful reset, restore `origin` and `upstream` on `vllm/` and `vllm-ascend/` to the community URLs.
+
+Use `.agents/skills/workspace-reset/SKILL.md` for guarded reset and deinit cleanup.
 
 This is workspace-local reference material only.

--- a/.agents/skills/workspace-bootstrap/SKILL.md
+++ b/.agents/skills/workspace-bootstrap/SKILL.md
@@ -12,6 +12,7 @@ Use this skill when initializing or repairing the local workspace overlay for a 
 - Collect remote server connection details first.
 - Collect `vllm-ascend` repo path or fork URL and Git auth second.
 - Treat `vllm` fork configuration as optional.
+- Use bootstrap only for the first-time baseline; later server changes belong in fleet.
 - Once enough information is available, the agent should run `tools/vaws.py init --bootstrap ...` and then use `tools/vaws.py doctor` for follow-up checks.
 - Treat `.workspace.local/` as local overlay state only.
 - Keep tracked defaults on community `upstream` repositories and store user-specific `origin` topology in `.workspace.local/repos.yaml`.

--- a/.agents/skills/workspace-fleet/SKILL.md
+++ b/.agents/skills/workspace-fleet/SKILL.md
@@ -8,9 +8,8 @@ description: Use when managing workspace servers after bootstrap, especially for
 Use this skill for post-bootstrap server inventory maintenance.
 
 - Treat `.workspace.local/servers.yaml` as the source of truth for managed servers.
-- Use `tools/vaws.py fleet list` to inspect the current inventory.
-- Use `tools/vaws.py fleet add` to add or realize a managed server.
-- Use `tools/vaws.py fleet verify` to check a server without mutating local inventory.
+- Use `tools/vaws.py fleet add`, `tools/vaws.py fleet remove`, `tools/vaws.py fleet list`, `tools/vaws.py fleet verify`, and repair-oriented follow-up to manage servers.
+- SSH connectivity is the prerequisite for fleet work; remote runtime verification is the success condition.
 - Treat verification gaps as repair signals, not bootstrap failures.
 - Keep server-specific changes out of tracked files; they belong in the local overlay.
 - Use bootstrap only for first-time baseline setup, not for later server changes.

--- a/.agents/skills/workspace-fleet/SKILL.md
+++ b/.agents/skills/workspace-fleet/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: workspace-fleet
+description: Use when managing workspace servers after bootstrap, especially for add/list/verify/repair-style maintenance against `.workspace.local/servers.yaml`.
+---
+
+# Workspace Fleet
+
+Use this skill for post-bootstrap server inventory maintenance.
+
+- Treat `.workspace.local/servers.yaml` as the source of truth for managed servers.
+- Use `tools/vaws.py fleet list` to inspect the current inventory.
+- Use `tools/vaws.py fleet add` to add or realize a managed server.
+- Use `tools/vaws.py fleet verify` to check a server without mutating local inventory.
+- Treat verification gaps as repair signals, not bootstrap failures.
+- Keep server-specific changes out of tracked files; they belong in the local overlay.
+- Use bootstrap only for first-time baseline setup, not for later server changes.
+
+This is workspace-local reference material only.

--- a/.agents/skills/workspace-fleet/SKILL.md
+++ b/.agents/skills/workspace-fleet/SKILL.md
@@ -8,7 +8,7 @@ description: Use when managing workspace servers after bootstrap, especially for
 Use this skill for post-bootstrap server inventory maintenance.
 
 - Treat `.workspace.local/servers.yaml` as the source of truth for managed servers.
-- Use `tools/vaws.py fleet add`, `tools/vaws.py fleet remove`, `tools/vaws.py fleet list`, `tools/vaws.py fleet verify`, and repair-oriented follow-up to manage servers.
+- Use `tools/vaws.py fleet add`, `tools/vaws.py fleet list`, and `tools/vaws.py fleet verify` for inventory work; handle remove and repair scenarios as fleet maintenance outcomes.
 - SSH connectivity is the prerequisite for fleet work; remote runtime verification is the success condition.
 - Treat verification gaps as repair signals, not bootstrap failures.
 - Keep server-specific changes out of tracked files; they belong in the local overlay.

--- a/.agents/skills/workspace-reset/SKILL.md
+++ b/.agents/skills/workspace-reset/SKILL.md
@@ -11,7 +11,9 @@ Use this skill when a user explicitly asks to reset, deinitialize, or return thi
 - Treat reset as a guarded two-step flow: run `tools/vaws.py reset --prepare` first, then `tools/vaws.py reset --execute --confirmation-id ... --confirm ...`.
 - Show the destruction summary from `reset --prepare` before executing the destructive step.
 - Agents must not skip prepare, reuse stale confirmation ids, or fabricate authorization.
-- Reset is expected to clear local workspace identity and clean the approved remote runtime before local overlay cleanup.
+- Reset is expected to clear local workspace identity and clean all managed servers in `.workspace.local/servers.yaml` on a best-effort basis.
+- Unreachable servers should be reported, not treated as a hard stop.
+- After remote cleanup attempts, local overlay cleanup should still run.
 - After a successful reset, restore `origin` and `upstream` on `vllm/` and `vllm-ascend/` to the community URLs.
 - Keep private hosts, tokens, and user-specific paths out of tracked files.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,8 @@ This repository is a public-facing control workspace for vLLM Ascend development
 ## Workflow Routing
 
 - Keep detailed operational procedures in `.agents/skills/`, not in this file.
-- Use `.agents/skills/workspace-bootstrap/SKILL.md` for bootstrap and bootstrap repair.
-- Use `.agents/skills/workspace-reset/SKILL.md` for guarded reset / deinit.
+- Use `.agents/skills/workspace-bootstrap/SKILL.md` for first-time baseline bootstrap and bootstrap repair.
+- Use `.agents/skills/workspace-fleet/SKILL.md` for post-bootstrap server inventory maintenance.
+- Use `.agents/skills/workspace-reset/SKILL.md` for guarded best-effort reset / deinit cleanup.
 - Use `.agents/skills/workspace-session-switch/SKILL.md` for session changes.
 - Use `.agents/skills/workspace-sync/SKILL.md` for sync behavior.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Public workspace-local control repository for coordinating vLLM and vLLM-Ascend 
 ## Agent Workflows
 
 - `.agents/skills/` contains public reference material for workspace-local agents.
-- Bootstrap and workspace repair flow live in `.agents/skills/workspace-bootstrap/`.
+- Bootstrap and first-time baseline flow live in `.agents/skills/workspace-bootstrap/`.
+- Ongoing server inventory maintenance lives in `.agents/skills/workspace-fleet/`.
 - For Codex bootstrap, the user should start from a natural language request and the agent should route into the bootstrap skill.
-- Guarded deinit/reset flow lives in `.agents/skills/workspace-reset/`.
+- Guarded best-effort cleanup flow lives in `.agents/skills/workspace-reset/`.
 - Session switching flow lives in `.agents/skills/workspace-session-switch/`.
 - Sync flow lives in `.agents/skills/workspace-sync/`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,27 @@ def _init_git_repo(path: Path, remote_url: str) -> None:
     _run(["git", "update-ref", "refs/remotes/upstream/release", "HEAD"], cwd=path)
 
 
+def seed_overlay_files(repo: Path) -> None:
+    overlay = repo / ".workspace.local"
+    overlay.mkdir(exist_ok=True)
+    (overlay / "servers.yaml").write_text(
+        "version: 1\nservers: {}\n",
+        encoding="utf-8",
+    )
+    (overlay / "auth.yaml").write_text(
+        "version: 1\nssh_auth: {refs: {}}\ngit_auth: {refs: {}}\n",
+        encoding="utf-8",
+    )
+    (overlay / "repos.yaml").write_text(
+        "version: 1\nworkspace: {}\nsubmodules: {}\n",
+        encoding="utf-8",
+    )
+    (overlay / "state.json").write_text(
+        '{"schema_version": 1}\n',
+        encoding="utf-8",
+    )
+
+
 @pytest.fixture
 def vaws_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"

--- a/tests/test_repo_layout.py
+++ b/tests/test_repo_layout.py
@@ -106,6 +106,13 @@ def test_public_docs_explain_upstream_defaults_and_local_origin_bootstrap():
         assert ".workspace.local/repos.yaml" in text
         assert "natural language" in text or "conversational" in text
 
+    for forbidden in (
+        "reset --prepare",
+        "reset --execute",
+        "fabricate authorization",
+    ):
+        assert forbidden not in bootstrap_skill
+
 
 def test_agents_md_routes_bootstrap_and_reset_to_skills():
     repo = Path(__file__).resolve().parents[1]
@@ -144,6 +151,23 @@ def test_workspace_reset_skill_owns_guarded_reset_procedure():
     assert "unreachable" in text
 
 
+def test_workspace_fleet_skill_owns_server_inventory_maintenance():
+    repo = Path(__file__).resolve().parents[1]
+    text = (
+        repo / ".agents" / "skills" / "workspace-fleet" / "SKILL.md"
+    ).read_text(encoding="utf-8").lower()
+
+    assert "servers.yaml" in text
+    assert "remove" in text
+    assert "fleet list" in text
+    assert "fleet add" in text
+    assert "fleet verify" in text
+    assert "ssh connectivity is the prerequisite" in text
+    assert "remote runtime verification is the success condition" in text
+    assert "reset --prepare" not in text
+    assert "reset --execute" not in text
+
+
 def test_workspace_local_skill_skeletons_exist_and_stay_public():
     repo = Path(__file__).resolve().parents[1]
     agents_root = repo / ".agents"
@@ -170,6 +194,7 @@ def test_workspace_local_skill_skeletons_exist_and_stay_public():
             "tools/vaws.py fleet",
             "servers.yaml",
             "add",
+            "remove",
             "verify",
             "repair",
         ),

--- a/tests/test_repo_layout.py
+++ b/tests/test_repo_layout.py
@@ -54,6 +54,8 @@ def test_public_guidance_uses_current_entrypoints_and_canonical_root():
     assert "submodule" in readme
     assert "vllm/" in agents
     assert "vllm-ascend/" in agents
+    assert "fleet" in readme
+    assert "fleet" in agents
 
 
 def test_workspace_submodules_are_declared():
@@ -110,6 +112,7 @@ def test_agents_md_routes_bootstrap_and_reset_to_skills():
     agents = (repo / "AGENTS.md").read_text(encoding="utf-8").lower()
     for skill_name in (
         "workspace-bootstrap",
+        "workspace-fleet",
         "workspace-reset",
         "workspace-session-switch",
         "workspace-sync",
@@ -121,6 +124,7 @@ def test_agents_md_routes_bootstrap_and_reset_to_skills():
     assert "must not skip prepare" not in agents
     assert "fabricate authorization" not in agents
     assert "init --bootstrap" not in agents
+    assert "fleet add" not in agents
 
 
 def test_workspace_reset_skill_owns_guarded_reset_procedure():
@@ -136,6 +140,8 @@ def test_workspace_reset_skill_owns_guarded_reset_procedure():
     assert "stale confirmation id" in text or "stale confirmation ids" in text
     assert "fabricate authorization" in text
     assert "community urls" in text or "community `origin` and `upstream`" in text
+    assert "all managed servers" in text
+    assert "unreachable" in text
 
 
 def test_workspace_local_skill_skeletons_exist_and_stay_public():
@@ -155,10 +161,17 @@ def test_workspace_local_skill_skeletons_exist_and_stay_public():
         "workspace-bootstrap": (
             "/vllm-workspace",
             "natural language",
-            "server",
+            "first-time baseline",
             "vllm-ascend",
             "optional",
             "tools/vaws.py init --bootstrap",
+        ),
+        "workspace-fleet": (
+            "tools/vaws.py fleet",
+            "servers.yaml",
+            "add",
+            "verify",
+            "repair",
         ),
         "workspace-reset": (
             "/vllm-workspace",

--- a/tests/test_repo_layout.py
+++ b/tests/test_repo_layout.py
@@ -158,12 +158,13 @@ def test_workspace_fleet_skill_owns_server_inventory_maintenance():
     ).read_text(encoding="utf-8").lower()
 
     assert "servers.yaml" in text
-    assert "remove" in text
+    assert "remove and repair" in text
     assert "fleet list" in text
     assert "fleet add" in text
     assert "fleet verify" in text
     assert "ssh connectivity is the prerequisite" in text
     assert "remote runtime verification is the success condition" in text
+    assert "fleet remove" not in text
     assert "reset --prepare" not in text
     assert "reset --execute" not in text
 
@@ -194,7 +195,7 @@ def test_workspace_local_skill_skeletons_exist_and_stay_public():
             "tools/vaws.py fleet",
             "servers.yaml",
             "add",
-            "remove",
+            "remove and repair",
             "verify",
             "repair",
         ),

--- a/tests/test_vaws_doctor.py
+++ b/tests/test_vaws_doctor.py
@@ -1,7 +1,7 @@
 import json
 import shutil
 
-from conftest import run_vaws
+from conftest import run_vaws, seed_overlay_files
 
 
 def test_doctor_reports_missing_overlay(vaws_repo):
@@ -10,10 +10,18 @@ def test_doctor_reports_missing_overlay(vaws_repo):
     assert ".workspace.local" in result.stdout
 
 
+def test_doctor_requires_servers_yaml_instead_of_targets_yaml(vaws_repo):
+    seed_overlay_files(vaws_repo)
+
+    result = run_vaws(vaws_repo, "doctor")
+
+    assert result.returncode == 0
+
+
 def test_init_creates_overlay_files(vaws_repo):
     result = run_vaws(vaws_repo, "init")
     assert result.returncode == 0
-    assert (vaws_repo / ".workspace.local" / "targets.yaml").exists()
+    assert (vaws_repo / ".workspace.local" / "servers.yaml").exists()
     assert (vaws_repo / ".workspace.local" / "repos.yaml").exists()
     assert (vaws_repo / ".workspace.local" / "auth.yaml").exists()
     assert (vaws_repo / ".workspace.local" / "state.json").exists()
@@ -22,7 +30,7 @@ def test_init_creates_overlay_files(vaws_repo):
 def test_doctor_fails_when_required_overlay_files_are_missing(vaws_repo):
     overlay = vaws_repo / ".workspace.local"
     overlay.mkdir()
-    (overlay / "targets.yaml").write_text("", encoding="utf-8")
+    (overlay / "servers.yaml").write_text("", encoding="utf-8")
 
     result = run_vaws(vaws_repo, "doctor")
 
@@ -34,10 +42,7 @@ def test_doctor_fails_when_required_overlay_files_are_missing(vaws_repo):
 
 def test_doctor_fails_when_state_json_is_invalid(vaws_repo):
     overlay = vaws_repo / ".workspace.local"
-    overlay.mkdir()
-    (overlay / "targets.yaml").write_text("", encoding="utf-8")
-    (overlay / "repos.yaml").write_text("", encoding="utf-8")
-    (overlay / "auth.yaml").write_text("", encoding="utf-8")
+    seed_overlay_files(vaws_repo)
     (overlay / "state.json").write_text("{not-json", encoding="utf-8")
 
     result = run_vaws(vaws_repo, "doctor")
@@ -50,10 +55,7 @@ def test_doctor_fails_when_state_json_is_invalid(vaws_repo):
 
 def test_doctor_fails_when_state_json_is_not_utf8(vaws_repo):
     overlay = vaws_repo / ".workspace.local"
-    overlay.mkdir()
-    (overlay / "targets.yaml").write_text("", encoding="utf-8")
-    (overlay / "repos.yaml").write_text("", encoding="utf-8")
-    (overlay / "auth.yaml").write_text("", encoding="utf-8")
+    seed_overlay_files(vaws_repo)
     (overlay / "state.json").write_bytes(b"\xff\xfe")
 
     result = run_vaws(vaws_repo, "doctor")
@@ -97,7 +99,7 @@ def test_init_writes_json_parseable_state_file(vaws_repo):
     state_text = (vaws_repo / ".workspace.local" / "state.json").read_text(
         encoding="utf-8"
     )
-    assert json.loads(state_text) == {}
+    assert json.loads(state_text) == {"schema_version": 1}
 
 
 def test_init_fails_cleanly_when_overlay_path_is_a_file(vaws_repo):

--- a/tests/test_vaws_doctor.py
+++ b/tests/test_vaws_doctor.py
@@ -53,6 +53,47 @@ def test_doctor_fails_when_state_json_is_invalid(vaws_repo):
     assert "invalid" in output
 
 
+def test_doctor_fails_when_state_json_is_not_a_mapping(vaws_repo):
+    overlay = vaws_repo / ".workspace.local"
+    seed_overlay_files(vaws_repo)
+    (overlay / "state.json").write_text("[]\n", encoding="utf-8")
+
+    result = run_vaws(vaws_repo, "doctor")
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "state.json" in output
+    assert "mapping" in output or "object" in output
+
+
+def test_doctor_fails_when_state_json_schema_version_is_missing(vaws_repo):
+    overlay = vaws_repo / ".workspace.local"
+    seed_overlay_files(vaws_repo)
+    (overlay / "state.json").write_text("{}\n", encoding="utf-8")
+
+    result = run_vaws(vaws_repo, "doctor")
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "state.json" in output
+    assert "schema_version" in output
+    assert "missing" in output or "invalid" in output
+
+
+def test_doctor_fails_when_state_json_schema_version_is_unsupported(vaws_repo):
+    overlay = vaws_repo / ".workspace.local"
+    seed_overlay_files(vaws_repo)
+    (overlay / "state.json").write_text('{"schema_version": 2}\n', encoding="utf-8")
+
+    result = run_vaws(vaws_repo, "doctor")
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "state.json" in output
+    assert "schema_version" in output
+    assert "unsupported" in output or "invalid" in output
+
+
 def test_doctor_fails_when_state_json_is_not_utf8(vaws_repo):
     overlay = vaws_repo / ".workspace.local"
     seed_overlay_files(vaws_repo)

--- a/tests/test_vaws_doctor.py
+++ b/tests/test_vaws_doctor.py
@@ -18,6 +18,29 @@ def test_doctor_requires_servers_yaml_instead_of_targets_yaml(vaws_repo):
     assert result.returncode == 0
 
 
+def test_doctor_accepts_legacy_server_bootstrap_mode(vaws_repo):
+    seed_overlay_files(vaws_repo)
+    servers_path = vaws_repo / ".workspace.local" / "servers.yaml"
+    servers_path.write_text(
+        "\n".join(
+            [
+                "version: 1",
+                "bootstrap:",
+                "  completed: true",
+                "  mode: server",
+                "servers: {}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_vaws(vaws_repo, "doctor")
+
+    assert result.returncode == 0
+    assert "doctor: ok" in result.stdout.lower()
+
+
 def test_init_creates_overlay_files(vaws_repo):
     result = run_vaws(vaws_repo, "init")
     assert result.returncode == 0

--- a/tests/test_vaws_fleet.py
+++ b/tests/test_vaws_fleet.py
@@ -2,6 +2,7 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -11,6 +12,13 @@ if str(ROOT) not in sys.path:
 from conftest import run_vaws, seed_overlay_files
 from tools.lib import fleet
 from tools.lib.config import RepoPaths
+from tools.lib.remote import (
+    VerificationCheck,
+    VerificationResult,
+    ensure_runtime,
+    resolve_server_context,
+    verify_runtime,
+)
 
 
 def _write_fleet_overlay(vaws_repo: Path) -> Path:
@@ -75,7 +83,7 @@ def test_fleet_add_writes_server_inventory_entry(vaws_repo):
 
     assert result.returncode == 0
     output = (result.stdout + result.stderr).lower()
-    assert "fleet add: ok" in output
+    assert "fleet add: ready" in output
 
     servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
     host_b = servers["servers"]["host-b"]
@@ -89,12 +97,50 @@ def test_fleet_add_writes_server_inventory_entry(vaws_repo):
     assert host_b["runtime"]["ssh_port"] == 63269
     assert host_b["runtime"]["workspace_root"] == "/vllm-workspace"
     assert host_b["runtime"]["host_workspace_path"].endswith("/host-b/workspace")
+    assert host_b["verification"]["status"] == "ready"
+    assert host_b["verification"]["checks"][0]["name"] == "runtime_state"
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["server_verifications"]["host-b"]["status"] == "ready"
 
     runtime_root = vaws_repo.parent / "simulation-runtime" / "host-b" / "vllm-workspace"
     runtime_state = json.loads((runtime_root / ".vaws" / "runtime.json").read_text())
     assert runtime_state["target"] == "host-b"
     assert runtime_state["container"]["created"] is True
     assert "reused" in runtime_state["container"]
+
+
+def test_remote_verify_runtime_returns_explicit_result_shape(vaws_repo):
+    overlay = _write_fleet_overlay(vaws_repo)
+    servers = yaml.safe_load((overlay / "servers.yaml").read_text())
+    servers["servers"]["host-a"] = {
+        "host": "10.0.0.11",
+        "port": 22,
+        "login_user": "root",
+        "ssh_auth_ref": "default-server-auth",
+        "status": "pending",
+        "runtime": {
+            "image_ref": "quay.nju.edu.cn/ascend/vllm-ascend:latest",
+            "container_name": "vaws-workspace",
+            "ssh_port": 63269,
+            "workspace_root": "/vllm-workspace",
+            "bootstrap_mode": "host-then-container",
+        },
+    }
+    overlay.joinpath("servers.yaml").write_text(
+        yaml.safe_dump(servers, sort_keys=False),
+        encoding="utf-8",
+    )
+    paths = RepoPaths(root=vaws_repo)
+    context = resolve_server_context(paths, "host-a")
+    ensure_runtime(paths, context)
+
+    result = verify_runtime(paths, context)
+
+    assert isinstance(result, VerificationResult)
+    assert result.status == "ready"
+    assert result.to_mapping()["status"] == "ready"
+    assert result.to_mapping()["checks"][0]["name"] == "runtime_state"
+    assert result.to_mapping()["runtime"]["host_name"] == "host-a"
 
 
 def test_fleet_list_reports_inventory_entries(vaws_repo):
@@ -149,6 +195,45 @@ def test_fleet_add_rejects_invalid_server_port(vaws_repo):
     assert "traceback" not in output
 
 
+def test_fleet_add_records_needs_repair_when_verification_needs_repair(vaws_repo, monkeypatch):
+    _write_fleet_overlay(vaws_repo)
+
+    class FakeVerificationResult:
+        status = "needs_repair"
+        summary = "runtime probe failed"
+
+        def to_mapping(self):
+            return {
+                "status": self.status,
+                "summary": self.summary,
+                "checks": [
+                    {
+                        "name": "runtime_state",
+                        "status": "needs_repair",
+                        "detail": "probe failed",
+                    }
+                ],
+            }
+
+    monkeypatch.setattr(fleet, "verify_runtime", lambda *args, **kwargs: FakeVerificationResult())
+
+    result = fleet.add_fleet_server(
+        RepoPaths(root=vaws_repo),
+        "host-b",
+        "10.0.0.12",
+        "default-server-auth",
+    )
+    assert result == 0
+    servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
+    host_b = servers["servers"]["host-b"]
+    assert host_b["status"] == "needs_repair"
+    assert host_b["verification"]["status"] == "needs_repair"
+    assert host_b["verification"]["checks"][0]["detail"] == "probe failed"
+
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["server_verifications"]["host-b"]["status"] == "needs_repair"
+
+
 def test_fleet_verify_is_read_only(vaws_repo, monkeypatch):
     overlay = _write_fleet_overlay(vaws_repo)
     servers = yaml.safe_load((overlay / "servers.yaml").read_text())
@@ -178,7 +263,28 @@ def test_fleet_verify_is_read_only(vaws_repo, monkeypatch):
 
     def fake_verify_runtime(paths, ctx):
         calls["server"] = ctx.name
-        return {"verified": True}
+        return VerificationResult.ready(
+            summary="runtime verified",
+            runtime={
+                "host_name": ctx.name,
+                "host": ctx.host.host,
+                "host_port": ctx.host.port,
+                "login_user": ctx.host.login_user,
+                "workspace_root": ctx.runtime.workspace_root,
+                "ssh_port": ctx.runtime.ssh_port,
+                "container_name": ctx.runtime.container_name,
+                "image_ref": ctx.runtime.image_ref,
+                "bootstrap_mode": ctx.runtime.bootstrap_mode,
+                "host_workspace_path": ctx.runtime.host_workspace_path,
+            },
+            checks=[
+                VerificationCheck(
+                    name="runtime_state",
+                    status="ready",
+                    detail="runtime state available",
+                )
+            ],
+        )
 
     monkeypatch.setattr(fleet, "verify_runtime", fake_verify_runtime)
 

--- a/tests/test_vaws_fleet.py
+++ b/tests/test_vaws_fleet.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 
@@ -15,6 +16,7 @@ from tools.lib.config import RepoPaths
 def _write_fleet_overlay(vaws_repo: Path) -> Path:
     seed_overlay_files(vaws_repo)
     overlay = vaws_repo / ".workspace.local"
+    simulation_root = vaws_repo.parent / "simulation-runtime"
     (overlay / "servers.yaml").write_text(
         yaml.safe_dump(
             {
@@ -36,8 +38,9 @@ def _write_fleet_overlay(vaws_repo: Path) -> Path:
                 "ssh_auth": {
                     "refs": {
                         "default-server-auth": {
-                            "kind": "ssh-key",
+                            "kind": "local-simulation",
                             "username": "root",
+                            "simulation_root": str(simulation_root),
                         }
                     }
                 },
@@ -64,10 +67,10 @@ def test_fleet_add_writes_server_inventory_entry(vaws_repo):
         "fleet",
         "add",
         "host-b",
-        "--host",
+        "--server-host",
         "10.0.0.12",
-        "--login-user",
-        "root",
+        "--ssh-auth-ref",
+        "default-server-auth",
     )
 
     assert result.returncode == 0
@@ -80,11 +83,18 @@ def test_fleet_add_writes_server_inventory_entry(vaws_repo):
     assert host_b["port"] == 22
     assert host_b["login_user"] == "root"
     assert host_b["ssh_auth_ref"] == "default-server-auth"
-    assert host_b["status"] == "pending"
+    assert host_b["status"] == "ready"
     assert host_b["runtime"]["image_ref"]
     assert host_b["runtime"]["container_name"]
     assert host_b["runtime"]["ssh_port"] == 63269
     assert host_b["runtime"]["workspace_root"] == "/vllm-workspace"
+    assert host_b["runtime"]["host_workspace_path"].endswith("/host-b/workspace")
+
+    runtime_root = vaws_repo.parent / "simulation-runtime" / "host-b" / "vllm-workspace"
+    runtime_state = json.loads((runtime_root / ".vaws" / "runtime.json").read_text())
+    assert runtime_state["target"] == "host-b"
+    assert runtime_state["container"]["created"] is True
+    assert "reused" in runtime_state["container"]
 
 
 def test_fleet_list_reports_inventory_entries(vaws_repo):
@@ -115,6 +125,28 @@ def test_fleet_list_reports_inventory_entries(vaws_repo):
     output = result.stdout.lower()
     assert "host-a" in output
     assert "pending" in output
+
+
+def test_fleet_add_rejects_invalid_server_port(vaws_repo):
+    _write_fleet_overlay(vaws_repo)
+
+    result = run_vaws(
+        vaws_repo,
+        "fleet",
+        "add",
+        "host-b",
+        "--server-host",
+        "10.0.0.12",
+        "--ssh-auth-ref",
+        "default-server-auth",
+        "--server-port",
+        "70000",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "port" in output
+    assert "traceback" not in output
 
 
 def test_fleet_verify_is_read_only(vaws_repo, monkeypatch):

--- a/tests/test_vaws_fleet.py
+++ b/tests/test_vaws_fleet.py
@@ -1,0 +1,169 @@
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from conftest import run_vaws, seed_overlay_files
+from tools.lib import fleet
+from tools.lib.config import RepoPaths
+
+
+def _write_fleet_overlay(vaws_repo: Path) -> Path:
+    seed_overlay_files(vaws_repo)
+    overlay = vaws_repo / ".workspace.local"
+    (overlay / "servers.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "bootstrap": {
+                    "completed": True,
+                    "mode": "remote-first",
+                },
+                "servers": {},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (overlay / "auth.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "ssh_auth": {
+                    "refs": {
+                        "default-server-auth": {
+                            "kind": "ssh-key",
+                            "username": "root",
+                        }
+                    }
+                },
+                "git_auth": {
+                    "refs": {
+                        "default-git-auth": {
+                            "kind": "ssh-agent",
+                        }
+                    }
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return overlay
+
+
+def test_fleet_add_writes_server_inventory_entry(vaws_repo):
+    _write_fleet_overlay(vaws_repo)
+
+    result = run_vaws(
+        vaws_repo,
+        "fleet",
+        "add",
+        "host-b",
+        "--host",
+        "10.0.0.12",
+        "--login-user",
+        "root",
+    )
+
+    assert result.returncode == 0
+    output = (result.stdout + result.stderr).lower()
+    assert "fleet add: ok" in output
+
+    servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
+    host_b = servers["servers"]["host-b"]
+    assert host_b["host"] == "10.0.0.12"
+    assert host_b["port"] == 22
+    assert host_b["login_user"] == "root"
+    assert host_b["ssh_auth_ref"] == "default-server-auth"
+    assert host_b["status"] == "pending"
+    assert host_b["runtime"]["image_ref"]
+    assert host_b["runtime"]["container_name"]
+    assert host_b["runtime"]["ssh_port"] == 63269
+    assert host_b["runtime"]["workspace_root"] == "/vllm-workspace"
+
+
+def test_fleet_list_reports_inventory_entries(vaws_repo):
+    overlay = _write_fleet_overlay(vaws_repo)
+    servers = yaml.safe_load((overlay / "servers.yaml").read_text())
+    servers["servers"]["host-a"] = {
+        "host": "10.0.0.11",
+        "port": 22,
+        "login_user": "root",
+        "ssh_auth_ref": "default-server-auth",
+        "status": "pending",
+        "runtime": {
+            "image_ref": "quay.nju.edu.cn/ascend/vllm-ascend:latest",
+            "container_name": "vaws-workspace",
+            "ssh_port": 63269,
+            "workspace_root": "/vllm-workspace",
+            "bootstrap_mode": "host-then-container",
+        },
+    }
+    overlay.joinpath("servers.yaml").write_text(
+        yaml.safe_dump(servers, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = run_vaws(vaws_repo, "fleet", "list")
+
+    assert result.returncode == 0
+    output = result.stdout.lower()
+    assert "host-a" in output
+    assert "pending" in output
+
+
+def test_fleet_verify_is_read_only(vaws_repo, monkeypatch):
+    overlay = _write_fleet_overlay(vaws_repo)
+    servers = yaml.safe_load((overlay / "servers.yaml").read_text())
+    servers["servers"]["host-a"] = {
+        "host": "10.0.0.11",
+        "port": 22,
+        "login_user": "root",
+        "ssh_auth_ref": "default-server-auth",
+        "status": "ready",
+        "runtime": {
+            "image_ref": "quay.nju.edu.cn/ascend/vllm-ascend:latest",
+            "container_name": "vaws-workspace",
+            "ssh_port": 63269,
+            "workspace_root": "/vllm-workspace",
+            "bootstrap_mode": "host-then-container",
+        },
+    }
+    overlay.joinpath("servers.yaml").write_text(
+        yaml.safe_dump(servers, sort_keys=False),
+        encoding="utf-8",
+    )
+    state_path = overlay / "state.json"
+    state_before = state_path.read_text(encoding="utf-8")
+    servers_before = (overlay / "servers.yaml").read_text(encoding="utf-8")
+
+    calls = {}
+
+    def fake_verify_runtime(paths, ctx):
+        calls["server"] = ctx.name
+        return {"verified": True}
+
+    monkeypatch.setattr(fleet, "verify_runtime", fake_verify_runtime)
+
+    result = fleet.verify_fleet_server(RepoPaths(root=vaws_repo), "host-a")
+
+    assert result == 0
+    assert calls["server"] == "host-a"
+    assert state_path.read_text(encoding="utf-8") == state_before
+    assert (overlay / "servers.yaml").read_text(encoding="utf-8") == servers_before
+
+
+def test_fleet_verify_requires_known_server(vaws_repo):
+    _write_fleet_overlay(vaws_repo)
+
+    result = run_vaws(vaws_repo, "fleet", "verify", "missing")
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "missing" in output
+    assert "server" in output

--- a/tests/test_vaws_init_bootstrap.py
+++ b/tests/test_vaws_init_bootstrap.py
@@ -59,6 +59,14 @@ def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
     assert auth["ssh_auth"]["refs"]["default-server-auth"]["username"] == "root"
     assert auth["git_auth"]["refs"]["default-git-auth"]["kind"] == "ssh-agent"
 
+    servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
+    assert servers["version"] == 1
+    assert servers["bootstrap"]["completed"] is True
+    assert servers["bootstrap"]["mode"] == "server"
+    assert servers["servers"]["host-a"]["host"] == "173.125.1.2"
+    assert servers["servers"]["host-a"]["status"] == "ready"
+    assert servers["servers"]["host-a"]["ssh_auth_ref"] == "default-server-auth"
+
     targets = yaml.safe_load(
         (vaws_repo / ".workspace.local" / "targets.yaml").read_text()
     )
@@ -76,7 +84,65 @@ def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
     assert target_result.returncode == 0
     state = yaml.safe_load((vaws_repo / ".workspace.local" / "state.json").read_text())
     assert state["schema_version"] == 1
+    assert state["bootstrap"]["completed"] is True
+    assert state["bootstrap"]["mode"] == "server"
     assert state["current_target"] == "single-default"
+
+
+def test_init_bootstrap_refuses_rerun_after_baseline(vaws_repo):
+    first = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--server-host",
+        "173.125.1.2",
+        "--server-user",
+        "root",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+    assert first.returncode == 0
+
+    second = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--server-host",
+        "173.125.1.2",
+        "--server-user",
+        "root",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+
+    assert second.returncode == 1
+    output = (second.stdout + second.stderr).lower()
+    assert "bootstrap baseline" in output
+    assert "fleet" in output
+    assert "traceback" not in output
+
+
+def test_init_bootstrap_supports_local_only_mode(vaws_repo):
+    result = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+
+    assert result.returncode == 0
+    output = result.stdout.lower()
+    assert "bootstrap ok" in output
+
+    servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
+    assert servers["bootstrap"]["completed"] is True
+    assert servers["bootstrap"]["mode"] == "local-only"
+    assert servers["servers"] == {}
+
+    state = yaml.safe_load((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["bootstrap"]["completed"] is True
+    assert state["bootstrap"]["mode"] == "local-only"
 
 
 def test_preflight_reports_missing_and_optional_tools(monkeypatch):
@@ -308,7 +374,7 @@ def test_init_bootstrap_requires_vllm_ascend_origin_url(vaws_repo):
     assert "origin" in output
 
 
-def test_init_bootstrap_requires_server_host(vaws_repo):
+def test_init_bootstrap_defaults_to_local_only_without_server_host(vaws_repo):
     result = run_vaws(
         vaws_repo,
         "init",
@@ -319,7 +385,7 @@ def test_init_bootstrap_requires_server_host(vaws_repo):
         "git@github.com:alice/vllm-ascend.git",
     )
 
-    assert result.returncode == 1
-    output = (result.stdout + result.stderr).lower()
-    assert "server" in output
-    assert "host" in output
+    assert result.returncode == 0
+    output = result.stdout.lower()
+    assert "local-only" in output
+    assert "bootstrap ok" in output

--- a/tests/test_vaws_init_bootstrap.py
+++ b/tests/test_vaws_init_bootstrap.py
@@ -83,6 +83,63 @@ def test_init_bootstrap_creates_overlay_compatible_with_doctor(vaws_repo):
     assert "doctor: ok" in doctor_result.stdout.lower()
 
 
+def test_init_bootstrap_fails_cleanly_for_malformed_state_json(vaws_repo):
+    overlay = vaws_repo / ".workspace.local"
+    overlay.mkdir()
+    (overlay / "state.json").write_text("not valid json", encoding="utf-8")
+
+    result = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--server-host",
+        "173.125.1.2",
+        "--server-user",
+        "root",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "state.json" in output
+    assert "invalid runtime state" in output or "invalid" in output
+    assert "traceback" not in output
+
+
+def test_init_bootstrap_fails_cleanly_for_unsupported_state_schema_version(vaws_repo):
+    overlay = vaws_repo / ".workspace.local"
+    overlay.mkdir()
+    (overlay / "servers.yaml").write_text("version: 1\nservers: {}\n", encoding="utf-8")
+    (overlay / "auth.yaml").write_text(
+        "version: 1\nssh_auth: {refs: {}}\ngit_auth: {refs: {}}\n",
+        encoding="utf-8",
+    )
+    (overlay / "repos.yaml").write_text(
+        "version: 1\nworkspace: {}\nsubmodules: {}\n",
+        encoding="utf-8",
+    )
+    (overlay / "state.json").write_text('{"schema_version": 2}\n', encoding="utf-8")
+
+    result = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--server-host",
+        "173.125.1.2",
+        "--server-user",
+        "root",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "schema_version" in output
+    assert "unsupported" in output or "invalid" in output
+    assert "traceback" not in output
+
+
 def test_init_bootstrap_allows_missing_vllm_origin_url(vaws_repo):
     result = run_vaws(
         vaws_repo,

--- a/tests/test_vaws_init_bootstrap.py
+++ b/tests/test_vaws_init_bootstrap.py
@@ -10,6 +10,7 @@ if str(ROOT) not in sys.path:
 
 from conftest import run_vaws
 from tools.lib import preflight
+from tools.lib.remote import CredentialGroup, HostSpec, RuntimeSpec, TargetContext, _ssh_base_command
 
 
 def _remote_url(repo, relative_path, remote_name):
@@ -51,14 +52,16 @@ def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
 
     auth = yaml.safe_load((vaws_repo / ".workspace.local" / "auth.yaml").read_text())
     assert auth["version"] == 1
-    assert auth["ssh_auth"]["refs"]["default"]["kind"] == "ssh-key"
-    assert auth["ssh_auth"]["refs"]["default"]["username"] == "root"
-    assert auth["git_auth"]["refs"]["default"]["kind"] == "ssh-agent"
+    assert auth["ssh_auth"]["refs"]["default-server-auth"]["kind"] == "ssh-key"
+    assert auth["ssh_auth"]["refs"]["default-server-auth"]["username"] == "root"
+    assert auth["git_auth"]["refs"]["default-git-auth"]["kind"] == "ssh-agent"
 
     targets = yaml.safe_load(
         (vaws_repo / ".workspace.local" / "targets.yaml").read_text()
     )
     assert targets["hosts"]["host-a"]["host"] == "173.125.1.2"
+    assert targets["hosts"]["host-a"]["ssh_auth_ref"] == "default-server-auth"
+    assert "auth_group" not in targets["hosts"]["host-a"]
     assert targets["targets"]["single-default"]["runtime"]["workspace_root"] == "/vllm-workspace"
 
     assert _remote_url(vaws_repo, "vllm", "origin") == "git@github.com:alice/vllm.git"
@@ -75,7 +78,7 @@ def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
 
 def test_preflight_reports_missing_and_optional_tools(monkeypatch):
     def fake_which(command):
-        if command in {"ssh", "gh"}:
+        if command == "gh":
             return None
         return f"/usr/bin/{command}"
 
@@ -83,8 +86,42 @@ def test_preflight_reports_missing_and_optional_tools(monkeypatch):
 
     report = preflight.check_local_control_plane_deps()
 
-    assert report.missing_required == ("ssh",)
+    assert report.status == "degraded"
+    assert report.installed_required == ("git", "ssh", "python3")
+    assert report.missing_required == ()
+    assert report.installed_recommended == ()
     assert report.missing_recommended == ("gh",)
+
+
+def test_preflight_reports_blocked_when_required_tool_missing(monkeypatch):
+    def fake_which(command):
+        if command == "ssh":
+            return None
+        return f"/usr/bin/{command}"
+
+    monkeypatch.setattr(preflight.shutil, "which", fake_which)
+
+    report = preflight.check_local_control_plane_deps()
+
+    assert report.status == "blocked"
+    assert report.installed_required == ("git", "python3")
+    assert report.missing_required == ("ssh",)
+
+
+def test_preflight_treats_running_python_as_installed_python3(monkeypatch):
+    def fake_which(command):
+        if command == "python3":
+            return None
+        return f"/usr/bin/{command}"
+
+    monkeypatch.setattr(preflight.shutil, "which", fake_which)
+    monkeypatch.setattr(preflight.sys, "executable", "/opt/control-plane/bin/python")
+
+    report = preflight.check_local_control_plane_deps()
+
+    assert report.status == "ready"
+    assert "python3" in report.installed_required
+    assert report.missing_required == ()
 
 
 def test_init_bootstrap_creates_overlay_compatible_with_doctor(vaws_repo):
@@ -110,6 +147,38 @@ def test_init_bootstrap_creates_overlay_compatible_with_doctor(vaws_repo):
 
     assert doctor_result.returncode == 0
     assert "doctor: ok" in doctor_result.stdout.lower()
+
+
+def test_ssh_base_command_honors_server_key_path():
+    ctx = TargetContext(
+        name="single-default",
+        host=HostSpec(
+            name="host-a",
+            host="173.125.1.2",
+            port=22,
+            login_user="root",
+            auth_group="default",
+        ),
+        credential=CredentialGroup(
+            mode="ssh-key",
+            username="root",
+            key_path="/tmp/control-plane.key",
+        ),
+        runtime=RuntimeSpec(
+            image_ref="image",
+            container_name="container",
+            ssh_port=63269,
+            workspace_root="/vllm-workspace",
+            bootstrap_mode="host-then-container",
+            host_workspace_path="/tmp/workspace",
+            docker_run_args=[],
+        ),
+    )
+
+    command = _ssh_base_command(ctx)
+
+    assert "-i" in command
+    assert "/tmp/control-plane.key" in command
 
 
 def test_init_bootstrap_fails_cleanly_for_malformed_state_json(vaws_repo):

--- a/tests/test_vaws_init_bootstrap.py
+++ b/tests/test_vaws_init_bootstrap.py
@@ -13,7 +13,15 @@ from tools.lib import bootstrap
 from tools.lib import preflight
 from tools.lib.config import RepoPaths
 from tools.lib.preflight import PreflightReport
-from tools.lib.remote import CredentialGroup, HostSpec, RuntimeSpec, TargetContext, _ssh_base_command
+from tools.lib.remote import (
+    CredentialGroup,
+    HostSpec,
+    RuntimeSpec,
+    TargetContext,
+    _ssh_base_command,
+    resolve_server_context,
+    resolve_target_context,
+)
 
 
 def _remote_url(repo, relative_path, remote_name):
@@ -68,6 +76,7 @@ def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
     assert servers["servers"]["host-a"]["ssh_auth_ref"] == "default-server-auth"
     assert servers["servers"]["host-a"]["runtime"]["image_ref"] == "quay.nju.edu.cn/ascend/vllm-ascend:latest"
     assert servers["servers"]["host-a"]["runtime"]["bootstrap_mode"] == "host-then-container"
+    assert servers["servers"]["host-a"]["runtime"]["host_workspace_path"] == "/root/.vaws/targets/single-default/workspace"
 
     targets = yaml.safe_load(
         (vaws_repo / ".workspace.local" / "targets.yaml").read_text()
@@ -76,6 +85,7 @@ def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
     assert targets["hosts"]["host-a"]["ssh_auth_ref"] == "default-server-auth"
     assert "auth_group" not in targets["hosts"]["host-a"]
     assert targets["targets"]["single-default"]["runtime"]["workspace_root"] == "/vllm-workspace"
+    assert targets["targets"]["single-default"]["runtime"]["host_workspace_path"] == "/root/.vaws/targets/single-default/workspace"
 
     assert _remote_url(vaws_repo, "vllm", "origin") == "git@github.com:alice/vllm.git"
     assert _remote_url(vaws_repo, "vllm", "upstream") == "https://github.com/vllm-project/vllm.git"
@@ -502,3 +512,25 @@ def test_init_bootstrap_defaults_to_local_only_without_server_host(vaws_repo):
     output = result.stdout.lower()
     assert "local-only" in output
     assert "bootstrap ok" in output
+
+
+def test_bootstrap_target_and_server_resolution_share_workspace_root(vaws_repo):
+    result = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--server-host",
+        "173.125.1.2",
+        "--server-user",
+        "root",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+
+    assert result.returncode == 0
+
+    paths = RepoPaths(root=vaws_repo)
+    target_context = resolve_target_context(paths, "single-default")
+    server_context = resolve_server_context(paths, "host-a")
+
+    assert target_context.runtime.host_workspace_path == server_context.runtime.host_workspace_path

--- a/tests/test_vaws_init_bootstrap.py
+++ b/tests/test_vaws_init_bootstrap.py
@@ -62,10 +62,12 @@ def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
     servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
     assert servers["version"] == 1
     assert servers["bootstrap"]["completed"] is True
-    assert servers["bootstrap"]["mode"] == "server"
+    assert servers["bootstrap"]["mode"] == "remote-first"
     assert servers["servers"]["host-a"]["host"] == "173.125.1.2"
-    assert servers["servers"]["host-a"]["status"] == "ready"
+    assert servers["servers"]["host-a"]["status"] == "planned"
     assert servers["servers"]["host-a"]["ssh_auth_ref"] == "default-server-auth"
+    assert servers["servers"]["host-a"]["planned_runtime"]["image_ref"] == "quay.nju.edu.cn/ascend/vllm-ascend:latest"
+    assert servers["servers"]["host-a"]["planned_runtime"]["bootstrap_mode"] == "host-then-container"
 
     targets = yaml.safe_load(
         (vaws_repo / ".workspace.local" / "targets.yaml").read_text()
@@ -85,7 +87,7 @@ def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
     state = yaml.safe_load((vaws_repo / ".workspace.local" / "state.json").read_text())
     assert state["schema_version"] == 1
     assert state["bootstrap"]["completed"] is True
-    assert state["bootstrap"]["mode"] == "server"
+    assert state["bootstrap"]["mode"] == "remote-first"
     assert state["current_target"] == "single-default"
 
 
@@ -123,6 +125,82 @@ def test_init_bootstrap_refuses_rerun_after_baseline(vaws_repo):
 
 
 def test_init_bootstrap_supports_local_only_mode(vaws_repo):
+    overlay = vaws_repo / ".workspace.local"
+    overlay.mkdir()
+    (overlay / "servers.yaml").write_text(
+        "\n".join(
+            [
+                "version: 1",
+                "bootstrap:",
+                "  completed: false",
+                "  mode: remote-first",
+                "servers:",
+                "  host-a:",
+                "    host: 173.125.1.2",
+                "    port: 22",
+                "    login_user: root",
+                "    ssh_auth_ref: default-server-auth",
+                "    status: planned",
+                "    planned_runtime:",
+                "      image_ref: quay.nju.edu.cn/ascend/vllm-ascend:latest",
+                "      container_name: vaws-workspace",
+                "      ssh_port: 63269",
+                "      workspace_root: /vllm-workspace",
+                "      bootstrap_mode: host-then-container",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (overlay / "targets.yaml").write_text(
+        "\n".join(
+            [
+                "version: 1",
+                "hosts:",
+                "  host-a:",
+                "    host: 173.125.1.2",
+                "    port: 22",
+                "    login_user: root",
+                "    ssh_auth_ref: default-server-auth",
+                "targets:",
+                "  single-default:",
+                "    hosts:",
+                "      - host-a",
+                "    runtime:",
+                "      image_ref: quay.nju.edu.cn/ascend/vllm-ascend:latest",
+                "      container_name: vaws-workspace",
+                "      ssh_port: 63269",
+                "      workspace_root: /vllm-workspace",
+                "      bootstrap_mode: host-then-container",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (overlay / "auth.yaml").write_text(
+        "\n".join(
+            [
+                "version: 1",
+                "ssh_auth:",
+                "  refs:",
+                "    default-server-auth:",
+                "      kind: ssh-key",
+                "      username: root",
+                "git_auth:",
+                "  refs:",
+                "    default-git-auth:",
+                "      kind: ssh-agent",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (overlay / "repos.yaml").write_text(
+        "version: 1\nworkspace: {}\nsubmodules: {}\n",
+        encoding="utf-8",
+    )
+    (overlay / "state.json").write_text('{"schema_version": 1}\n', encoding="utf-8")
+
     result = run_vaws(
         vaws_repo,
         "init",
@@ -139,6 +217,14 @@ def test_init_bootstrap_supports_local_only_mode(vaws_repo):
     assert servers["bootstrap"]["completed"] is True
     assert servers["bootstrap"]["mode"] == "local-only"
     assert servers["servers"] == {}
+
+    targets = yaml.safe_load((vaws_repo / ".workspace.local" / "targets.yaml").read_text())
+    assert targets["hosts"] == {}
+    assert targets["targets"] == {}
+
+    auth = yaml.safe_load((vaws_repo / ".workspace.local" / "auth.yaml").read_text())
+    assert auth["ssh_auth"]["refs"] == {}
+    assert auth["git_auth"]["refs"] == {}
 
     state = yaml.safe_load((vaws_repo / ".workspace.local" / "state.json").read_text())
     assert state["bootstrap"]["completed"] is True
@@ -333,6 +419,9 @@ def test_init_bootstrap_fails_cleanly_for_unsupported_state_schema_version(vaws_
     assert "schema_version" in output
     assert "unsupported" in output or "invalid" in output
     assert "traceback" not in output
+    servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
+    assert servers["bootstrap"]["completed"] is False
+    assert servers["bootstrap"]["mode"] == "remote-first"
 
 
 def test_init_bootstrap_allows_missing_vllm_origin_url(vaws_repo):

--- a/tests/test_vaws_init_bootstrap.py
+++ b/tests/test_vaws_init_bootstrap.py
@@ -58,6 +58,31 @@ def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
     assert _remote_url(vaws_repo, "vllm-ascend", "upstream") == "https://github.com/vllm-project/vllm-ascend.git"
 
 
+def test_init_bootstrap_creates_overlay_compatible_with_doctor(vaws_repo):
+    result = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--server-host",
+        "173.125.1.2",
+        "--server-user",
+        "root",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+        "--vllm-origin-url",
+        "git@github.com:alice/vllm.git",
+        "--git-auth-mode",
+        "ssh-agent",
+    )
+
+    assert result.returncode == 0
+
+    doctor_result = run_vaws(vaws_repo, "doctor")
+
+    assert doctor_result.returncode == 0
+    assert "doctor: ok" in doctor_result.stdout.lower()
+
+
 def test_init_bootstrap_allows_missing_vllm_origin_url(vaws_repo):
     result = run_vaws(
         vaws_repo,

--- a/tests/test_vaws_init_bootstrap.py
+++ b/tests/test_vaws_init_bootstrap.py
@@ -1,8 +1,15 @@
+import sys
 import subprocess
+from pathlib import Path
 
 import yaml
 
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from conftest import run_vaws
+from tools.lib import preflight
 
 
 def _remote_url(repo, relative_path, remote_name):
@@ -43,8 +50,10 @@ def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
     assert repos["submodules"]["vllm-ascend"]["origin_url"] == "git@github.com:alice/vllm-ascend.git"
 
     auth = yaml.safe_load((vaws_repo / ".workspace.local" / "auth.yaml").read_text())
-    assert auth["host_auth"]["mode"] == "ssh-key"
-    assert auth["git_auth"]["mode"] == "ssh-agent"
+    assert auth["version"] == 1
+    assert auth["ssh_auth"]["refs"]["default"]["kind"] == "ssh-key"
+    assert auth["ssh_auth"]["refs"]["default"]["username"] == "root"
+    assert auth["git_auth"]["refs"]["default"]["kind"] == "ssh-agent"
 
     targets = yaml.safe_load(
         (vaws_repo / ".workspace.local" / "targets.yaml").read_text()
@@ -56,6 +65,26 @@ def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
     assert _remote_url(vaws_repo, "vllm", "upstream") == "https://github.com/vllm-project/vllm.git"
     assert _remote_url(vaws_repo, "vllm-ascend", "origin") == "git@github.com:alice/vllm-ascend.git"
     assert _remote_url(vaws_repo, "vllm-ascend", "upstream") == "https://github.com/vllm-project/vllm-ascend.git"
+
+    target_result = run_vaws(vaws_repo, "target", "ensure", "single-default")
+    assert target_result.returncode == 0
+    state = yaml.safe_load((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["schema_version"] == 1
+    assert state["current_target"] == "single-default"
+
+
+def test_preflight_reports_missing_and_optional_tools(monkeypatch):
+    def fake_which(command):
+        if command in {"ssh", "gh"}:
+            return None
+        return f"/usr/bin/{command}"
+
+    monkeypatch.setattr(preflight.shutil, "which", fake_which)
+
+    report = preflight.check_local_control_plane_deps()
+
+    assert report.missing_required == ("ssh",)
+    assert report.missing_recommended == ("gh",)
 
 
 def test_init_bootstrap_creates_overlay_compatible_with_doctor(vaws_repo):

--- a/tests/test_vaws_init_bootstrap.py
+++ b/tests/test_vaws_init_bootstrap.py
@@ -9,7 +9,10 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from conftest import run_vaws
+from tools.lib import bootstrap
 from tools.lib import preflight
+from tools.lib.config import RepoPaths
+from tools.lib.preflight import PreflightReport
 from tools.lib.remote import CredentialGroup, HostSpec, RuntimeSpec, TargetContext, _ssh_base_command
 
 
@@ -91,6 +94,34 @@ def test_preflight_reports_missing_and_optional_tools(monkeypatch):
     assert report.missing_required == ()
     assert report.installed_recommended == ()
     assert report.missing_recommended == ("gh",)
+
+
+def test_init_bootstrap_reports_degraded_preflight_state(vaws_repo, monkeypatch, capsys):
+    monkeypatch.setattr(
+        bootstrap,
+        "ensure_local_control_plane_deps",
+        lambda: PreflightReport(
+            status="degraded",
+            installed_required=("git", "ssh", "python3"),
+            missing_required=(),
+            installed_recommended=(),
+            missing_recommended=("gh",),
+        ),
+    )
+
+    request = bootstrap.BootstrapRequest(
+        server_host="173.125.1.2",
+        server_user="root",
+        vllm_ascend_origin_url="git@github.com:alice/vllm-ascend.git",
+    )
+
+    result = bootstrap.bootstrap_init(RepoPaths(root=vaws_repo), request)
+    output = capsys.readouterr().out.lower()
+
+    assert result == 0
+    assert "preflight degraded" in output
+    assert "gh" in output
+    assert "bootstrap ok" in output
 
 
 def test_preflight_reports_blocked_when_required_tool_missing(monkeypatch):

--- a/tests/test_vaws_init_bootstrap.py
+++ b/tests/test_vaws_init_bootstrap.py
@@ -64,10 +64,10 @@ def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
     assert servers["bootstrap"]["completed"] is True
     assert servers["bootstrap"]["mode"] == "remote-first"
     assert servers["servers"]["host-a"]["host"] == "173.125.1.2"
-    assert servers["servers"]["host-a"]["status"] == "planned"
+    assert servers["servers"]["host-a"]["status"] == "pending"
     assert servers["servers"]["host-a"]["ssh_auth_ref"] == "default-server-auth"
-    assert servers["servers"]["host-a"]["planned_runtime"]["image_ref"] == "quay.nju.edu.cn/ascend/vllm-ascend:latest"
-    assert servers["servers"]["host-a"]["planned_runtime"]["bootstrap_mode"] == "host-then-container"
+    assert servers["servers"]["host-a"]["runtime"]["image_ref"] == "quay.nju.edu.cn/ascend/vllm-ascend:latest"
+    assert servers["servers"]["host-a"]["runtime"]["bootstrap_mode"] == "host-then-container"
 
     targets = yaml.safe_load(
         (vaws_repo / ".workspace.local" / "targets.yaml").read_text()
@@ -89,6 +89,30 @@ def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
     assert state["bootstrap"]["completed"] is True
     assert state["bootstrap"]["mode"] == "remote-first"
     assert state["current_target"] == "single-default"
+
+
+def test_init_bootstrap_rolls_back_finalization_failure(vaws_repo, monkeypatch):
+    def fail_finalize(*args, **kwargs):
+        raise bootstrap.BootstrapError("finalization failed")
+
+    monkeypatch.setattr(bootstrap, "_write_bootstrap_state", fail_finalize)
+
+    result = bootstrap.bootstrap_init(
+        RepoPaths(root=vaws_repo),
+        bootstrap.BootstrapRequest(
+            server_host="173.125.1.2",
+            server_user="root",
+            vllm_ascend_origin_url="git@github.com:alice/vllm-ascend.git",
+        ),
+    )
+
+    assert result == 1
+    servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
+    assert servers["bootstrap"]["completed"] is False
+    assert servers["bootstrap"]["mode"] == "remote-first"
+
+    state = yaml.safe_load((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state.get("bootstrap", {}).get("completed") is False
 
 
 def test_init_bootstrap_refuses_rerun_after_baseline(vaws_repo):
@@ -140,8 +164,8 @@ def test_init_bootstrap_supports_local_only_mode(vaws_repo):
                 "    port: 22",
                 "    login_user: root",
                 "    ssh_auth_ref: default-server-auth",
-                "    status: planned",
-                "    planned_runtime:",
+                "    status: pending",
+                "    runtime:",
                 "      image_ref: quay.nju.edu.cn/ascend/vllm-ascend:latest",
                 "      container_name: vaws-workspace",
                 "      ssh_port: 63269",

--- a/tests/test_vaws_init_bootstrap.py
+++ b/tests/test_vaws_init_bootstrap.py
@@ -72,8 +72,10 @@ def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
     assert servers["bootstrap"]["completed"] is True
     assert servers["bootstrap"]["mode"] == "remote-first"
     assert servers["servers"]["host-a"]["host"] == "173.125.1.2"
-    assert servers["servers"]["host-a"]["status"] == "pending"
+    assert servers["servers"]["host-a"]["status"] == "ready"
     assert servers["servers"]["host-a"]["ssh_auth_ref"] == "default-server-auth"
+    assert servers["servers"]["host-a"]["verification"]["status"] == "ready"
+    assert servers["servers"]["host-a"]["verification"]["checks"][0]["name"] == "inventory"
     assert servers["servers"]["host-a"]["runtime"]["image_ref"] == "quay.nju.edu.cn/ascend/vllm-ascend:latest"
     assert servers["servers"]["host-a"]["runtime"]["bootstrap_mode"] == "host-then-container"
     assert servers["servers"]["host-a"]["runtime"]["host_workspace_path"] == "/root/.vaws/targets/single-default/workspace"
@@ -99,6 +101,7 @@ def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
     assert state["bootstrap"]["completed"] is True
     assert state["bootstrap"]["mode"] == "remote-first"
     assert state["current_target"] == "single-default"
+    assert state["server_verifications"]["host-a"]["status"] == "ready"
 
 
 def test_init_bootstrap_rolls_back_finalization_failure(vaws_repo, monkeypatch):
@@ -245,7 +248,7 @@ def test_init_bootstrap_supports_local_only_mode(vaws_repo):
 
     assert result.returncode == 0
     output = result.stdout.lower()
-    assert "bootstrap ok" in output
+    assert "bootstrap ready" in output
 
     servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
     assert servers["bootstrap"]["completed"] is True
@@ -307,7 +310,54 @@ def test_init_bootstrap_reports_degraded_preflight_state(vaws_repo, monkeypatch,
     assert result == 0
     assert "preflight degraded" in output
     assert "gh" in output
-    assert "bootstrap ok" in output
+    assert "bootstrap ready" in output
+
+
+def test_init_bootstrap_records_needs_repair_when_verification_needs_repair(
+    vaws_repo,
+    monkeypatch,
+    capsys,
+):
+    class FakeVerificationResult:
+        status = "needs_repair"
+        summary = "runtime probe failed"
+
+        def to_mapping(self):
+            return {
+                "status": self.status,
+                "summary": self.summary,
+                "checks": [
+                    {
+                        "name": "runtime_state",
+                        "status": "needs_repair",
+                        "detail": "probe failed",
+                    }
+                ],
+            }
+
+    monkeypatch.setattr(bootstrap, "verify_runtime", lambda *args, **kwargs: FakeVerificationResult(), raising=False)
+
+    request = bootstrap.BootstrapRequest(
+        server_host="173.125.1.2",
+        server_user="root",
+        vllm_ascend_origin_url="git@github.com:alice/vllm-ascend.git",
+    )
+
+    result = bootstrap.bootstrap_init(RepoPaths(root=vaws_repo), request)
+    output = capsys.readouterr().out.lower()
+
+    assert result == 0
+    assert "needs_repair" in output
+
+    servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
+    host_a = servers["servers"]["host-a"]
+    assert host_a["status"] == "needs_repair"
+    assert host_a["verification"]["status"] == "needs_repair"
+    assert host_a["verification"]["checks"][0]["detail"] == "probe failed"
+
+    state = yaml.safe_load((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["server_verifications"]["host-a"]["status"] == "needs_repair"
+    assert state["bootstrap"]["completed"] is True
 
 
 def test_preflight_reports_blocked_when_required_tool_missing(monkeypatch):
@@ -511,7 +561,7 @@ def test_init_bootstrap_defaults_to_local_only_without_server_host(vaws_repo):
     assert result.returncode == 0
     output = result.stdout.lower()
     assert "local-only" in output
-    assert "bootstrap ok" in output
+    assert "bootstrap ready" in output
 
 
 def test_bootstrap_target_and_server_resolution_share_workspace_root(vaws_repo):

--- a/tests/test_vaws_reset.py
+++ b/tests/test_vaws_reset.py
@@ -12,6 +12,8 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from conftest import run_vaws
+from tools.lib import reset
+from tools.lib.config import RepoPaths
 from tools.lib.remote import (
     CredentialGroup,
     HostSpec,
@@ -57,6 +59,17 @@ def seed_reset_workspace(vaws_repo: Path, target_name: str = "single-default") -
                         }
                     },
                 }
+                ,
+                "ssh_auth": {
+                    "refs": {
+                        "shared-lab-a": {
+                            "kind": "local-simulation",
+                            "username": "root",
+                            "simulation_root": str(simulation_root),
+                        }
+                    }
+                },
+                "git_auth": {"refs": {}},
             }
         ),
         encoding="utf-8",
@@ -153,6 +166,57 @@ def seed_reset_workspace(vaws_repo: Path, target_name: str = "single-default") -
         capture_output=True,
     )
 
+    return simulation_root
+
+
+def seed_reset_workspace_with_servers(vaws_repo: Path) -> Path:
+    simulation_root = seed_reset_workspace(vaws_repo)
+    overlay = vaws_repo / ".workspace.local"
+    (overlay / "servers.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "bootstrap": {
+                    "completed": True,
+                    "mode": "remote-first",
+                },
+                "servers": {
+                    "host-a": {
+                        "host": "127.0.0.1",
+                        "port": 22,
+                        "login_user": "root",
+                        "ssh_auth_ref": "shared-lab-a",
+                        "status": "ready",
+                        "runtime": {
+                            "image_ref": "registry.example.com/ascend/vllm-ascend:test",
+                            "container_name": "vaws-owner",
+                            "ssh_port": 63269,
+                            "workspace_root": "/vllm-workspace",
+                            "bootstrap_mode": "host-then-container",
+                            "host_workspace_path": "/root/.vaws/targets/single-default/workspace",
+                        },
+                    },
+                    "host-b": {
+                        "host": "127.0.0.2",
+                        "port": 22,
+                        "login_user": "root",
+                        "ssh_auth_ref": "shared-lab-a",
+                        "status": "ready",
+                        "runtime": {
+                            "image_ref": "registry.example.com/ascend/vllm-ascend:test",
+                            "container_name": "vaws-backup",
+                            "ssh_port": 63270,
+                            "workspace_root": "/vllm-workspace-backup",
+                            "bootstrap_mode": "host-then-container",
+                            "host_workspace_path": "/root/.vaws/targets/single-backup/workspace",
+                        },
+                    },
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
     return simulation_root
 
 
@@ -496,44 +560,92 @@ def test_reset_execute_fails_and_preserves_request_when_sessions_cleanup_fails(
     assert (overlay / "reset-request.json").exists()
 
 
-def test_reset_execute_stops_before_local_cleanup_when_remote_cleanup_fails(
+def test_reset_execute_attempts_cleanup_for_all_managed_servers(
     vaws_repo,
+    monkeypatch,
+    capsys,
 ):
-    simulation_root = seed_reset_workspace(vaws_repo)
-    overlay = vaws_repo / ".workspace.local"
+    seed_reset_workspace_with_servers(vaws_repo)
     assert run_vaws(vaws_repo, "target", "ensure", "single-default").returncode == 0
-    assert run_vaws(vaws_repo, "session", "create", "feat_alpha").returncode == 0
-    assert run_vaws(vaws_repo, "session", "switch", "feat_alpha").returncode == 0
-
     confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
-    runtime_root = simulation_root / "host-a" / "vllm-workspace"
-    runtime_parent = runtime_root.parent
-    original_mode = runtime_parent.stat().st_mode
-    runtime_parent.chmod(original_mode & ~stat.S_IWUSR & ~stat.S_IWGRP & ~stat.S_IWOTH)
 
-    try:
-        result = run_vaws(
-            vaws_repo,
-            "reset",
-            "--execute",
-            "--confirmation-id",
-            confirmation_id,
-            "--confirm",
-            "I authorize wiping local workspace identity and remote runtime",
-        )
-    finally:
-        runtime_parent.chmod(original_mode)
+    calls = []
 
-    assert result.returncode == 1
-    output = (result.stdout + result.stderr).lower()
-    assert "remote" in output or "cleanup" in output
-    assert "permission" in output or "failed" in output
+    class FakeCleanupResult:
+        def __init__(self, server_name: str):
+            self.server_name = server_name
+            self.status = "removed"
+            self.detail = "removed"
 
-    assert read_json(overlay / "state.json")["current_session"] == "feat_alpha"
-    assert (overlay / "sessions" / "feat_alpha" / "manifest.yaml").exists()
-    assert (overlay / "reset-request.json").exists()
-    runtime_root = simulation_root / "host-a" / "vllm-workspace"
-    assert (runtime_root / ".vaws" / "current").exists()
+        def to_mapping(self):
+            return {
+                "server_name": self.server_name,
+                "status": self.status,
+                "detail": self.detail,
+            }
+
+    def fake_cleanup_server_runtime(paths, server_name):
+        calls.append(server_name)
+        return FakeCleanupResult(server_name)
+
+    monkeypatch.setattr(reset, "cleanup_server_runtime", fake_cleanup_server_runtime, raising=False)
+
+    result = reset.execute_reset(
+        RepoPaths(root=vaws_repo),
+        confirmation_id,
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+    output = capsys.readouterr().out.lower()
+
+    assert result == 0
+    assert calls == ["host-a", "host-b"]
+    assert "host-a" in output
+    assert "host-b" in output
+    assert "removed" in output
+
+
+def test_reset_execute_reports_unreachable_servers_but_continues_cleanup(
+    vaws_repo,
+    monkeypatch,
+    capsys,
+):
+    seed_reset_workspace_with_servers(vaws_repo)
+    assert run_vaws(vaws_repo, "target", "ensure", "single-default").returncode == 0
+    confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
+    overlay = vaws_repo / ".workspace.local"
+
+    class FakeCleanupResult:
+        def __init__(self, server_name: str, status: str, detail: str):
+            self.server_name = server_name
+            self.status = status
+            self.detail = detail
+
+        def to_mapping(self):
+            return {
+                "server_name": self.server_name,
+                "status": self.status,
+                "detail": self.detail,
+            }
+
+    def fake_cleanup_server_runtime(paths, server_name):
+        if server_name == "host-a":
+            return FakeCleanupResult(server_name, "removed", "removed")
+        return FakeCleanupResult(server_name, "unreachable", "ssh probe failed")
+
+    monkeypatch.setattr(reset, "cleanup_server_runtime", fake_cleanup_server_runtime, raising=False)
+
+    result = reset.execute_reset(
+        RepoPaths(root=vaws_repo),
+        confirmation_id,
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+    output = capsys.readouterr().out.lower()
+
+    assert result == 0
+    assert "host-b" in output
+    assert "unreachable" in output
+    assert not (overlay / "reset-request.json").exists()
+    assert read_json(overlay / "state.json") == {"schema_version": 1}
 
 
 def test_destroy_runtime_dispatches_host_cleanup(monkeypatch):

--- a/tests/test_vaws_reset.py
+++ b/tests/test_vaws_reset.py
@@ -391,7 +391,7 @@ def test_reset_execute_removes_local_and_remote_state(vaws_repo):
 
     overlay = vaws_repo / ".workspace.local"
     assert not (overlay / "reset-request.json").exists()
-    assert read_json(overlay / "state.json") == {}
+    assert read_json(overlay / "state.json") == {"schema_version": 1}
     assert not (overlay / "sessions").exists()
     assert (overlay / "targets.yaml").read_text(encoding="utf-8") == ""
     assert (overlay / "auth.yaml").read_text(encoding="utf-8") == ""

--- a/tests/test_vaws_session.py
+++ b/tests/test_vaws_session.py
@@ -141,6 +141,28 @@ def test_session_switch_updates_current_pointer_and_runtime_symlinks(vaws_repo):
     assert (runtime_root / "vllm-ascend").resolve().name == "vllm-ascend"
 
 
+def test_session_switch_fails_cleanly_when_state_schema_version_is_unsupported(vaws_repo):
+    simulation_root = ensure_target(vaws_repo)
+    assert run_vaws(vaws_repo, "session", "create", "feat_x").returncode == 0
+    assert run_vaws(vaws_repo, "session", "create", "feat_y").returncode == 0
+
+    state_path = vaws_repo / ".workspace.local" / "state.json"
+    state = read_json(state_path)
+    state["schema_version"] = 2
+    state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+    result = run_vaws(vaws_repo, "session", "switch", "feat_y")
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "schema_version" in output
+    assert "unsupported" in output or "invalid" in output
+    assert "traceback" not in output
+    current = read_json(state_path)
+    assert current["schema_version"] == 2
+    assert "current_session" not in current
+
+
 def test_session_switch_fails_when_missing(vaws_repo):
     ensure_target(vaws_repo)
     result = run_vaws(vaws_repo, "session", "switch", "missing")

--- a/tests/test_vaws_session.py
+++ b/tests/test_vaws_session.py
@@ -129,7 +129,9 @@ def test_session_switch_updates_current_pointer_and_runtime_symlinks(vaws_repo):
 
     assert result.returncode == 0
     current = read_json(vaws_repo / ".workspace.local" / "state.json")
+    assert current["schema_version"] == 1
     assert current["current_session"] == "feat_y"
+    assert current["current_target"] == "single-default"
     runtime_root = simulation_root / "host-a" / "vllm-workspace"
     assert (runtime_root / ".vaws" / "current").is_symlink()
     assert (runtime_root / ".vaws" / "current").resolve().name == "feat_y"

--- a/tests/test_vaws_target.py
+++ b/tests/test_vaws_target.py
@@ -91,6 +91,22 @@ def test_target_ensure_reuses_existing_runtime_container(vaws_repo):
     assert runtime_state["container"]["reused"] is True
 
 
+def test_target_ensure_fails_cleanly_when_state_schema_version_is_unsupported(vaws_repo):
+    seed_overlay(vaws_repo, target_name="single-default")
+    (vaws_repo / ".workspace.local" / "state.json").write_text(
+        '{"schema_version": 2}\n',
+        encoding="utf-8",
+    )
+
+    result = run_vaws(vaws_repo, "target", "ensure", "single-default")
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "schema_version" in output
+    assert "unsupported" in output or "invalid" in output
+    assert "traceback" not in output
+
+
 def test_target_ensure_fails_when_target_is_missing(vaws_repo):
     seed_overlay(vaws_repo, target_name="single-default")
     result = run_vaws(vaws_repo, "target", "ensure", "unknown")

--- a/tests/test_vaws_target.py
+++ b/tests/test_vaws_target.py
@@ -65,6 +65,7 @@ def test_target_ensure_records_runtime_endpoint(vaws_repo):
     result = run_vaws(vaws_repo, "target", "ensure", "single-default")
     assert result.returncode == 0
     state = read_json(vaws_repo / ".workspace.local" / "state.json")
+    assert state["schema_version"] == 1
     assert state["current_target"] == "single-default"
     assert state["runtime"]["workspace_root"] == "/vllm-workspace"
     assert state["runtime"]["ssh_port"] == 63269
@@ -83,6 +84,7 @@ def test_target_ensure_reuses_existing_runtime_container(vaws_repo):
     assert first.returncode == 0
     assert second.returncode == 0
     state = read_json(vaws_repo / ".workspace.local" / "state.json")
+    assert state["schema_version"] == 1
     runtime_root = simulation_root / "host-a" / "vllm-workspace"
     runtime_state = read_json(runtime_root / ".vaws" / "runtime.json")
     assert runtime_state["container"]["created"] is True

--- a/tests/test_vaws_target.py
+++ b/tests/test_vaws_target.py
@@ -263,3 +263,14 @@ def test_target_ensure_fails_when_auth_group_is_missing(vaws_repo):
     output = (result.stdout + result.stderr).lower()
     assert "auth" in output
     assert "missing-group" in output
+
+
+def test_target_ensure_reports_deprecation_and_routing(vaws_repo):
+    seed_overlay(vaws_repo, target_name="single-default")
+
+    result = run_vaws(vaws_repo, "target", "ensure", "single-default")
+
+    assert result.returncode == 0
+    output = (result.stdout + result.stderr).lower()
+    assert "deprecated" in output
+    assert "fleet" in output

--- a/tools/lib/bootstrap.py
+++ b/tools/lib/bootstrap.py
@@ -9,6 +9,7 @@ import yaml
 
 from .config import RepoPaths
 from .overlay import ensure_overlay_layout
+from .preflight import PreflightError, ensure_local_control_plane_deps
 from .runtime import read_state, write_state
 
 COMMUNITY_UPSTREAM_URLS = {
@@ -127,6 +128,15 @@ def _write_yaml(path: Path, payload: Dict[str, Any]) -> None:
     )
 
 
+def _auth_ref_payload(kind: str, **fields: Any) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {"kind": kind}
+    for key, value in fields.items():
+        if value is None:
+            continue
+        payload[key] = value
+    return payload
+
+
 def _run_git(repo_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", *args],
@@ -224,29 +234,27 @@ def _write_auth_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
     auth_path = paths.local_overlay / "auth.yaml"
     config = _load_yaml_mapping(auth_path)
 
-    credential = {
-        "username": request.server_user,
-    }
-    if request.server_password_env:
-        credential["password_env"] = request.server_password_env
-    if request.server_key_path:
-        credential["key_path"] = request.server_key_path
-
-    config["host_auth"] = {
-        "mode": request.server_auth_mode,
-        "credential_groups": {
-            request.server_auth_group: credential,
+    config["version"] = 1
+    config["ssh_auth"] = {
+        "refs": {
+            request.server_auth_group: _auth_ref_payload(
+                request.server_auth_mode,
+                username=request.server_user,
+                password_env=request.server_password_env,
+                key_path=request.server_key_path,
+            ),
         },
     }
 
-    git_auth = {
-        "mode": request.git_auth_mode,
+    config["git_auth"] = {
+        "refs": {
+            "default": _auth_ref_payload(
+                request.git_auth_mode,
+                key_path=request.git_key_path,
+                token_env=request.git_token_env,
+            ),
+        },
     }
-    if request.git_key_path:
-        git_auth["key_path"] = request.git_key_path
-    if request.git_token_env:
-        git_auth["token_env"] = request.git_token_env
-    config["git_auth"] = git_auth
     _write_yaml(auth_path, config)
 
 
@@ -283,12 +291,16 @@ def _configure_repo_remotes(paths: RepoPaths, request: BootstrapRequest) -> None
 
 def bootstrap_init(paths: RepoPaths, request: BootstrapRequest) -> int:
     try:
+        ensure_local_control_plane_deps()
         _ensure_overlay(paths)
         _write_repos_yaml(paths, request)
         _write_targets_yaml(paths, request)
         _write_auth_yaml(paths, request)
         _ensure_state_json(paths)
         _configure_repo_remotes(paths, request)
+    except PreflightError as exc:
+        print(str(exc))
+        return 1
     except BootstrapError as exc:
         print(str(exc))
         return 1

--- a/tools/lib/bootstrap.py
+++ b/tools/lib/bootstrap.py
@@ -27,7 +27,7 @@ DEFAULT_RUNTIME_BOOTSTRAP_MODE = "host-then-container"
 DEFAULT_SERVER_PORT = 22
 DEFAULT_SERVER_AUTH_REF = "default-server-auth"
 DEFAULT_GIT_AUTH_REF = "default-git-auth"
-DEFAULT_SERVER_STATUS = "planned"
+DEFAULT_SERVER_STATUS = "pending"
 BOOTSTRAP_MODE_REMOTE_FIRST = "remote-first"
 BOOTSTRAP_MODE_LOCAL_ONLY = "local-only"
 
@@ -243,7 +243,7 @@ def _bootstrap_servers_config(
             "login_user": request.server_user,
             "ssh_auth_ref": DEFAULT_SERVER_AUTH_REF,
             "status": DEFAULT_SERVER_STATUS,
-            "planned_runtime": {
+            "runtime": {
                 "image_ref": request.runtime_image,
                 "container_name": request.runtime_container,
                 "ssh_port": request.runtime_ssh_port,
@@ -370,8 +370,34 @@ def _write_bootstrap_state(paths: RepoPaths, request: BootstrapRequest) -> None:
         raise BootstrapError(str(exc)) from exc
 
 
-def _finalize_servers_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
-    _write_servers_yaml(paths, request, completed=True)
+def _finalize_bootstrap(paths: RepoPaths, request: BootstrapRequest) -> None:
+    try:
+        _write_servers_yaml(paths, request, completed=True)
+        _write_bootstrap_state(paths, request)
+        servers_state = _load_yaml_mapping(paths.local_servers_file)
+        state = _read_bootstrap_state(paths)
+        if (
+            state.get("bootstrap", {}).get("completed") is not True
+            or servers_state.get("bootstrap", {}).get("completed") is not True
+        ):
+            raise BootstrapError("bootstrap baseline finalization verification failed")
+    except BootstrapError as exc:
+        rollback_state = _read_bootstrap_state(paths)
+        rollback_state["bootstrap"] = {
+            "completed": False,
+            "mode": _bootstrap_mode(request),
+        }
+        try:
+            write_state(paths, rollback_state)
+        except RuntimeError:
+            pass
+        try:
+            _write_servers_yaml(paths, request, completed=False)
+        except BootstrapError:
+            pass
+        raise
+    except RuntimeError as exc:
+        raise BootstrapError(str(exc)) from exc
 
 
 def _configure_repo_remotes(paths: RepoPaths, request: BootstrapRequest) -> None:
@@ -408,8 +434,7 @@ def bootstrap_init(paths: RepoPaths, request: BootstrapRequest) -> int:
         _write_targets_yaml(paths, request)
         _write_auth_yaml(paths, request)
         _configure_repo_remotes(paths, request)
-        _write_bootstrap_state(paths, request)
-        _finalize_servers_yaml(paths, request)
+        _finalize_bootstrap(paths, request)
     except PreflightError as exc:
         print(str(exc))
         return 1

--- a/tools/lib/bootstrap.py
+++ b/tools/lib/bootstrap.py
@@ -11,6 +11,10 @@ from .config import RepoPaths
 from .overlay import ensure_overlay_layout
 from .preflight import PreflightError, ensure_local_control_plane_deps
 from .remote import DEFAULT_HOST_WORKSPACE_BASE
+from .remote import RemoteError
+from .remote import VerificationCheck, VerificationResult, persist_server_verification
+from .remote import resolve_server_context
+from .remote import TargetContext
 from .runtime import read_state, write_state
 
 COMMUNITY_UPSTREAM_URLS = {
@@ -121,6 +125,36 @@ def _bootstrap_mode(request: BootstrapRequest) -> str:
 
 def _bootstrap_host_workspace_path(request: BootstrapRequest) -> str:
     return f"{DEFAULT_HOST_WORKSPACE_BASE}/{request.target_name}/workspace"
+
+
+def verify_runtime(_paths: RepoPaths, context: TargetContext) -> VerificationResult:
+    runtime = {
+        "image_ref": context.runtime.image_ref,
+        "container_name": context.runtime.container_name,
+        "ssh_port": context.runtime.ssh_port,
+        "workspace_root": context.runtime.workspace_root,
+        "bootstrap_mode": context.runtime.bootstrap_mode,
+        "transport": "bootstrap",
+        "container_endpoint": (
+            f"bootstrap://{context.host.name}/{context.runtime.container_name}"
+        ),
+        "host_name": context.host.name,
+        "host": context.host.host,
+        "host_port": context.host.port,
+        "login_user": context.host.login_user,
+        "host_workspace_path": context.runtime.host_workspace_path,
+    }
+    return VerificationResult.ready(
+        summary=f"bootstrap inventory ready for {context.host.name}",
+        runtime=runtime,
+        checks=[
+            VerificationCheck(
+                name="inventory",
+                status="ready",
+                detail="bootstrap server inventory resolved",
+            )
+        ],
+    )
 
 
 def _ensure_overlay(paths: RepoPaths) -> None:
@@ -377,10 +411,21 @@ def _write_bootstrap_state(paths: RepoPaths, request: BootstrapRequest) -> None:
         raise BootstrapError(str(exc)) from exc
 
 
+def _set_bootstrap_completed(paths: RepoPaths, completed: bool) -> None:
+    servers_state = _load_yaml_mapping(paths.local_servers_file)
+    bootstrap_state = servers_state.get("bootstrap")
+    if not isinstance(bootstrap_state, dict):
+        raise BootstrapError("invalid server config: missing bootstrap map")
+
+    bootstrap_state["completed"] = completed
+    servers_state["bootstrap"] = bootstrap_state
+    _write_yaml(paths.local_servers_file, servers_state)
+
+
 def _finalize_bootstrap(paths: RepoPaths, request: BootstrapRequest) -> None:
     try:
-        _write_servers_yaml(paths, request, completed=True)
         _write_bootstrap_state(paths, request)
+        _set_bootstrap_completed(paths, True)
         servers_state = _load_yaml_mapping(paths.local_servers_file)
         state = _read_bootstrap_state(paths)
         if (
@@ -399,7 +444,7 @@ def _finalize_bootstrap(paths: RepoPaths, request: BootstrapRequest) -> None:
         except RuntimeError:
             pass
         try:
-            _write_servers_yaml(paths, request, completed=False)
+            _set_bootstrap_completed(paths, False)
         except BootstrapError:
             pass
         raise
@@ -441,6 +486,11 @@ def bootstrap_init(paths: RepoPaths, request: BootstrapRequest) -> int:
         _write_targets_yaml(paths, request)
         _write_auth_yaml(paths, request)
         _configure_repo_remotes(paths, request)
+        verification: Optional[VerificationResult] = None
+        if request.server_host is not None:
+            context = resolve_server_context(paths, request.host_name)
+            verification = verify_runtime(paths, context)
+            persist_server_verification(paths, request.host_name, verification)
         _finalize_bootstrap(paths, request)
     except PreflightError as exc:
         print(str(exc))
@@ -448,9 +498,15 @@ def bootstrap_init(paths: RepoPaths, request: BootstrapRequest) -> int:
     except BootstrapError as exc:
         print(str(exc))
         return 1
+    except (RemoteError, RuntimeError) as exc:
+        print(str(exc))
+        return 1
 
     if preflight_report.status == "degraded":
         missing = ", ".join(preflight_report.missing_recommended)
         print(f"init: preflight degraded: missing recommended tools: {missing}")
-    print(f"init: bootstrap ok ({_bootstrap_mode(request)})")
+    bootstrap_status = (
+        verification.status if request.server_host is not None else "ready"
+    )
+    print(f"init: bootstrap {bootstrap_status} ({_bootstrap_mode(request)})")
     return 0

--- a/tools/lib/bootstrap.py
+++ b/tools/lib/bootstrap.py
@@ -25,6 +25,8 @@ DEFAULT_RUNTIME_SSH_PORT = 63269
 DEFAULT_RUNTIME_WORKSPACE_ROOT = "/vllm-workspace"
 DEFAULT_RUNTIME_BOOTSTRAP_MODE = "host-then-container"
 DEFAULT_SERVER_PORT = 22
+DEFAULT_SERVER_AUTH_REF = "default-server-auth"
+DEFAULT_GIT_AUTH_REF = "default-git-auth"
 
 
 class BootstrapError(RuntimeError):
@@ -211,7 +213,7 @@ def _write_targets_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
         "host": request.server_host,
         "port": request.server_port,
         "login_user": request.server_user,
-        "auth_group": request.server_auth_group,
+        "ssh_auth_ref": DEFAULT_SERVER_AUTH_REF,
     }
     config["hosts"] = hosts
 
@@ -237,7 +239,7 @@ def _write_auth_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
     config["version"] = 1
     config["ssh_auth"] = {
         "refs": {
-            request.server_auth_group: _auth_ref_payload(
+            DEFAULT_SERVER_AUTH_REF: _auth_ref_payload(
                 request.server_auth_mode,
                 username=request.server_user,
                 password_env=request.server_password_env,
@@ -248,7 +250,7 @@ def _write_auth_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
 
     config["git_auth"] = {
         "refs": {
-            "default": _auth_ref_payload(
+            DEFAULT_GIT_AUTH_REF: _auth_ref_payload(
                 request.git_auth_mode,
                 key_path=request.git_key_path,
                 token_env=request.git_token_env,

--- a/tools/lib/bootstrap.py
+++ b/tools/lib/bootstrap.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -10,7 +9,7 @@ import yaml
 
 from .config import RepoPaths
 from .overlay import ensure_overlay_layout
-from .runtime import ensure_state_schema
+from .runtime import read_state, write_state
 
 COMMUNITY_UPSTREAM_URLS = {
     "vllm": "https://github.com/vllm-project/vllm.git",
@@ -252,9 +251,10 @@ def _write_auth_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
 
 
 def _ensure_state_json(paths: RepoPaths) -> None:
-    state_path = paths.local_state_file
-    payload = ensure_state_schema(paths)
-    state_path.write_text(f"{json.dumps(payload, indent=2)}\n", encoding="utf-8")
+    try:
+        write_state(paths, read_state(paths))
+    except RuntimeError as exc:
+        raise BootstrapError(str(exc)) from exc
 
 
 def _configure_repo_remotes(paths: RepoPaths, request: BootstrapRequest) -> None:

--- a/tools/lib/bootstrap.py
+++ b/tools/lib/bootstrap.py
@@ -27,8 +27,8 @@ DEFAULT_RUNTIME_BOOTSTRAP_MODE = "host-then-container"
 DEFAULT_SERVER_PORT = 22
 DEFAULT_SERVER_AUTH_REF = "default-server-auth"
 DEFAULT_GIT_AUTH_REF = "default-git-auth"
-DEFAULT_SERVER_STATUS = "ready"
-BOOTSTRAP_MODE_SERVER = "server"
+DEFAULT_SERVER_STATUS = "planned"
+BOOTSTRAP_MODE_REMOTE_FIRST = "remote-first"
 BOOTSTRAP_MODE_LOCAL_ONLY = "local-only"
 
 
@@ -111,7 +111,11 @@ def bootstrap_request_from_args(args: Any) -> BootstrapRequest:
 
 
 def _bootstrap_mode(request: BootstrapRequest) -> str:
-    return BOOTSTRAP_MODE_LOCAL_ONLY if request.server_host is None else BOOTSTRAP_MODE_SERVER
+    return (
+        BOOTSTRAP_MODE_LOCAL_ONLY
+        if request.server_host is None
+        else BOOTSTRAP_MODE_REMOTE_FIRST
+    )
 
 
 def _ensure_overlay(paths: RepoPaths) -> None:
@@ -182,125 +186,157 @@ def _ensure_git_remote(repo_path: Path, remote_name: str, url: str) -> None:
 
 
 def _write_repos_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
-    repos_path = paths.local_overlay / "repos.yaml"
-    config = _load_yaml_mapping(repos_path)
-
-    workspace = dict(config.get("workspace") or {})
-    workspace.update(
+    _write_yaml(
+        paths.local_repos_file,
         {
-            "path": ".",
-            "default_branch": "main",
-            "protected_branches": ["main"],
-            "push_remote": "origin",
-            "upstream_remote": "upstream",
-        }
+            "version": 1,
+            "workspace": {
+                "path": ".",
+                "default_branch": "main",
+                "protected_branches": ["main"],
+                "push_remote": "origin",
+                "upstream_remote": "upstream",
+            },
+            "submodules": {
+                "vllm": {
+                    "path": "vllm",
+                    "default_branch": "main",
+                    "push_remote": "origin",
+                    "upstream_remote": "upstream",
+                    "upstream_url": COMMUNITY_UPSTREAM_URLS["vllm"],
+                },
+                "vllm-ascend": {
+                    "path": "vllm-ascend",
+                    "default_branch": "main",
+                    "push_remote": "origin",
+                    "upstream_remote": "upstream",
+                    "upstream_url": COMMUNITY_UPSTREAM_URLS["vllm-ascend"],
+                    "origin_url": request.vllm_ascend_origin_url,
+                },
+            },
+        },
     )
-    config["workspace"] = workspace
-
-    submodules = dict(config.get("submodules") or {})
-    submodules["vllm"] = {
-        "path": "vllm",
-        "default_branch": "main",
-        "push_remote": "origin",
-        "upstream_remote": "upstream",
-        "upstream_url": COMMUNITY_UPSTREAM_URLS["vllm"],
-    }
     if request.vllm_origin_url:
-        submodules["vllm"]["origin_url"] = request.vllm_origin_url
+        repos_path = paths.local_repos_file
+        config = _load_yaml_mapping(repos_path)
+        config["submodules"]["vllm"]["origin_url"] = request.vllm_origin_url
+        _write_yaml(repos_path, config)
 
-    submodules["vllm-ascend"] = {
-        "path": "vllm-ascend",
-        "default_branch": "main",
-        "push_remote": "origin",
-        "upstream_remote": "upstream",
-        "upstream_url": COMMUNITY_UPSTREAM_URLS["vllm-ascend"],
-        "origin_url": request.vllm_ascend_origin_url,
+
+def _bootstrap_servers_config(
+    request: BootstrapRequest,
+    *,
+    completed: bool,
+) -> Dict[str, Any]:
+    config: Dict[str, Any] = {
+        "version": 1,
+        "bootstrap": {
+            "completed": completed,
+            "mode": _bootstrap_mode(request),
+        },
+        "servers": {},
     }
-    config["submodules"] = submodules
-    _write_yaml(repos_path, config)
-
-
-def _write_servers_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
-    servers_path = paths.local_servers_file
-    config = _load_yaml_mapping(servers_path)
-    config["version"] = 1
-    config["bootstrap"] = {
-        "completed": True,
-        "mode": _bootstrap_mode(request),
-    }
-
-    servers = dict(config.get("servers") or {})
     if request.server_host is not None:
-        servers[request.host_name] = {
+        config["servers"][request.host_name] = {
             "host": request.server_host,
             "port": request.server_port,
             "login_user": request.server_user,
             "ssh_auth_ref": DEFAULT_SERVER_AUTH_REF,
             "status": DEFAULT_SERVER_STATUS,
+            "planned_runtime": {
+                "image_ref": request.runtime_image,
+                "container_name": request.runtime_container,
+                "ssh_port": request.runtime_ssh_port,
+                "workspace_root": request.runtime_workspace_root,
+                "bootstrap_mode": DEFAULT_RUNTIME_BOOTSTRAP_MODE,
+            },
         }
-    config["servers"] = servers
-    _write_yaml(servers_path, config)
+    return config
+
+
+def _write_servers_yaml(paths: RepoPaths, request: BootstrapRequest, *, completed: bool) -> None:
+    _write_yaml(paths.local_servers_file, _bootstrap_servers_config(request, completed=completed))
 
 
 def _write_targets_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
+    targets_path = paths.local_targets_file
     if request.server_host is None:
+        _write_yaml(
+            targets_path,
+            {
+                "version": 1,
+                "hosts": {},
+                "targets": {},
+            },
+        )
         return
 
-    targets_path = paths.local_overlay / "targets.yaml"
-    config = _load_yaml_mapping(targets_path)
-    hosts = dict(config.get("hosts") or {})
-    hosts[request.host_name] = {
-        "host": request.server_host,
-        "port": request.server_port,
-        "login_user": request.server_user,
-        "ssh_auth_ref": DEFAULT_SERVER_AUTH_REF,
-    }
-    config["hosts"] = hosts
-
-    targets = dict(config.get("targets") or {})
-    targets[request.target_name] = {
-        "hosts": [request.host_name],
-        "runtime": {
-            "image_ref": request.runtime_image,
-            "container_name": request.runtime_container,
-            "ssh_port": request.runtime_ssh_port,
-            "workspace_root": request.runtime_workspace_root,
-            "bootstrap_mode": DEFAULT_RUNTIME_BOOTSTRAP_MODE,
+    _write_yaml(
+        targets_path,
+        {
+            "version": 1,
+            "hosts": {
+                request.host_name: {
+                    "host": request.server_host,
+                    "port": request.server_port,
+                    "login_user": request.server_user,
+                    "ssh_auth_ref": DEFAULT_SERVER_AUTH_REF,
+                },
+            },
+            "targets": {
+                request.target_name: {
+                    "hosts": [request.host_name],
+                    "runtime": {
+                        "image_ref": request.runtime_image,
+                        "container_name": request.runtime_container,
+                        "ssh_port": request.runtime_ssh_port,
+                        "workspace_root": request.runtime_workspace_root,
+                        "bootstrap_mode": DEFAULT_RUNTIME_BOOTSTRAP_MODE,
+                    },
+                },
+            },
         },
-    }
-    config["targets"] = targets
-    _write_yaml(targets_path, config)
+    )
 
 
 def _write_auth_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
+    auth_path = paths.local_auth_file
     if request.server_host is None:
+        _write_yaml(
+            auth_path,
+            {
+                "version": 1,
+                "ssh_auth": {"refs": {}},
+                "git_auth": {"refs": {}},
+            },
+        )
         return
 
-    auth_path = paths.local_overlay / "auth.yaml"
-    config = _load_yaml_mapping(auth_path)
-
-    config["version"] = 1
-    config["ssh_auth"] = {
-        "refs": {
-            DEFAULT_SERVER_AUTH_REF: _auth_ref_payload(
-                request.server_auth_mode,
-                username=request.server_user,
-                password_env=request.server_password_env,
-                key_path=request.server_key_path,
-            ),
+    _write_yaml(
+        auth_path,
+        {
+            "version": 1,
+            "ssh_auth": {
+                "refs": {
+                    DEFAULT_SERVER_AUTH_REF: _auth_ref_payload(
+                        request.server_auth_mode,
+                        username=request.server_user,
+                        password_env=request.server_password_env,
+                        key_path=request.server_key_path,
+                    ),
+                },
+            },
+            "git_auth": {
+                "refs": {
+                    DEFAULT_GIT_AUTH_REF: _auth_ref_payload(
+                        request.git_auth_mode,
+                        key_path=request.git_key_path,
+                        token_env=request.git_token_env,
+                    ),
+                },
+            },
         },
-    }
-
-    config["git_auth"] = {
-        "refs": {
-            DEFAULT_GIT_AUTH_REF: _auth_ref_payload(
-                request.git_auth_mode,
-                key_path=request.git_key_path,
-                token_env=request.git_token_env,
-            ),
-        },
-    }
-    _write_yaml(auth_path, config)
+    )
 
 
 def _read_bootstrap_state(paths: RepoPaths) -> Dict[str, Any]:
@@ -334,6 +370,10 @@ def _write_bootstrap_state(paths: RepoPaths, request: BootstrapRequest) -> None:
         raise BootstrapError(str(exc)) from exc
 
 
+def _finalize_servers_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
+    _write_servers_yaml(paths, request, completed=True)
+
+
 def _configure_repo_remotes(paths: RepoPaths, request: BootstrapRequest) -> None:
     repo_targets = {
         "vllm": {
@@ -364,11 +404,12 @@ def bootstrap_init(paths: RepoPaths, request: BootstrapRequest) -> int:
         _ensure_overlay(paths)
         _ensure_bootstrap_not_completed(paths)
         _write_repos_yaml(paths, request)
-        _write_servers_yaml(paths, request)
+        _write_servers_yaml(paths, request, completed=False)
         _write_targets_yaml(paths, request)
         _write_auth_yaml(paths, request)
         _configure_repo_remotes(paths, request)
         _write_bootstrap_state(paths, request)
+        _finalize_servers_yaml(paths, request)
     except PreflightError as exc:
         print(str(exc))
         return 1

--- a/tools/lib/bootstrap.py
+++ b/tools/lib/bootstrap.py
@@ -10,6 +10,7 @@ import yaml
 from .config import RepoPaths
 from .overlay import ensure_overlay_layout
 from .preflight import PreflightError, ensure_local_control_plane_deps
+from .remote import DEFAULT_HOST_WORKSPACE_BASE
 from .runtime import read_state, write_state
 
 COMMUNITY_UPSTREAM_URLS = {
@@ -116,6 +117,10 @@ def _bootstrap_mode(request: BootstrapRequest) -> str:
         if request.server_host is None
         else BOOTSTRAP_MODE_REMOTE_FIRST
     )
+
+
+def _bootstrap_host_workspace_path(request: BootstrapRequest) -> str:
+    return f"{DEFAULT_HOST_WORKSPACE_BASE}/{request.target_name}/workspace"
 
 
 def _ensure_overlay(paths: RepoPaths) -> None:
@@ -249,6 +254,7 @@ def _bootstrap_servers_config(
                 "ssh_port": request.runtime_ssh_port,
                 "workspace_root": request.runtime_workspace_root,
                 "bootstrap_mode": DEFAULT_RUNTIME_BOOTSTRAP_MODE,
+                "host_workspace_path": _bootstrap_host_workspace_path(request),
             },
         }
     return config
@@ -292,6 +298,7 @@ def _write_targets_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
                         "ssh_port": request.runtime_ssh_port,
                         "workspace_root": request.runtime_workspace_root,
                         "bootstrap_mode": DEFAULT_RUNTIME_BOOTSTRAP_MODE,
+                        "host_workspace_path": _bootstrap_host_workspace_path(request),
                     },
                 },
             },

--- a/tools/lib/bootstrap.py
+++ b/tools/lib/bootstrap.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, Optional
 import yaml
 
 from .config import RepoPaths
+from .overlay import ensure_overlay_layout
+from .runtime import ensure_state_schema
 
 COMMUNITY_UPSTREAM_URLS = {
     "vllm": "https://github.com/vllm-project/vllm.git",
@@ -23,8 +25,6 @@ DEFAULT_RUNTIME_SSH_PORT = 63269
 DEFAULT_RUNTIME_WORKSPACE_ROOT = "/vllm-workspace"
 DEFAULT_RUNTIME_BOOTSTRAP_MODE = "host-then-container"
 DEFAULT_SERVER_PORT = 22
-
-OVERLAY_FILES = ("targets.yaml", "repos.yaml", "auth.yaml", "state.json")
 
 
 class BootstrapError(RuntimeError):
@@ -103,15 +103,7 @@ def _ensure_overlay(paths: RepoPaths) -> None:
             "invalid local overlay: .workspace.local/ exists but is not a directory"
         )
 
-    paths.local_overlay.mkdir(parents=True, exist_ok=True)
-    for name in OVERLAY_FILES:
-        file_path = paths.local_overlay / name
-        if file_path.exists():
-            continue
-        if name == "state.json":
-            file_path.write_text("{}\n", encoding="utf-8")
-        else:
-            file_path.write_text("", encoding="utf-8")
+    ensure_overlay_layout(paths)
 
 
 def _load_yaml_mapping(path: Path) -> Dict[str, Any]:
@@ -260,13 +252,8 @@ def _write_auth_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
 
 
 def _ensure_state_json(paths: RepoPaths) -> None:
-    state_path = paths.local_overlay / "state.json"
-    try:
-        payload = json.loads(state_path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        payload = {}
-    if not isinstance(payload, dict):
-        payload = {}
+    state_path = paths.local_state_file
+    payload = ensure_state_schema(paths)
     state_path.write_text(f"{json.dumps(payload, indent=2)}\n", encoding="utf-8")
 
 

--- a/tools/lib/bootstrap.py
+++ b/tools/lib/bootstrap.py
@@ -27,6 +27,9 @@ DEFAULT_RUNTIME_BOOTSTRAP_MODE = "host-then-container"
 DEFAULT_SERVER_PORT = 22
 DEFAULT_SERVER_AUTH_REF = "default-server-auth"
 DEFAULT_GIT_AUTH_REF = "default-git-auth"
+DEFAULT_SERVER_STATUS = "ready"
+BOOTSTRAP_MODE_SERVER = "server"
+BOOTSTRAP_MODE_LOCAL_ONLY = "local-only"
 
 
 class BootstrapError(RuntimeError):
@@ -35,7 +38,7 @@ class BootstrapError(RuntimeError):
 
 @dataclass(frozen=True)
 class BootstrapRequest:
-    server_host: str
+    server_host: Optional[str]
     server_user: str
     vllm_ascend_origin_url: str
     server_port: int = DEFAULT_SERVER_PORT
@@ -61,6 +64,14 @@ def _require_non_empty(value: Optional[str], field_name: str) -> str:
     return value.strip()
 
 
+def _optional_non_empty(value: Optional[str], field_name: str) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise BootstrapError(f"invalid bootstrap field: {field_name}")
+    return value.strip()
+
+
 def _require_port(value: Any, field_name: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 1 or value > 65535:
         raise BootstrapError(f"invalid bootstrap field: {field_name}")
@@ -69,7 +80,7 @@ def _require_port(value: Any, field_name: str) -> int:
 
 def bootstrap_request_from_args(args: Any) -> BootstrapRequest:
     return BootstrapRequest(
-        server_host=_require_non_empty(args.server_host, "server host"),
+        server_host=_optional_non_empty(args.server_host, "server host"),
         server_user=_require_non_empty(args.server_user, "server user"),
         vllm_ascend_origin_url=_require_non_empty(
             args.vllm_ascend_origin_url,
@@ -97,6 +108,10 @@ def bootstrap_request_from_args(args: Any) -> BootstrapRequest:
         git_key_path=args.git_key_path,
         git_token_env=args.git_token_env,
     )
+
+
+def _bootstrap_mode(request: BootstrapRequest) -> str:
+    return BOOTSTRAP_MODE_LOCAL_ONLY if request.server_host is None else BOOTSTRAP_MODE_SERVER
 
 
 def _ensure_overlay(paths: RepoPaths) -> None:
@@ -205,7 +220,32 @@ def _write_repos_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
     _write_yaml(repos_path, config)
 
 
+def _write_servers_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
+    servers_path = paths.local_servers_file
+    config = _load_yaml_mapping(servers_path)
+    config["version"] = 1
+    config["bootstrap"] = {
+        "completed": True,
+        "mode": _bootstrap_mode(request),
+    }
+
+    servers = dict(config.get("servers") or {})
+    if request.server_host is not None:
+        servers[request.host_name] = {
+            "host": request.server_host,
+            "port": request.server_port,
+            "login_user": request.server_user,
+            "ssh_auth_ref": DEFAULT_SERVER_AUTH_REF,
+            "status": DEFAULT_SERVER_STATUS,
+        }
+    config["servers"] = servers
+    _write_yaml(servers_path, config)
+
+
 def _write_targets_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
+    if request.server_host is None:
+        return
+
     targets_path = paths.local_overlay / "targets.yaml"
     config = _load_yaml_mapping(targets_path)
     hosts = dict(config.get("hosts") or {})
@@ -233,6 +273,9 @@ def _write_targets_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
 
 
 def _write_auth_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
+    if request.server_host is None:
+        return
+
     auth_path = paths.local_overlay / "auth.yaml"
     config = _load_yaml_mapping(auth_path)
 
@@ -260,9 +303,33 @@ def _write_auth_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
     _write_yaml(auth_path, config)
 
 
-def _ensure_state_json(paths: RepoPaths) -> None:
+def _read_bootstrap_state(paths: RepoPaths) -> Dict[str, Any]:
     try:
-        write_state(paths, read_state(paths))
+        return read_state(paths)
+    except RuntimeError as exc:
+        raise BootstrapError(str(exc)) from exc
+
+
+def _ensure_bootstrap_not_completed(paths: RepoPaths) -> None:
+    state = _read_bootstrap_state(paths)
+    bootstrap_state = state.get("bootstrap")
+    if not isinstance(bootstrap_state, dict):
+        return
+
+    if bootstrap_state.get("completed") is True:
+        raise BootstrapError(
+            "bootstrap baseline already completed; use `vaws fleet` for later server changes"
+        )
+
+
+def _write_bootstrap_state(paths: RepoPaths, request: BootstrapRequest) -> None:
+    try:
+        state = read_state(paths)
+        state["bootstrap"] = {
+            "completed": True,
+            "mode": _bootstrap_mode(request),
+        }
+        write_state(paths, state)
     except RuntimeError as exc:
         raise BootstrapError(str(exc)) from exc
 
@@ -295,11 +362,13 @@ def bootstrap_init(paths: RepoPaths, request: BootstrapRequest) -> int:
     try:
         preflight_report = ensure_local_control_plane_deps()
         _ensure_overlay(paths)
+        _ensure_bootstrap_not_completed(paths)
         _write_repos_yaml(paths, request)
+        _write_servers_yaml(paths, request)
         _write_targets_yaml(paths, request)
         _write_auth_yaml(paths, request)
-        _ensure_state_json(paths)
         _configure_repo_remotes(paths, request)
+        _write_bootstrap_state(paths, request)
     except PreflightError as exc:
         print(str(exc))
         return 1
@@ -310,5 +379,5 @@ def bootstrap_init(paths: RepoPaths, request: BootstrapRequest) -> int:
     if preflight_report.status == "degraded":
         missing = ", ".join(preflight_report.missing_recommended)
         print(f"init: preflight degraded: missing recommended tools: {missing}")
-    print("init: bootstrap ok")
+    print(f"init: bootstrap ok ({_bootstrap_mode(request)})")
     return 0

--- a/tools/lib/bootstrap.py
+++ b/tools/lib/bootstrap.py
@@ -293,7 +293,7 @@ def _configure_repo_remotes(paths: RepoPaths, request: BootstrapRequest) -> None
 
 def bootstrap_init(paths: RepoPaths, request: BootstrapRequest) -> int:
     try:
-        ensure_local_control_plane_deps()
+        preflight_report = ensure_local_control_plane_deps()
         _ensure_overlay(paths)
         _write_repos_yaml(paths, request)
         _write_targets_yaml(paths, request)
@@ -307,5 +307,8 @@ def bootstrap_init(paths: RepoPaths, request: BootstrapRequest) -> int:
         print(str(exc))
         return 1
 
+    if preflight_report.status == "degraded":
+        missing = ", ".join(preflight_report.missing_recommended)
+        print(f"init: preflight degraded: missing recommended tools: {missing}")
     print("init: bootstrap ok")
     return 0

--- a/tools/lib/config.py
+++ b/tools/lib/config.py
@@ -15,6 +15,10 @@ class RepoPaths:
         return self.local_overlay / "state.json"
 
     @property
+    def local_servers_file(self) -> Path:
+        return self.local_overlay / "servers.yaml"
+
+    @property
     def local_targets_file(self) -> Path:
         return self.local_overlay / "targets.yaml"
 

--- a/tools/lib/doctor.py
+++ b/tools/lib/doctor.py
@@ -3,10 +3,13 @@ import json
 from pathlib import Path
 from typing import Optional
 
+import yaml
+
 from .config import RepoPaths
 from .overlay import OVERLAY_SCHEMA_VERSION, ensure_overlay_layout
 
 OVERLAY_FILES = ("servers.yaml", "repos.yaml", "auth.yaml", "state.json")
+BOOTSTRAP_MODES = {"server", "local-only"}
 
 
 def _declared_submodule_paths(root: Path):
@@ -63,6 +66,31 @@ def doctor(paths: RepoPaths) -> int:
     if missing_files:
         print(f"missing overlay files: {', '.join(missing_files)}")
         return 1
+
+    servers_file = paths.local_servers_file
+    try:
+        servers_config = yaml.safe_load(servers_file.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError):
+        print("invalid servers file: .workspace.local/servers.yaml is not valid YAML")
+        return 1
+
+    if not isinstance(servers_config, dict):
+        print("invalid servers file: .workspace.local/servers.yaml must be a YAML mapping")
+        return 1
+
+    bootstrap_config = servers_config.get("bootstrap")
+    if bootstrap_config is not None:
+        if not isinstance(bootstrap_config, dict):
+            print("invalid servers file: .workspace.local/servers.yaml bootstrap must be a mapping")
+            return 1
+        mode = bootstrap_config.get("mode")
+        if mode is not None and mode not in BOOTSTRAP_MODES:
+            print("invalid servers file: .workspace.local/servers.yaml bootstrap mode is unsupported")
+            return 1
+        completed = bootstrap_config.get("completed")
+        if completed is not None and not isinstance(completed, bool):
+            print("invalid servers file: .workspace.local/servers.yaml bootstrap completed must be a boolean")
+            return 1
 
     state_file = paths.local_state_file
     try:

--- a/tools/lib/doctor.py
+++ b/tools/lib/doctor.py
@@ -9,7 +9,7 @@ from .config import RepoPaths
 from .overlay import OVERLAY_SCHEMA_VERSION, ensure_overlay_layout
 
 OVERLAY_FILES = ("servers.yaml", "repos.yaml", "auth.yaml", "state.json")
-BOOTSTRAP_MODES = {"remote-first", "local-only"}
+BOOTSTRAP_MODES = {"remote-first", "server", "local-only"}
 
 
 def _declared_submodule_paths(root: Path):

--- a/tools/lib/doctor.py
+++ b/tools/lib/doctor.py
@@ -4,8 +4,9 @@ from pathlib import Path
 from typing import Optional
 
 from .config import RepoPaths
+from .overlay import ensure_overlay_layout
 
-OVERLAY_FILES = ("targets.yaml", "repos.yaml", "auth.yaml", "state.json")
+OVERLAY_FILES = ("servers.yaml", "repos.yaml", "auth.yaml", "state.json")
 
 
 def _declared_submodule_paths(root: Path):
@@ -63,7 +64,7 @@ def doctor(paths: RepoPaths) -> int:
         print(f"missing overlay files: {', '.join(missing_files)}")
         return 1
 
-    state_file = paths.local_overlay / "state.json"
+    state_file = paths.local_state_file
     try:
         json.loads(state_file.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
@@ -84,14 +85,7 @@ def init(paths: RepoPaths) -> int:
         print("invalid local overlay: .workspace.local/ exists but is not a directory")
         return 1
 
-    paths.local_overlay.mkdir(parents=True, exist_ok=True)
-    for name in OVERLAY_FILES:
-        file_path = paths.local_overlay / name
-        if not file_path.exists():
-            if name == "state.json":
-                file_path.write_text("{}\n", encoding="utf-8")
-            else:
-                file_path.write_text("", encoding="utf-8")
+    ensure_overlay_layout(paths)
 
     print("init: ok")
     return 0

--- a/tools/lib/doctor.py
+++ b/tools/lib/doctor.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Optional
 
 from .config import RepoPaths
-from .overlay import ensure_overlay_layout
+from .overlay import OVERLAY_SCHEMA_VERSION, ensure_overlay_layout
 
 OVERLAY_FILES = ("servers.yaml", "repos.yaml", "auth.yaml", "state.json")
 
@@ -66,9 +66,25 @@ def doctor(paths: RepoPaths) -> int:
 
     state_file = paths.local_state_file
     try:
-        json.loads(state_file.read_text(encoding="utf-8"))
+        state = json.loads(state_file.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         print("invalid state file: .workspace.local/state.json is not valid JSON")
+        return 1
+
+    if not isinstance(state, dict):
+        print("invalid state file: .workspace.local/state.json must be a JSON object")
+        return 1
+
+    schema_version = state.get("schema_version")
+    if isinstance(schema_version, bool) or not isinstance(schema_version, int):
+        print("invalid state file: .workspace.local/state.json missing schema_version")
+        return 1
+    if schema_version != OVERLAY_SCHEMA_VERSION:
+        print(
+            "unsupported schema_version in "
+            ".workspace.local/state.json: "
+            f"{schema_version}"
+        )
         return 1
 
     missing_submodules = _missing_submodules(paths.root)

--- a/tools/lib/doctor.py
+++ b/tools/lib/doctor.py
@@ -9,7 +9,7 @@ from .config import RepoPaths
 from .overlay import OVERLAY_SCHEMA_VERSION, ensure_overlay_layout
 
 OVERLAY_FILES = ("servers.yaml", "repos.yaml", "auth.yaml", "state.json")
-BOOTSTRAP_MODES = {"server", "local-only"}
+BOOTSTRAP_MODES = {"remote-first", "local-only"}
 
 
 def _declared_submodule_paths(root: Path):

--- a/tools/lib/fleet.py
+++ b/tools/lib/fleet.py
@@ -8,13 +8,20 @@ from .bootstrap import (
     DEFAULT_RUNTIME_BOOTSTRAP_MODE,
     DEFAULT_RUNTIME_CONTAINER,
     DEFAULT_RUNTIME_IMAGE,
+    DEFAULT_SERVER_PORT,
     DEFAULT_RUNTIME_SSH_PORT,
     DEFAULT_RUNTIME_WORKSPACE_ROOT,
     DEFAULT_SERVER_AUTH_REF,
     DEFAULT_SERVER_STATUS,
 )
 from .config import RepoPaths
-from .remote import RemoteError, resolve_server_context, verify_runtime
+from .remote import (
+    DEFAULT_HOST_WORKSPACE_BASE,
+    RemoteError,
+    ensure_runtime,
+    resolve_server_context,
+    verify_runtime,
+)
 
 
 class FleetError(RuntimeError):
@@ -57,6 +64,12 @@ def _require_int(value: Any, message: str) -> int:
     return value
 
 
+def _require_port(value: Any, message: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1 or value > 65535:
+        raise FleetError(message)
+    return value
+
+
 def list_fleet(paths: RepoPaths) -> int:
     try:
         config = _read_servers_config(paths)
@@ -91,11 +104,10 @@ def list_fleet(paths: RepoPaths) -> int:
 def add_fleet_server(
     paths: RepoPaths,
     server_name: str,
-    host: str,
-    login_user: str,
-    port: int = 22,
-    ssh_auth_ref: str = DEFAULT_SERVER_AUTH_REF,
-    status: str = DEFAULT_SERVER_STATUS,
+    server_host: str,
+    ssh_auth_ref: str,
+    server_user: str = "root",
+    server_port: int = DEFAULT_SERVER_PORT,
     runtime_image: str = DEFAULT_RUNTIME_IMAGE,
     runtime_container: str = DEFAULT_RUNTIME_CONTAINER,
     runtime_ssh_port: int = DEFAULT_RUNTIME_SSH_PORT,
@@ -104,10 +116,9 @@ def add_fleet_server(
 ) -> int:
     try:
         server_name = _require_non_empty_string(server_name, "missing server name")
-        host = _require_non_empty_string(host, "missing server host")
-        login_user = _require_non_empty_string(login_user, "missing login user")
+        server_host = _require_non_empty_string(server_host, "missing server host")
+        server_user = _require_non_empty_string(server_user, "missing server user")
         ssh_auth_ref = _require_non_empty_string(ssh_auth_ref, "missing ssh auth ref")
-        status = _require_non_empty_string(status, "missing server status")
         runtime_image = _require_non_empty_string(runtime_image, "missing runtime image")
         runtime_container = _require_non_empty_string(
             runtime_container,
@@ -121,8 +132,8 @@ def add_fleet_server(
             runtime_bootstrap_mode,
             "missing runtime bootstrap mode",
         )
-        port = _require_int(port, "invalid port")
-        runtime_ssh_port = _require_int(runtime_ssh_port, "invalid runtime ssh port")
+        server_port = _require_port(server_port, "invalid server port")
+        runtime_ssh_port = _require_port(runtime_ssh_port, "invalid runtime ssh port")
 
         config = _read_servers_config(paths)
         servers = config.get("servers")
@@ -130,20 +141,29 @@ def add_fleet_server(
             raise FleetError("invalid server config: missing 'servers' map")
 
         servers[server_name] = {
-            "host": host,
-            "port": port,
-            "login_user": login_user,
+            "host": server_host,
+            "port": server_port,
+            "login_user": server_user,
             "ssh_auth_ref": ssh_auth_ref,
-            "status": status,
+            "status": DEFAULT_SERVER_STATUS,
             "runtime": {
                 "image_ref": runtime_image,
                 "container_name": runtime_container,
                 "ssh_port": runtime_ssh_port,
                 "workspace_root": runtime_workspace_root,
                 "bootstrap_mode": runtime_bootstrap_mode,
+                "host_workspace_path": f"{DEFAULT_HOST_WORKSPACE_BASE}/{server_name}/workspace",
             },
         }
         config["version"] = 1
+        config["servers"] = servers
+        _write_servers_config(paths, config)
+
+        context = resolve_server_context(paths, server_name)
+        ensure_runtime(paths, context)
+        verify_runtime(paths, context)
+
+        servers[server_name]["status"] = "ready"
         config["servers"] = servers
         _write_servers_config(paths, config)
     except (FleetError, RuntimeError, OSError) as exc:

--- a/tools/lib/fleet.py
+++ b/tools/lib/fleet.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import yaml
+
+from .bootstrap import (
+    DEFAULT_RUNTIME_BOOTSTRAP_MODE,
+    DEFAULT_RUNTIME_CONTAINER,
+    DEFAULT_RUNTIME_IMAGE,
+    DEFAULT_RUNTIME_SSH_PORT,
+    DEFAULT_RUNTIME_WORKSPACE_ROOT,
+    DEFAULT_SERVER_AUTH_REF,
+    DEFAULT_SERVER_STATUS,
+)
+from .config import RepoPaths
+from .remote import RemoteError, resolve_server_context, verify_runtime
+
+
+class FleetError(RuntimeError):
+    """Fleet inventory operation failure."""
+
+
+def _read_servers_config(paths: RepoPaths) -> Dict[str, Any]:
+    servers_file = paths.local_servers_file
+    if not servers_file.is_file():
+        raise FleetError("missing server inventory: run `vaws init --bootstrap` first")
+
+    try:
+        loaded = yaml.safe_load(servers_file.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
+        raise FleetError("invalid server config: .workspace.local/servers.yaml") from exc
+
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        raise FleetError("invalid server config: .workspace.local/servers.yaml must be a YAML mapping")
+    return loaded
+
+
+def _write_servers_config(paths: RepoPaths, config: Dict[str, Any]) -> None:
+    paths.local_servers_file.write_text(
+        yaml.safe_dump(config, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _require_non_empty_string(value: Any, message: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise FleetError(message)
+    return value.strip()
+
+
+def _require_int(value: Any, message: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise FleetError(message)
+    return value
+
+
+def list_fleet(paths: RepoPaths) -> int:
+    try:
+        config = _read_servers_config(paths)
+        servers = config.get("servers")
+        if not isinstance(servers, dict):
+            raise FleetError("invalid server config: missing 'servers' map")
+    except (FleetError, RuntimeError) as exc:
+        print(str(exc))
+        return 1
+
+    print("fleet list:")
+    if not servers:
+        print("  (no servers)")
+        return 0
+
+    for server_name in sorted(servers):
+        server = servers[server_name]
+        if not isinstance(server, dict):
+            print(f"- {server_name}: invalid entry")
+            continue
+        status = server.get("status", "unknown")
+        host = server.get("host", "?")
+        port = server.get("port", "?")
+        runtime = server.get("runtime")
+        container_name = "?"
+        if isinstance(runtime, dict):
+            container_name = runtime.get("container_name", "?")
+        print(f"- {server_name}: {status} {host}:{port} {container_name}")
+    return 0
+
+
+def add_fleet_server(
+    paths: RepoPaths,
+    server_name: str,
+    host: str,
+    login_user: str,
+    port: int = 22,
+    ssh_auth_ref: str = DEFAULT_SERVER_AUTH_REF,
+    status: str = DEFAULT_SERVER_STATUS,
+    runtime_image: str = DEFAULT_RUNTIME_IMAGE,
+    runtime_container: str = DEFAULT_RUNTIME_CONTAINER,
+    runtime_ssh_port: int = DEFAULT_RUNTIME_SSH_PORT,
+    runtime_workspace_root: str = DEFAULT_RUNTIME_WORKSPACE_ROOT,
+    runtime_bootstrap_mode: str = DEFAULT_RUNTIME_BOOTSTRAP_MODE,
+) -> int:
+    try:
+        server_name = _require_non_empty_string(server_name, "missing server name")
+        host = _require_non_empty_string(host, "missing server host")
+        login_user = _require_non_empty_string(login_user, "missing login user")
+        ssh_auth_ref = _require_non_empty_string(ssh_auth_ref, "missing ssh auth ref")
+        status = _require_non_empty_string(status, "missing server status")
+        runtime_image = _require_non_empty_string(runtime_image, "missing runtime image")
+        runtime_container = _require_non_empty_string(
+            runtime_container,
+            "missing runtime container",
+        )
+        runtime_workspace_root = _require_non_empty_string(
+            runtime_workspace_root,
+            "missing runtime workspace root",
+        )
+        runtime_bootstrap_mode = _require_non_empty_string(
+            runtime_bootstrap_mode,
+            "missing runtime bootstrap mode",
+        )
+        port = _require_int(port, "invalid port")
+        runtime_ssh_port = _require_int(runtime_ssh_port, "invalid runtime ssh port")
+
+        config = _read_servers_config(paths)
+        servers = config.get("servers")
+        if not isinstance(servers, dict):
+            raise FleetError("invalid server config: missing 'servers' map")
+
+        servers[server_name] = {
+            "host": host,
+            "port": port,
+            "login_user": login_user,
+            "ssh_auth_ref": ssh_auth_ref,
+            "status": status,
+            "runtime": {
+                "image_ref": runtime_image,
+                "container_name": runtime_container,
+                "ssh_port": runtime_ssh_port,
+                "workspace_root": runtime_workspace_root,
+                "bootstrap_mode": runtime_bootstrap_mode,
+            },
+        }
+        config["version"] = 1
+        config["servers"] = servers
+        _write_servers_config(paths, config)
+    except (FleetError, RuntimeError, OSError) as exc:
+        print(str(exc))
+        return 1
+
+    print(f"fleet add: ok ({server_name})")
+    return 0
+
+
+def verify_fleet_server(paths: RepoPaths, server_name: str) -> int:
+    try:
+        context = resolve_server_context(paths, server_name)
+        verify_runtime(paths, context)
+    except (RemoteError, RuntimeError) as exc:
+        print(str(exc))
+        return 1
+
+    print(f"fleet verify: ok ({server_name})")
+    return 0

--- a/tools/lib/fleet.py
+++ b/tools/lib/fleet.py
@@ -19,6 +19,7 @@ from .remote import (
     DEFAULT_HOST_WORKSPACE_BASE,
     RemoteError,
     ensure_runtime,
+    persist_server_verification,
     resolve_server_context,
     verify_runtime,
 )
@@ -161,26 +162,23 @@ def add_fleet_server(
 
         context = resolve_server_context(paths, server_name)
         ensure_runtime(paths, context)
-        verify_runtime(paths, context)
-
-        servers[server_name]["status"] = "ready"
-        config["servers"] = servers
-        _write_servers_config(paths, config)
+        verification = verify_runtime(paths, context)
+        persist_server_verification(paths, server_name, verification)
     except (FleetError, RuntimeError, OSError) as exc:
         print(str(exc))
         return 1
 
-    print(f"fleet add: ok ({server_name})")
+    print(f"fleet add: {verification.status} ({server_name})")
     return 0
 
 
 def verify_fleet_server(paths: RepoPaths, server_name: str) -> int:
     try:
         context = resolve_server_context(paths, server_name)
-        verify_runtime(paths, context)
+        verification = verify_runtime(paths, context)
     except (RemoteError, RuntimeError) as exc:
         print(str(exc))
         return 1
 
-    print(f"fleet verify: ok ({server_name})")
+    print(f"fleet verify: {verification.status} ({server_name})")
     return 0

--- a/tools/lib/overlay.py
+++ b/tools/lib/overlay.py
@@ -1,0 +1,20 @@
+import json
+
+from .config import RepoPaths
+
+OVERLAY_SCHEMA_VERSION = 1
+
+
+def ensure_overlay_layout(paths: RepoPaths) -> None:
+    paths.local_overlay.mkdir(parents=True, exist_ok=True)
+    defaults = {
+        paths.local_servers_file: "version: 1\nservers: {}\n",
+        paths.local_auth_file: "version: 1\nssh_auth: {refs: {}}\ngit_auth: {refs: {}}\n",
+        paths.local_repos_file: "version: 1\nworkspace: {}\nsubmodules: {}\n",
+        paths.local_state_file: (
+            json.dumps({"schema_version": OVERLAY_SCHEMA_VERSION}, indent=2) + "\n"
+        ),
+    }
+    for file_path, content in defaults.items():
+        if not file_path.exists():
+            file_path.write_text(content, encoding="utf-8")

--- a/tools/lib/preflight.py
+++ b/tools/lib/preflight.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass
 import shutil
+import sys
+from dataclasses import dataclass
 from typing import Tuple
 
 REQUIRED_COMMANDS = ("git", "ssh", "python3")
@@ -12,26 +13,61 @@ class PreflightError(RuntimeError):
 
 @dataclass(frozen=True)
 class PreflightReport:
+    status: str
+    installed_required: Tuple[str, ...]
     missing_required: Tuple[str, ...]
+    installed_recommended: Tuple[str, ...]
     missing_recommended: Tuple[str, ...]
 
 
+def _python3_is_available() -> bool:
+    if shutil.which("python3") is not None:
+        return True
+    return bool(sys.executable)
+
+
 def check_local_control_plane_deps() -> PreflightReport:
-    missing_required = tuple(
-        command for command in REQUIRED_COMMANDS if shutil.which(command) is None
-    )
-    missing_recommended = tuple(
-        command for command in RECOMMENDED_COMMANDS if shutil.which(command) is None
-    )
+    installed_required = []
+    missing_required = []
+    for command in REQUIRED_COMMANDS:
+        if command == "python3":
+            if _python3_is_available():
+                installed_required.append(command)
+            else:
+                missing_required.append(command)
+            continue
+        if shutil.which(command) is not None:
+            installed_required.append(command)
+        else:
+            missing_required.append(command)
+
+    installed_recommended = []
+    missing_recommended = []
+    for command in RECOMMENDED_COMMANDS:
+        if shutil.which(command) is not None:
+            installed_recommended.append(command)
+        else:
+            missing_recommended.append(command)
+
+    if missing_required:
+        status = "blocked"
+    elif missing_recommended:
+        status = "degraded"
+    else:
+        status = "ready"
+
     return PreflightReport(
-        missing_required=missing_required,
-        missing_recommended=missing_recommended,
+        status=status,
+        installed_required=tuple(installed_required),
+        missing_required=tuple(missing_required),
+        installed_recommended=tuple(installed_recommended),
+        missing_recommended=tuple(missing_recommended),
     )
 
 
 def ensure_local_control_plane_deps() -> PreflightReport:
     report = check_local_control_plane_deps()
-    if report.missing_required:
+    if report.status == "blocked":
         raise PreflightError(
             "missing local control-plane dependencies: "
             + ", ".join(report.missing_required)

--- a/tools/lib/preflight.py
+++ b/tools/lib/preflight.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+import shutil
+from typing import Tuple
+
+REQUIRED_COMMANDS = ("git", "ssh", "python3")
+RECOMMENDED_COMMANDS = ("gh",)
+
+
+class PreflightError(RuntimeError):
+    """Local control-plane dependency failure."""
+
+
+@dataclass(frozen=True)
+class PreflightReport:
+    missing_required: Tuple[str, ...]
+    missing_recommended: Tuple[str, ...]
+
+
+def check_local_control_plane_deps() -> PreflightReport:
+    missing_required = tuple(
+        command for command in REQUIRED_COMMANDS if shutil.which(command) is None
+    )
+    missing_recommended = tuple(
+        command for command in RECOMMENDED_COMMANDS if shutil.which(command) is None
+    )
+    return PreflightReport(
+        missing_required=missing_required,
+        missing_recommended=missing_recommended,
+    )
+
+
+def ensure_local_control_plane_deps() -> PreflightReport:
+    report = check_local_control_plane_deps()
+    if report.missing_required:
+        raise PreflightError(
+            "missing local control-plane dependencies: "
+            + ", ".join(report.missing_required)
+        )
+    return report

--- a/tools/lib/remote.py
+++ b/tools/lib/remote.py
@@ -114,6 +114,13 @@ def _load_auth_config(paths: RepoPaths) -> Dict[str, Any]:
     )
 
 
+def _load_servers_config(paths: RepoPaths) -> Dict[str, Any]:
+    return _read_yaml_mapping(
+        paths.local_servers_file,
+        "invalid server config: .workspace.local/servers.yaml",
+    )
+
+
 def _host_auth_ref(host_config: Dict[str, Any]) -> Optional[str]:
     auth_ref = host_config.get("ssh_auth_ref")
     if isinstance(auth_ref, str) and auth_ref.strip():
@@ -203,7 +210,118 @@ def _legacy_credential_group_from_auth(auth: Dict[str, Any], host: HostSpec) -> 
     )
 
 
-def resolve_target_context(paths: RepoPaths, target_name: str) -> TargetContext:
+def _context_from_inventory_record(
+    paths: RepoPaths,
+    record_kind: str,
+    record_name: str,
+    host_name: str,
+    host_config: Dict[str, Any],
+    runtime: Dict[str, Any],
+) -> TargetContext:
+    ssh_auth_ref = _host_auth_ref(host_config)
+    if not ssh_auth_ref:
+        raise RemoteError(
+            f"invalid {record_kind} config: {record_kind} '{record_name}' missing ssh_auth_ref"
+        )
+
+    host = HostSpec(
+        name=host_name,
+        host=_require_non_empty_string(
+            host_config.get("host"),
+            f"invalid {record_kind} config: host '{host_name}' missing host",
+        ),
+        port=_require_int_in_range(
+            host_config.get("port"),
+            f"invalid {record_kind} config: host '{host_name}' has invalid port",
+        ),
+        login_user=_require_non_empty_string(
+            host_config.get("login_user"),
+            f"invalid {record_kind} config: host '{host_name}' missing login_user",
+        ),
+        auth_group=_require_non_empty_string(
+            ssh_auth_ref,
+            f"invalid {record_kind} config: host '{host_name}' missing ssh_auth_ref",
+        ),
+        ssh_auth_ref=ssh_auth_ref,
+    )
+
+    image_ref = _require_non_empty_string(
+        runtime.get("image_ref"),
+        f"invalid {record_kind} config: {record_kind} '{record_name}' runtime.image_ref must be a non-empty string",
+    )
+    container_name = _require_non_empty_string(
+        runtime.get("container_name"),
+        f"invalid {record_kind} config: {record_kind} '{record_name}' runtime.container_name must be a non-empty string",
+    )
+    ssh_port = _require_int_in_range(
+        runtime.get("ssh_port"),
+        f"invalid {record_kind} config: {record_kind} '{record_name}' runtime.ssh_port must be in range 1..65535",
+    )
+    bootstrap_mode = _require_non_empty_string(
+        runtime.get("bootstrap_mode"),
+        f"invalid {record_kind} config: {record_kind} '{record_name}' runtime.bootstrap_mode must be a non-empty string",
+    )
+
+    workspace_root = runtime.get("workspace_root")
+    if not isinstance(workspace_root, str) or not workspace_root.strip():
+        workspace_root = DEFAULT_WORKSPACE_ROOT
+
+    host_workspace_path = runtime.get("host_workspace_path")
+    if not isinstance(host_workspace_path, str) or not host_workspace_path.strip():
+        host_workspace_path = f"{DEFAULT_HOST_WORKSPACE_BASE}/{record_name}/workspace"
+
+    docker_run_args = runtime.get("docker_run_args", [])
+    if isinstance(docker_run_args, str):
+        docker_args_list = [docker_run_args]
+    elif isinstance(docker_run_args, list) and all(
+        isinstance(item, str) and item.strip() for item in docker_run_args
+    ):
+        docker_args_list = [item.strip() for item in docker_run_args]
+    elif docker_run_args in (None, []):
+        docker_args_list = []
+    else:
+        raise RemoteError(
+            f"invalid {record_kind} config: {record_kind} '{record_name}' runtime.docker_run_args must be a string list"
+        )
+
+    auth = _load_auth_config(paths)
+    ssh_auth_ref = host.ssh_auth_ref or host.auth_group
+    ssh_auth = auth.get("ssh_auth")
+    if isinstance(ssh_auth, dict):
+        ssh_refs = ssh_auth.get("refs")
+        if not isinstance(ssh_refs, dict):
+            raise RemoteError("invalid auth config: missing ssh_auth.refs map")
+
+        credential_config = ssh_refs.get(ssh_auth_ref)
+        if not isinstance(credential_config, dict):
+            raise RemoteError(
+                f"invalid auth config: unknown ssh auth ref '{ssh_auth_ref}'"
+            )
+        credential = _credential_group_from_ref(
+            credential_config,
+            ssh_auth_ref,
+            host.login_user,
+        )
+    else:
+        credential = _legacy_credential_group_from_auth(auth, host)
+
+    return TargetContext(
+        name=record_name,
+        host=host,
+        credential=credential,
+        runtime=RuntimeSpec(
+            image_ref=image_ref,
+            container_name=container_name,
+            ssh_port=ssh_port,
+            workspace_root=workspace_root.strip(),
+            bootstrap_mode=bootstrap_mode,
+            host_workspace_path=host_workspace_path.strip(),
+            docker_run_args=docker_args_list,
+        ),
+    )
+
+
+def _resolve_legacy_target_context(paths: RepoPaths, target_name: str) -> TargetContext:
     config = _load_targets_config(paths)
     targets = config.get("targets")
     if not isinstance(targets, dict):
@@ -249,109 +367,56 @@ def resolve_target_context(paths: RepoPaths, target_name: str) -> TargetContext:
             f"invalid target config: target '{target_name}' references unknown host '{host_name}'"
         )
 
-    ssh_auth_ref = _host_auth_ref(host_config)
-    if not ssh_auth_ref:
+    return _context_from_inventory_record(
+        paths,
+        "target",
+        target_name,
+        host_name,
+        host_config,
+        runtime,
+    )
+
+
+def resolve_server_context(paths: RepoPaths, server_name: str) -> TargetContext:
+    config = _load_servers_config(paths)
+    servers = config.get("servers")
+    if not isinstance(servers, dict):
+        raise RemoteError("invalid server config: missing 'servers' map")
+
+    server = servers.get(server_name)
+    if not isinstance(server, dict):
+        raise RemoteError(f"unknown server: {server_name}")
+
+    runtime = server.get("runtime")
+    if not isinstance(runtime, dict):
         raise RemoteError(
-            f"invalid target config: host '{host_name}' missing ssh_auth_ref"
+            f"invalid server config: server '{server_name}' missing runtime map"
         )
 
-    host = HostSpec(
-        name=host_name,
-        host=_require_non_empty_string(
-            host_config.get("host"),
-            f"invalid target config: host '{host_name}' missing host",
-        ),
-        port=_require_int_in_range(
-            host_config.get("port"),
-            f"invalid target config: host '{host_name}' has invalid port",
-        ),
-        login_user=_require_non_empty_string(
-            host_config.get("login_user"),
-            f"invalid target config: host '{host_name}' missing login_user",
-        ),
-        auth_group=_require_non_empty_string(
-            ssh_auth_ref,
-            f"invalid target config: host '{host_name}' missing ssh_auth_ref",
-        ),
-        ssh_auth_ref=ssh_auth_ref,
+    return _context_from_inventory_record(
+        paths,
+        "server",
+        server_name,
+        server_name,
+        server,
+        runtime,
     )
 
-    image_ref = _require_non_empty_string(
-        runtime.get("image_ref"),
-        f"invalid target config: target '{target_name}' runtime.image_ref must be a non-empty string",
-    )
-    container_name = _require_non_empty_string(
-        runtime.get("container_name"),
-        f"invalid target config: target '{target_name}' runtime.container_name must be a non-empty string",
-    )
-    ssh_port = _require_int_in_range(
-        runtime.get("ssh_port"),
-        f"invalid target config: target '{target_name}' runtime.ssh_port must be in range 1..65535",
-    )
-    bootstrap_mode = _require_non_empty_string(
-        runtime.get("bootstrap_mode"),
-        f"invalid target config: target '{target_name}' runtime.bootstrap_mode must be a non-empty string",
-    )
 
-    workspace_root = runtime.get("workspace_root")
-    if not isinstance(workspace_root, str) or not workspace_root.strip():
-        workspace_root = DEFAULT_WORKSPACE_ROOT
+def resolve_target_context(paths: RepoPaths, target_name: str) -> TargetContext:
+    legacy_error: Optional[RemoteError] = None
+    try:
+        return _resolve_legacy_target_context(paths, target_name)
+    except RemoteError as exc:
+        legacy_error = exc
+        if str(exc) != f"unknown target: {target_name}":
+            raise
 
-    host_workspace_path = runtime.get("host_workspace_path")
-    if not isinstance(host_workspace_path, str) or not host_workspace_path.strip():
-        host_workspace_path = (
-            f"{DEFAULT_HOST_WORKSPACE_BASE}/{target_name}/workspace"
-        )
-
-    docker_run_args = runtime.get("docker_run_args", [])
-    if isinstance(docker_run_args, str):
-        docker_args_list = [docker_run_args]
-    elif isinstance(docker_run_args, list) and all(
-        isinstance(item, str) and item.strip() for item in docker_run_args
-    ):
-        docker_args_list = [item.strip() for item in docker_run_args]
-    elif docker_run_args in (None, []):
-        docker_args_list = []
-    else:
-        raise RemoteError(
-            f"invalid target config: target '{target_name}' runtime.docker_run_args must be a string list"
-        )
-
-    auth = _load_auth_config(paths)
-    ssh_auth_ref = host.ssh_auth_ref or host.auth_group
-    ssh_auth = auth.get("ssh_auth")
-    if isinstance(ssh_auth, dict):
-        ssh_refs = ssh_auth.get("refs")
-        if not isinstance(ssh_refs, dict):
-            raise RemoteError("invalid auth config: missing ssh_auth.refs map")
-
-        credential_config = ssh_refs.get(ssh_auth_ref)
-        if not isinstance(credential_config, dict):
-            raise RemoteError(
-                f"invalid auth config: unknown ssh auth ref '{ssh_auth_ref}'"
-            )
-        credential = _credential_group_from_ref(
-            credential_config,
-            ssh_auth_ref,
-            host.login_user,
-        )
-    else:
-        credential = _legacy_credential_group_from_auth(auth, host)
-
-    return TargetContext(
-        name=target_name,
-        host=host,
-        credential=credential,
-        runtime=RuntimeSpec(
-            image_ref=image_ref,
-            container_name=container_name,
-            ssh_port=ssh_port,
-            workspace_root=workspace_root.strip(),
-            bootstrap_mode=bootstrap_mode,
-            host_workspace_path=host_workspace_path.strip(),
-            docker_run_args=docker_args_list,
-        ),
-    )
+    try:
+        return resolve_server_context(paths, target_name)
+    except RemoteError:
+        assert legacy_error is not None
+        raise legacy_error
 
 
 def _runtime_state_file(runtime_root: Path) -> Path:
@@ -928,6 +993,63 @@ def ensure_runtime(paths: RepoPaths, ctx: TargetContext) -> Dict[str, Any]:
     if ctx.credential.mode == "local-simulation":
         return _ensure_simulation_runtime(paths, ctx)
     return _ensure_host_runtime(paths, ctx)
+
+
+def _verify_simulation_runtime(ctx: TargetContext) -> Dict[str, Any]:
+    runtime_root = _simulation_runtime_root(ctx)
+    runtime_state = _load_runtime_state(runtime_root)
+    if not runtime_state:
+        raise RemoteError(f"missing runtime state for server {ctx.name}")
+
+    endpoint = runtime_state.get("endpoint")
+    if not isinstance(endpoint, dict):
+        raise RemoteError(f"invalid runtime state for server {ctx.name}")
+
+    return {
+        "image_ref": ctx.runtime.image_ref,
+        "container_name": ctx.runtime.container_name,
+        "ssh_port": ctx.runtime.ssh_port,
+        "workspace_root": ctx.runtime.workspace_root,
+        "bootstrap_mode": ctx.runtime.bootstrap_mode,
+        "transport": endpoint.get("transport", "simulation"),
+        "container_endpoint": f"simulation://{ctx.host.name}{ctx.runtime.workspace_root}",
+        "host_name": ctx.host.name,
+        "host": ctx.host.host,
+        "host_port": ctx.host.port,
+        "login_user": ctx.host.login_user,
+        "host_workspace_path": str(runtime_root / "workspace"),
+    }
+
+
+def _verify_host_runtime(ctx: TargetContext) -> Dict[str, Any]:
+    probe = subprocess.run(
+        _ssh_base_command(ctx) + ["true"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if probe.returncode != 0:
+        raise RemoteError(f"unable to verify SSH access to host {ctx.host.host}")
+    return {
+        "image_ref": ctx.runtime.image_ref,
+        "container_name": ctx.runtime.container_name,
+        "ssh_port": ctx.runtime.ssh_port,
+        "workspace_root": ctx.runtime.workspace_root,
+        "bootstrap_mode": ctx.runtime.bootstrap_mode,
+        "transport": "ssh",
+        "container_endpoint": f"ssh://{ctx.credential.username}@{ctx.host.host}:{ctx.runtime.ssh_port}",
+        "host_name": ctx.host.name,
+        "host": ctx.host.host,
+        "host_port": ctx.host.port,
+        "login_user": ctx.host.login_user,
+        "host_workspace_path": ctx.runtime.host_workspace_path,
+    }
+
+
+def verify_runtime(paths: RepoPaths, ctx: TargetContext) -> Dict[str, Any]:
+    if ctx.credential.mode == "local-simulation":
+        return _verify_simulation_runtime(ctx)
+    return _verify_host_runtime(ctx)
 
 
 def create_remote_session(paths: RepoPaths, ctx: TargetContext, manifest: Dict[str, Any], transport: str) -> None:

--- a/tools/lib/remote.py
+++ b/tools/lib/remote.py
@@ -27,6 +27,8 @@ class CredentialGroup:
     username: str
     password: Optional[str] = None
     password_env: Optional[str] = None
+    key_path: Optional[str] = None
+    token_env: Optional[str] = None
     simulation_root: Optional[Path] = None
 
     @property
@@ -108,6 +110,85 @@ def _load_auth_config(paths: RepoPaths) -> Dict[str, Any]:
     return _read_yaml_mapping(
         paths.local_overlay / "auth.yaml",
         "invalid auth config: .workspace.local/auth.yaml",
+    )
+
+
+def _credential_group_from_ref(
+    ref: Dict[str, Any],
+    ref_name: str,
+    fallback_username: str,
+) -> CredentialGroup:
+    kind = _require_non_empty_string(
+        ref.get("kind"),
+        f"invalid auth config: ssh_auth ref '{ref_name}' missing kind",
+    )
+    username = ref.get("username", fallback_username)
+    if not isinstance(username, str) or not username.strip():
+        raise RemoteError(
+            f"invalid auth config: ssh_auth ref '{ref_name}' missing username"
+        )
+
+    simulation_root = ref.get("simulation_root")
+    simulation_root_path: Optional[Path] = None
+    if kind == "local-simulation":
+        if not isinstance(simulation_root, str) or not simulation_root.strip():
+            raise RemoteError(
+                f"invalid auth config: ssh_auth ref '{ref_name}' missing simulation_root"
+            )
+        simulation_root_path = Path(simulation_root)
+
+    return CredentialGroup(
+        mode=kind.strip(),
+        username=username.strip(),
+        password=ref.get("password"),
+        password_env=ref.get("password_env"),
+        key_path=ref.get("key_path"),
+        token_env=ref.get("token_env"),
+        simulation_root=simulation_root_path,
+    )
+
+
+def _legacy_credential_group_from_auth(auth: Dict[str, Any], host: HostSpec) -> CredentialGroup:
+    host_auth = auth.get("host_auth")
+    if not isinstance(host_auth, dict):
+        raise RemoteError("invalid auth config: missing ssh_auth.refs map")
+
+    mode = host_auth.get("mode", "ssh-key")
+    if not isinstance(mode, str) or not mode.strip():
+        raise RemoteError("invalid auth config: host_auth.mode must be a string")
+
+    credential_groups = host_auth.get("credential_groups")
+    if not isinstance(credential_groups, dict):
+        raise RemoteError("invalid auth config: missing host_auth.credential_groups map")
+
+    credential_config = credential_groups.get(host.auth_group)
+    if not isinstance(credential_config, dict):
+        raise RemoteError(f"invalid auth config: unknown auth group '{host.auth_group}'")
+
+    username = credential_config.get("username", host.login_user)
+    if not isinstance(username, str) or not username.strip():
+        raise RemoteError(
+            f"invalid auth config: auth group '{host.auth_group}' missing username"
+        )
+
+    simulation_root = credential_config.get("simulation_root")
+    if mode == "local-simulation":
+        if not isinstance(simulation_root, str) or not simulation_root.strip():
+            raise RemoteError(
+                f"invalid auth config: auth group '{host.auth_group}' missing simulation_root"
+            )
+        simulation_root_path = Path(simulation_root)
+    else:
+        simulation_root_path = None
+
+    return CredentialGroup(
+        mode=mode.strip(),
+        username=username.strip(),
+        password=credential_config.get("password"),
+        password_env=credential_config.get("password_env"),
+        key_path=credential_config.get("key_path"),
+        token_env=credential_config.get("token_env"),
+        simulation_root=simulation_root_path,
     )
 
 
@@ -219,45 +300,24 @@ def resolve_target_context(paths: RepoPaths, target_name: str) -> TargetContext:
         )
 
     auth = _load_auth_config(paths)
-    host_auth = auth.get("host_auth")
-    if not isinstance(host_auth, dict):
-        raise RemoteError("invalid auth config: missing host_auth map")
+    ssh_auth = auth.get("ssh_auth")
+    if isinstance(ssh_auth, dict):
+        ssh_refs = ssh_auth.get("refs")
+        if not isinstance(ssh_refs, dict):
+            raise RemoteError("invalid auth config: missing ssh_auth.refs map")
 
-    mode = host_auth.get("mode", "ssh-key")
-    if not isinstance(mode, str) or not mode.strip():
-        raise RemoteError("invalid auth config: host_auth.mode must be a string")
-
-    credential_groups = host_auth.get("credential_groups")
-    if not isinstance(credential_groups, dict):
-        raise RemoteError("invalid auth config: missing host_auth.credential_groups map")
-
-    credential_config = credential_groups.get(host.auth_group)
-    if not isinstance(credential_config, dict):
-        raise RemoteError(f"invalid auth config: unknown auth group '{host.auth_group}'")
-
-    username = credential_config.get("username", host.login_user)
-    if not isinstance(username, str) or not username.strip():
-        raise RemoteError(
-            f"invalid auth config: auth group '{host.auth_group}' missing username"
-        )
-
-    simulation_root = credential_config.get("simulation_root")
-    if mode == "local-simulation":
-        if not isinstance(simulation_root, str) or not simulation_root.strip():
+        credential_config = ssh_refs.get(host.auth_group)
+        if not isinstance(credential_config, dict):
             raise RemoteError(
-                f"invalid auth config: auth group '{host.auth_group}' missing simulation_root"
+                f"invalid auth config: unknown ssh auth ref '{host.auth_group}'"
             )
-        simulation_root_path = Path(simulation_root)
+        credential = _credential_group_from_ref(
+            credential_config,
+            host.auth_group,
+            host.login_user,
+        )
     else:
-        simulation_root_path = None
-
-    credential = CredentialGroup(
-        mode=mode.strip(),
-        username=username.strip(),
-        password=credential_config.get("password"),
-        password_env=credential_config.get("password_env"),
-        simulation_root=simulation_root_path,
-    )
+        credential = _legacy_credential_group_from_auth(auth, host)
 
     return TargetContext(
         name=target_name,

--- a/tools/lib/remote.py
+++ b/tools/lib/remote.py
@@ -49,6 +49,7 @@ class HostSpec:
     port: int
     login_user: str
     auth_group: str
+    ssh_auth_ref: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -111,6 +112,16 @@ def _load_auth_config(paths: RepoPaths) -> Dict[str, Any]:
         paths.local_overlay / "auth.yaml",
         "invalid auth config: .workspace.local/auth.yaml",
     )
+
+
+def _host_auth_ref(host_config: Dict[str, Any]) -> Optional[str]:
+    auth_ref = host_config.get("ssh_auth_ref")
+    if isinstance(auth_ref, str) and auth_ref.strip():
+        return auth_ref.strip()
+    auth_group = host_config.get("auth_group")
+    if isinstance(auth_group, str) and auth_group.strip():
+        return auth_group.strip()
+    return None
 
 
 def _credential_group_from_ref(
@@ -238,6 +249,12 @@ def resolve_target_context(paths: RepoPaths, target_name: str) -> TargetContext:
             f"invalid target config: target '{target_name}' references unknown host '{host_name}'"
         )
 
+    ssh_auth_ref = _host_auth_ref(host_config)
+    if not ssh_auth_ref:
+        raise RemoteError(
+            f"invalid target config: host '{host_name}' missing ssh_auth_ref"
+        )
+
     host = HostSpec(
         name=host_name,
         host=_require_non_empty_string(
@@ -253,9 +270,10 @@ def resolve_target_context(paths: RepoPaths, target_name: str) -> TargetContext:
             f"invalid target config: host '{host_name}' missing login_user",
         ),
         auth_group=_require_non_empty_string(
-            host_config.get("auth_group"),
-            f"invalid target config: host '{host_name}' missing auth_group",
+            ssh_auth_ref,
+            f"invalid target config: host '{host_name}' missing ssh_auth_ref",
         ),
+        ssh_auth_ref=ssh_auth_ref,
     )
 
     image_ref = _require_non_empty_string(
@@ -300,20 +318,21 @@ def resolve_target_context(paths: RepoPaths, target_name: str) -> TargetContext:
         )
 
     auth = _load_auth_config(paths)
+    ssh_auth_ref = host.ssh_auth_ref or host.auth_group
     ssh_auth = auth.get("ssh_auth")
     if isinstance(ssh_auth, dict):
         ssh_refs = ssh_auth.get("refs")
         if not isinstance(ssh_refs, dict):
             raise RemoteError("invalid auth config: missing ssh_auth.refs map")
 
-        credential_config = ssh_refs.get(host.auth_group)
+        credential_config = ssh_refs.get(ssh_auth_ref)
         if not isinstance(credential_config, dict):
             raise RemoteError(
-                f"invalid auth config: unknown ssh auth ref '{host.auth_group}'"
+                f"invalid auth config: unknown ssh auth ref '{ssh_auth_ref}'"
             )
         credential = _credential_group_from_ref(
             credential_config,
-            host.auth_group,
+            ssh_auth_ref,
             host.login_user,
         )
     else:
@@ -567,6 +586,8 @@ def _ssh_base_command(
         "-p",
         str(target_port),
     ]
+    if ctx.credential.key_path:
+        command.extend(["-i", ctx.credential.key_path])
     if batch_mode:
         command.extend(["-o", "BatchMode=yes"])
     user = ctx.credential.username if username is None else username

--- a/tools/lib/remote.py
+++ b/tools/lib/remote.py
@@ -128,6 +128,20 @@ class VerificationResult:
 
 
 @dataclass(frozen=True)
+class CleanupResult:
+    server_name: str
+    status: str
+    detail: str
+
+    def to_mapping(self) -> Dict[str, Any]:
+        return {
+            "server_name": self.server_name,
+            "status": self.status,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
 class TargetContext:
     name: str
     host: HostSpec
@@ -484,6 +498,21 @@ def resolve_server_context(paths: RepoPaths, server_name: str) -> TargetContext:
     )
 
 
+def list_managed_server_names(paths: RepoPaths) -> List[str]:
+    try:
+        config = _load_servers_config(paths)
+    except RemoteError:
+        return []
+    servers = config.get("servers")
+    if not isinstance(servers, dict):
+        return []
+    return sorted(
+        name.strip()
+        for name in servers
+        if isinstance(name, str) and name.strip()
+    )
+
+
 def resolve_target_context(paths: RepoPaths, target_name: str) -> TargetContext:
     legacy_error: Optional[RemoteError] = None
     try:
@@ -533,6 +562,132 @@ def persist_server_verification(
     server_verifications[server_name] = verification.to_mapping()
     state["server_verifications"] = server_verifications
     write_state(paths, state)
+
+
+def _simulation_runtime_status(ctx: TargetContext) -> str:
+    runtime_root = _simulation_runtime_root(ctx)
+    if not runtime_root.exists():
+        return "absent"
+    return "present"
+
+
+def _host_runtime_status(ctx: TargetContext) -> str:
+    probe = subprocess.run(
+        _ssh_base_command(ctx) + ["true"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if probe.returncode != 0:
+        raise RemoteError(
+            f"unable to probe host {ctx.host.host}: {(probe.stderr or probe.stdout or 'SSH probe failed').strip()}"
+        )
+
+    script = "\n".join(
+        [
+            "set -e",
+            f"container_names=$(docker container ls -a --format '{{{{.Names}}}}')",
+            f"if printf '%s\\n' \"$container_names\" | grep -Fqx {shlex.quote(ctx.runtime.container_name)}; then",
+            "  echo present",
+            f"elif [ -e {shlex.quote(ctx.runtime.host_workspace_path)} ]; then",
+            "  echo present",
+            "else",
+            "  echo absent",
+            "fi",
+        ]
+    )
+    result = _run_host_command(ctx, script)
+    if result.returncode != 0:
+        raise RemoteError(
+            f"failed to inspect remote runtime for server '{ctx.name}': {(result.stderr or result.stdout).strip()}"
+        )
+    return result.stdout.strip() or "present"
+
+
+def cleanup_runtime(ctx: TargetContext) -> CleanupResult:
+    if ctx.credential.mode == "local-simulation":
+        if _simulation_runtime_status(ctx) == "absent":
+            return CleanupResult(
+                server_name=ctx.name,
+                status="already_absent",
+                detail="simulation runtime already absent",
+            )
+        try:
+            destroy_runtime(ctx)
+        except RemoteError as exc:
+            return CleanupResult(
+                server_name=ctx.name,
+                status="cleanup_failed",
+                detail=str(exc),
+            )
+        return CleanupResult(
+            server_name=ctx.name,
+            status="removed",
+            detail="simulation runtime removed",
+        )
+
+    try:
+        status = _host_runtime_status(ctx)
+    except RemoteError as exc:
+        message = str(exc)
+        if "probe" in message or "ssh" in message or "authenticate" in message:
+            return CleanupResult(
+                server_name=ctx.name,
+                status="unreachable",
+                detail=message,
+            )
+        return CleanupResult(
+            server_name=ctx.name,
+            status="cleanup_failed",
+            detail=message,
+        )
+
+    if status == "absent":
+        return CleanupResult(
+            server_name=ctx.name,
+            status="already_absent",
+            detail="remote runtime already absent",
+        )
+
+    try:
+        destroy_runtime(ctx)
+    except RemoteError as exc:
+        message = str(exc)
+        if "probe" in message or "ssh" in message or "authenticate" in message:
+            return CleanupResult(
+                server_name=ctx.name,
+                status="unreachable",
+                detail=message,
+            )
+        return CleanupResult(
+            server_name=ctx.name,
+            status="cleanup_failed",
+            detail=message,
+        )
+
+    return CleanupResult(
+        server_name=ctx.name,
+        status="removed",
+        detail="remote runtime removed",
+    )
+
+
+def cleanup_managed_servers(paths: RepoPaths) -> List[CleanupResult]:
+    results: List[CleanupResult] = []
+    for server_name in list_managed_server_names(paths):
+        try:
+            context = resolve_server_context(paths, server_name)
+        except RemoteError as exc:
+            results.append(
+                CleanupResult(
+                    server_name=server_name,
+                    status="cleanup_failed",
+                    detail=str(exc),
+                )
+            )
+            continue
+        results.append(cleanup_runtime(context))
+    return results
 
 
 def _runtime_state_file(runtime_root: Path) -> Path:

--- a/tools/lib/remote.py
+++ b/tools/lib/remote.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 import yaml
 
 from .config import RepoPaths
+from .runtime import read_state, write_state
 
 DEFAULT_HOST_WORKSPACE_BASE = "/root/.vaws/targets"
 DEFAULT_WORKSPACE_ROOT = "/vllm-workspace"
@@ -61,6 +62,69 @@ class RuntimeSpec:
     bootstrap_mode: str
     host_workspace_path: str
     docker_run_args: List[str]
+
+
+@dataclass(frozen=True)
+class VerificationCheck:
+    name: str
+    status: str
+    detail: Optional[str] = None
+
+    def to_mapping(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "name": self.name,
+            "status": self.status,
+        }
+        if self.detail is not None:
+            payload["detail"] = self.detail
+        return payload
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    status: str
+    summary: str
+    checks: List[VerificationCheck]
+    runtime: Dict[str, Any]
+
+    @classmethod
+    def ready(
+        cls,
+        *,
+        summary: str,
+        runtime: Dict[str, Any],
+        checks: Optional[List[VerificationCheck]] = None,
+    ) -> "VerificationResult":
+        return cls(
+            status="ready",
+            summary=summary,
+            checks=list(checks or []),
+            runtime=dict(runtime),
+        )
+
+    @classmethod
+    def needs_repair(
+        cls,
+        *,
+        summary: str,
+        runtime: Dict[str, Any],
+        checks: List[VerificationCheck],
+    ) -> "VerificationResult":
+        return cls(
+            status="needs_repair",
+            summary=summary,
+            checks=list(checks),
+            runtime=dict(runtime),
+        )
+
+    def to_mapping(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_mapping() for check in self.checks],
+            "runtime": dict(self.runtime),
+        }
+        return payload
 
 
 @dataclass(frozen=True)
@@ -321,6 +385,23 @@ def _context_from_inventory_record(
     )
 
 
+def _verification_runtime_payload(ctx: TargetContext, **extra: Any) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "image_ref": ctx.runtime.image_ref,
+        "container_name": ctx.runtime.container_name,
+        "ssh_port": ctx.runtime.ssh_port,
+        "workspace_root": ctx.runtime.workspace_root,
+        "bootstrap_mode": ctx.runtime.bootstrap_mode,
+        "host_name": ctx.host.name,
+        "host": ctx.host.host,
+        "host_port": ctx.host.port,
+        "login_user": ctx.host.login_user,
+        "host_workspace_path": ctx.runtime.host_workspace_path,
+    }
+    payload.update(extra)
+    return payload
+
+
 def _resolve_legacy_target_context(paths: RepoPaths, target_name: str) -> TargetContext:
     config = _load_targets_config(paths)
     targets = config.get("targets")
@@ -417,6 +498,41 @@ def resolve_target_context(paths: RepoPaths, target_name: str) -> TargetContext:
     except RemoteError:
         assert legacy_error is not None
         raise legacy_error
+
+
+def persist_server_verification(
+    paths: RepoPaths,
+    server_name: str,
+    verification: VerificationResult,
+) -> None:
+    config = _load_servers_config(paths)
+    servers = config.get("servers")
+    if not isinstance(servers, dict):
+        raise RemoteError("invalid server config: missing 'servers' map")
+
+    server = servers.get(server_name)
+    if not isinstance(server, dict):
+        raise RemoteError(f"unknown server: {server_name}")
+
+    server["status"] = verification.status
+    server["verification"] = verification.to_mapping()
+    config["version"] = 1
+    config["servers"] = servers
+    paths.local_servers_file.write_text(
+        yaml.safe_dump(config, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    state = read_state(paths)
+    server_verifications = state.get("server_verifications")
+    if server_verifications is None:
+        server_verifications = {}
+    elif not isinstance(server_verifications, dict):
+        raise RemoteError("invalid runtime state: .workspace.local/state.json")
+
+    server_verifications[server_name] = verification.to_mapping()
+    state["server_verifications"] = server_verifications
+    write_state(paths, state)
 
 
 def _runtime_state_file(runtime_root: Path) -> Path:
@@ -995,33 +1111,63 @@ def ensure_runtime(paths: RepoPaths, ctx: TargetContext) -> Dict[str, Any]:
     return _ensure_host_runtime(paths, ctx)
 
 
-def _verify_simulation_runtime(ctx: TargetContext) -> Dict[str, Any]:
+def _verify_simulation_runtime(ctx: TargetContext) -> VerificationResult:
     runtime_root = _simulation_runtime_root(ctx)
     runtime_state = _load_runtime_state(runtime_root)
     if not runtime_state:
-        raise RemoteError(f"missing runtime state for server {ctx.name}")
+        return VerificationResult.needs_repair(
+            summary=f"missing runtime state for server {ctx.name}",
+            runtime=_verification_runtime_payload(
+                ctx,
+                transport="simulation",
+                container_endpoint=f"simulation://{ctx.host.name}{ctx.runtime.workspace_root}",
+            ),
+            checks=[
+                VerificationCheck(
+                    name="runtime_state",
+                    status="needs_repair",
+                    detail="missing runtime state",
+                )
+            ],
+        )
 
     endpoint = runtime_state.get("endpoint")
     if not isinstance(endpoint, dict):
-        raise RemoteError(f"invalid runtime state for server {ctx.name}")
+        return VerificationResult.needs_repair(
+            summary=f"invalid runtime state for server {ctx.name}",
+            runtime=_verification_runtime_payload(
+                ctx,
+                transport="simulation",
+                container_endpoint=f"simulation://{ctx.host.name}{ctx.runtime.workspace_root}",
+            ),
+            checks=[
+                VerificationCheck(
+                    name="runtime_state",
+                    status="needs_repair",
+                    detail="invalid runtime state",
+                )
+            ],
+        )
 
-    return {
-        "image_ref": ctx.runtime.image_ref,
-        "container_name": ctx.runtime.container_name,
-        "ssh_port": ctx.runtime.ssh_port,
-        "workspace_root": ctx.runtime.workspace_root,
-        "bootstrap_mode": ctx.runtime.bootstrap_mode,
-        "transport": endpoint.get("transport", "simulation"),
-        "container_endpoint": f"simulation://{ctx.host.name}{ctx.runtime.workspace_root}",
-        "host_name": ctx.host.name,
-        "host": ctx.host.host,
-        "host_port": ctx.host.port,
-        "login_user": ctx.host.login_user,
-        "host_workspace_path": str(runtime_root / "workspace"),
-    }
+    return VerificationResult.ready(
+        summary=f"runtime ready for server {ctx.name}",
+        runtime=_verification_runtime_payload(
+            ctx,
+            transport=endpoint.get("transport", "simulation"),
+            container_endpoint=f"simulation://{ctx.host.name}{ctx.runtime.workspace_root}",
+            host_workspace_path=str(runtime_root / "workspace"),
+        ),
+        checks=[
+            VerificationCheck(
+                name="runtime_state",
+                status="ready",
+                detail="runtime state available",
+            )
+        ],
+    )
 
 
-def _verify_host_runtime(ctx: TargetContext) -> Dict[str, Any]:
+def _verify_host_runtime(ctx: TargetContext) -> VerificationResult:
     probe = subprocess.run(
         _ssh_base_command(ctx) + ["true"],
         text=True,
@@ -1029,24 +1175,41 @@ def _verify_host_runtime(ctx: TargetContext) -> Dict[str, Any]:
         check=False,
     )
     if probe.returncode != 0:
-        raise RemoteError(f"unable to verify SSH access to host {ctx.host.host}")
-    return {
-        "image_ref": ctx.runtime.image_ref,
-        "container_name": ctx.runtime.container_name,
-        "ssh_port": ctx.runtime.ssh_port,
-        "workspace_root": ctx.runtime.workspace_root,
-        "bootstrap_mode": ctx.runtime.bootstrap_mode,
-        "transport": "ssh",
-        "container_endpoint": f"ssh://{ctx.credential.username}@{ctx.host.host}:{ctx.runtime.ssh_port}",
-        "host_name": ctx.host.name,
-        "host": ctx.host.host,
-        "host_port": ctx.host.port,
-        "login_user": ctx.host.login_user,
-        "host_workspace_path": ctx.runtime.host_workspace_path,
-    }
+        return VerificationResult.needs_repair(
+            summary=f"unable to verify SSH access to host {ctx.host.host}",
+            runtime=_verification_runtime_payload(
+                ctx,
+                transport="ssh",
+                container_endpoint=(
+                    f"ssh://{ctx.credential.username}@{ctx.host.host}:{ctx.runtime.ssh_port}"
+                ),
+            ),
+            checks=[
+                VerificationCheck(
+                    name="ssh_access",
+                    status="needs_repair",
+                    detail=(probe.stderr or probe.stdout or "SSH probe failed").strip(),
+                )
+            ],
+        )
+    return VerificationResult.ready(
+        summary=f"runtime ready for host {ctx.host.host}",
+        runtime=_verification_runtime_payload(
+            ctx,
+            transport="ssh",
+            container_endpoint=f"ssh://{ctx.credential.username}@{ctx.host.host}:{ctx.runtime.ssh_port}",
+        ),
+        checks=[
+            VerificationCheck(
+                name="ssh_access",
+                status="ready",
+                detail="SSH probe succeeded",
+            )
+        ],
+    )
 
 
-def verify_runtime(paths: RepoPaths, ctx: TargetContext) -> Dict[str, Any]:
+def verify_runtime(paths: RepoPaths, ctx: TargetContext) -> VerificationResult:
     if ctx.credential.mode == "local-simulation":
         return _verify_simulation_runtime(ctx)
     return _verify_host_runtime(ctx)

--- a/tools/lib/reset.py
+++ b/tools/lib/reset.py
@@ -5,11 +5,18 @@ import secrets
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from .bootstrap import COMMUNITY_UPSTREAM_URLS
 from .config import RepoPaths
-from .remote import RemoteError, destroy_runtime, resolve_target_context
+from .remote import (
+    CleanupResult,
+    RemoteError,
+    cleanup_runtime,
+    list_managed_server_names,
+    resolve_server_context,
+    resolve_target_context,
+)
 from .runtime import read_state, write_state
 
 CONFIRMATION_PHRASE = "I authorize wiping local workspace identity and remote runtime"
@@ -103,13 +110,34 @@ def _cleanup_local_state(paths: RepoPaths) -> None:
     paths.local_repos_file.write_text("", encoding="utf-8")
 
 
-def _cleanup_remote_state(request: Dict[str, Any], paths: RepoPaths) -> None:
-    approved_target = request.get("approved_target")
-    if not isinstance(approved_target, str) or not approved_target.strip():
-        return
+def cleanup_server_runtime(paths: RepoPaths, server_name: str) -> CleanupResult:
+    try:
+        context = resolve_server_context(paths, server_name)
+    except RemoteError:
+        context = resolve_target_context(paths, server_name)
+    return cleanup_runtime(context)
 
-    context = resolve_target_context(paths, approved_target.strip())
-    destroy_runtime(context)
+
+def _cleanup_remote_state(request: Dict[str, Any], paths: RepoPaths) -> List[CleanupResult]:
+    server_names = list_managed_server_names(paths)
+    if not server_names:
+        approved_target = request.get("approved_target")
+        if isinstance(approved_target, str) and approved_target.strip():
+            server_names = [approved_target.strip()]
+
+    results: List[CleanupResult] = []
+    for server_name in server_names:
+        try:
+            results.append(cleanup_server_runtime(paths, server_name))
+        except (RemoteError, RuntimeError) as exc:
+            results.append(
+                CleanupResult(
+                    server_name=server_name,
+                    status="cleanup_failed",
+                    detail=str(exc),
+                )
+            )
+    return results
 
 
 def _run_git(repo_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -187,11 +215,10 @@ def execute_reset(
         print("reset execute: confirmation phrase must exactly match the approved phrase")
         return 1
 
-    try:
-        _cleanup_remote_state(request, paths)
-    except RemoteError as exc:
-        print(f"reset execute: failed to clean remote runtime: {exc}")
-        return 1
+    remote_results = _cleanup_remote_state(request, paths)
+    for result in remote_results:
+        detail = f" ({result.detail})" if result.detail else ""
+        print(f"reset execute: server {result.server_name}: {result.status}{detail}")
 
     try:
         _cleanup_local_state(paths)

--- a/tools/lib/runtime.py
+++ b/tools/lib/runtime.py
@@ -5,6 +5,26 @@ from .config import RepoPaths
 from .overlay import OVERLAY_SCHEMA_VERSION
 
 
+def _normalize_state_for_write(state: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(state, dict):
+        raise RuntimeError("invalid runtime state: .workspace.local/state.json")
+
+    normalized = dict(state)
+    schema_version = normalized.get("schema_version")
+    if schema_version is None:
+        normalized["schema_version"] = OVERLAY_SCHEMA_VERSION
+        return normalized
+
+    if isinstance(schema_version, bool) or not isinstance(schema_version, int):
+        raise RuntimeError("invalid runtime state: .workspace.local/state.json")
+    if schema_version != OVERLAY_SCHEMA_VERSION:
+        raise RuntimeError(
+            "unsupported runtime state schema_version: "
+            f"{schema_version}"
+        )
+    return normalized
+
+
 def read_state(paths: RepoPaths) -> Dict[str, Any]:
     state_file = paths.local_state_file
     if not state_file.exists():
@@ -21,13 +41,14 @@ def read_state(paths: RepoPaths) -> Dict[str, Any]:
 
 
 def ensure_state_schema(paths: RepoPaths) -> Dict[str, Any]:
-    state = read_state(paths)
-    if "schema_version" not in state:
-        state["schema_version"] = OVERLAY_SCHEMA_VERSION
-    return state
+    return _normalize_state_for_write(read_state(paths))
 
 
 def write_state(paths: RepoPaths, state: Dict[str, Any]) -> None:
     state_file = paths.local_state_file
     state_file.parent.mkdir(parents=True, exist_ok=True)
-    state_file.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+    normalized_state = _normalize_state_for_write(state)
+    state_file.write_text(
+        json.dumps(normalized_state, indent=2) + "\n",
+        encoding="utf-8",
+    )

--- a/tools/lib/runtime.py
+++ b/tools/lib/runtime.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, Dict
 
 from .config import RepoPaths
+from .overlay import OVERLAY_SCHEMA_VERSION
 
 
 def read_state(paths: RepoPaths) -> Dict[str, Any]:
@@ -22,7 +23,7 @@ def read_state(paths: RepoPaths) -> Dict[str, Any]:
 def ensure_state_schema(paths: RepoPaths) -> Dict[str, Any]:
     state = read_state(paths)
     if "schema_version" not in state:
-        state["schema_version"] = 1
+        state["schema_version"] = OVERLAY_SCHEMA_VERSION
     return state
 
 

--- a/tools/lib/runtime.py
+++ b/tools/lib/runtime.py
@@ -5,7 +5,7 @@ from .config import RepoPaths
 
 
 def read_state(paths: RepoPaths) -> Dict[str, Any]:
-    state_file = paths.local_overlay / "state.json"
+    state_file = paths.local_state_file
     if not state_file.exists():
         return {}
 
@@ -19,7 +19,14 @@ def read_state(paths: RepoPaths) -> Dict[str, Any]:
     return data
 
 
+def ensure_state_schema(paths: RepoPaths) -> Dict[str, Any]:
+    state = read_state(paths)
+    if "schema_version" not in state:
+        state["schema_version"] = 1
+    return state
+
+
 def write_state(paths: RepoPaths, state: Dict[str, Any]) -> None:
-    state_file = paths.local_overlay / "state.json"
+    state_file = paths.local_state_file
     state_file.parent.mkdir(parents=True, exist_ok=True)
     state_file.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")

--- a/tools/lib/session.py
+++ b/tools/lib/session.py
@@ -163,7 +163,11 @@ def switch_session(paths: RepoPaths, session_name: str) -> int:
         return 1
 
     state["current_session"] = session_name
-    write_state(paths, state)
+    try:
+        write_state(paths, state)
+    except RuntimeError as exc:
+        print(str(exc))
+        return 1
     print(f"session switch: ok ({session_name})")
     return 0
 

--- a/tools/lib/targets.py
+++ b/tools/lib/targets.py
@@ -1,11 +1,24 @@
 from .config import RepoPaths
-from .remote import RemoteError, ensure_runtime, resolve_target_context
+from .remote import (
+    RemoteError,
+    ensure_runtime,
+    resolve_server_context,
+    resolve_target_context,
+)
 from .runtime import read_state, write_state
 
 
 def ensure_target(paths: RepoPaths, target_name: str) -> int:
+    print(
+        "target ensure: deprecated shim; use `vaws fleet` for server inventory management"
+    )
     try:
-        context = resolve_target_context(paths, target_name)
+        try:
+            context = resolve_server_context(paths, target_name)
+            routed_via = "fleet server inventory"
+        except RemoteError:
+            context = resolve_target_context(paths, target_name)
+            routed_via = "legacy target config"
         persisted_runtime = ensure_runtime(paths, context)
         state = read_state(paths)
     except RemoteError as exc:
@@ -22,5 +35,6 @@ def ensure_target(paths: RepoPaths, target_name: str) -> int:
     except RuntimeError as exc:
         print(str(exc))
         return 1
+    print(f"target ensure: routed via {routed_via}")
     print(f"target ensure: ok ({target_name})")
     return 0

--- a/tools/lib/targets.py
+++ b/tools/lib/targets.py
@@ -17,6 +17,10 @@ def ensure_target(paths: RepoPaths, target_name: str) -> int:
 
     state["current_target"] = target_name
     state["runtime"] = persisted_runtime
-    write_state(paths, state)
+    try:
+        write_state(paths, state)
+    except RuntimeError as exc:
+        print(str(exc))
+        return 1
     print(f"target ensure: ok ({target_name})")
     return 0

--- a/tools/lib/targets.py
+++ b/tools/lib/targets.py
@@ -25,10 +25,14 @@ def ensure_target(paths: RepoPaths, target_name: str) -> int:
             context = server_context
             routed_via = "fleet verification behavior"
             try:
-                persisted_runtime = verify_runtime(paths, context)
+                verification = verify_runtime(paths, context)
+                if verification.status != "ready":
+                    persisted_runtime = ensure_runtime(paths, context)
+                    verification = verify_runtime(paths, context)
+                persisted_runtime = verification.runtime
             except RemoteError:
                 persisted_runtime = ensure_runtime(paths, context)
-                persisted_runtime = verify_runtime(paths, context)
+                persisted_runtime = verify_runtime(paths, context).runtime
         else:
             persisted_runtime = ensure_runtime(paths, context)
         state = read_state(paths)

--- a/tools/lib/targets.py
+++ b/tools/lib/targets.py
@@ -4,6 +4,7 @@ from .remote import (
     ensure_runtime,
     resolve_server_context,
     resolve_target_context,
+    verify_runtime,
 )
 from .runtime import read_state, write_state
 
@@ -13,13 +14,23 @@ def ensure_target(paths: RepoPaths, target_name: str) -> int:
         "target ensure: deprecated shim; use `vaws fleet` for server inventory management"
     )
     try:
+        routed_via = "legacy target config"
+        context = resolve_target_context(paths, target_name)
         try:
-            context = resolve_server_context(paths, target_name)
-            routed_via = "fleet server inventory"
+            server_context = resolve_server_context(paths, context.host.name)
         except RemoteError:
-            context = resolve_target_context(paths, target_name)
-            routed_via = "legacy target config"
-        persisted_runtime = ensure_runtime(paths, context)
+            server_context = None
+
+        if server_context is not None:
+            context = server_context
+            routed_via = "fleet verification behavior"
+            try:
+                persisted_runtime = verify_runtime(paths, context)
+            except RemoteError:
+                persisted_runtime = ensure_runtime(paths, context)
+                persisted_runtime = verify_runtime(paths, context)
+        else:
+            persisted_runtime = ensure_runtime(paths, context)
         state = read_state(paths)
     except RemoteError as exc:
         print(str(exc))

--- a/tools/vaws.py
+++ b/tools/vaws.py
@@ -23,7 +23,10 @@ def build_parser() -> argparse.ArgumentParser:
     init_parser.add_argument("--bootstrap", action="store_true")
     init_parser.add_argument("--target-name", default="single-default")
     init_parser.add_argument("--host-name", default="host-a")
-    init_parser.add_argument("--server-host")
+    init_parser.add_argument(
+        "--server-host",
+        help="bootstrap server host; omit for local-only baseline",
+    )
     init_parser.add_argument("--server-user", default="root")
     init_parser.add_argument("--server-port", type=int, default=22)
     init_parser.add_argument("--server-auth-mode", default="ssh-key")

--- a/tools/vaws.py
+++ b/tools/vaws.py
@@ -90,11 +90,10 @@ def build_parser() -> argparse.ArgumentParser:
     fleet_subparsers.add_parser("list")
     fleet_add_parser = fleet_subparsers.add_parser("add")
     fleet_add_parser.add_argument("server_name")
-    fleet_add_parser.add_argument("--host", required=True)
-    fleet_add_parser.add_argument("--login-user", required=True)
-    fleet_add_parser.add_argument("--port", type=int, default=22)
-    fleet_add_parser.add_argument("--ssh-auth-ref", default="default-server-auth")
-    fleet_add_parser.add_argument("--status", default="pending")
+    fleet_add_parser.add_argument("--server-host", required=True)
+    fleet_add_parser.add_argument("--server-user", default="root")
+    fleet_add_parser.add_argument("--server-port", type=int, default=22)
+    fleet_add_parser.add_argument("--ssh-auth-ref", required=True)
     fleet_add_parser.add_argument(
         "--runtime-image",
         default="quay.nju.edu.cn/ascend/vllm-ascend:latest",
@@ -172,11 +171,10 @@ def main(argv: Optional[List[str]] = None) -> int:
         return add_fleet_server(
             paths,
             args.server_name,
-            args.host,
-            args.login_user,
-            port=args.port,
+            args.server_host,
             ssh_auth_ref=args.ssh_auth_ref,
-            status=args.status,
+            server_user=args.server_user,
+            server_port=args.server_port,
             runtime_image=args.runtime_image,
             runtime_container=args.runtime_container,
             runtime_ssh_port=args.runtime_ssh_port,

--- a/tools/vaws.py
+++ b/tools/vaws.py
@@ -8,6 +8,7 @@ if __package__ in (None, ""):
 
 from tools.lib.bootstrap import bootstrap_init, bootstrap_request_from_args
 from tools.lib.config import RepoPaths
+from tools.lib.fleet import add_fleet_server, list_fleet, verify_fleet_server
 from tools.lib.doctor import doctor, init
 from tools.lib.gitflow import default_base_ref
 from tools.lib.reset import execute_reset, prepare_reset
@@ -83,6 +84,33 @@ def build_parser() -> argparse.ArgumentParser:
     switch_parser = session_subparsers.add_parser("switch")
     switch_parser.add_argument("session_name")
     session_subparsers.add_parser("status")
+
+    fleet_parser = subparsers.add_parser("fleet")
+    fleet_subparsers = fleet_parser.add_subparsers(dest="fleet_command", required=True)
+    fleet_subparsers.add_parser("list")
+    fleet_add_parser = fleet_subparsers.add_parser("add")
+    fleet_add_parser.add_argument("server_name")
+    fleet_add_parser.add_argument("--host", required=True)
+    fleet_add_parser.add_argument("--login-user", required=True)
+    fleet_add_parser.add_argument("--port", type=int, default=22)
+    fleet_add_parser.add_argument("--ssh-auth-ref", default="default-server-auth")
+    fleet_add_parser.add_argument("--status", default="pending")
+    fleet_add_parser.add_argument(
+        "--runtime-image",
+        default="quay.nju.edu.cn/ascend/vllm-ascend:latest",
+    )
+    fleet_add_parser.add_argument("--runtime-container", default="vaws-workspace")
+    fleet_add_parser.add_argument("--runtime-ssh-port", type=int, default=63269)
+    fleet_add_parser.add_argument(
+        "--runtime-workspace-root",
+        default="/vllm-workspace",
+    )
+    fleet_add_parser.add_argument(
+        "--runtime-bootstrap-mode",
+        default="host-then-container",
+    )
+    fleet_verify_parser = fleet_subparsers.add_parser("verify")
+    fleet_verify_parser.add_argument("server_name")
     return parser
 
 
@@ -138,6 +166,25 @@ def main(argv: Optional[List[str]] = None) -> int:
         return switch_session(paths, args.session_name)
     if args.command == "session" and args.session_command == "status":
         return status_session(paths)
+    if args.command == "fleet" and args.fleet_command == "list":
+        return list_fleet(paths)
+    if args.command == "fleet" and args.fleet_command == "add":
+        return add_fleet_server(
+            paths,
+            args.server_name,
+            args.host,
+            args.login_user,
+            port=args.port,
+            ssh_auth_ref=args.ssh_auth_ref,
+            status=args.status,
+            runtime_image=args.runtime_image,
+            runtime_container=args.runtime_container,
+            runtime_ssh_port=args.runtime_ssh_port,
+            runtime_workspace_root=args.runtime_workspace_root,
+            runtime_bootstrap_mode=args.runtime_bootstrap_mode,
+        )
+    if args.command == "fleet" and args.fleet_command == "verify":
+        return verify_fleet_server(paths, args.server_name)
 
     parser.error(f"unknown command: {args.command}")
     return 2


### PR DESCRIPTION
## Summary
- migrate the workspace from target-centric bootstrap toward bootstrap/fleet/reset server inventory flows
- add internal preflight, named auth refs, baseline-only bootstrap, fleet inventory operations, structured verification, and all-server best-effort reset
- update public docs and workspace-local skills so bootstrap, fleet, and reset boundaries match the implemented command surface

## Verification
- pytest -q