### PR TITLE
[codex] add skill-first control plane contracts

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,21 +1,18 @@
 # Workspace-Local Agent Guidance
 
-This directory contains public, workspace-local reference material for agents working in `vllm-ascend-workspace`.
+This directory contains the shared workspace-local contract layer for agents working in `vllm-ascend-workspace`.
 
 - Canonical runtime root: `/vllm-workspace`
-- Primary command surface: `tools/vaws.py`
+- Primary implementation surface: `tools/vaws.py`
 - Compatibility entrypoints: `./setup` and `./sync`
-- Workflow skills live under `.agents/skills/`.
-- Bootstrap and first-time baseline procedure: `.agents/skills/workspace-bootstrap/`
-- Fleet server maintenance procedure: `.agents/skills/workspace-fleet/`
-- For Codex bootstrap, start from natural language user input and route into the bootstrap skill.
-- Guarded best-effort reset and deinit procedure: `.agents/skills/workspace-reset/`
-- Session switching procedure: `.agents/skills/workspace-session-switch/`
-- Sync procedure: `.agents/skills/workspace-sync/`
-- Local overlay state: `.workspace.local/`
-- `.workspace.local/repos.yaml` stores local `origin`/`upstream` repo topology.
-- Tracked repo defaults stay on community `upstream` repositories; user forks are configured locally.
-- Current control-plane session manifests: `.workspace.local/sessions/<session>/manifest.yaml`
-- Target runtime session manifests: `/vllm-workspace/.vaws/sessions/<session>/manifest.yaml`
-- These files are reference material only.
-- Keep private tokens, private hosts, and legacy path references out of tracked files.
+- Shared public contracts live under `.agents/skills/`
+- Exact internal routing notes live under each skill’s `references/` directory
+- First baseline contract: `.agents/skills/workspace-bootstrap/`
+- Post-bootstrap server management contract: `.agents/skills/workspace-fleet/`
+- Destructive teardown contract: `.agents/skills/workspace-reset/`
+- Session lifecycle contract: `.agents/skills/workspace-session-switch/`
+- Session-oriented compatibility sync contract: `.agents/skills/workspace-sync/`
+- `.workspace.local/` is local-only overlay state
+- Local `origin` / `upstream` repository topology lives in `.workspace.local/repos.yaml`
+- Bootstrap starts from natural language user intent and resolves through shared contracts instead of direct CLI phrasebooks
+- Keep private tokens, private hosts, and legacy path references out of tracked files

--- a/.agents/skills/workspace-bootstrap/SKILL.md
+++ b/.agents/skills/workspace-bootstrap/SKILL.md
@@ -1,24 +1,82 @@
 ---
 name: workspace-bootstrap
-description: Use when initializing or repairing this workspace from natural language user input, especially when the agent needs to gather server access details and vllm-ascend repo ownership before running internal bootstrap steps.
+description: Use when the user wants the first usable baseline for this workspace, needs the first development server attached, or needs to recover an incomplete first bootstrap.
 ---
 
 # Workspace Bootstrap
 
-Use this skill when initializing or repairing the local workspace overlay for a real user.
+## Overview
 
-- Keep the canonical runtime root at `/vllm-workspace`.
-- Start from natural language user input, not by telling the user to invoke internal tools.
-- Collect remote server connection details first.
-- Collect `vllm-ascend` repo path or fork URL and Git auth second.
-- Treat `vllm` fork configuration as optional.
-- Use bootstrap only for the first-time baseline; later server changes belong in fleet.
-- Once enough information is available, the agent should run `tools/vaws.py init --bootstrap ...` and then use `tools/vaws.py doctor` for follow-up checks.
-- Treat `.workspace.local/` as local overlay state only.
-- Keep tracked defaults on community `upstream` repositories and store user-specific `origin` topology in `.workspace.local/repos.yaml`.
-- Prefer `config/*.example.yaml` as the public template source.
-- Keep secrets, private hosts, and private paths out of tracked files.
+Use this skill for the first usable workspace baseline. It owns bootstrap intent and bootstrap-facing user semantics for the workspace lifecycle.
 
-Use `.agents/skills/workspace-reset/SKILL.md` for guarded reset and deinit cleanup.
+If exact internal routing details are required, see `references/internal-routing.md`.
 
-This is workspace-local reference material only.
+## When to Use
+
+### Intent Signals
+
+- The user wants to initialize this workspace for the first time.
+- The user wants the first development server attached to this workspace.
+- The user wants a local-only baseline because no remote server is available.
+- The user wants to recover an incomplete first baseline.
+
+### Examples Include, But Are Not Limited To:
+
+- `帮我初始化这个仓库`
+- `先把这个 workspace 跑起来`
+- `没有远端机器，先本地初始化`
+
+### Do Not Use
+
+- Adding or repairing later servers belongs to `workspace-fleet`.
+- Explicit teardown belongs to `workspace-reset`.
+- Session switching belongs to `workspace-session-switch`.
+
+## User-Visible Output Contract
+
+- Report whether the workspace is `ready`, `needs_input`, `blocked`, or `needs_repair`.
+- Explain whether a first usable baseline now exists.
+- Say whether the result is remote-first or local-only in user language.
+
+## Never Expose
+
+- overlay file paths as public workflow steps
+- raw password values, raw token values, or secret-bearing shell commands
+- private hosts or private local filesystem paths
+
+## Default Inference Rules
+
+- Prefer remote-first when the user provides a server.
+- Fall back to local-only only when the user explicitly wants it or has no remote server.
+- Treat `vllm-ascend` origin ownership as required for personalized development.
+- Treat `vllm` origin ownership as optional.
+
+## Cross-Skill Boundary
+
+- Post-bootstrap server inventory work belongs to `workspace-fleet`.
+- Explicit teardown belongs to `workspace-reset`.
+- Feature session changes belong to `workspace-session-switch`.
+
+## Failure Handling Notes
+
+- If the first baseline already exists, route to `workspace-fleet` instead of retrying bootstrap blindly.
+- If required auth or ownership information is missing, return `needs_input`.
+- If runtime verification is incomplete, return `needs_repair`.
+
+## Security Notes
+
+- Secret handles must be pre-staged outside the agent transcript path.
+- Never ask the user to echo or paste secrets into shell commands.
+- Never expose private hosts or private paths in tracked docs.
+
+## Common Mistakes
+
+- Treating later machine additions as bootstrap work.
+- Explaining bootstrap through internal files or command flags.
+- Claiming bootstrap is ready before a first usable baseline actually exists.
+
+## Red Flags
+
+- explaining bootstrap with CLI syntax instead of lifecycle semantics
+- routing a post-bootstrap machine request back into bootstrap
+- asking the user to edit local overlay files directly

--- a/.agents/skills/workspace-bootstrap/references/internal-routing.md
+++ b/.agents/skills/workspace-bootstrap/references/internal-routing.md
@@ -1,0 +1,31 @@
+# Internal Routing: Workspace Bootstrap
+
+Public contract: `../SKILL.md`
+
+Use this file only after the public bootstrap contract has been selected.
+
+## Command Mapping
+
+- Primary entrypoint: `tools/vaws.py init --bootstrap`
+- Supporting verification command: `tools/vaws.py doctor`
+
+## Internal Inputs
+
+- first remote server details, or explicit local-only intent
+- `vllm-ascend` origin URL
+- optional `vllm` origin URL
+- pre-staged auth handles or safe auth refs
+
+## Internal State Touched
+
+- `.workspace.local/repos.yaml`
+- `.workspace.local/auth.yaml`
+- `.workspace.local/servers.yaml`
+- `.workspace.local/targets.yaml`
+- `.workspace.local/state.json`
+- git remotes under `vllm/` and `vllm-ascend/`
+
+## Related Tests
+
+- `tests/test_vaws_init_bootstrap.py`
+- `tests/test_secret_boundary.py`

--- a/.agents/skills/workspace-fleet/SKILL.md
+++ b/.agents/skills/workspace-fleet/SKILL.md
@@ -1,17 +1,85 @@
 ---
 name: workspace-fleet
-description: Use when managing workspace servers after bootstrap, especially for add/list/verify/repair-style maintenance against `.workspace.local/servers.yaml`.
+description: Use when the user wants to manage additional servers after the first workspace baseline already exists, including attach, verify, list, or clearly blocked unsupported maintenance requests.
 ---
 
 # Workspace Fleet
 
-Use this skill for post-bootstrap server inventory maintenance.
+## Overview
 
-- Treat `.workspace.local/servers.yaml` as the source of truth for managed servers.
-- Use `tools/vaws.py fleet add`, `tools/vaws.py fleet list`, and `tools/vaws.py fleet verify` for inventory work; handle remove and repair scenarios as fleet maintenance outcomes.
-- SSH connectivity is the prerequisite for fleet work; remote runtime verification is the success condition.
-- Treat verification gaps as repair signals, not bootstrap failures.
-- Keep server-specific changes out of tracked files; they belong in the local overlay.
-- Use bootstrap only for first-time baseline setup, not for later server changes.
+Use this skill for post-bootstrap server inventory management. It owns the lifecycle of additional managed servers after the first baseline exists.
 
-This is workspace-local reference material only.
+If exact internal routing details are required, see `references/internal-routing.md`.
+
+## When to Use
+
+### Intent Signals
+
+- The user wants to attach an additional managed server after baseline bootstrap.
+- The user wants to verify or list a managed server.
+- The user asks for post-bootstrap maintenance that may not have a sanctioned implementation path yet.
+- The user wants to know whether a post-bootstrap server is usable for this workspace.
+
+### Examples Include, But Are Not Limited To:
+
+- `帮我配置一下 ip 为 b 的机器`
+- `把 10.0.0.12 这台机器也接进来`
+- `现在想把 server-b 也配到这个 workspace`
+
+### Do Not Use
+
+- The first baseline belongs to `workspace-bootstrap`.
+- Explicit teardown belongs to `workspace-reset`.
+- Session switching belongs to `workspace-session-switch`.
+
+## User-Visible Output Contract
+
+- Report whether the requested server operation is `ready`, `partial`, `needs_repair`, or `blocked`.
+- Explain what changed in server terms.
+- Keep read-only verification distinct from any state-changing request.
+- Surface unsupported post-bootstrap maintenance requests as `blocked` and say plainly that no sanctioned implementation path exists yet.
+
+## Never Expose
+
+- local inventory file paths as user workflow steps
+- raw auth handle names or secret-bearing values in ordinary guidance
+- implementation-specific helper naming
+
+## Default Inference Rules
+
+- Reuse the single configured SSH auth profile when exactly one safe profile exists.
+- Ask for clarification when multiple profiles exist and the correct one cannot be inferred safely.
+- Treat verify as read-only.
+- Do not improvise repair or removal behavior when no sanctioned implementation path exists.
+
+## Cross-Skill Boundary
+
+- First baseline work belongs to `workspace-bootstrap`.
+- Explicit teardown belongs to `workspace-reset`.
+- Session changes and sync do not belong to this skill.
+
+## Failure Handling Notes
+
+- If baseline bootstrap never completed, route back to `workspace-bootstrap`.
+- If a server cannot be reached, return `needs_repair` or `blocked` instead of silently skipping it.
+- If some requested changes succeed and others fail, return `partial`.
+- If the user requests unsupported maintenance, return `blocked` instead of inventing a workflow.
+
+## Security Notes
+
+- Never ask the user to paste a password into a shell command.
+- Never expose private hosts or tracked secrets in workflow guidance.
+- Keep auth-ref resolution internal.
+
+## Common Mistakes
+
+- Treating fleet work as a bootstrap rerun.
+- Explaining server inventory through YAML file edits.
+- Improvising unsupported repair or removal behavior.
+
+## Red Flags
+
+- overfitting the skill to one literal “add machine” sentence
+- leaking internal auth-ref vocabulary into user-facing guidance
+- silently mutating server state during a verify-only request
+- pretending remove or repair is supported when no sanctioned path exists

--- a/.agents/skills/workspace-fleet/references/internal-routing.md
+++ b/.agents/skills/workspace-fleet/references/internal-routing.md
@@ -1,0 +1,29 @@
+# Internal Routing: Workspace Fleet
+
+Public contract: `../SKILL.md`
+
+Use this file only after the fleet contract has been selected.
+
+## Command Mapping
+
+- list: `tools/vaws.py fleet list`
+- add: `tools/vaws.py fleet add`
+- verify: `tools/vaws.py fleet verify`
+- repair: no sanctioned CLI mapping yet; do not improvise one
+- remove: no sanctioned CLI mapping yet; do not improvise one
+
+## Internal Behavior Notes
+
+- when `--ssh-auth-ref` is omitted and exactly one safe profile exists, infer it
+- when multiple safe profiles exist, stop and ask for clarification
+- inventory state remains local-only
+- unsupported repair or remove requests must be surfaced as blocked/unsupported
+
+## Internal State Touched
+
+- `.workspace.local/servers.yaml`
+- `.workspace.local/state.json`
+
+## Related Tests
+
+- `tests/test_vaws_fleet.py`

--- a/.agents/skills/workspace-reset/SKILL.md
+++ b/.agents/skills/workspace-reset/SKILL.md
@@ -1,20 +1,81 @@
 ---
 name: workspace-reset
-description: Use when resetting or deinitializing this workspace after an explicit user request, especially when the agent must clear local overlay identity and remote runtime state without skipping the guarded confirmation flow.
+description: Use when the user explicitly wants destructive teardown, deinitialization, or a return to a near post-clone workspace state.
 ---
 
 # Workspace Reset
 
-Use this skill when a user explicitly asks to reset, deinitialize, or return this workspace to a near post-clone state.
+## Overview
 
-- Keep the canonical runtime root at `/vllm-workspace`.
-- Treat reset as a guarded two-step flow: run `tools/vaws.py reset --prepare` first, then `tools/vaws.py reset --execute --confirmation-id ... --confirm ...`.
-- Show the destruction summary from `reset --prepare` before executing the destructive step.
-- Agents must not skip prepare, reuse stale confirmation ids, or fabricate authorization.
-- Reset is expected to clear local workspace identity and clean all managed servers in `.workspace.local/servers.yaml` on a best-effort basis.
-- Unreachable servers should be reported, not treated as a hard stop.
-- After remote cleanup attempts, local overlay cleanup should still run.
-- After a successful reset, restore `origin` and `upstream` on `vllm/` and `vllm-ascend/` to the community URLs.
-- Keep private hosts, tokens, and user-specific paths out of tracked files.
+Use this skill for explicit guarded destructive teardown in the workspace lifecycle. It owns reset semantics, authorization friction, and best-effort cleanup reporting.
 
-This is workspace-local reference material only.
+If exact internal routing details are required, see `references/internal-routing.md`.
+
+## When to Use
+
+### Intent Signals
+
+- The user explicitly wants this workspace reset or deinitialized.
+- The user wants to clear bootstrap state and managed runtime state.
+- The user wants a near post-clone state for repeated bootstrap testing.
+
+### Examples Include, But Are Not Limited To:
+
+- `把这个 workspace 重置掉`
+- `把环境回到刚 clone 的状态`
+- `把现在这套 bootstrap 痕迹都清干净`
+
+### Do Not Use
+
+- Ordinary server repair belongs to `workspace-fleet`.
+- First setup belongs to `workspace-bootstrap`.
+- Session switching belongs to `workspace-session-switch`.
+
+## User-Visible Output Contract
+
+- Show a destruction summary before any destructive action.
+- Ask for explicit authorization before teardown proceeds.
+- Report the final result as `ready`, `partial`, `blocked`, or `failed`.
+- Say plainly when some cleanup steps were unreachable or incomplete.
+
+## Never Expose
+
+- raw confirmation tokens or internal reset records as normal user guidance
+- fabricated authorization
+- raw private hosts, secrets, or internal cleanup paths
+
+## Default Inference Rules
+
+- Treat reset as high-friction by default.
+- Clean all managed servers on a best-effort basis.
+- Preserve the guarded two-phase internal flow even when the user-facing explanation stays high-level.
+
+## Cross-Skill Boundary
+
+- First setup belongs to `workspace-bootstrap`.
+- Post-bootstrap server maintenance belongs to `workspace-fleet`.
+- Session switching belongs to `workspace-session-switch`.
+
+## Failure Handling Notes
+
+- Never skip the internal prepare phase.
+- Never reuse stale authorization state.
+- If cleanup is incomplete, report a partial result instead of pretending full success.
+
+## Security Notes
+
+- Never fabricate authorization on the user's behalf.
+- Never compress reset into a silent one-step action.
+- Never expose raw secrets or private hosts in user-facing output.
+
+## Common Mistakes
+
+- Treating reset as routine cleanup.
+- Explaining reset through overlay-file mutations.
+- Hiding unreachable cleanup outcomes.
+
+## Red Flags
+
+- asking the user for internal token syntax
+- claiming success when teardown was only partial
+- using reset language for ordinary maintenance work

--- a/.agents/skills/workspace-reset/references/internal-routing.md
+++ b/.agents/skills/workspace-reset/references/internal-routing.md
@@ -1,0 +1,34 @@
+# Internal Routing: Workspace Reset
+
+Public contract: `../SKILL.md`
+
+Use this file only after the reset contract has been selected.
+
+## Command Mapping
+
+- prepare: `tools/vaws.py reset --prepare`
+- execute: `tools/vaws.py reset --execute --confirmation-id <id> --confirm <phrase>`
+
+## Internal Behavior Notes
+
+- preserve the guarded two-phase reset flow
+- require `--confirmation-id <id>` and `--confirm <phrase>` for execute
+- clear all managed servers on a best-effort basis
+- downgrade the user-visible result to `partial` whenever any per-server cleanup result is `unreachable` or `cleanup_failed`, even if the command itself completes
+- restore repo remotes to community defaults
+- treat stale authorization state as invalid
+
+## Internal State Touched
+
+- `.workspace.local/servers.yaml`
+- `.workspace.local/auth.yaml`
+- `.workspace.local/repos.yaml`
+- `.workspace.local/targets.yaml`
+- `.workspace.local/state.json`
+- `.workspace.local/sessions/`
+- `.workspace.local/reset-request.json`
+- git remotes under `vllm/` and `vllm-ascend/`
+
+## Related Tests
+
+- `tests/test_vaws_reset.py`

--- a/.agents/skills/workspace-session-switch/SKILL.md
+++ b/.agents/skills/workspace-session-switch/SKILL.md
@@ -1,18 +1,74 @@
 ---
 name: workspace-session-switch
-description: Public workspace-local guidance for switching feature sessions.
+description: Use when the user wants to create, change, or inspect the active feature session for this workspace.
 ---
 
 # Workspace Session Switch
 
-Use this skill when changing the active feature session in `.workspace.local/state.json`.
+## Overview
 
-- The current control-plane manifest written by `tools/vaws.py session create` lives at `.workspace.local/sessions/<session>/manifest.yaml`.
-- The target runtime session manifest model lives at `/vllm-workspace/.vaws/sessions/<session>/manifest.yaml`.
-- Preserve `/vllm-workspace` as the runtime root inside manifests and wrappers.
-- Route new local session manifests through `tools/vaws.py session create`.
-- Route session changes through `tools/vaws.py session switch`.
-- Reject unsafe session names and avoid writing private environment details into tracked files.
-- Keep session guidance local to this repository.
+Use this skill for active feature-session lifecycle semantics. It owns session creation, session switching, and “which session am I on” requests in the workspace lifecycle.
 
-This is workspace-local reference material only.
+If exact internal routing details are required, see `references/internal-routing.md`.
+
+## When to Use
+
+### Intent Signals
+
+- The user wants to create a new feature session.
+- The user wants to switch the active session.
+- The user wants to know which session is currently active.
+
+### Examples Include, But Are Not Limited To:
+
+- `给我新建一个 feature session`
+- `看下现在在哪个 session`
+- `把当前工作切到 feat_x`
+
+### Do Not Use
+
+- First setup belongs to `workspace-bootstrap`.
+- Server inventory work belongs to `workspace-fleet`.
+- Repository or session sync belongs to `workspace-sync`.
+
+## User-Visible Output Contract
+
+- Report whether the requested session action is `ready`, `blocked`, or `failed`.
+- Explain which session is now active, or why the requested session action could not complete.
+
+## Never Expose
+
+- local manifest file paths as public workflow steps
+- raw local environment internals unrelated to the user’s requested session action
+
+## Default Inference Rules
+
+- Reuse the requested session name when it is safe and explicit.
+- Ask for clarification when the target session name is ambiguous.
+
+## Cross-Skill Boundary
+
+- Bootstrap belongs to `workspace-bootstrap`.
+- Fleet server management belongs to `workspace-fleet`.
+- Sync belongs to `workspace-sync`.
+- Destructive teardown belongs to `workspace-reset`.
+
+## Failure Handling Notes
+
+- Reject unsafe or invalid session names clearly.
+- If the target session does not exist, explain whether creation is required.
+
+## Security Notes
+
+- Never expose private environment details from local session manifests.
+- Never treat session switching as a place to leak internal runtime paths.
+
+## Common Mistakes
+
+- Explaining session changes through manifest file edits.
+- Collapsing creation and switching into one unclear workflow.
+
+## Red Flags
+
+- telling the user to edit local session state manually
+- treating sync or reset as part of ordinary session switching

--- a/.agents/skills/workspace-session-switch/references/internal-routing.md
+++ b/.agents/skills/workspace-session-switch/references/internal-routing.md
@@ -1,0 +1,21 @@
+# Internal Routing: Workspace Session Switch
+
+Public contract: `../SKILL.md`
+
+Use this file only after the session-switch contract has been selected.
+
+## Command Mapping
+
+- create: `tools/vaws.py session create`
+- switch: `tools/vaws.py session switch`
+- status: `tools/vaws.py session status`
+
+## Internal State Touched
+
+- `.workspace.local/state.json`
+- `.workspace.local/sessions/<session>/manifest.yaml`
+- `/vllm-workspace/.vaws/sessions/<session>/manifest.yaml`
+
+## Related Tests
+
+- `tests/test_vaws_session.py`

--- a/.agents/skills/workspace-sync/SKILL.md
+++ b/.agents/skills/workspace-sync/SKILL.md
@@ -1,16 +1,78 @@
 ---
 name: workspace-sync
-description: Public workspace-local guidance for repository and session sync flows.
+description: Use when the user wants to check sync status, start or finish the session-oriented compatibility sync flow, or discuss sync in workspace lifecycle terms without internal command wiring.
 ---
 
 # Workspace Sync
 
-Use this skill when synchronizing repo state or compatibility wrappers.
+## Overview
 
-- Keep `tools/vaws.py sync` as the public sync entrypoint.
-- Preserve `./sync` as the compatibility wrapper.
-- Default new workspace references to `origin/main` unless local overlay data says otherwise.
-- Keep tracked files free of private hosts, tokens, and old canonical paths.
-- Use example configs and local overlay files for environment-specific values.
+Use this skill for session-oriented compatibility sync semantics in the workspace lifecycle. It owns the user-facing meaning of sync status, sync start, and sync done, not the low-level command mapping.
 
-This is workspace-local reference material only.
+If exact internal routing details are required, see `references/internal-routing.md`.
+
+## When to Use
+
+### Intent Signals
+
+- The user wants to check current sync status.
+- The user wants to start the compatibility sync flow for a session.
+- The user wants to finish the compatibility sync flow cleanly.
+
+### Examples Include, But Are Not Limited To:
+
+- `帮我同步一下`
+- `看下当前 sync 状态`
+- `给 feat_x 开始 sync`
+
+### Do Not Use
+
+- Bootstrap belongs to `workspace-bootstrap`.
+- Additional server management belongs to `workspace-fleet`.
+- Session creation or switching belongs to `workspace-session-switch`.
+- Destructive teardown belongs to `workspace-reset`.
+- Requests framed as generic repository or session state sync must be narrowed to the session-oriented compatibility flow before proceeding.
+
+## User-Visible Output Contract
+
+- Report whether sync is current, started, completed, blocked, or needs follow-up.
+- Explain the outcome in session or compatibility-flow terms, not overlay-file terms.
+
+## Never Expose
+
+- exact low-level sync command routing
+- overlay file paths as public workflow steps
+- secret-bearing environment setup
+
+## Default Inference Rules
+
+- Prefer the current active session when status or done can be resolved safely from workspace state.
+- Ask for clarification when a sync start request does not identify the target session clearly.
+
+## Cross-Skill Boundary
+
+- Bootstrap belongs to `workspace-bootstrap`.
+- Server management belongs to `workspace-fleet`.
+- Session selection belongs to `workspace-session-switch`.
+- Teardown belongs to `workspace-reset`.
+
+## Failure Handling Notes
+
+- If sync cannot proceed, report the blocking reason plainly.
+- If sync is partial, say what remains unresolved.
+- If a sync start request lacks a usable session target, stop and ask instead of improvising.
+
+## Security Notes
+
+- Never ask the user to paste secrets into shell commands.
+- Never expose private remotes or private hosts in tracked docs.
+
+## Common Mistakes
+
+- Treating sync as a bootstrap substitute.
+- Explaining sync through internal file mutations.
+
+## Red Flags
+
+- telling the user to run internal sync commands directly during normal guidance
+- treating sync as a destructive reset

--- a/.agents/skills/workspace-sync/references/internal-routing.md
+++ b/.agents/skills/workspace-sync/references/internal-routing.md
@@ -1,0 +1,23 @@
+# Internal Routing: Workspace Sync
+
+Public contract: `../SKILL.md`
+
+Use this file only after the sync contract has been selected.
+
+## Command Mapping
+
+- status: `tools/vaws.py sync status`
+- start: `tools/vaws.py sync start <session_name>`
+- done: `tools/vaws.py sync done`
+- compatibility wrapper: `./sync`
+
+## Internal Behavior Notes
+
+- `sync status` delegates to session status reporting
+- `sync start` creates and switches to the target session
+- `sync done` is a reserved compatibility completion step
+- compatibility behavior stays internal
+
+## Related Tests
+
+- `tests/test_vaws_sync.py`

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,10 +1,14 @@
 # Workspace rules
 
 - Work from the checked-out workspace repository root.
-- Treat `/vllm-workspace` as the canonical runtime root for container actions.
-- Use `tools/vaws.py` as the implementation entrypoint.
-- Keep compatibility commands `./setup` and `./sync` available.
-- Never embed private credentials, hosts, or local-only filesystem paths in tracked files.
-- Never commit `.workspace.local/` and treat it as local overlay state.
-- Treat `.agents/skills/` as workspace-local reference material only.
-- Preserve generic defaults that do not assume private environments.
+- Treat `/vllm-workspace` as the canonical runtime root.
+- Keep `tools/vaws.py` as the internal implementation surface.
+- Keep `./setup` and `./sync` available as compatibility entrypoints.
+- Treat `.agents/skills/workspace-bootstrap/SKILL.md` as the first baseline bootstrap contract.
+- Treat `.agents/skills/workspace-fleet/SKILL.md` as the post-bootstrap server management contract.
+- Treat `.agents/skills/workspace-reset/SKILL.md` as the destructive teardown contract.
+- Treat `.agents/skills/workspace-session-switch/SKILL.md` as the session lifecycle contract.
+- Treat `.agents/skills/workspace-sync/SKILL.md` as the session-oriented compatibility sync contract.
+- Treat skill-local routing references as internal execution notes, not public workflow steps.
+- Never expose overlay file paths as public workflow steps.
+- Never emit shell commands that inline raw secret values.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,19 +5,22 @@ This repository is a public-facing control workspace for vLLM Ascend development
 ## Always-On Context
 
 - Runtime root: `/vllm-workspace`
-- Primary command surface: `tools/vaws.py`
+- Primary implementation surface: `tools/vaws.py`
 - Compatibility entrypoints: `./setup`, `./sync`
 - Source repos: `vllm/`, `vllm-ascend/` as submodules
 - Clone and refresh sources recursively: `git submodule update --init --recursive`
-- `config/*.example.yaml` are the only tracked config templates for bootstrap guidance.
-- `.workspace.local/` must stay local-only and is never committed.
-- Do not commit credentials, private hosts, private paths, tokens, or keys.
+- `.workspace.local/` is local-only overlay state and must never be committed
+- Never commit credentials, private hosts, private paths, tokens, or keys
 
 ## Workflow Routing
 
-- Keep detailed operational procedures in `.agents/skills/`, not in this file.
-- Use `.agents/skills/workspace-bootstrap/SKILL.md` for first-time baseline bootstrap and bootstrap repair.
-- Use `.agents/skills/workspace-fleet/SKILL.md` for post-bootstrap server inventory maintenance.
-- Use `.agents/skills/workspace-reset/SKILL.md` for guarded best-effort reset / deinit cleanup.
-- Use `.agents/skills/workspace-session-switch/SKILL.md` for session changes.
-- Use `.agents/skills/workspace-sync/SKILL.md` for sync behavior.
+- Use `.agents/skills/workspace-bootstrap/SKILL.md` for first baseline bootstrap intent
+- Use `.agents/skills/workspace-fleet/SKILL.md` for post-bootstrap server management
+- Use `.agents/skills/workspace-reset/SKILL.md` for explicit destructive teardown
+- Use `.agents/skills/workspace-session-switch/SKILL.md` for session lifecycle intent
+- Use `.agents/skills/workspace-sync/SKILL.md` for sync status and compatibility sync intent
+
+## Adapter Boundary
+
+- Treat shared `SKILL.md` files as the public contract layer
+- Treat skill-local routing references as internal execution notes, not public workflow docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE
+
+This repository keeps its workflow contract inside the workspace. Do not rely on user-global skill installation for the workspace lifecycle.
+
+## Always-On Context
+
+- Runtime root: `/vllm-workspace`
+- Primary implementation surface: `tools/vaws.py`
+- Compatibility entrypoints: `./setup`, `./sync`
+- Source repos: `vllm/`, `vllm-ascend/` as submodules
+- `.workspace.local/` is local-only overlay state and must never be committed
+
+## Workflow Routing
+
+- Route first baseline initialization to `.agents/skills/workspace-bootstrap/SKILL.md`
+- Route post-bootstrap server management to `.agents/skills/workspace-fleet/SKILL.md`
+- Route destructive teardown to `.agents/skills/workspace-reset/SKILL.md`
+- Route session lifecycle changes to `.agents/skills/workspace-session-switch/SKILL.md`
+- Route sync status and compatibility sync flow to `.agents/skills/workspace-sync/SKILL.md`
+
+## Adapter Boundary
+
+- Treat shared `SKILL.md` files as the public contract layer
+- Treat skill-local routing references as internal execution notes only

--- a/README.md
+++ b/README.md
@@ -27,13 +27,17 @@ Public workspace-local control repository for coordinating vLLM and vLLM-Ascend 
 - `.workspace.local/` is local-only overlay state and stays untracked.
 - `.workspace.local/repos.yaml` is the local source of truth for `origin`/`upstream` repo topology.
 - Tracked files must not contain private tokens, private hosts, or legacy path references.
+- Bootstrap starts from natural language workspace requests and resolves them against the tracked `upstream` defaults plus local `origin` overlay data.
 
 ## Agent Workflows
 
-- `.agents/skills/` contains public reference material for workspace-local agents.
-- Bootstrap and first-time baseline flow live in `.agents/skills/workspace-bootstrap/`.
-- Ongoing server inventory maintenance lives in `.agents/skills/workspace-fleet/`.
-- For Codex bootstrap, the user should start from a natural language request and the agent should route into the bootstrap skill.
+- `.agents/skills/` contains the shared workspace-local contracts for bootstrap, fleet, reset, session-switch, and sync.
+- `AGENTS.md` is the Codex adapter.
+- `CLAUDE.md` is the Claude Code adapter.
+- `.cursorrules` is the Cursor adapter.
+- Exact internal routing is kept in skill-local `references/internal-routing.md` files and is not the public workflow surface.
+- Bootstrap and first baseline flow live in `.agents/skills/workspace-bootstrap/`.
+- Ongoing server inventory management lives in `.agents/skills/workspace-fleet/`.
 - Guarded best-effort cleanup flow lives in `.agents/skills/workspace-reset/`.
-- Session switching flow lives in `.agents/skills/workspace-session-switch/`.
-- Sync flow lives in `.agents/skills/workspace-sync/`.
+- Session lifecycle flow lives in `.agents/skills/workspace-session-switch/`.
+- Session-oriented compatibility sync flow lives in `.agents/skills/workspace-sync/`.

--- a/tests/test_repo_layout.py
+++ b/tests/test_repo_layout.py
@@ -10,6 +10,7 @@ def test_public_repo_layout_exists():
     assert (repo / "config" / "repos.example.yaml").exists()
     assert (repo / "config" / "targets.example.yaml").exists()
     assert (repo / "AGENTS.md").exists()
+    assert (repo / "CLAUDE.md").exists()
     assert (repo / ".cursorrules").exists()
     assert (repo / "pytest.ini").exists()
     assert (repo / "vllm").exists()
@@ -100,11 +101,13 @@ def test_public_docs_explain_upstream_defaults_and_local_origin_bootstrap():
         encoding="utf-8"
     ).lower()
 
-    for text in (readme, bootstrap_skill, agents_readme):
+    for text in (readme, agents_readme):
         assert "upstream" in text
         assert "origin" in text
         assert ".workspace.local/repos.yaml" in text
         assert "natural language" in text or "conversational" in text
+
+    assert "origin ownership" in bootstrap_skill
 
     for forbidden in (
         "reset --prepare",
@@ -133,102 +136,80 @@ def test_agents_md_routes_bootstrap_and_reset_to_skills():
     assert "init --bootstrap" not in agents
     assert "fleet add" not in agents
 
-
-def test_workspace_reset_skill_owns_guarded_reset_procedure():
+def test_first_class_workspace_skills_and_internal_routing_refs_exist():
     repo = Path(__file__).resolve().parents[1]
-    text = (
-        repo / ".agents" / "skills" / "workspace-reset" / "SKILL.md"
-    ).read_text(encoding="utf-8").lower()
-
-    assert "workspace-local" in text
-    assert "reset --prepare" in text
-    assert "reset --execute" in text
-    assert "must not skip prepare" in text
-    assert "stale confirmation id" in text or "stale confirmation ids" in text
-    assert "fabricate authorization" in text
-    assert "community urls" in text or "community `origin` and `upstream`" in text
-    assert "all managed servers" in text
-    assert "unreachable" in text
+    for skill_name in (
+        "workspace-bootstrap",
+        "workspace-fleet",
+        "workspace-reset",
+        "workspace-session-switch",
+        "workspace-sync",
+    ):
+        skill_root = repo / ".agents" / "skills" / skill_name
+        assert (skill_root / "SKILL.md").exists()
+        assert (skill_root / "references" / "internal-routing.md").exists()
 
 
-def test_workspace_fleet_skill_owns_server_inventory_maintenance():
+def test_internal_routing_refs_contain_command_mapping_and_related_tests():
     repo = Path(__file__).resolve().parents[1]
-    text = (
-        repo / ".agents" / "skills" / "workspace-fleet" / "SKILL.md"
-    ).read_text(encoding="utf-8").lower()
+    for skill_name in (
+        "workspace-bootstrap",
+        "workspace-fleet",
+        "workspace-reset",
+        "workspace-session-switch",
+        "workspace-sync",
+    ):
+        text = (
+            repo / ".agents" / "skills" / skill_name / "references" / "internal-routing.md"
+        ).read_text(encoding="utf-8").lower()
+        assert "## command mapping" in text
+        assert "## related tests" in text
+        assert "tools/vaws.py" in text or "./sync" in text or "./setup" in text
 
-    assert "servers.yaml" in text
-    assert "remove and repair" in text
-    assert "fleet list" in text
-    assert "fleet add" in text
-    assert "fleet verify" in text
-    assert "ssh connectivity is the prerequisite" in text
-    assert "remote runtime verification is the success condition" in text
-    assert "fleet remove" not in text
-    assert "reset --prepare" not in text
-    assert "reset --execute" not in text
 
-
-def test_workspace_local_skill_skeletons_exist_and_stay_public():
+def test_first_class_workspace_skills_share_contract_shape():
     repo = Path(__file__).resolve().parents[1]
-    agents_root = repo / ".agents"
-    agents_readme = (agents_root / "README.md").read_text(encoding="utf-8").lower()
-    assert "/vllm-workspace" in agents_readme
-    assert "tools/vaws.py" in agents_readme
-    assert "./setup" in agents_readme
-    assert "./sync" in agents_readme
-    assert ".workspace.local/" in agents_readme
-    assert ".workspace.local/sessions/<session>/manifest.yaml" in agents_readme
-    assert "/vllm-workspace/.vaws/sessions/<session>/manifest.yaml" in agents_readme
-    assert "/workspace/vllm_workspace" not in agents_readme
+    required_headers = (
+        "## overview",
+        "## when to use",
+        "## user-visible output contract",
+        "## never expose",
+        "## default inference rules",
+        "## cross-skill boundary",
+        "## failure handling notes",
+        "## security notes",
+        "## common mistakes",
+        "## red flags",
+    )
+    for skill_name in (
+        "workspace-bootstrap",
+        "workspace-fleet",
+        "workspace-reset",
+        "workspace-session-switch",
+        "workspace-sync",
+    ):
+        text = (
+            repo / ".agents" / "skills" / skill_name / "SKILL.md"
+        ).read_text(encoding="utf-8").lower()
+        assert "description: use when" in text
+        assert "examples include, but are not limited to:" in text
+        assert "internal-routing.md" in text
+        for header in required_headers:
+            assert header in text
 
-    expected_skill_content = {
-        "workspace-bootstrap": (
-            "/vllm-workspace",
-            "natural language",
-            "first-time baseline",
-            "vllm-ascend",
-            "optional",
-            "tools/vaws.py init --bootstrap",
-        ),
-        "workspace-fleet": (
-            "tools/vaws.py fleet",
-            "servers.yaml",
-            "add",
-            "remove and repair",
-            "verify",
-            "repair",
-        ),
-        "workspace-reset": (
-            "/vllm-workspace",
-            "tools/vaws.py reset --prepare",
-            "tools/vaws.py reset --execute",
-            "stale confirmation id",
-            "community",
-        ),
-        "workspace-session-switch": (
-            ".workspace.local/state.json",
-            ".workspace.local/sessions/<session>/manifest.yaml",
-            "/vllm-workspace/.vaws/sessions/<session>/manifest.yaml",
-            "tools/vaws.py session create",
-            "tools/vaws.py session switch",
-        ),
-        "workspace-sync": (
-            "tools/vaws.py sync",
-            "./sync",
-            "origin/main",
-        ),
-        "profiling-analysis": (
-            "/vllm-workspace",
-            "active feature session",
-        ),
-    }
-    for skill_name, required_snippets in expected_skill_content.items():
-        skill_path = agents_root / "skills" / skill_name / "SKILL.md"
-        assert skill_path.exists()
-        text = skill_path.read_text(encoding="utf-8").lower()
-        assert "workspace-local" in text
-        assert "global skill installer" not in text
-        assert "/workspace/vllm_workspace" not in text
-        for snippet in required_snippets:
-            assert snippet in text
+
+def test_public_workspace_skill_contracts_do_not_require_exact_cli_syntax():
+    repo = Path(__file__).resolve().parents[1]
+    for skill_name in (
+        "workspace-bootstrap",
+        "workspace-fleet",
+        "workspace-reset",
+        "workspace-session-switch",
+        "workspace-sync",
+    ):
+        text = (
+            repo / ".agents" / "skills" / skill_name / "SKILL.md"
+        ).read_text(encoding="utf-8").lower()
+        assert "tools/vaws.py " not in text
+        assert "./sync" not in text
+        assert "./setup" not in text

--- a/tests/test_secret_boundary.py
+++ b/tests/test_secret_boundary.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.lib.secret_boundary import (
+    SecretBoundaryError,
+    ensure_bootstrap_secret_refs,
+    require_pre_staged_env_handle,
+)
+
+
+def test_require_pre_staged_env_handle_rejects_missing_handle(monkeypatch):
+    monkeypatch.delenv("SERVER_PASSWORD", raising=False)
+
+    with pytest.raises(SecretBoundaryError) as exc:
+        require_pre_staged_env_handle("SERVER_PASSWORD", field_label="server password")
+
+    assert "pre-stage" in str(exc.value).lower()
+    assert "server_password" in str(exc.value).lower()
+
+
+def test_require_pre_staged_env_handle_rejects_invalid_handle_name():
+    with pytest.raises(SecretBoundaryError) as exc:
+        require_pre_staged_env_handle("bad-name", field_label="server password")
+
+    assert "invalid secret handle" in str(exc.value).lower()
+
+
+def test_ensure_bootstrap_secret_refs_allows_pre_staged_password(monkeypatch):
+    monkeypatch.setenv("SERVER_PASSWORD", "already-staged")
+
+    ensure_bootstrap_secret_refs(
+        server_auth_mode="password",
+        server_password_env="SERVER_PASSWORD",
+        git_auth_mode="ssh-agent",
+        git_token_env=None,
+    )
+
+
+def test_ensure_bootstrap_secret_refs_requires_git_token_handle(monkeypatch):
+    monkeypatch.delenv("GIT_TOKEN", raising=False)
+
+    with pytest.raises(SecretBoundaryError) as exc:
+        ensure_bootstrap_secret_refs(
+            server_auth_mode="ssh-key",
+            server_password_env=None,
+            git_auth_mode="token",
+            git_token_env="GIT_TOKEN",
+        )
+
+    assert "git token" in str(exc.value).lower()

--- a/tests/test_vaws_fleet.py
+++ b/tests/test_vaws_fleet.py
@@ -67,6 +67,47 @@ def _write_fleet_overlay(vaws_repo: Path) -> Path:
     return overlay
 
 
+def _write_ssh_auth_refs(vaws_repo: Path, *ref_names: str) -> None:
+    overlay = vaws_repo / ".workspace.local"
+    auth = yaml.safe_load((overlay / "auth.yaml").read_text(encoding="utf-8"))
+    simulation_root = vaws_repo.parent / "simulation-runtime"
+    auth["ssh_auth"]["refs"] = {
+        ref_name: {
+            "kind": "local-simulation",
+            "username": "root",
+            "simulation_root": str(simulation_root),
+        }
+        for ref_name in ref_names
+    }
+    (overlay / "auth.yaml").write_text(
+        yaml.safe_dump(auth, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _write_legacy_host_auth(vaws_repo: Path, *group_names: str) -> None:
+    overlay = vaws_repo / ".workspace.local"
+    simulation_root = vaws_repo.parent / "simulation-runtime"
+    (overlay / "auth.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "host_auth": {
+                    "mode": "local-simulation",
+                    "credential_groups": {
+                        group_name: {
+                            "username": "root",
+                            "simulation_root": str(simulation_root),
+                        }
+                        for group_name in group_names
+                    },
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_fleet_add_writes_server_inventory_entry(vaws_repo):
     _write_fleet_overlay(vaws_repo)
 
@@ -107,6 +148,151 @@ def test_fleet_add_writes_server_inventory_entry(vaws_repo):
     assert runtime_state["target"] == "host-b"
     assert runtime_state["container"]["created"] is True
     assert "reused" in runtime_state["container"]
+
+
+def test_fleet_add_infers_single_available_ssh_auth_ref(vaws_repo):
+    _write_fleet_overlay(vaws_repo)
+    _write_ssh_auth_refs(vaws_repo, "lab-sim")
+
+    result = run_vaws(
+        vaws_repo,
+        "fleet",
+        "add",
+        "host-b",
+        "--server-host",
+        "10.0.0.12",
+    )
+
+    assert result.returncode == 0
+    servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
+    assert servers["servers"]["host-b"]["ssh_auth_ref"] == "lab-sim"
+
+
+def test_fleet_add_requires_bootstrap_before_auth_resolution(vaws_repo):
+    result = run_vaws(
+        vaws_repo,
+        "fleet",
+        "add",
+        "host-b",
+        "--server-host",
+        "10.0.0.12",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "bootstrap" in output
+    assert "init --bootstrap" in output
+    assert "auth config" not in output
+
+
+def test_fleet_add_requires_completed_bootstrap_baseline(vaws_repo):
+    _write_fleet_overlay(vaws_repo)
+    overlay = vaws_repo / ".workspace.local"
+    servers = yaml.safe_load((overlay / "servers.yaml").read_text(encoding="utf-8"))
+    servers["bootstrap"]["completed"] = False
+    (overlay / "servers.yaml").write_text(
+        yaml.safe_dump(servers, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = run_vaws(
+        vaws_repo,
+        "fleet",
+        "add",
+        "host-b",
+        "--server-host",
+        "10.0.0.12",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "bootstrap" in output
+    assert "init --bootstrap" in output
+
+
+def test_fleet_add_requires_bootstrap_map_in_server_inventory(vaws_repo):
+    _write_fleet_overlay(vaws_repo)
+    overlay = vaws_repo / ".workspace.local"
+    servers = yaml.safe_load((overlay / "servers.yaml").read_text(encoding="utf-8"))
+    servers.pop("bootstrap", None)
+    (overlay / "servers.yaml").write_text(
+        yaml.safe_dump(servers, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = run_vaws(
+        vaws_repo,
+        "fleet",
+        "add",
+        "host-b",
+        "--server-host",
+        "10.0.0.12",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "bootstrap" in output
+    assert "init --bootstrap" in output
+
+
+def test_fleet_add_infers_single_legacy_host_auth_group(vaws_repo):
+    _write_fleet_overlay(vaws_repo)
+    _write_legacy_host_auth(vaws_repo, "shared-lab-a")
+
+    result = run_vaws(
+        vaws_repo,
+        "fleet",
+        "add",
+        "host-b",
+        "--server-host",
+        "10.0.0.12",
+    )
+
+    assert result.returncode == 0
+    servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
+    assert servers["servers"]["host-b"]["ssh_auth_ref"] == "shared-lab-a"
+
+
+def test_fleet_add_requires_explicit_ssh_auth_ref_when_multiple_legacy_groups_exist(vaws_repo):
+    _write_fleet_overlay(vaws_repo)
+    _write_legacy_host_auth(vaws_repo, "shared-lab-a", "shared-lab-b")
+
+    result = run_vaws(
+        vaws_repo,
+        "fleet",
+        "add",
+        "host-b",
+        "--server-host",
+        "10.0.0.12",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "multiple" in output
+    assert "ssh auth ref" in output
+    assert "shared-lab-a" in output
+    assert "shared-lab-b" in output
+
+
+def test_fleet_add_requires_explicit_ssh_auth_ref_when_multiple_refs_exist(vaws_repo):
+    _write_fleet_overlay(vaws_repo)
+    _write_ssh_auth_refs(vaws_repo, "lab-a", "lab-b")
+
+    result = run_vaws(
+        vaws_repo,
+        "fleet",
+        "add",
+        "host-b",
+        "--server-host",
+        "10.0.0.12",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "multiple" in output
+    assert "ssh auth ref" in output
+    assert "lab-a" in output
+    assert "lab-b" in output
 
 
 def test_remote_verify_runtime_returns_explicit_result_shape(vaws_repo):

--- a/tests/test_vaws_init_bootstrap.py
+++ b/tests/test_vaws_init_bootstrap.py
@@ -584,3 +584,48 @@ def test_bootstrap_target_and_server_resolution_share_workspace_root(vaws_repo):
     server_context = resolve_server_context(paths, "host-a")
 
     assert target_context.runtime.host_workspace_path == server_context.runtime.host_workspace_path
+
+
+def test_init_bootstrap_rejects_missing_pre_staged_password_handle(vaws_repo):
+    result = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--server-host",
+        "173.125.1.2",
+        "--server-user",
+        "root",
+        "--server-auth-mode",
+        "password",
+        "--server-password-env",
+        "SERVER_PASSWORD",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "pre-stage" in output
+    assert "server_password" in output
+
+
+def test_init_bootstrap_rejects_invalid_secret_handle_name(vaws_repo):
+    result = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--server-host",
+        "173.125.1.2",
+        "--server-user",
+        "root",
+        "--server-auth-mode",
+        "password",
+        "--server-password-env",
+        "bad-name",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "invalid secret handle" in output

--- a/tests/test_workspace_adapter_contracts.py
+++ b/tests/test_workspace_adapter_contracts.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8").lower()
+
+
+def test_first_class_adapter_files_exist():
+    assert (ROOT / "AGENTS.md").exists()
+    assert (ROOT / "CLAUDE.md").exists()
+    assert (ROOT / ".cursorrules").exists()
+
+
+def test_adapters_route_to_all_first_class_workspace_skills():
+    expected_routes = (
+        ".agents/skills/workspace-bootstrap/skill.md",
+        ".agents/skills/workspace-fleet/skill.md",
+        ".agents/skills/workspace-reset/skill.md",
+        ".agents/skills/workspace-session-switch/skill.md",
+        ".agents/skills/workspace-sync/skill.md",
+    )
+    for path in ("AGENTS.md", "CLAUDE.md", ".cursorrules"):
+        text = _text(path)
+        for route in expected_routes:
+            assert route in text
+
+
+def test_adapters_do_not_link_to_internal_routing_files_or_procedure_tokens():
+    forbidden_terms = (
+        "internal-routing.md",
+        "init --bootstrap",
+        "fleet add",
+        "fleet verify",
+        "reset --prepare",
+        "reset --execute",
+        "session create",
+        "session switch",
+    )
+    for path in ("AGENTS.md", "CLAUDE.md", ".cursorrules"):
+        text = _text(path)
+        for term in forbidden_terms:
+            assert term not in text

--- a/tests/test_workspace_skill_contracts.py
+++ b/tests/test_workspace_skill_contracts.py
@@ -1,0 +1,144 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIRST_CLASS_SKILLS = {
+    "workspace-bootstrap": {
+        "intent_groups": (
+            ("first usable workspace baseline", "initialize this workspace for the first time"),
+            ("first development server", "development server attached"),
+            ("examples include, but are not limited to:",),
+        ),
+    },
+    "workspace-fleet": {
+        "intent_groups": (
+            ("additional managed server", "additional server"),
+            ("post-bootstrap", "after baseline"),
+            ("examples include, but are not limited to:",),
+        ),
+    },
+    "workspace-reset": {
+        "intent_groups": (
+            ("reset or deinitialized", "reset this workspace"),
+            ("near post-clone state", "post-clone state"),
+            ("examples include, but are not limited to:",),
+        ),
+    },
+    "workspace-session-switch": {
+        "intent_groups": (
+            ("create a new feature session", "new feature session"),
+            ("switch the active session", "active session"),
+            ("examples include, but are not limited to:",),
+        ),
+    },
+    "workspace-sync": {
+        "intent_groups": (
+            ("sync repository or session state", "repository or session state"),
+            ("check current sync status", "current sync status"),
+            ("examples include, but are not limited to:",),
+        ),
+    },
+}
+REQUIRED_SECTIONS = (
+    "## Overview",
+    "## When to Use",
+    "## User-Visible Output Contract",
+    "## Never Expose",
+    "## Default Inference Rules",
+    "## Cross-Skill Boundary",
+    "## Failure Handling Notes",
+    "## Security Notes",
+    "## Common Mistakes",
+    "## Red Flags",
+)
+FORBIDDEN_DESCRIPTION_TERMS = (
+    "tools/vaws.py",
+    ".workspace.local",
+    "reset --prepare",
+    "reset --execute",
+    "fleet add",
+    "fleet verify",
+    "session create",
+    "session switch",
+)
+PUBLIC_BODY_FORBIDDEN_TERMS = (
+    "tools/vaws.py ",
+    "./sync",
+    "./setup",
+)
+
+
+def _skill_text(skill_name: str) -> str:
+    return (ROOT / ".agents" / "skills" / skill_name / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+
+def _description_line(skill_name: str) -> str:
+    for line in _skill_text(skill_name).splitlines():
+        if line.startswith("description:"):
+            return line.lower()
+    raise AssertionError(f"missing description for {skill_name}")
+
+
+def _section_body(skill_name: str, header: str) -> str:
+    text = _skill_text(skill_name)
+    marker = f"\n{header}\n"
+    start = text.find(marker)
+    assert start != -1, f"{skill_name} missing section {header}"
+    start += len(marker)
+    tail = text[start:]
+    next_header = tail.find("\n## ")
+    if next_header == -1:
+        return tail.strip()
+    return tail[:next_header].strip()
+
+
+def test_first_class_workspace_skills_share_canonical_sections():
+    for skill_name in FIRST_CLASS_SKILLS:
+        text = _skill_text(skill_name)
+        for section in REQUIRED_SECTIONS:
+            assert section in text, f"{skill_name} missing section: {section}"
+
+
+def test_first_class_workspace_skill_descriptions_are_trigger_only():
+    for skill_name in FIRST_CLASS_SKILLS:
+        description = _description_line(skill_name)
+        assert "description: use when" in description
+        for forbidden in FORBIDDEN_DESCRIPTION_TERMS:
+            assert forbidden not in description, f"{skill_name} leaked {forbidden} into description"
+
+
+def test_when_to_use_sections_are_intent_led_and_non_exhaustive():
+    for skill_name, expectations in FIRST_CLASS_SKILLS.items():
+        when_to_use = _section_body(skill_name, "## When to Use").lower()
+        for group in expectations["intent_groups"]:
+            assert any(marker.lower() in when_to_use for marker in group), (
+                f"{skill_name} missing intent signal group: {group}"
+            )
+
+
+def test_public_contract_sections_do_not_embed_internal_command_syntax():
+    public_sections = (
+        "## Overview",
+        "## When to Use",
+        "## User-Visible Output Contract",
+        "## Default Inference Rules",
+        "## Cross-Skill Boundary",
+        "## Failure Handling Notes",
+        "## Security Notes",
+        "## Common Mistakes",
+        "## Red Flags",
+    )
+    for skill_name in FIRST_CLASS_SKILLS:
+        for header in public_sections:
+            body = _section_body(skill_name, header).lower()
+            for forbidden in PUBLIC_BODY_FORBIDDEN_TERMS:
+                assert forbidden not in body, f"{skill_name} leaked {forbidden} into {header}"
+
+
+def test_never_expose_sections_contain_concrete_hidden_items():
+    for skill_name in FIRST_CLASS_SKILLS:
+        body = _section_body(skill_name, "## Never Expose").lower()
+        assert "-" in body
+        assert "raw" in body or "internal" in body or "overlay" in body or "secret" in body

--- a/tests/test_workspace_skill_pressure.py
+++ b/tests/test_workspace_skill_pressure.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCENARIOS = {
+    "workspace-bootstrap": {
+        "intent_groups": (
+            ("first usable workspace baseline", "initialize this workspace for the first time"),
+            ("first development server", "development server attached"),
+        ),
+        "pressure_only_variants": (
+            "把第一套开发环境先搭起来",
+            "先把仓库基础环境准备好",
+        ),
+    },
+    "workspace-fleet": {
+        "intent_groups": (
+            ("additional managed server", "additional server"),
+            ("post-bootstrap", "after baseline"),
+        ),
+        "pressure_only_variants": (
+            "把另一台开发机挂上来",
+            "这台新 server 也纳入当前 workspace",
+        ),
+    },
+    "workspace-reset": {
+        "intent_groups": (
+            ("reset or deinitialized", "reset this workspace"),
+            ("near post-clone state", "post-clone state"),
+        ),
+        "pressure_only_variants": (
+            "把这套实验环境彻底清场",
+            "把本地和远端的初始化痕迹都抹掉",
+        ),
+    },
+    "workspace-session-switch": {
+        "intent_groups": (
+            ("create a new feature session", "new feature session"),
+            ("switch the active session", "active session"),
+        ),
+        "pressure_only_variants": (
+            "给我切到另一个工作分支会话",
+            "新开一个隔离开发会话",
+        ),
+    },
+    "workspace-sync": {
+        "intent_groups": (
+            ("sync repository or session state", "repository or session state"),
+            ("check current sync status", "current sync status"),
+        ),
+        "pressure_only_variants": (
+            "把当前工作树和兼容同步流程对一下",
+            "同步一下 repo 和 session 状态",
+        ),
+    },
+}
+
+
+def _skill_text(skill_name: str) -> str:
+    return (ROOT / ".agents" / "skills" / skill_name / "SKILL.md").read_text(
+        encoding="utf-8"
+    ).lower()
+
+
+def test_pressure_scenarios_route_by_intent_not_phrase_lock():
+    for skill_name, scenario in SCENARIOS.items():
+        text = _skill_text(skill_name)
+        assert "examples include, but are not limited to:" in text
+        for group in scenario["intent_groups"]:
+            assert any(marker.lower() in text for marker in group), (
+                f"{skill_name} missing intent signal group: {group}"
+            )
+        for phrase in scenario["pressure_only_variants"]:
+            assert phrase.lower() not in text, (
+                f"{skill_name} copied pressure-only variant {phrase!r} into the contract body"
+            )

--- a/tools/lib/bootstrap.py
+++ b/tools/lib/bootstrap.py
@@ -10,6 +10,7 @@ import yaml
 from .config import RepoPaths
 from .overlay import ensure_overlay_layout
 from .preflight import PreflightError, ensure_local_control_plane_deps
+from .secret_boundary import SecretBoundaryError, ensure_bootstrap_secret_refs
 from .remote import DEFAULT_HOST_WORKSPACE_BASE
 from .remote import RemoteError
 from .remote import VerificationCheck, VerificationResult, persist_server_verification
@@ -481,6 +482,12 @@ def bootstrap_init(paths: RepoPaths, request: BootstrapRequest) -> int:
         preflight_report = ensure_local_control_plane_deps()
         _ensure_overlay(paths)
         _ensure_bootstrap_not_completed(paths)
+        ensure_bootstrap_secret_refs(
+            server_auth_mode=request.server_auth_mode,
+            server_password_env=request.server_password_env,
+            git_auth_mode=request.git_auth_mode,
+            git_token_env=request.git_token_env,
+        )
         _write_repos_yaml(paths, request)
         _write_servers_yaml(paths, request, completed=False)
         _write_targets_yaml(paths, request)
@@ -492,7 +499,7 @@ def bootstrap_init(paths: RepoPaths, request: BootstrapRequest) -> int:
             verification = verify_runtime(paths, context)
             persist_server_verification(paths, request.host_name, verification)
         _finalize_bootstrap(paths, request)
-    except PreflightError as exc:
+    except (PreflightError, SecretBoundaryError) as exc:
         print(str(exc))
         return 1
     except BootstrapError as exc:

--- a/tools/lib/fleet.py
+++ b/tools/lib/fleet.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import yaml
 
@@ -18,6 +18,7 @@ from .config import RepoPaths
 from .remote import (
     DEFAULT_HOST_WORKSPACE_BASE,
     RemoteError,
+    _load_auth_config,
     ensure_runtime,
     persist_server_verification,
     resolve_server_context,
@@ -53,6 +54,12 @@ def _write_servers_config(paths: RepoPaths, config: Dict[str, Any]) -> None:
     )
 
 
+def _require_bootstrap_completed(config: Dict[str, Any]) -> None:
+    bootstrap = config.get("bootstrap")
+    if not isinstance(bootstrap, dict) or bootstrap.get("completed") is not True:
+        raise FleetError("missing bootstrap baseline: run `vaws init --bootstrap` first")
+
+
 def _require_non_empty_string(value: Any, message: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise FleetError(message)
@@ -69,6 +76,51 @@ def _require_port(value: Any, message: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 1 or value > 65535:
         raise FleetError(message)
     return value
+
+
+def _single_auth_ref_name(ref_names: list[str]) -> str:
+    if not ref_names:
+        raise FleetError("missing ssh auth ref")
+    if len(ref_names) > 1:
+        raise FleetError(
+            "multiple ssh auth refs configured: "
+            f"{', '.join(ref_names)}; pass --ssh-auth-ref"
+        )
+    return ref_names[0]
+
+
+def _resolve_ssh_auth_ref(paths: RepoPaths, ssh_auth_ref: Optional[str]) -> str:
+    if ssh_auth_ref is not None:
+        return _require_non_empty_string(ssh_auth_ref, "missing ssh auth ref")
+
+    auth = _load_auth_config(paths)
+    ssh_auth = auth.get("ssh_auth")
+    if not isinstance(ssh_auth, dict):
+        host_auth = auth.get("host_auth")
+        if not isinstance(host_auth, dict):
+            raise FleetError("invalid auth config: missing ssh_auth.refs map")
+
+        credential_groups = host_auth.get("credential_groups")
+        if not isinstance(credential_groups, dict):
+            raise FleetError("invalid auth config: missing host_auth.credential_groups map")
+
+        ref_names = sorted(
+            ref_name.strip()
+            for ref_name in credential_groups
+            if isinstance(ref_name, str) and ref_name.strip()
+        )
+        return _single_auth_ref_name(ref_names)
+
+    refs = ssh_auth.get("refs")
+    if not isinstance(refs, dict):
+        raise FleetError("invalid auth config: missing ssh_auth.refs map")
+
+    ref_names = sorted(
+        ref_name.strip()
+        for ref_name in refs
+        if isinstance(ref_name, str) and ref_name.strip()
+    )
+    return _single_auth_ref_name(ref_names)
 
 
 def list_fleet(paths: RepoPaths) -> int:
@@ -106,7 +158,7 @@ def add_fleet_server(
     paths: RepoPaths,
     server_name: str,
     server_host: str,
-    ssh_auth_ref: str,
+    ssh_auth_ref: Optional[str] = None,
     server_user: str = "root",
     server_port: int = DEFAULT_SERVER_PORT,
     runtime_image: str = DEFAULT_RUNTIME_IMAGE,
@@ -119,7 +171,6 @@ def add_fleet_server(
         server_name = _require_non_empty_string(server_name, "missing server name")
         server_host = _require_non_empty_string(server_host, "missing server host")
         server_user = _require_non_empty_string(server_user, "missing server user")
-        ssh_auth_ref = _require_non_empty_string(ssh_auth_ref, "missing ssh auth ref")
         runtime_image = _require_non_empty_string(runtime_image, "missing runtime image")
         runtime_container = _require_non_empty_string(
             runtime_container,
@@ -137,9 +188,11 @@ def add_fleet_server(
         runtime_ssh_port = _require_port(runtime_ssh_port, "invalid runtime ssh port")
 
         config = _read_servers_config(paths)
+        _require_bootstrap_completed(config)
         servers = config.get("servers")
         if not isinstance(servers, dict):
             raise FleetError("invalid server config: missing 'servers' map")
+        ssh_auth_ref = _resolve_ssh_auth_ref(paths, ssh_auth_ref)
 
         servers[server_name] = {
             "host": server_host,

--- a/tools/lib/secret_boundary.py
+++ b/tools/lib/secret_boundary.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+ENV_HANDLE_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+
+
+class SecretBoundaryError(RuntimeError):
+    """Unsafe or missing secret handle for workspace control-plane flows."""
+
+
+@dataclass(frozen=True)
+class SecretHandle:
+    source: str
+    name: str
+
+
+def require_pre_staged_env_handle(
+    name: Optional[str],
+    *,
+    field_label: str,
+) -> SecretHandle:
+    if not isinstance(name, str) or not name.strip():
+        raise SecretBoundaryError(
+            f"missing pre-staged secret handle for {field_label}; stage it outside the agent session"
+        )
+
+    normalized = name.strip()
+    if not ENV_HANDLE_RE.fullmatch(normalized):
+        raise SecretBoundaryError(
+            f"invalid secret handle for {field_label}: {normalized}"
+        )
+
+    value = os.environ.get(normalized)
+    if not value:
+        raise SecretBoundaryError(
+            f"missing pre-staged secret handle for {field_label}: {normalized}; stage it outside the agent session"
+        )
+
+    return SecretHandle(source="env", name=normalized)
+
+
+def ensure_bootstrap_secret_refs(
+    *,
+    server_auth_mode: str,
+    server_password_env: Optional[str],
+    git_auth_mode: str,
+    git_token_env: Optional[str],
+) -> None:
+    if server_auth_mode == "password":
+        require_pre_staged_env_handle(
+            server_password_env,
+            field_label="server password",
+        )
+
+    if git_auth_mode == "token":
+        require_pre_staged_env_handle(
+            git_token_env,
+            field_label="git token",
+        )

--- a/tools/vaws.py
+++ b/tools/vaws.py
@@ -93,7 +93,7 @@ def build_parser() -> argparse.ArgumentParser:
     fleet_add_parser.add_argument("--server-host", required=True)
     fleet_add_parser.add_argument("--server-user", default="root")
     fleet_add_parser.add_argument("--server-port", type=int, default=22)
-    fleet_add_parser.add_argument("--ssh-auth-ref", required=True)
+    fleet_add_parser.add_argument("--ssh-auth-ref")
     fleet_add_parser.add_argument(
         "--runtime-image",
         default="quay.nju.edu.cn/ascend/vllm-ascend:latest",


### PR DESCRIPTION
## Summary
- rewrite bootstrap, fleet, and reset into shared workspace-local skill contracts
- add first-class Codex, Claude Code, and Cursor adapter docs plus contract tests
- enforce pre-staged secret handles for bootstrap and infer the fleet auth ref when exactly one profile exists

## Testing
- `pytest -q tests/test_workspace_skill_contracts.py tests/test_workspace_adapter_contracts.py tests/test_secret_boundary.py tests/test_repo_layout.py tests/test_vaws_init_bootstrap.py tests/test_vaws_fleet.py -q`
- `pytest -q`
