### PR TITLE
refactor: decouple init, foundation, git-profile, and fleet

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -7,11 +7,14 @@ This directory contains the shared workspace-local contract layer for agents wor
 - Compatibility entrypoints: `./setup` and `./sync`
 - Shared public contracts live under `.agents/skills/`
 - Exact internal routing notes live under each skill’s `references/` directory
-- First baseline contract: `.agents/skills/workspace-bootstrap/`
-- Post-bootstrap server management contract: `.agents/skills/workspace-fleet/`
+- Staged init contract: `.agents/skills/workspace-init/`
+- Local readiness contract: `.agents/skills/workspace-foundation/`
+- Git profile contract: `.agents/skills/workspace-git-profile/`
+- Post-staged server management contract: `.agents/skills/workspace-fleet/`
 - Destructive teardown contract: `.agents/skills/workspace-reset/`
 - Session lifecycle contract: `.agents/skills/workspace-session-switch/`
 - Session-oriented compatibility sync contract: `.agents/skills/workspace-sync/`
+- Legacy bootstrap wording routes through the staged init flow instead of a separate workflow.
 - `.workspace.local/` is local-only overlay state
 - Local `origin` / `upstream` repository topology lives in `.workspace.local/repos.yaml`
 - Bootstrap starts from natural language user intent and resolves through shared contracts instead of direct CLI phrasebooks

--- a/.agents/skills/workspace-bootstrap/SKILL.md
+++ b/.agents/skills/workspace-bootstrap/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: workspace-bootstrap
-description: Use when the user wants the first usable baseline for this workspace, needs the first development server attached, or needs to recover an incomplete first bootstrap.
+description: Use when older workspace guidance still mentions bootstrap or asks to route that intent into workspace-init.
 ---
 
 # Workspace Bootstrap
 
 ## Overview
 
-Use this skill for the first usable workspace baseline. It owns bootstrap intent and bootstrap-facing user semantics for the workspace lifecycle.
+Compatibility alias for legacy bootstrap wording. It forwards bootstrap intent to `workspace-init` semantics instead of owning a separate lifecycle path.
 
 If exact internal routing details are required, see `references/internal-routing.md`.
 
@@ -15,68 +15,67 @@ If exact internal routing details are required, see `references/internal-routing
 
 ### Intent Signals
 
-- The user wants to initialize this workspace for the first time.
-- The user wants the first development server attached to this workspace.
-- The user wants a local-only baseline because no remote server is available.
-- The user wants to recover an incomplete first baseline.
+- The user still says bootstrap.
+- Older workspace guidance refers to staged init with bootstrap language.
+- A compatibility shim is needed for legacy prompts or docs.
 
 ### Examples Include, But Are Not Limited To:
 
-- `帮我初始化这个仓库`
-- `先把这个 workspace 跑起来`
-- `没有远端机器，先本地初始化`
+- `这个老流程里还在说 bootstrap`
+- `把旧版 workspace 初始化说法接过来`
+- `按兼容方式理解这次初始化`
 
 ### Do Not Use
 
-- Adding or repairing later servers belongs to `workspace-fleet`.
-- Explicit teardown belongs to `workspace-reset`.
-- Session switching belongs to `workspace-session-switch`.
+- First-time orchestration belongs to `workspace-init`.
+- Local readiness belongs to `workspace-foundation`.
+- Git profile belongs to `workspace-git-profile`.
 
 ## User-Visible Output Contract
 
-- Report whether the workspace is `ready`, `needs_input`, `blocked`, or `needs_repair`.
-- Explain whether a first usable baseline now exists.
-- Say whether the result is remote-first or local-only in user language.
+- Report the request using `workspace-init` semantics.
+- Explain that this is a compatibility alias when relevant.
+- Keep the response centered on the actual lifecycle outcome, not on the alias itself.
 
 ## Never Expose
 
-- overlay file paths as public workflow steps
-- raw password values, raw token values, or secret-bearing shell commands
-- private hosts or private local filesystem paths
+- internal overlay mutation steps
+- raw secret values or secret-bearing handles
+- private filesystem paths from lifecycle state
 
 ## Default Inference Rules
 
-- Prefer remote-first when the user provides a server.
-- Fall back to local-only only when the user explicitly wants it or has no remote server.
-- Treat `vllm-ascend` origin ownership as required for personalized development.
-- Treat `vllm` origin ownership as optional.
+- Prefer the staged init interpretation when the request is ambiguous.
+- Keep legacy bootstrap wording mapped to first-time initialization semantics.
+- Treat later server attachment as fleet-owned, not bootstrap-owned.
 
 ## Cross-Skill Boundary
 
-- Post-bootstrap server inventory work belongs to `workspace-fleet`.
-- Explicit teardown belongs to `workspace-reset`.
-- Feature session changes belong to `workspace-session-switch`.
+- `workspace-init` owns staged workspace orchestration.
+- `workspace-foundation` owns local prerequisite readiness.
+- `workspace-git-profile` owns repository topology and auth-ready remotes.
+- `workspace-fleet` owns managed server attachment.
 
 ## Failure Handling Notes
 
-- If the first baseline already exists, route to `workspace-fleet` instead of retrying bootstrap blindly.
-- If required auth or ownership information is missing, return `needs_input`.
-- If runtime verification is incomplete, return `needs_repair`.
+- Do not invent a separate bootstrap runtime path.
+- Route missing local readiness to foundation instead of expanding the alias.
+- Route server attachment work to fleet.
 
 ## Security Notes
 
-- Secret handles must be pre-staged outside the agent transcript path.
-- Never ask the user to echo or paste secrets into shell commands.
-- Never expose private hosts or private paths in tracked docs.
+- Do not ask for pasted raw secrets when staged handles are available.
+- Keep secret resolution internal to the workspace lifecycle.
+- Never expose private hosts, tokens, or paths in the public contract.
 
 ## Common Mistakes
 
-- Treating later machine additions as bootstrap work.
-- Explaining bootstrap through internal files or command flags.
-- Claiming bootstrap is ready before a first usable baseline actually exists.
+- Treating the alias as a separate lifecycle.
+- Reintroducing bootstrap-era wording as if it were first-class.
+- Folding server attachment or repo topology into the alias.
 
 ## Red Flags
 
-- explaining bootstrap with CLI syntax instead of lifecycle semantics
-- routing a post-bootstrap machine request back into bootstrap
-- asking the user to edit local overlay files directly
+- routing first-time setup away from `workspace-init`
+- exposing secret or overlay details in public guidance
+- claiming a bootstrap-specific runtime path exists

--- a/.agents/skills/workspace-bootstrap/references/internal-routing.md
+++ b/.agents/skills/workspace-bootstrap/references/internal-routing.md
@@ -2,30 +2,27 @@
 
 Public contract: `../SKILL.md`
 
-Use this file only after the public bootstrap contract has been selected.
+Use this file only after the compatibility alias has been selected.
 
 ## Command Mapping
 
-- Primary entrypoint: `tools/vaws.py init --bootstrap`
-- Supporting verification command: `tools/vaws.py doctor`
+- compatibility alias: `tools/vaws.py init --bootstrap`
+- primary staged route: `tools/vaws.py init`
 
-## Internal Inputs
+## Internal Behavior Notes
 
-- first remote server details, or explicit local-only intent
-- `vllm-ascend` origin URL
-- optional `vllm` origin URL
-- pre-staged auth handles or safe auth refs
+- keep bootstrap wording mapped to staged init semantics
+- do not create a separate bootstrap runtime implementation
+- defer local readiness, git topology, and server attachment to their first-class skills
 
 ## Internal State Touched
 
+- `.workspace.local/state.json`
 - `.workspace.local/repos.yaml`
 - `.workspace.local/auth.yaml`
 - `.workspace.local/servers.yaml`
 - `.workspace.local/targets.yaml`
-- `.workspace.local/state.json`
-- git remotes under `vllm/` and `vllm-ascend/`
 
 ## Related Tests
 
 - `tests/test_vaws_init_bootstrap.py`
-- `tests/test_secret_boundary.py`

--- a/.agents/skills/workspace-fleet/SKILL.md
+++ b/.agents/skills/workspace-fleet/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: workspace-fleet
-description: Use when the user wants to manage additional servers after the first workspace baseline already exists, including attach, verify, list, or clearly blocked unsupported maintenance requests.
+description: Use when the user wants to attach, verify, list, or otherwise manage workspace servers after foundation and git-profile readiness exist, including first-server runtime handoff.
 ---
 
 # Workspace Fleet
 
 ## Overview
 
-Use this skill for post-bootstrap server inventory management. It owns the lifecycle of additional managed servers after the first baseline exists.
+Use this skill for managed server inventory and runtime handoff. It owns first-server attachment and later server attachment as the same fleet lifecycle once foundation and git-profile readiness are both complete.
 
 If exact internal routing details are required, see `references/internal-routing.md`.
 
@@ -15,10 +15,10 @@ If exact internal routing details are required, see `references/internal-routing
 
 ### Intent Signals
 
-- The user wants to attach an additional managed server after baseline bootstrap.
+- The user wants to attach an additional managed server after foundation and git-profile readiness exist.
 - The user wants to verify or list a managed server.
-- The user asks for post-bootstrap maintenance that may not have a sanctioned implementation path yet.
-- The user wants to know whether a post-bootstrap server is usable for this workspace.
+- The user wants first server handoff after foundation and git-profile readiness is complete.
+- The user wants to know whether a managed server is usable for this workspace.
 
 ### Examples Include, But Are Not Limited To:
 
@@ -28,16 +28,18 @@ If exact internal routing details are required, see `references/internal-routing
 
 ### Do Not Use
 
-- The first baseline belongs to `workspace-bootstrap`.
+- First-time orchestration belongs to `workspace-init`.
+- Foundation readiness belongs to `workspace-foundation`.
+- Git profile readiness belongs to `workspace-git-profile`.
 - Explicit teardown belongs to `workspace-reset`.
 - Session switching belongs to `workspace-session-switch`.
 
 ## User-Visible Output Contract
 
 - Report whether the requested server operation is `ready`, `partial`, `needs_repair`, or `blocked`.
-- Explain what changed in server terms.
+- Explain what changed in managed server terms.
 - Keep read-only verification distinct from any state-changing request.
-- Surface unsupported post-bootstrap maintenance requests as `blocked` and say plainly that no sanctioned implementation path exists yet.
+- Surface unsupported maintenance requests as `blocked` and say plainly that no sanctioned implementation path exists yet.
 
 ## Never Expose
 
@@ -50,17 +52,20 @@ If exact internal routing details are required, see `references/internal-routing
 - Reuse the single configured SSH auth profile when exactly one safe profile exists.
 - Ask for clarification when multiple profiles exist and the correct one cannot be inferred safely.
 - Treat verify as read-only.
+- Treat first-server attachment and later attachment through the same fleet ownership boundary.
 - Do not improvise repair or removal behavior when no sanctioned implementation path exists.
 
 ## Cross-Skill Boundary
 
-- First baseline work belongs to `workspace-bootstrap`.
+- First-time orchestration belongs to `workspace-init`.
+- Local readiness belongs to `workspace-foundation`.
+- Git topology belongs to `workspace-git-profile`.
 - Explicit teardown belongs to `workspace-reset`.
 - Session changes and sync do not belong to this skill.
 
 ## Failure Handling Notes
 
-- If baseline bootstrap never completed, route back to `workspace-bootstrap`.
+- If foundation or git-profile readiness never completed, route back to `workspace-init`.
 - If a server cannot be reached, return `needs_repair` or `blocked` instead of silently skipping it.
 - If some requested changes succeed and others fail, return `partial`.
 - If the user requests unsupported maintenance, return `blocked` instead of inventing a workflow.
@@ -73,7 +78,7 @@ If exact internal routing details are required, see `references/internal-routing
 
 ## Common Mistakes
 
-- Treating fleet work as a bootstrap rerun.
+- Treating fleet work as an init rerun.
 - Explaining server inventory through YAML file edits.
 - Improvising unsupported repair or removal behavior.
 

--- a/.agents/skills/workspace-fleet/references/internal-routing.md
+++ b/.agents/skills/workspace-fleet/references/internal-routing.md
@@ -14,6 +14,8 @@ Use this file only after the fleet contract has been selected.
 
 ## Internal Behavior Notes
 
+- first-server runtime handoff and later server attachment use the same fleet path
+- lifecycle readiness for fleet attachment and maintenance requires both `lifecycle.foundation.status == ready` and `lifecycle.git_profile.status == ready`
 - when `--ssh-auth-ref` is omitted and exactly one safe profile exists, infer it
 - when multiple safe profiles exist, stop and ask for clarification
 - inventory state remains local-only

--- a/.agents/skills/workspace-foundation/SKILL.md
+++ b/.agents/skills/workspace-foundation/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: workspace-foundation
+description: Use when the user needs local prerequisite checks, control-plane readiness, or recovery from missing optional tooling before staged workspace initialization.
+---
+
+# Workspace Foundation
+
+## Overview
+
+Handle local readiness checks for the workspace control plane before any staged initialization or server attachment work continues.
+
+If exact internal routing details are required, see `references/internal-routing.md`.
+
+## When to Use
+
+### Intent Signals
+
+- The user wants local prerequisite checks.
+- The user wants to know whether the control plane is ready, degraded, or blocked.
+- The user is missing optional tooling and needs a readiness judgment before init continues.
+- The user wants foundation checks before staged setup continues.
+
+### Examples Include, But Are Not Limited To:
+
+- `先看一下本地依赖是不是齐了`
+- `把控制平面健康状态确认一下`
+- `先确认现在能不能继续 staged 初始化`
+
+### Do Not Use
+
+- Full workspace orchestration belongs to `workspace-init`.
+- Git identity and fork topology belong to `workspace-git-profile`.
+- Managed server attachment belongs to `workspace-fleet`.
+
+## User-Visible Output Contract
+
+- Report whether foundation is `ready`, `degraded`, or `blocked`.
+- Explain which prerequisite class is missing or only recommended.
+- Keep the result readable as a readiness judgment, not a shell transcript.
+
+## Never Expose
+
+- exact dependency probe commands
+- raw environment values or secret handles
+- private file paths from local readiness state
+
+## Default Inference Rules
+
+- Treat missing required local tools as blocked.
+- Treat missing recommended tooling as degraded.
+- Prefer to continue the staged flow only when the readiness result is acceptable for the requested path.
+
+## Cross-Skill Boundary
+
+- Init owns orchestration across the staged lifecycle.
+- Git profile owns repository topology and auth-ready remotes.
+- Fleet owns server attachment and runtime verification.
+- Doctor only reports repository and overlay health, not staged lifecycle policy.
+
+## Failure Handling Notes
+
+- Stop if a required prerequisite is missing.
+- Preserve a degraded result when only recommended tooling is absent.
+- Do not convert control-plane readiness into server lifecycle work.
+
+## Security Notes
+
+- Never request raw secrets for local readiness checks.
+- Avoid leaking local environment details that are not needed for the readiness judgment.
+
+## Common Mistakes
+
+- Treating optional tooling as a hard blocker.
+- Moving init or fleet ownership into foundation.
+- Explaining readiness through implementation details instead of the result.
+
+## Red Flags
+
+- leaking command syntax into public readiness guidance
+- calling server attachment a foundation concern
+- hiding degraded readiness behind a generic success message

--- a/.agents/skills/workspace-foundation/references/internal-routing.md
+++ b/.agents/skills/workspace-foundation/references/internal-routing.md
@@ -1,0 +1,23 @@
+# Internal Routing: Workspace Foundation
+
+Public contract: `../SKILL.md`
+
+Use this file only after the foundation contract has been selected.
+
+## Command Mapping
+
+- primary: `tools/vaws.py foundation`
+
+## Internal Behavior Notes
+
+- foundation reports local prerequisite readiness only
+- degraded is acceptable when only recommended tooling is missing
+- blocked means a required prerequisite must be fixed before init can proceed
+
+## Internal State Touched
+
+- `.workspace.local/state.json`
+
+## Related Tests
+
+- `tests/test_vaws_foundation.py`

--- a/.agents/skills/workspace-git-profile/SKILL.md
+++ b/.agents/skills/workspace-git-profile/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: workspace-git-profile
+description: Use when the user needs Git identity, fork topology, or repo remotes prepared for a personalized workspace.
+---
+
+# Workspace Git Profile
+
+## Overview
+
+Handle repository identity and fork topology for a personalized workspace, including the remotes and auth references needed by later lifecycle steps.
+
+If exact internal routing details are required, see `references/internal-routing.md`.
+
+## When to Use
+
+### Intent Signals
+
+- The user wants Git identity prepared for this workspace.
+- The user wants repository remotes or fork topology normalized.
+- The user wants a personalized workspace setup rather than community defaults.
+- The user wants repo remotes ready for a personalized git setup.
+
+### Examples Include, But Are Not Limited To:
+
+- `把这套仓库的来源和身份收口`
+- `先整理 Git 侧的个人化配置`
+- `让我用自己的 fork 关系继续`
+
+### Do Not Use
+
+- Local prerequisite readiness belongs to `workspace-foundation`.
+- Staged orchestration belongs to `workspace-init`.
+- Managed server attachment belongs to `workspace-fleet`.
+
+## User-Visible Output Contract
+
+- Report whether git profile setup is `ready`, `needs_input`, `needs_repair`, or `blocked`.
+- Explain which repository identity or fork inputs are missing.
+- Keep the result framed as topology and auth readiness, not as raw config editing.
+
+## Never Expose
+
+- raw token values or key material
+- internal remotes or auth refs that the user did not ask for
+- private overlay paths or file contents
+
+## Default Inference Rules
+
+- Prefer a personalized topology when the workspace already has explicit origin information.
+- Ask for missing origin input instead of silently falling back to community defaults.
+- Reuse existing ready topology when it still matches the requested workspace identity.
+
+## Cross-Skill Boundary
+
+- Foundation owns local prerequisite readiness.
+- Init owns orchestration across staged setup.
+- Fleet owns runtime handoff after git profile is ready.
+- Reset owns cleanup of repository identity and server state.
+
+## Failure Handling Notes
+
+- Stop when the workspace needs origin input that cannot be inferred safely.
+- Treat partially populated topology as needing input or repair, not as ready.
+- Do not move server attachment work into git profile.
+
+## Security Notes
+
+- Never ask the user to paste raw credentials into the transcript.
+- Keep secret-bearing auth material internal to the workspace overlay.
+- Do not expose private hosts or private repository paths in public guidance.
+
+## Common Mistakes
+
+- Treating git profile as a generic git command wrapper.
+- Falling back to community defaults when personalization is required.
+- Collapsing remote topology into server attachment.
+
+## Red Flags
+
+- exposing auth ref internals in public guidance
+- pretending repo remotes are ready without a personalized topology
+- routing fleet or init work into git profile

--- a/.agents/skills/workspace-git-profile/references/internal-routing.md
+++ b/.agents/skills/workspace-git-profile/references/internal-routing.md
@@ -1,0 +1,24 @@
+# Internal Routing: Workspace Git Profile
+
+Public contract: `../SKILL.md`
+
+Use this file only after the git-profile contract has been selected.
+
+## Command Mapping
+
+- primary: `tools/vaws.py git-profile`
+
+## Internal Behavior Notes
+
+- populate repository topology and auth refs for personalized workspace use
+- keep workspace and submodule origin configuration consistent with the staged lifecycle
+- do not treat this as a server attachment or readiness probe step
+
+## Internal State Touched
+
+- `.workspace.local/repos.yaml`
+- `.workspace.local/auth.yaml`
+
+## Related Tests
+
+- `tests/test_vaws_git_profile.py`

--- a/.agents/skills/workspace-init/SKILL.md
+++ b/.agents/skills/workspace-init/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: workspace-init
+description: Use when the user wants a first-time workspace baseline, staged re-initialization after reset, or recovery from a partially completed setup.
+---
+
+# Workspace Init
+
+## Overview
+
+Coordinate staged workspace initialization as one lifecycle, with foundation, git profile, and fleet handled as separate ownership boundaries.
+
+If exact internal routing details are required, see `references/internal-routing.md`.
+
+## When to Use
+
+### Intent Signals
+
+- The user wants first-time initialization for this workspace.
+- The user wants staged re-initialization after reset or partial failure.
+- The user wants a first usable baseline that may still need follow-up lifecycle work.
+
+### Examples Include, But Are Not Limited To:
+
+- `先把这个 workspace 按 staged 流程跑起来`
+- `把初始化拆成基础检查、Git 配置和 server 接入`
+- `刚 reset 完，重新走一遍初始化`
+
+### Do Not Use
+
+- Local prerequisite checks without orchestration belong to `workspace-foundation`.
+- Git identity or fork topology preparation belongs to `workspace-git-profile`.
+- Managed server attachment belongs to `workspace-fleet`.
+
+## User-Visible Output Contract
+
+- Report whether initialization is `ready`, `needs_input`, `needs_repair`, or `blocked`.
+- Explain whether the workspace now has a usable baseline.
+- Say whether the outcome is fully staged, partially staged, or waiting on input.
+
+## Never Expose
+
+- internal overlay mutation steps
+- raw secret values or secret-bearing handles
+- private filesystem paths from lifecycle state
+
+## Default Inference Rules
+
+- Prefer remote-first when a usable server is supplied.
+- Fall back to local-only only when remote attachment is unavailable or explicitly not requested.
+- Treat first usable baseline and later server attachment as separate lifecycle responsibilities.
+
+## Cross-Skill Boundary
+
+- Foundation owns local prerequisite readiness.
+- Git profile owns repository identity and fork topology.
+- Fleet owns server attachment and runtime handoff.
+- Reset owns destructive teardown.
+
+## Failure Handling Notes
+
+- Stop when required local or remote inputs are missing.
+- Do not invent a first baseline if foundation or git profile is still incomplete.
+- Route later server attachment work to fleet instead of retrying init as a separate runtime path.
+
+## Security Notes
+
+- Do not ask for pasted raw secrets when staged handles are available.
+- Keep secret resolution internal to the workspace lifecycle.
+- Never expose private hosts, tokens, or paths in the public contract.
+
+## Common Mistakes
+
+- Treating init as a monolithic runtime implementation.
+- Folding repository topology or server attachment into one step.
+- Reusing bootstrap wording as if it were a separate lifecycle.
+
+## Red Flags
+
+- routing first-server attachment outside fleet
+- exposing secret or overlay details in public guidance
+- claiming a usable baseline before the staged flow is complete

--- a/.agents/skills/workspace-init/references/internal-routing.md
+++ b/.agents/skills/workspace-init/references/internal-routing.md
@@ -1,0 +1,29 @@
+# Internal Routing: Workspace Init
+
+Public contract: `../SKILL.md`
+
+Use this file only after the staged init contract has been selected.
+
+## Command Mapping
+
+- primary: `tools/vaws.py init`
+- compatibility bootstrap alias: `tools/vaws.py init --bootstrap`
+
+## Internal Behavior Notes
+
+- route local prerequisite work through foundation before git profile or fleet
+- keep re-initialization idempotent when the existing staged state already matches the request
+- treat first server attachment as fleet-owned, not init-owned
+
+## Internal State Touched
+
+- `.workspace.local/state.json`
+- `.workspace.local/repos.yaml`
+- `.workspace.local/auth.yaml`
+- `.workspace.local/servers.yaml`
+- `.workspace.local/targets.yaml`
+
+## Related Tests
+
+- `tests/test_vaws_init.py`
+- `tests/test_vaws_init_bootstrap.py`

--- a/.agents/skills/workspace-reset/SKILL.md
+++ b/.agents/skills/workspace-reset/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: workspace-reset
-description: Use when the user explicitly wants destructive teardown, deinitialization, or a return to a near post-clone workspace state.
+description: Use when the user explicitly wants destructive teardown, deinitialization, or a return to a near post-clone workspace state after lifecycle-managed setup exists.
 ---
 
 # Workspace Reset
 
 ## Overview
 
-Use this skill for explicit guarded destructive teardown in the workspace lifecycle. It owns reset semantics, authorization friction, and best-effort cleanup reporting.
+Use this skill for explicit guarded destructive teardown in the workspace lifecycle. It owns reset semantics, authorization friction, and lifecycle-owned cleanup reporting.
 
 If exact internal routing details are required, see `references/internal-routing.md`.
 
@@ -16,7 +16,7 @@ If exact internal routing details are required, see `references/internal-routing
 ### Intent Signals
 
 - The user explicitly wants this workspace reset or deinitialized.
-- The user wants to clear bootstrap state and managed runtime state.
+- The user wants to clear lifecycle state and managed runtime state.
 - The user wants a near post-clone state for repeated bootstrap testing.
 
 ### Examples Include, But Are Not Limited To:
@@ -27,8 +27,8 @@ If exact internal routing details are required, see `references/internal-routing
 
 ### Do Not Use
 
-- Ordinary server repair belongs to `workspace-fleet`.
-- First setup belongs to `workspace-bootstrap`.
+- Ordinary server management belongs to `workspace-fleet`.
+- First setup belongs to `workspace-init`.
 - Session switching belongs to `workspace-session-switch`.
 
 ## User-Visible Output Contract
@@ -48,11 +48,12 @@ If exact internal routing details are required, see `references/internal-routing
 
 - Treat reset as high-friction by default.
 - Clean all managed servers on a best-effort basis.
-- Preserve the guarded two-phase internal flow even when the user-facing explanation stays high-level.
+- Preserve the guarded two-phase internal flow even when the user-facing explanation stays high level.
+- Treat lifecycle-owned managed-server cleanup as part of reset, not fleet.
 
 ## Cross-Skill Boundary
 
-- First setup belongs to `workspace-bootstrap`.
+- First setup belongs to `workspace-init`.
 - Post-bootstrap server maintenance belongs to `workspace-fleet`.
 - Session switching belongs to `workspace-session-switch`.
 
@@ -71,7 +72,7 @@ If exact internal routing details are required, see `references/internal-routing
 ## Common Mistakes
 
 - Treating reset as routine cleanup.
-- Explaining reset through overlay-file mutations.
+- Explaining reset through overlay file mutations.
 - Hiding unreachable cleanup outcomes.
 
 ## Red Flags

--- a/.agents/skills/workspace-reset/references/internal-routing.md
+++ b/.agents/skills/workspace-reset/references/internal-routing.md
@@ -17,6 +17,7 @@ Use this file only after the reset contract has been selected.
 - downgrade the user-visible result to `partial` whenever any per-server cleanup result is `unreachable` or `cleanup_failed`, even if the command itself completes
 - restore repo remotes to community defaults
 - treat stale authorization state as invalid
+- derive cleanup ownership from lifecycle state and current target handoff kind rather than bootstrap.completed
 
 ## Internal State Touched
 

--- a/.agents/skills/workspace-session-switch/SKILL.md
+++ b/.agents/skills/workspace-session-switch/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: workspace-session-switch
-description: Use when the user wants to create, change, or inspect the active feature session for this workspace.
+description: Use when the user wants to create, change, or inspect the active feature session for this workspace after fleet-owned handoff or a compatible legacy target handoff exists.
 ---
 
 # Workspace Session Switch
 
 ## Overview
 
-Use this skill for active feature-session lifecycle semantics. It owns session creation, session switching, and “which session am I on” requests in the workspace lifecycle.
+Use this skill for active feature-session lifecycle semantics. It owns session creation, session switching, and “which session am I on” requests after fleet has established the current target or a compatible legacy target handoff.
 
 If exact internal routing details are required, see `references/internal-routing.md`.
 
@@ -18,6 +18,7 @@ If exact internal routing details are required, see `references/internal-routing
 - The user wants to create a new feature session.
 - The user wants to switch the active session.
 - The user wants to know which session is currently active.
+- The user has a fleet-owned current target or a compatible legacy target handoff and wants session lifecycle work.
 
 ### Examples Include, But Are Not Limited To:
 
@@ -27,7 +28,7 @@ If exact internal routing details are required, see `references/internal-routing
 
 ### Do Not Use
 
-- First setup belongs to `workspace-bootstrap`.
+- First setup belongs to `workspace-init`.
 - Server inventory work belongs to `workspace-fleet`.
 - Repository or session sync belongs to `workspace-sync`.
 
@@ -45,10 +46,11 @@ If exact internal routing details are required, see `references/internal-routing
 
 - Reuse the requested session name when it is safe and explicit.
 - Ask for clarification when the target session name is ambiguous.
+- Treat the fleet-owned current target or a compatible legacy target handoff as the session-switch precondition.
 
 ## Cross-Skill Boundary
 
-- Bootstrap belongs to `workspace-bootstrap`.
+- Init belongs to `workspace-init`.
 - Fleet server management belongs to `workspace-fleet`.
 - Sync belongs to `workspace-sync`.
 - Destructive teardown belongs to `workspace-reset`.
@@ -57,6 +59,7 @@ If exact internal routing details are required, see `references/internal-routing
 
 - Reject unsafe or invalid session names clearly.
 - If the target session does not exist, explain whether creation is required.
+- If the current target is missing, say that fleet handoff or compatible legacy target handoff is required first.
 
 ## Security Notes
 

--- a/.agents/skills/workspace-session-switch/references/internal-routing.md
+++ b/.agents/skills/workspace-session-switch/references/internal-routing.md
@@ -10,6 +10,12 @@ Use this file only after the session-switch contract has been selected.
 - switch: `tools/vaws.py session switch`
 - status: `tools/vaws.py session status`
 
+## Internal Behavior Notes
+
+- session create and switch require a fleet-owned current target or a compatible legacy target handoff
+- keep current_target and current_target_kind authoritative for session lifecycle resolution
+- session switching does not own server attachment or init orchestration
+
 ## Internal State Touched
 
 - `.workspace.local/state.json`

--- a/.agents/skills/workspace-sync/SKILL.md
+++ b/.agents/skills/workspace-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workspace-sync
-description: Use when the user wants to check sync status, start or finish the session-oriented compatibility sync flow, or discuss sync in workspace lifecycle terms without internal command wiring.
+description: Use when the user wants to check sync status, start or finish the session-oriented compatibility sync flow, or discuss sync around an active session without internal command wiring.
 ---
 
 # Workspace Sync
@@ -18,6 +18,7 @@ If exact internal routing details are required, see `references/internal-routing
 - The user wants to check current sync status.
 - The user wants to start the compatibility sync flow for a session.
 - The user wants to finish the compatibility sync flow cleanly.
+- The user wants to sync repository or session state around the active session.
 
 ### Examples Include, But Are Not Limited To:
 
@@ -27,7 +28,7 @@ If exact internal routing details are required, see `references/internal-routing
 
 ### Do Not Use
 
-- Bootstrap belongs to `workspace-bootstrap`.
+- Init belongs to `workspace-init`.
 - Additional server management belongs to `workspace-fleet`.
 - Session creation or switching belongs to `workspace-session-switch`.
 - Destructive teardown belongs to `workspace-reset`.
@@ -48,10 +49,11 @@ If exact internal routing details are required, see `references/internal-routing
 
 - Prefer the current active session when status or done can be resolved safely from workspace state.
 - Ask for clarification when a sync start request does not identify the target session clearly.
+- Treat sync start as session-oriented compatibility flow, not as bootstrap or server attachment.
 
 ## Cross-Skill Boundary
 
-- Bootstrap belongs to `workspace-bootstrap`.
+- Init belongs to `workspace-init`.
 - Server management belongs to `workspace-fleet`.
 - Session selection belongs to `workspace-session-switch`.
 - Teardown belongs to `workspace-reset`.
@@ -61,6 +63,7 @@ If exact internal routing details are required, see `references/internal-routing
 - If sync cannot proceed, report the blocking reason plainly.
 - If sync is partial, say what remains unresolved.
 - If a sync start request lacks a usable session target, stop and ask instead of improvising.
+- If no current session exists, use the active session or target selection skills first.
 
 ## Security Notes
 

--- a/.agents/skills/workspace-sync/references/internal-routing.md
+++ b/.agents/skills/workspace-sync/references/internal-routing.md
@@ -17,6 +17,7 @@ Use this file only after the sync contract has been selected.
 - `sync start` creates and switches to the target session
 - `sync done` is a reserved compatibility completion step
 - compatibility behavior stays internal
+- sync is session-oriented and does not own init or fleet responsibilities
 
 ## Related Tests
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -4,8 +4,10 @@
 - Treat `/vllm-workspace` as the canonical runtime root.
 - Keep `tools/vaws.py` as the internal implementation surface.
 - Keep `./setup` and `./sync` available as compatibility entrypoints.
-- Treat `.agents/skills/workspace-bootstrap/SKILL.md` as the first baseline bootstrap contract.
-- Treat `.agents/skills/workspace-fleet/SKILL.md` as the post-bootstrap server management contract.
+- Treat `.agents/skills/workspace-init/SKILL.md` as the staged workspace initialization contract.
+- Treat `.agents/skills/workspace-foundation/SKILL.md` as the local prerequisite readiness contract.
+- Treat `.agents/skills/workspace-git-profile/SKILL.md` as the repository identity and fork topology contract.
+- Treat `.agents/skills/workspace-fleet/SKILL.md` as the managed server lifecycle contract.
 - Treat `.agents/skills/workspace-reset/SKILL.md` as the destructive teardown contract.
 - Treat `.agents/skills/workspace-session-switch/SKILL.md` as the session lifecycle contract.
 - Treat `.agents/skills/workspace-sync/SKILL.md` as the session-oriented compatibility sync contract.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,10 @@ This repository is a public-facing control workspace for vLLM Ascend development
 
 ## Workflow Routing
 
-- Use `.agents/skills/workspace-bootstrap/SKILL.md` for first baseline bootstrap intent
-- Use `.agents/skills/workspace-fleet/SKILL.md` for post-bootstrap server management
+- Use `.agents/skills/workspace-init/SKILL.md` for staged workspace initialization
+- Use `.agents/skills/workspace-foundation/SKILL.md` for local prerequisite readiness
+- Use `.agents/skills/workspace-git-profile/SKILL.md` for repository identity and fork topology
+- Use `.agents/skills/workspace-fleet/SKILL.md` for managed server lifecycle
 - Use `.agents/skills/workspace-reset/SKILL.md` for explicit destructive teardown
 - Use `.agents/skills/workspace-session-switch/SKILL.md` for session lifecycle intent
 - Use `.agents/skills/workspace-sync/SKILL.md` for sync status and compatibility sync intent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,10 @@ This repository keeps its workflow contract inside the workspace. Do not rely on
 
 ## Workflow Routing
 
-- Route first baseline initialization to `.agents/skills/workspace-bootstrap/SKILL.md`
-- Route post-bootstrap server management to `.agents/skills/workspace-fleet/SKILL.md`
+- Route staged initialization to `.agents/skills/workspace-init/SKILL.md`
+- Route local prerequisite readiness to `.agents/skills/workspace-foundation/SKILL.md`
+- Route repository identity and fork topology to `.agents/skills/workspace-git-profile/SKILL.md`
+- Route managed server lifecycle to `.agents/skills/workspace-fleet/SKILL.md`
 - Route destructive teardown to `.agents/skills/workspace-reset/SKILL.md`
 - Route session lifecycle changes to `.agents/skills/workspace-session-switch/SKILL.md`
 - Route sync status and compatibility sync flow to `.agents/skills/workspace-sync/SKILL.md`

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ Public workspace-local control repository for coordinating vLLM and vLLM-Ascend 
 
 ## Agent Workflows
 
-- `.agents/skills/` contains the shared workspace-local contracts for bootstrap, fleet, reset, session-switch, and sync.
+- `.agents/skills/` contains the shared workspace-local contracts for staged init, foundation, git profile, fleet, reset, session-switch, and sync.
 - `AGENTS.md` is the Codex adapter.
 - `CLAUDE.md` is the Claude Code adapter.
 - `.cursorrules` is the Cursor adapter.
 - Exact internal routing is kept in skill-local `references/internal-routing.md` files and is not the public workflow surface.
-- Bootstrap and first baseline flow live in `.agents/skills/workspace-bootstrap/`.
+- Staged initialization routes through `.agents/skills/workspace-init/`, `.agents/skills/workspace-foundation/`, and `.agents/skills/workspace-git-profile/`.
 - Ongoing server inventory management lives in `.agents/skills/workspace-fleet/`.
 - Guarded best-effort cleanup flow lives in `.agents/skills/workspace-reset/`.
 - Session lifecycle flow lives in `.agents/skills/workspace-session-switch/`.

--- a/tests/test_lifecycle_state.py
+++ b/tests/test_lifecycle_state.py
@@ -1,0 +1,151 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.lib.config import RepoPaths
+from tools.lib.lifecycle_state import (
+    LEGACY_TARGET_HANDOFF_KIND,
+    infer_current_target_kind,
+    get_lifecycle_state,
+    record_foundation_status,
+    record_git_profile_status,
+    record_requested_mode,
+    record_runtime_handoff,
+)
+from tools.lib.overlay import ensure_overlay_layout
+from tools.lib.runtime import read_state, write_state
+from tools.lib.remote import CredentialGroup, HostSpec, RuntimeSpec, TargetContext
+
+
+def test_record_requested_mode_and_skill_statuses(tmp_path):
+    paths = RepoPaths(root=tmp_path)
+    ensure_overlay_layout(paths)
+    write_state(paths, {})
+
+    assert read_state(paths)["schema_version"] == 1
+
+    record_requested_mode(paths, "foundation")
+    record_foundation_status(paths, "ready")
+    record_git_profile_status(paths, "pending")
+
+    lifecycle = get_lifecycle_state(paths)
+    state = read_state(paths)
+
+    assert lifecycle["requested_mode"] == "foundation"
+    assert state["lifecycle"]["requested_mode"] == "foundation"
+    assert state["lifecycle"]["foundation"]["status"] == "ready"
+    assert state["lifecycle"]["git_profile"]["status"] == "pending"
+
+
+def test_record_runtime_handoff_sets_current_target_and_runtime(tmp_path):
+    paths = RepoPaths(root=tmp_path)
+    ensure_overlay_layout(paths)
+    write_state(paths, {"lifecycle": {}})
+
+    runtime = {
+        "workspace_root": "/vllm-workspace",
+        "ssh_port": 63269,
+        "transport": "bootstrap",
+    }
+
+    record_runtime_handoff(
+        paths,
+        current_target="single-default",
+        handoff_kind=LEGACY_TARGET_HANDOFF_KIND,
+        runtime=runtime,
+    )
+
+    state = read_state(paths)
+
+    assert state["current_target"] == "single-default"
+    assert state["current_target_kind"] == LEGACY_TARGET_HANDOFF_KIND
+    assert state["runtime"] == runtime
+
+
+def test_get_lifecycle_state_returns_empty_without_mutating_state_file(tmp_path):
+    paths = RepoPaths(root=tmp_path)
+    ensure_overlay_layout(paths)
+    write_state(paths, {"schema_version": 1})
+
+    before = (paths.local_state_file).read_text(encoding="utf-8")
+
+    lifecycle = get_lifecycle_state(paths)
+
+    after = (paths.local_state_file).read_text(encoding="utf-8")
+
+    assert lifecycle == {}
+    assert after == before
+
+
+def test_infer_current_target_kind_prefers_runtime_match_over_colliding_name(
+    tmp_path,
+    monkeypatch,
+):
+    paths = RepoPaths(root=tmp_path)
+    ensure_overlay_layout(paths)
+    write_state(
+        paths,
+        {
+            "schema_version": 1,
+            "current_target": "shared-name",
+            "runtime": {
+                "container_name": "legacy-owner",
+                "ssh_port": 63269,
+                "workspace_root": "/vllm-workspace",
+                "bootstrap_mode": "host-then-container",
+                "host_workspace_path": "/root/.vaws/targets/shared-name/workspace",
+                "host_name": "host-a",
+            },
+        },
+    )
+
+    legacy_ctx = TargetContext(
+        name="shared-name",
+        host=HostSpec(
+            name="host-a",
+            host="127.0.0.1",
+            port=22,
+            login_user="root",
+            auth_group="shared-lab-a",
+        ),
+        credential=CredentialGroup(mode="local-simulation", username="root"),
+        runtime=RuntimeSpec(
+            image_ref="registry.example.com/ascend/vllm-ascend:test",
+            container_name="legacy-owner",
+            ssh_port=63269,
+            workspace_root="/vllm-workspace",
+            bootstrap_mode="host-then-container",
+            host_workspace_path="/root/.vaws/targets/shared-name/workspace",
+            docker_run_args=[],
+        ),
+    )
+    managed_ctx = TargetContext(
+        name="shared-name",
+        host=HostSpec(
+            name="shared-name",
+            host="127.0.0.1",
+            port=22,
+            login_user="root",
+            auth_group="shared-lab-a",
+        ),
+        credential=CredentialGroup(mode="local-simulation", username="root"),
+        runtime=RuntimeSpec(
+            image_ref="registry.example.com/ascend/vllm-ascend:test",
+            container_name="server-owner",
+            ssh_port=63270,
+            workspace_root="/vllm-workspace",
+            bootstrap_mode="host-then-container",
+            host_workspace_path="/root/.vaws/targets/shared-name/workspace",
+            docker_run_args=[],
+        ),
+    )
+
+    monkeypatch.setattr("tools.lib.remote.resolve_server_context", lambda paths, name: managed_ctx)
+    monkeypatch.setattr("tools.lib.remote.resolve_target_context", lambda paths, name: legacy_ctx)
+
+    kind = infer_current_target_kind(paths, "shared-name", read_state(paths)["runtime"])
+
+    assert kind == LEGACY_TARGET_HANDOFF_KIND

--- a/tests/test_repo_layout.py
+++ b/tests/test_repo_layout.py
@@ -47,6 +47,12 @@ def test_public_guidance_uses_current_entrypoints_and_canonical_root():
         assert "process docs" not in text
         assert "process documentation" not in text
 
+    for text in (readme, agents_readme):
+        assert "workspace-init" in text
+        assert "workspace-foundation" in text
+        assert "workspace-git-profile" in text
+        assert "workspace-bootstrap" not in text
+
     assert ".agents/skills/" in readme
     assert ".agents/skills/" in agents_readme
     assert ".agents/skills/" in cursorrules
@@ -91,9 +97,12 @@ def test_public_repo_topology_example_stays_public_and_upstream_oriented():
     assert "git@github.com:" not in repos_example
 
 
-def test_public_docs_explain_upstream_defaults_and_local_origin_bootstrap():
+def test_public_docs_explain_upstream_defaults_and_staged_init_routing():
     repo = Path(__file__).resolve().parents[1]
     readme = (repo / "README.md").read_text(encoding="utf-8").lower()
+    init_skill = (repo / ".agents" / "skills" / "workspace-init" / "SKILL.md").read_text(
+        encoding="utf-8"
+    ).lower()
     bootstrap_skill = (
         repo / ".agents" / "skills" / "workspace-bootstrap" / "SKILL.md"
     ).read_text(encoding="utf-8").lower()
@@ -106,8 +115,16 @@ def test_public_docs_explain_upstream_defaults_and_local_origin_bootstrap():
         assert "origin" in text
         assert ".workspace.local/repos.yaml" in text
         assert "natural language" in text or "conversational" in text
+        assert "workspace-init" in text
+        assert "workspace-foundation" in text
+        assert "workspace-git-profile" in text
+        assert "workspace-bootstrap" not in text
 
-    assert "origin ownership" in bootstrap_skill
+    assert "staged" in init_skill
+    assert "workspace-foundation" in init_skill
+    assert "workspace-git-profile" in init_skill
+    assert "compatibility alias" in bootstrap_skill
+    assert "workspace-init" in bootstrap_skill
 
     for forbidden in (
         "reset --prepare",
@@ -117,11 +134,13 @@ def test_public_docs_explain_upstream_defaults_and_local_origin_bootstrap():
         assert forbidden not in bootstrap_skill
 
 
-def test_agents_md_routes_bootstrap_and_reset_to_skills():
+def test_agents_md_routes_first_class_workspace_skills():
     repo = Path(__file__).resolve().parents[1]
     agents = (repo / "AGENTS.md").read_text(encoding="utf-8").lower()
     for skill_name in (
-        "workspace-bootstrap",
+        "workspace-init",
+        "workspace-foundation",
+        "workspace-git-profile",
         "workspace-fleet",
         "workspace-reset",
         "workspace-session-switch",
@@ -129,6 +148,7 @@ def test_agents_md_routes_bootstrap_and_reset_to_skills():
     ):
         assert skill_name in agents
 
+    assert "workspace-bootstrap" not in agents
     assert "reset --prepare" not in agents
     assert "reset --execute" not in agents
     assert "must not skip prepare" not in agents
@@ -139,7 +159,9 @@ def test_agents_md_routes_bootstrap_and_reset_to_skills():
 def test_first_class_workspace_skills_and_internal_routing_refs_exist():
     repo = Path(__file__).resolve().parents[1]
     for skill_name in (
-        "workspace-bootstrap",
+        "workspace-init",
+        "workspace-foundation",
+        "workspace-git-profile",
         "workspace-fleet",
         "workspace-reset",
         "workspace-session-switch",
@@ -149,10 +171,17 @@ def test_first_class_workspace_skills_and_internal_routing_refs_exist():
         assert (skill_root / "SKILL.md").exists()
         assert (skill_root / "references" / "internal-routing.md").exists()
 
+    bootstrap_root = repo / ".agents" / "skills" / "workspace-bootstrap"
+    assert (bootstrap_root / "SKILL.md").exists()
+    assert (bootstrap_root / "references" / "internal-routing.md").exists()
+
 
 def test_internal_routing_refs_contain_command_mapping_and_related_tests():
     repo = Path(__file__).resolve().parents[1]
     for skill_name in (
+        "workspace-init",
+        "workspace-foundation",
+        "workspace-git-profile",
         "workspace-bootstrap",
         "workspace-fleet",
         "workspace-reset",
@@ -182,7 +211,9 @@ def test_first_class_workspace_skills_share_contract_shape():
         "## red flags",
     )
     for skill_name in (
-        "workspace-bootstrap",
+        "workspace-init",
+        "workspace-foundation",
+        "workspace-git-profile",
         "workspace-fleet",
         "workspace-reset",
         "workspace-session-switch",
@@ -201,7 +232,9 @@ def test_first_class_workspace_skills_share_contract_shape():
 def test_public_workspace_skill_contracts_do_not_require_exact_cli_syntax():
     repo = Path(__file__).resolve().parents[1]
     for skill_name in (
-        "workspace-bootstrap",
+        "workspace-init",
+        "workspace-foundation",
+        "workspace-git-profile",
         "workspace-fleet",
         "workspace-reset",
         "workspace-session-switch",

--- a/tests/test_vaws_doctor.py
+++ b/tests/test_vaws_doctor.py
@@ -117,6 +117,22 @@ def test_doctor_fails_when_state_json_schema_version_is_unsupported(vaws_repo):
     assert "unsupported" in output or "invalid" in output
 
 
+def test_doctor_fails_when_lifecycle_is_not_a_mapping(vaws_repo):
+    overlay = vaws_repo / ".workspace.local"
+    seed_overlay_files(vaws_repo)
+    (overlay / "state.json").write_text(
+        '{"schema_version": 1, "lifecycle": []}\n',
+        encoding="utf-8",
+    )
+
+    result = run_vaws(vaws_repo, "doctor")
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "lifecycle" in output
+    assert "mapping" in output or "object" in output
+
+
 def test_doctor_fails_when_state_json_is_not_utf8(vaws_repo):
     overlay = vaws_repo / ".workspace.local"
     seed_overlay_files(vaws_repo)
@@ -163,7 +179,9 @@ def test_init_writes_json_parseable_state_file(vaws_repo):
     state_text = (vaws_repo / ".workspace.local" / "state.json").read_text(
         encoding="utf-8"
     )
-    assert json.loads(state_text) == {"schema_version": 1}
+    state = json.loads(state_text)
+    assert state["schema_version"] == 1
+    assert state["lifecycle"]["requested_mode"] == "local-only"
 
 
 def test_init_fails_cleanly_when_overlay_path_is_a_file(vaws_repo):

--- a/tests/test_vaws_fleet.py
+++ b/tests/test_vaws_fleet.py
@@ -64,6 +64,15 @@ def _write_fleet_overlay(vaws_repo: Path) -> Path:
         ),
         encoding="utf-8",
     )
+    state = json.loads((overlay / "state.json").read_text(encoding="utf-8"))
+    state["lifecycle"] = {
+        "foundation": {"status": "ready"},
+        "git_profile": {"status": "ready"},
+    }
+    (overlay / "state.json").write_text(
+        json.dumps(state, indent=2) + "\n",
+        encoding="utf-8",
+    )
     return overlay
 
 
@@ -106,6 +115,21 @@ def _write_legacy_host_auth(vaws_repo: Path, *group_names: str) -> None:
         ),
         encoding="utf-8",
     )
+
+
+def _write_lifecycle_statuses(
+    vaws_repo: Path,
+    *,
+    foundation_status: str,
+    git_profile_status: str,
+) -> None:
+    state_path = vaws_repo / ".workspace.local" / "state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["lifecycle"] = {
+        "foundation": {"status": foundation_status},
+        "git_profile": {"status": git_profile_status},
+    }
+    state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
 
 
 def test_fleet_add_writes_server_inventory_entry(vaws_repo):
@@ -168,7 +192,7 @@ def test_fleet_add_infers_single_available_ssh_auth_ref(vaws_repo):
     assert servers["servers"]["host-b"]["ssh_auth_ref"] == "lab-sim"
 
 
-def test_fleet_add_requires_bootstrap_before_auth_resolution(vaws_repo):
+def test_fleet_add_requires_staged_lifecycle_before_auth_resolution(vaws_repo):
     result = run_vaws(
         vaws_repo,
         "fleet",
@@ -180,12 +204,13 @@ def test_fleet_add_requires_bootstrap_before_auth_resolution(vaws_repo):
 
     assert result.returncode == 1
     output = (result.stdout + result.stderr).lower()
-    assert "bootstrap" in output
-    assert "init --bootstrap" in output
+    assert "staged init" in output or "foundation" in output
+    assert "init --bootstrap" not in output
+    assert "bootstrap" not in output
     assert "auth config" not in output
 
 
-def test_fleet_add_requires_completed_bootstrap_baseline(vaws_repo):
+def test_fleet_add_uses_lifecycle_preconditions_instead_of_bootstrap_completed(vaws_repo):
     _write_fleet_overlay(vaws_repo)
     overlay = vaws_repo / ".workspace.local"
     servers = yaml.safe_load((overlay / "servers.yaml").read_text(encoding="utf-8"))
@@ -194,6 +219,38 @@ def test_fleet_add_requires_completed_bootstrap_baseline(vaws_repo):
         yaml.safe_dump(servers, sort_keys=False),
         encoding="utf-8",
     )
+    _write_lifecycle_statuses(
+        vaws_repo,
+        foundation_status="degraded",
+        git_profile_status="ready",
+    )
+
+    result = run_vaws(
+        vaws_repo,
+        "fleet",
+        "add",
+        "host-b",
+        "--server-host",
+        "10.0.0.12",
+    )
+
+    assert result.returncode == 0
+    output = (result.stdout + result.stderr).lower()
+    assert "fleet add: ready" in output
+
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["current_target"] == "host-b"
+    assert state["runtime"]["host_name"] == "host-b"
+    assert state["runtime"]["transport"] == "simulation"
+
+
+def test_fleet_add_rejects_unready_git_profile_lifecycle(vaws_repo):
+    _write_fleet_overlay(vaws_repo)
+    _write_lifecycle_statuses(
+        vaws_repo,
+        foundation_status="ready",
+        git_profile_status="needs_input",
+    )
 
     result = run_vaws(
         vaws_repo,
@@ -206,17 +263,17 @@ def test_fleet_add_requires_completed_bootstrap_baseline(vaws_repo):
 
     assert result.returncode == 1
     output = (result.stdout + result.stderr).lower()
-    assert "bootstrap" in output
-    assert "init --bootstrap" in output
+    assert "git_profile" in output
+    assert "ready" in output
 
 
-def test_fleet_add_requires_bootstrap_map_in_server_inventory(vaws_repo):
+def test_fleet_add_requires_lifecycle_state_in_server_inventory(vaws_repo):
     _write_fleet_overlay(vaws_repo)
     overlay = vaws_repo / ".workspace.local"
-    servers = yaml.safe_load((overlay / "servers.yaml").read_text(encoding="utf-8"))
-    servers.pop("bootstrap", None)
-    (overlay / "servers.yaml").write_text(
-        yaml.safe_dump(servers, sort_keys=False),
+    state = json.loads((overlay / "state.json").read_text(encoding="utf-8"))
+    state.pop("lifecycle", None)
+    (overlay / "state.json").write_text(
+        json.dumps(state, indent=2) + "\n",
         encoding="utf-8",
     )
 
@@ -231,11 +288,11 @@ def test_fleet_add_requires_bootstrap_map_in_server_inventory(vaws_repo):
 
     assert result.returncode == 1
     output = (result.stdout + result.stderr).lower()
-    assert "bootstrap" in output
-    assert "init --bootstrap" in output
+    assert "lifecycle" in output
+    assert "foundation" in output or "git_profile" in output
 
 
-def test_fleet_add_infers_single_legacy_host_auth_group(vaws_repo):
+def test_fleet_add_rejects_legacy_host_auth_only_without_modern_ssh_auth_refs(vaws_repo):
     _write_fleet_overlay(vaws_repo)
     _write_legacy_host_auth(vaws_repo, "shared-lab-a")
 
@@ -248,12 +305,15 @@ def test_fleet_add_infers_single_legacy_host_auth_group(vaws_repo):
         "10.0.0.12",
     )
 
-    assert result.returncode == 0
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "invalid auth config" in output
+    assert "ssh_auth.refs" in output
     servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
-    assert servers["servers"]["host-b"]["ssh_auth_ref"] == "shared-lab-a"
+    assert "host-b" not in servers["servers"]
 
 
-def test_fleet_add_requires_explicit_ssh_auth_ref_when_multiple_legacy_groups_exist(vaws_repo):
+def test_fleet_add_rejects_legacy_host_auth_only_even_with_multiple_groups(vaws_repo):
     _write_fleet_overlay(vaws_repo)
     _write_legacy_host_auth(vaws_repo, "shared-lab-a", "shared-lab-b")
 
@@ -268,10 +328,8 @@ def test_fleet_add_requires_explicit_ssh_auth_ref_when_multiple_legacy_groups_ex
 
     assert result.returncode == 1
     output = (result.stdout + result.stderr).lower()
-    assert "multiple" in output
-    assert "ssh auth ref" in output
-    assert "shared-lab-a" in output
-    assert "shared-lab-b" in output
+    assert "invalid auth config" in output
+    assert "ssh_auth.refs" in output
 
 
 def test_fleet_add_requires_explicit_ssh_auth_ref_when_multiple_refs_exist(vaws_repo):
@@ -387,6 +445,11 @@ def test_fleet_add_records_needs_repair_when_verification_needs_repair(vaws_repo
     class FakeVerificationResult:
         status = "needs_repair"
         summary = "runtime probe failed"
+        runtime = {
+            "host_name": "host-b",
+            "transport": "simulation",
+            "workspace_root": "/vllm-workspace",
+        }
 
         def to_mapping(self):
             return {
@@ -409,7 +472,7 @@ def test_fleet_add_records_needs_repair_when_verification_needs_repair(vaws_repo
         "10.0.0.12",
         "default-server-auth",
     )
-    assert result == 0
+    assert result == 1
     servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
     host_b = servers["servers"]["host-b"]
     assert host_b["status"] == "needs_repair"
@@ -418,9 +481,151 @@ def test_fleet_add_records_needs_repair_when_verification_needs_repair(vaws_repo
 
     state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
     assert state["server_verifications"]["host-b"]["status"] == "needs_repair"
+    assert "current_target" not in state
+    assert "runtime" not in state
 
 
-def test_fleet_verify_is_read_only(vaws_repo, monkeypatch):
+def test_fleet_verify_persists_needs_repair_result_without_clobbering_handoff(
+    vaws_repo,
+    monkeypatch,
+):
+    overlay = _write_fleet_overlay(vaws_repo)
+    servers = yaml.safe_load((overlay / "servers.yaml").read_text())
+    servers["servers"]["host-a"] = {
+        "host": "10.0.0.11",
+        "port": 22,
+        "login_user": "root",
+        "ssh_auth_ref": "default-server-auth",
+        "status": "ready",
+        "runtime": {
+            "image_ref": "quay.nju.edu.cn/ascend/vllm-ascend:latest",
+            "container_name": "vaws-workspace",
+            "ssh_port": 63269,
+            "workspace_root": "/vllm-workspace",
+            "bootstrap_mode": "host-then-container",
+        },
+    }
+    overlay.joinpath("servers.yaml").write_text(
+        yaml.safe_dump(servers, sort_keys=False),
+        encoding="utf-8",
+    )
+    state = json.loads((overlay / "state.json").read_text(encoding="utf-8"))
+    state["current_target"] = "existing-target"
+    state["runtime"] = {"host_name": "existing-target", "transport": "simulation"}
+    (overlay / "state.json").write_text(
+        json.dumps(state, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    class FakeVerificationResult:
+        status = "needs_repair"
+        summary = "runtime probe failed"
+        runtime = {
+            "host_name": "host-a",
+            "transport": "simulation",
+            "container_endpoint": "simulation://host-a/vllm-workspace",
+        }
+
+        def to_mapping(self):
+            return {
+                "status": self.status,
+                "summary": self.summary,
+                "checks": [
+                    {
+                        "name": "runtime_state",
+                        "status": "needs_repair",
+                        "detail": "probe failed",
+                    }
+                ],
+                "runtime": dict(self.runtime),
+            }
+
+    monkeypatch.setattr(fleet, "verify_runtime", lambda *args, **kwargs: FakeVerificationResult())
+
+    result = fleet.verify_fleet_server(RepoPaths(root=vaws_repo), "host-a")
+
+    assert result == 1
+    servers = yaml.safe_load((overlay / "servers.yaml").read_text())
+    host_a = servers["servers"]["host-a"]
+    assert host_a["status"] == "needs_repair"
+    assert host_a["verification"]["status"] == "needs_repair"
+    assert host_a["verification"]["checks"][0]["detail"] == "probe failed"
+
+    state = json.loads((overlay / "state.json").read_text(encoding="utf-8"))
+    assert state["server_verifications"]["host-a"]["status"] == "needs_repair"
+    assert state["current_target"] == "existing-target"
+    assert state["runtime"]["host_name"] == "existing-target"
+
+
+def test_fleet_verify_clears_current_session_on_new_handoff(vaws_repo, monkeypatch):
+    overlay = _write_fleet_overlay(vaws_repo)
+    servers = yaml.safe_load((overlay / "servers.yaml").read_text())
+    servers["servers"]["host-a"] = {
+        "host": "10.0.0.11",
+        "port": 22,
+        "login_user": "root",
+        "ssh_auth_ref": "default-server-auth",
+        "status": "ready",
+        "runtime": {
+            "image_ref": "quay.nju.edu.cn/ascend/vllm-ascend:latest",
+            "container_name": "vaws-workspace",
+            "ssh_port": 63269,
+            "workspace_root": "/vllm-workspace",
+            "bootstrap_mode": "host-then-container",
+        },
+    }
+    overlay.joinpath("servers.yaml").write_text(
+        yaml.safe_dump(servers, sort_keys=False),
+        encoding="utf-8",
+    )
+    state = json.loads((overlay / "state.json").read_text(encoding="utf-8"))
+    state["current_target"] = "existing-target"
+    state["current_session"] = "stale-session"
+    state["runtime"] = {"host_name": "existing-target", "transport": "simulation"}
+    (overlay / "state.json").write_text(
+        json.dumps(state, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    def fake_verify_runtime(paths, ctx):
+        return VerificationResult.ready(
+            summary="runtime verified",
+            runtime={
+                "host_name": ctx.name,
+                "host": ctx.host.host,
+                "host_port": ctx.host.port,
+                "login_user": ctx.host.login_user,
+                "transport": "simulation",
+                "container_endpoint": "simulation://host-a/vllm-workspace",
+                "workspace_root": ctx.runtime.workspace_root,
+                "ssh_port": ctx.runtime.ssh_port,
+                "container_name": ctx.runtime.container_name,
+                "image_ref": ctx.runtime.image_ref,
+                "bootstrap_mode": ctx.runtime.bootstrap_mode,
+                "host_workspace_path": ctx.runtime.host_workspace_path,
+            },
+            checks=[
+                VerificationCheck(
+                    name="runtime_state",
+                    status="ready",
+                    detail="runtime state available",
+                )
+            ],
+        )
+
+    monkeypatch.setattr(fleet, "verify_runtime", fake_verify_runtime)
+
+    result = fleet.verify_fleet_server(RepoPaths(root=vaws_repo), "host-a")
+
+    assert result == 0
+    state = json.loads((overlay / "state.json").read_text(encoding="utf-8"))
+    assert state["current_target"] == "host-a"
+    assert "current_session" not in state
+    assert state["runtime"]["host_name"] == "host-a"
+    assert state["runtime"]["transport"] == "simulation"
+
+
+def test_fleet_verify_records_runtime_handoff(vaws_repo, monkeypatch):
     overlay = _write_fleet_overlay(vaws_repo)
     servers = yaml.safe_load((overlay / "servers.yaml").read_text())
     servers["servers"]["host-a"] = {
@@ -442,8 +647,6 @@ def test_fleet_verify_is_read_only(vaws_repo, monkeypatch):
         encoding="utf-8",
     )
     state_path = overlay / "state.json"
-    state_before = state_path.read_text(encoding="utf-8")
-    servers_before = (overlay / "servers.yaml").read_text(encoding="utf-8")
 
     calls = {}
 
@@ -456,6 +659,8 @@ def test_fleet_verify_is_read_only(vaws_repo, monkeypatch):
                 "host": ctx.host.host,
                 "host_port": ctx.host.port,
                 "login_user": ctx.host.login_user,
+                "transport": "simulation",
+                "container_endpoint": "simulation://host-a/vllm-workspace",
                 "workspace_root": ctx.runtime.workspace_root,
                 "ssh_port": ctx.runtime.ssh_port,
                 "container_name": ctx.runtime.container_name,
@@ -478,8 +683,11 @@ def test_fleet_verify_is_read_only(vaws_repo, monkeypatch):
 
     assert result == 0
     assert calls["server"] == "host-a"
-    assert state_path.read_text(encoding="utf-8") == state_before
-    assert (overlay / "servers.yaml").read_text(encoding="utf-8") == servers_before
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["current_target"] == "host-a"
+    assert state["runtime"]["host_name"] == "host-a"
+    assert state["runtime"]["transport"] == "simulation"
+    assert state["runtime"]["container_endpoint"] == "simulation://host-a/vllm-workspace"
 
 
 def test_fleet_verify_requires_known_server(vaws_repo):

--- a/tests/test_vaws_foundation.py
+++ b/tests/test_vaws_foundation.py
@@ -1,0 +1,69 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from conftest import run_vaws, seed_overlay_files
+from tools.lib import foundation
+from tools.lib.config import RepoPaths
+from tools.lib.preflight import PreflightReport
+
+
+def test_vaws_foundation_persists_status_in_state(vaws_repo, monkeypatch, capsys):
+    monkeypatch.setattr(
+        foundation,
+        "check_local_control_plane_deps",
+        lambda: PreflightReport(
+            status="ready",
+            installed_required=("git", "ssh", "python3"),
+            missing_required=(),
+            installed_recommended=("gh",),
+            missing_recommended=(),
+        ),
+    )
+
+    result = foundation.run_foundation(RepoPaths(root=vaws_repo))
+
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    output = capsys.readouterr().out
+    assert result == 0
+    assert "foundation: ready" in output
+    assert state["lifecycle"]["foundation"]["status"] == "ready"
+
+
+def test_run_foundation_returns_nonzero_for_blocked_status(vaws_repo, monkeypatch, capsys):
+    monkeypatch.setattr(
+        foundation,
+        "check_local_control_plane_deps",
+        lambda: PreflightReport(
+            status="blocked",
+            installed_required=("git",),
+            missing_required=("ssh", "python3"),
+            installed_recommended=(),
+            missing_recommended=("gh",),
+        ),
+    )
+
+    result = foundation.run_foundation(RepoPaths(root=vaws_repo))
+
+    output = capsys.readouterr().out
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert result == 1
+    assert "foundation: blocked" in output
+    assert state["lifecycle"]["foundation"]["status"] == "blocked"
+
+
+def test_vaws_foundation_cli_fails_cleanly_for_invalid_state(vaws_repo):
+    overlay = vaws_repo / ".workspace.local"
+    seed_overlay_files(vaws_repo)
+    (overlay / "state.json").write_text("{not-json", encoding="utf-8")
+
+    result = run_vaws(vaws_repo, "foundation")
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert "invalid runtime state: .workspace.local/state.json" in output
+    assert "traceback" not in output.lower()

--- a/tests/test_vaws_git_profile.py
+++ b/tests/test_vaws_git_profile.py
@@ -1,0 +1,397 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from conftest import run_vaws, seed_overlay_files
+
+
+def _remote_url(repo: Path, relative_path: str, remote_name: str) -> str:
+    result = subprocess.run(
+        ["git", "remote", "get-url", remote_name],
+        cwd=repo / relative_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def _set_remote_url(repo: Path, relative_path: str, remote_name: str, url: str) -> None:
+    result = subprocess.run(
+        ["git", "remote", "set-url", remote_name, url],
+        cwd=repo / relative_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def _write_auth_overlay(vaws_repo: Path) -> None:
+    overlay = vaws_repo / ".workspace.local"
+    (overlay / "auth.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "ssh_auth": {
+                    "refs": {
+                        "legacy-server-auth": {
+                            "kind": "ssh-key",
+                            "username": "root",
+                        }
+                    }
+                },
+                "git_auth": {
+                    "refs": {
+                        "legacy-git-auth": {
+                            "kind": "ssh-agent",
+                        }
+                    }
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_ready_repos_overlay(vaws_repo: Path) -> None:
+    overlay = vaws_repo / ".workspace.local"
+    (overlay / "repos.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "workspace": {
+                    "path": ".",
+                    "default_branch": "main",
+                    "protected_branches": ["main"],
+                    "push_remote": "origin",
+                    "upstream_remote": "upstream",
+                },
+                "submodules": {
+                    "vllm": {
+                        "path": "vllm",
+                        "default_branch": "main",
+                        "push_remote": "origin",
+                        "upstream_remote": "upstream",
+                        "upstream_url": "https://github.com/vllm-project/vllm.git",
+                        "origin_url": "git@github.com:alice/vllm.git",
+                    },
+                    "vllm-ascend": {
+                        "path": "vllm-ascend",
+                        "default_branch": "main",
+                        "push_remote": "origin",
+                        "upstream_remote": "upstream",
+                        "upstream_url": "https://github.com/vllm-project/vllm-ascend.git",
+                        "origin_url": "git@github.com:alice/vllm-ascend.git",
+                    },
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    _set_remote_url(vaws_repo, "vllm", "origin", "git@github.com:alice/vllm.git")
+    _set_remote_url(
+        vaws_repo,
+        "vllm-ascend",
+        "origin",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+
+
+def _write_optional_vllm_origin_repos_overlay(vaws_repo: Path) -> None:
+    overlay = vaws_repo / ".workspace.local"
+    (overlay / "repos.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "workspace": {
+                    "path": ".",
+                    "default_branch": "main",
+                    "protected_branches": ["main"],
+                    "push_remote": "origin",
+                    "upstream_remote": "upstream",
+                },
+                "submodules": {
+                    "vllm": {
+                        "path": "vllm",
+                        "default_branch": "main",
+                        "push_remote": "origin",
+                        "upstream_remote": "upstream",
+                        "upstream_url": "https://github.com/vllm-project/vllm.git",
+                    },
+                    "vllm-ascend": {
+                        "path": "vllm-ascend",
+                        "default_branch": "main",
+                        "push_remote": "origin",
+                        "upstream_remote": "upstream",
+                        "upstream_url": "https://github.com/vllm-project/vllm-ascend.git",
+                        "origin_url": "git@github.com:alice/vllm-ascend.git",
+                    },
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_community_origin_repos_overlay(vaws_repo: Path) -> None:
+    overlay = vaws_repo / ".workspace.local"
+    (overlay / "repos.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "workspace": {
+                    "path": ".",
+                    "default_branch": "main",
+                    "protected_branches": ["main"],
+                    "push_remote": "origin",
+                    "upstream_remote": "upstream",
+                },
+                "submodules": {
+                    "vllm": {
+                        "path": "vllm",
+                        "default_branch": "main",
+                        "push_remote": "origin",
+                        "upstream_remote": "upstream",
+                        "upstream_url": "https://github.com/vllm-project/vllm.git",
+                    },
+                    "vllm-ascend": {
+                        "path": "vllm-ascend",
+                        "default_branch": "main",
+                        "push_remote": "origin",
+                        "upstream_remote": "upstream",
+                        "upstream_url": "https://github.com/vllm-project/vllm-ascend.git",
+                        "origin_url": "https://github.com/vllm-project/vllm-ascend.git",
+                    },
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_git_profile_reports_ready_for_existing_topology(vaws_repo):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+    _write_ready_repos_overlay(vaws_repo)
+
+    before = (vaws_repo / ".workspace.local" / "auth.yaml").read_text(encoding="utf-8")
+
+    result = run_vaws(vaws_repo, "git-profile")
+
+    assert result.returncode == 0
+    output = (result.stdout + result.stderr).lower()
+    assert "git-profile: ready" in output
+
+    auth_after = (vaws_repo / ".workspace.local" / "auth.yaml").read_text(encoding="utf-8")
+    assert auth_after != before
+    auth = yaml.safe_load(auth_after)
+    assert auth["ssh_auth"]["refs"]["legacy-server-auth"]["kind"] == "ssh-key"
+    assert auth["git_auth"]["refs"]["legacy-git-auth"]["kind"] == "ssh-agent"
+    assert auth["git_auth"]["refs"]["default-git-auth"]["kind"] == "ssh-agent"
+
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["lifecycle"]["git_profile"]["status"] == "ready"
+
+
+def test_git_profile_rejects_community_origin_topology(vaws_repo):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+    _write_community_origin_repos_overlay(vaws_repo)
+
+    result = run_vaws(vaws_repo, "git-profile")
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "needs_input" in output
+    assert "vllm-ascend" in output
+
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["lifecycle"]["git_profile"]["status"] == "needs_input"
+
+
+def test_git_profile_needs_input_without_vllm_ascend_origin(vaws_repo):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+
+    result = run_vaws(
+        vaws_repo,
+        "git-profile",
+        "--vllm-origin-url",
+        "git@github.com:alice/vllm.git",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "needs_input" in output
+    assert "vllm-ascend" in output
+
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["lifecycle"]["git_profile"]["status"] == "needs_input"
+
+    repos = yaml.safe_load((vaws_repo / ".workspace.local" / "repos.yaml").read_text())
+    assert repos["submodules"] == {}
+
+
+def test_git_profile_needs_input_when_run_without_personalized_origin(vaws_repo):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+
+    result = run_vaws(vaws_repo, "git-profile")
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "needs_input" in output
+    assert "vllm-ascend" in output
+
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["lifecycle"]["git_profile"]["status"] == "needs_input"
+
+    repos = yaml.safe_load((vaws_repo / ".workspace.local" / "repos.yaml").read_text())
+    assert repos["submodules"] == {}
+
+
+def test_git_profile_writes_personalized_topology_and_preserves_ssh_auth_namespace(vaws_repo):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+
+    result = run_vaws(
+        vaws_repo,
+        "git-profile",
+        "--vllm-origin-url",
+        "git@github.com:alice/vllm.git",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+
+    assert result.returncode == 0
+    output = (result.stdout + result.stderr).lower()
+    assert "git-profile: ready" in output
+
+    repos = yaml.safe_load((vaws_repo / ".workspace.local" / "repos.yaml").read_text())
+    assert repos["submodules"]["vllm"]["origin_url"] == "git@github.com:alice/vllm.git"
+    assert repos["submodules"]["vllm"]["upstream_url"] == "https://github.com/vllm-project/vllm.git"
+    assert repos["submodules"]["vllm-ascend"]["origin_url"] == "git@github.com:alice/vllm-ascend.git"
+    assert repos["submodules"]["vllm-ascend"]["upstream_url"] == "https://github.com/vllm-project/vllm-ascend.git"
+
+    assert _remote_url(vaws_repo, "vllm", "origin") == "git@github.com:alice/vllm.git"
+    assert _remote_url(vaws_repo, "vllm", "upstream") == "https://github.com/vllm-project/vllm.git"
+    assert _remote_url(vaws_repo, "vllm-ascend", "origin") == "git@github.com:alice/vllm-ascend.git"
+    assert _remote_url(vaws_repo, "vllm-ascend", "upstream") == "https://github.com/vllm-project/vllm-ascend.git"
+
+    auth = yaml.safe_load((vaws_repo / ".workspace.local" / "auth.yaml").read_text())
+    assert "legacy-server-auth" in auth["ssh_auth"]["refs"]
+    assert auth["ssh_auth"]["refs"]["legacy-server-auth"]["kind"] == "ssh-key"
+    assert "legacy-git-auth" in auth["git_auth"]["refs"]
+    assert auth["git_auth"]["refs"]["default-git-auth"]["kind"] == "ssh-agent"
+
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["lifecycle"]["git_profile"]["status"] == "ready"
+
+
+def test_git_profile_accepts_only_vllm_ascend_origin_without_inventing_vllm_origin(vaws_repo):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+    _set_remote_url(
+        vaws_repo,
+        "vllm",
+        "origin",
+        "git@github.com:alice/custom-vllm.git",
+    )
+
+    result = run_vaws(
+        vaws_repo,
+        "git-profile",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+
+    assert result.returncode == 0
+    output = (result.stdout + result.stderr).lower()
+    assert "git-profile: ready" in output
+
+    repos = yaml.safe_load((vaws_repo / ".workspace.local" / "repos.yaml").read_text())
+    assert repos["submodules"]["vllm"]["upstream_url"] == "https://github.com/vllm-project/vllm.git"
+    assert "origin_url" not in repos["submodules"]["vllm"]
+    assert repos["submodules"]["vllm-ascend"]["origin_url"] == "git@github.com:alice/vllm-ascend.git"
+
+    assert _remote_url(vaws_repo, "vllm", "origin") == "git@github.com:alice/custom-vllm.git"
+    assert _remote_url(vaws_repo, "vllm", "upstream") == "https://github.com/vllm-project/vllm.git"
+    assert _remote_url(vaws_repo, "vllm-ascend", "origin") == "git@github.com:alice/vllm-ascend.git"
+
+
+def test_git_profile_reports_ready_for_optional_vllm_origin_topology(vaws_repo):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+    _set_remote_url(
+        vaws_repo,
+        "vllm",
+        "origin",
+        "git@github.com:alice/custom-vllm.git",
+    )
+    _set_remote_url(
+        vaws_repo,
+        "vllm-ascend",
+        "origin",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+    _write_optional_vllm_origin_repos_overlay(vaws_repo)
+
+    result = run_vaws(vaws_repo, "git-profile")
+
+    assert result.returncode == 0
+    output = (result.stdout + result.stderr).lower()
+    assert "git-profile: ready" in output
+
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["lifecycle"]["git_profile"]["status"] == "ready"
+    assert _remote_url(vaws_repo, "vllm", "origin") == "git@github.com:alice/custom-vllm.git"
+    assert _remote_url(vaws_repo, "vllm", "upstream") == "https://github.com/vllm-project/vllm.git"
+
+
+def test_git_profile_heals_default_git_auth_on_ready_path(vaws_repo):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+    _write_ready_repos_overlay(vaws_repo)
+
+    auth_path = vaws_repo / ".workspace.local" / "auth.yaml"
+    auth = yaml.safe_load(auth_path.read_text())
+    auth["git_auth"]["refs"].pop("default-git-auth", None)
+    auth_path.write_text(yaml.safe_dump(auth, sort_keys=False), encoding="utf-8")
+
+    result = run_vaws(vaws_repo, "git-profile")
+
+    assert result.returncode == 0
+    output = (result.stdout + result.stderr).lower()
+    assert "git-profile: ready" in output
+
+    healed_auth = yaml.safe_load(auth_path.read_text())
+    assert healed_auth["ssh_auth"]["refs"]["legacy-server-auth"]["kind"] == "ssh-key"
+    assert healed_auth["git_auth"]["refs"]["legacy-git-auth"]["kind"] == "ssh-agent"
+    assert healed_auth["git_auth"]["refs"]["default-git-auth"]["kind"] == "ssh-agent"
+
+
+def test_git_profile_handles_malformed_state_file_without_traceback(vaws_repo):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+    _write_ready_repos_overlay(vaws_repo)
+    (vaws_repo / ".workspace.local" / "state.json").write_text("{", encoding="utf-8")
+
+    result = run_vaws(vaws_repo, "git-profile")
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "invalid runtime state" in output
+    assert "traceback" not in output

--- a/tests/test_vaws_init.py
+++ b/tests/test_vaws_init.py
@@ -1,0 +1,746 @@
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from conftest import seed_overlay_files
+from tools.lib.config import RepoPaths
+from tools.lib.init_flow import InitRequest, run_init
+from tools.vaws import build_parser
+
+
+def _write_auth_overlay(vaws_repo: Path) -> None:
+    overlay = vaws_repo / ".workspace.local"
+    overlay.mkdir(exist_ok=True)
+    (overlay / "auth.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "ssh_auth": {
+                    "refs": {
+                        "legacy-server-auth": {
+                            "kind": "ssh-key",
+                            "username": "root",
+                        }
+                    }
+                },
+                "git_auth": {
+                    "refs": {
+                        "legacy-git-auth": {
+                            "kind": "ssh-agent",
+                        }
+                    }
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_default_server_auth(
+    vaws_repo: Path,
+    *,
+    kind: str,
+    username: str = "root",
+    password_env: Optional[str] = None,
+    key_path: Optional[str] = None,
+) -> None:
+    overlay = vaws_repo / ".workspace.local"
+    auth = yaml.safe_load((overlay / "auth.yaml").read_text(encoding="utf-8"))
+    auth["ssh_auth"]["refs"]["default-server-auth"] = {
+        "kind": kind,
+        "username": username,
+    }
+    if password_env is not None:
+        auth["ssh_auth"]["refs"]["default-server-auth"]["password_env"] = password_env
+    if key_path is not None:
+        auth["ssh_auth"]["refs"]["default-server-auth"]["key_path"] = key_path
+    (overlay / "auth.yaml").write_text(
+        yaml.safe_dump(auth, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _set_remote_url(repo: Path, relative_path: str, remote_name: str, url: str) -> None:
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "remote", "set-url", remote_name, url],
+        cwd=repo / relative_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def _write_ready_repos_overlay(vaws_repo: Path) -> None:
+    overlay = vaws_repo / ".workspace.local"
+    overlay.mkdir(exist_ok=True)
+    (overlay / "repos.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "workspace": {
+                    "path": ".",
+                    "default_branch": "main",
+                    "protected_branches": ["main"],
+                    "push_remote": "origin",
+                    "upstream_remote": "upstream",
+                },
+                "submodules": {
+                    "vllm": {
+                        "path": "vllm",
+                        "default_branch": "main",
+                        "push_remote": "origin",
+                        "upstream_remote": "upstream",
+                        "upstream_url": "https://github.com/vllm-project/vllm.git",
+                        "origin_url": "git@github.com:alice/vllm.git",
+                    },
+                    "vllm-ascend": {
+                        "path": "vllm-ascend",
+                        "default_branch": "main",
+                        "push_remote": "origin",
+                        "upstream_remote": "upstream",
+                        "upstream_url": "https://github.com/vllm-project/vllm-ascend.git",
+                        "origin_url": "git@github.com:alice/vllm-ascend.git",
+                    },
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    _set_remote_url(vaws_repo, "vllm", "origin", "git@github.com:alice/vllm.git")
+    _set_remote_url(
+        vaws_repo,
+        "vllm-ascend",
+        "origin",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+
+
+def _write_ready_server(vaws_repo: Path, *, server_name: str, server_host: str) -> None:
+    overlay = vaws_repo / ".workspace.local"
+    servers = yaml.safe_load((overlay / "servers.yaml").read_text(encoding="utf-8"))
+    servers["servers"][server_name] = {
+        "host": server_host,
+        "port": 22,
+        "login_user": "root",
+        "ssh_auth_ref": "default-server-auth",
+        "status": "ready",
+        "verification": {
+            "status": "ready",
+            "summary": "runtime already verified",
+            "checks": [],
+            "runtime": {
+                "host_name": server_name,
+                "host": server_host,
+                "host_port": 22,
+                "login_user": "root",
+                "transport": "simulation",
+                "workspace_root": "/vllm-workspace",
+                "ssh_port": 63269,
+                "container_name": "vaws-workspace",
+                "image_ref": "quay.nju.edu.cn/ascend/vllm-ascend:latest",
+                "bootstrap_mode": "host-then-container",
+                "container_endpoint": f"simulation://{server_name}/vaws-workspace",
+                "host_workspace_path": f"/root/.vaws/targets/{server_name}/workspace",
+            },
+        },
+        "runtime": {
+            "image_ref": "quay.nju.edu.cn/ascend/vllm-ascend:latest",
+            "container_name": "vaws-workspace",
+            "ssh_port": 63269,
+            "workspace_root": "/vllm-workspace",
+            "bootstrap_mode": "host-then-container",
+            "host_workspace_path": f"/root/.vaws/targets/{server_name}/workspace",
+        },
+    }
+    (overlay / "servers.yaml").write_text(
+        yaml.safe_dump(servers, sort_keys=False),
+        encoding="utf-8",
+    )
+    state = json.loads((overlay / "state.json").read_text(encoding="utf-8"))
+    state["server_verifications"] = {
+        server_name: {
+            "status": "ready",
+            "summary": "runtime already verified",
+            "checks": [],
+            "runtime": {
+                "host_name": server_name,
+                "host": server_host,
+                "host_port": 22,
+                "login_user": "root",
+                "transport": "simulation",
+                "workspace_root": "/vllm-workspace",
+                "ssh_port": 63269,
+                "container_name": "vaws-workspace",
+                "image_ref": "quay.nju.edu.cn/ascend/vllm-ascend:latest",
+                "bootstrap_mode": "host-then-container",
+                "container_endpoint": f"simulation://{server_name}/vaws-workspace",
+                "host_workspace_path": f"/root/.vaws/targets/{server_name}/workspace",
+            },
+        }
+    }
+    (overlay / "state.json").write_text(
+        json.dumps(state, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_build_parser_accepts_init_server_name_and_local_only():
+    parser = build_parser()
+
+    args = parser.parse_args(
+        ["init", "--server-name", "lab-a", "--local-only"]
+    )
+
+    assert args.command == "init"
+    assert args.server_name == "lab-a"
+    assert args.local_only is True
+
+
+def test_run_init_remote_first_runs_foundation_git_profile_then_fleet_add(
+    vaws_repo, monkeypatch
+):
+    calls = []
+
+    def fake_foundation(paths):
+        calls.append("foundation")
+        return 0
+
+    def fake_git_profile(paths, **kwargs):
+        calls.append(("git-profile", kwargs))
+        return 0
+
+    def fake_ensure_secret_refs(**kwargs):
+        calls.append(("secret-refs", kwargs))
+
+    def fake_add_fleet_server(
+        paths,
+        server_name,
+        server_host,
+        ssh_auth_ref=None,
+        server_user="root",
+        server_port=22,
+        runtime_image="",
+        runtime_container="",
+        runtime_ssh_port=63269,
+        runtime_workspace_root="",
+        runtime_bootstrap_mode="",
+    ):
+        calls.append(
+            (
+                "fleet-add",
+                {
+                    "server_name": server_name,
+                    "server_host": server_host,
+                    "server_user": server_user,
+                    "server_port": server_port,
+                    "runtime_image": runtime_image,
+                    "runtime_container": runtime_container,
+                    "runtime_ssh_port": runtime_ssh_port,
+                    "runtime_workspace_root": runtime_workspace_root,
+                    "runtime_bootstrap_mode": runtime_bootstrap_mode,
+                },
+            )
+        )
+        return 0
+
+    from tools.lib import init_flow
+
+    monkeypatch.setattr(init_flow, "run_foundation", fake_foundation)
+    monkeypatch.setattr(init_flow, "git_profile", fake_git_profile)
+    monkeypatch.setattr(init_flow, "ensure_bootstrap_secret_refs", fake_ensure_secret_refs)
+    monkeypatch.setattr(init_flow, "add_fleet_server", fake_add_fleet_server)
+
+    result = run_init(
+        RepoPaths(root=vaws_repo),
+        InitRequest(
+            server_host="10.0.0.12",
+            server_user="root",
+            vllm_origin_url="git@github.com:alice/vllm.git",
+            vllm_ascend_origin_url="git@github.com:alice/vllm-ascend.git",
+        ),
+    )
+
+    assert result == 0
+    assert [entry[0] if isinstance(entry, tuple) else entry for entry in calls] == [
+        "foundation",
+        "git-profile",
+        "secret-refs",
+        "fleet-add",
+    ]
+    fleet_call = calls[-1][1]
+    assert fleet_call["server_name"] == "10.0.0.12"
+    assert fleet_call["server_host"] == "10.0.0.12"
+
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["lifecycle"]["requested_mode"] == "remote-first"
+
+
+def test_run_init_fails_cleanly_when_server_name_resolution_returns_none(
+    vaws_repo, monkeypatch, capsys
+):
+    from tools.lib import init_flow
+
+    monkeypatch.setattr(init_flow, "_ensure_overlay", lambda paths: None)
+    monkeypatch.setattr(init_flow, "run_foundation", lambda paths: 0)
+    monkeypatch.setattr(init_flow, "git_profile", lambda paths, **kwargs: 0)
+    monkeypatch.setattr(
+        init_flow,
+        "_ensure_requested_git_auth_secret_refs",
+        lambda request: None,
+    )
+    monkeypatch.setattr(
+        init_flow,
+        "_preserve_requested_git_auth",
+        lambda paths, request: None,
+    )
+    monkeypatch.setattr(init_flow, "_resolved_server_name", lambda request: None)
+
+    result = run_init(
+        RepoPaths(root=vaws_repo),
+        InitRequest(
+            server_host="173.125.1.2",
+            vllm_ascend_origin_url="git@github.com:alice/vllm-ascend.git",
+        ),
+    )
+    output = capsys.readouterr().out.lower()
+
+    assert result == 1
+    assert "missing server name" in output
+
+
+def test_run_init_rerun_reuses_existing_topology_and_ready_server(
+    vaws_repo, monkeypatch, capsys
+):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+    _write_default_server_auth(vaws_repo, kind="ssh-key", username="root")
+    _write_ready_repos_overlay(vaws_repo)
+    _write_ready_server(vaws_repo, server_name="lab-a", server_host="10.0.0.12")
+
+    from tools.lib import init_flow
+
+    monkeypatch.setattr(init_flow, "run_foundation", lambda paths: 0)
+    monkeypatch.setattr(
+        init_flow,
+        "ensure_bootstrap_secret_refs",
+        lambda **kwargs: pytest.fail("secret refs should not run for existing ready server"),
+    )
+    monkeypatch.setattr(
+        init_flow,
+        "add_fleet_server",
+        lambda *args, **kwargs: pytest.fail("fleet add should not run for existing ready server"),
+    )
+
+    result = run_init(
+        RepoPaths(root=vaws_repo),
+        InitRequest(
+            server_host="10.0.0.12",
+            server_name="lab-a",
+            server_user="root",
+        ),
+    )
+
+    assert result == 0
+    output = capsys.readouterr().out.lower()
+    assert "init: ready" in output
+    assert "existing" in output
+
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["lifecycle"]["requested_mode"] == "remote-first"
+    assert state["current_target"] == "lab-a"
+    assert state["runtime"]["host_name"] == "lab-a"
+    assert state["runtime"]["transport"] == "simulation"
+
+
+def test_run_init_rerun_reuses_ready_server_for_same_host_without_explicit_server_name(
+    vaws_repo, monkeypatch, capsys
+):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+    _write_default_server_auth(vaws_repo, kind="ssh-key", username="root")
+    _write_ready_repos_overlay(vaws_repo)
+    _write_ready_server(vaws_repo, server_name="lab-a", server_host="10.0.0.12")
+
+    from tools.lib import init_flow
+
+    monkeypatch.setattr(init_flow, "run_foundation", lambda paths: 0)
+    monkeypatch.setattr(
+        init_flow,
+        "ensure_bootstrap_secret_refs",
+        lambda **kwargs: pytest.fail("secret refs should not run for existing ready server"),
+    )
+    monkeypatch.setattr(
+        init_flow,
+        "add_fleet_server",
+        lambda *args, **kwargs: pytest.fail("fleet add should not run when a ready host match already exists"),
+    )
+
+    result = run_init(
+        RepoPaths(root=vaws_repo),
+        InitRequest(
+            server_host="10.0.0.12",
+            server_user="root",
+        ),
+    )
+
+    assert result == 0
+    output = capsys.readouterr().out.lower()
+    assert "init: ready" in output
+    assert "existing lab-a" in output
+
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["current_target"] == "lab-a"
+    assert state["runtime"]["host_name"] == "lab-a"
+
+
+def test_run_init_explicit_server_name_does_not_silently_reuse_different_ready_name(
+    vaws_repo, monkeypatch
+):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+    _write_ready_repos_overlay(vaws_repo)
+    _write_ready_server(vaws_repo, server_name="lab-a", server_host="10.0.0.12")
+
+    calls = {}
+
+    from tools.lib import init_flow
+
+    monkeypatch.setattr(init_flow, "run_foundation", lambda paths: 0)
+    monkeypatch.setattr(
+        init_flow,
+        "ensure_bootstrap_secret_refs",
+        lambda **kwargs: calls.setdefault("secret_refs", True),
+    )
+
+    def fake_add_fleet_server(
+        paths,
+        server_name,
+        server_host,
+        ssh_auth_ref=None,
+        server_user="root",
+        server_port=22,
+        runtime_image="",
+        runtime_container="",
+        runtime_ssh_port=63269,
+        runtime_workspace_root="",
+        runtime_bootstrap_mode="",
+    ):
+        calls["fleet_add"] = {
+            "server_name": server_name,
+            "server_host": server_host,
+        }
+        return 0
+
+    monkeypatch.setattr(init_flow, "add_fleet_server", fake_add_fleet_server)
+
+    result = run_init(
+        RepoPaths(root=vaws_repo),
+        InitRequest(
+            server_host="10.0.0.12",
+            server_name="lab-b",
+            server_user="root",
+        ),
+    )
+
+    assert result == 0
+    assert calls["fleet_add"]["server_name"] == "lab-b"
+    assert calls["fleet_add"]["server_host"] == "10.0.0.12"
+
+
+def test_run_init_same_host_with_mismatched_runtime_config_does_not_reuse_ready_server(
+    vaws_repo, monkeypatch
+):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+    _write_ready_repos_overlay(vaws_repo)
+    _write_ready_server(vaws_repo, server_name="lab-a", server_host="10.0.0.12")
+
+    calls = {}
+
+    from tools.lib import init_flow
+
+    monkeypatch.setattr(init_flow, "run_foundation", lambda paths: 0)
+    monkeypatch.setattr(
+        init_flow,
+        "ensure_bootstrap_secret_refs",
+        lambda **kwargs: calls.setdefault("secret_refs", kwargs),
+    )
+
+    def fake_add_fleet_server(
+        paths,
+        server_name,
+        server_host,
+        ssh_auth_ref=None,
+        server_user="root",
+        server_port=22,
+        runtime_image="",
+        runtime_container="",
+        runtime_ssh_port=63269,
+        runtime_workspace_root="",
+        runtime_bootstrap_mode="",
+    ):
+        calls["fleet_add"] = {
+            "server_name": server_name,
+            "server_host": server_host,
+            "server_user": server_user,
+            "server_port": server_port,
+            "runtime_image": runtime_image,
+            "runtime_container": runtime_container,
+            "runtime_ssh_port": runtime_ssh_port,
+            "runtime_workspace_root": runtime_workspace_root,
+            "runtime_bootstrap_mode": runtime_bootstrap_mode,
+        }
+        return 0
+
+    monkeypatch.setattr(init_flow, "add_fleet_server", fake_add_fleet_server)
+
+    result = run_init(
+        RepoPaths(root=vaws_repo),
+        InitRequest(
+            server_host="10.0.0.12",
+            server_user="root",
+            server_port=2201,
+            runtime_image="example/runtime:latest",
+            runtime_container="workspace-a",
+            runtime_ssh_port=63270,
+            runtime_workspace_root="/workspace-root",
+        ),
+    )
+
+    assert result == 0
+    assert calls["fleet_add"]["server_name"] == "10.0.0.12"
+    assert calls["fleet_add"]["server_host"] == "10.0.0.12"
+    assert calls["fleet_add"]["server_port"] == 2201
+    assert calls["fleet_add"]["runtime_image"] == "example/runtime:latest"
+    assert calls["fleet_add"]["runtime_container"] == "workspace-a"
+    assert calls["fleet_add"]["runtime_ssh_port"] == 63270
+    assert calls["fleet_add"]["runtime_workspace_root"] == "/workspace-root"
+
+
+def test_run_init_reuse_updates_requested_server_auth_settings(vaws_repo, monkeypatch):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+    _write_default_server_auth(
+        vaws_repo,
+        kind="ssh-key",
+        username="root",
+        key_path="/tmp/old-server.key",
+    )
+    _write_ready_repos_overlay(vaws_repo)
+    _write_ready_server(vaws_repo, server_name="lab-a", server_host="10.0.0.12")
+    monkeypatch.setenv("SERVER_PASSWORD", "already-staged")
+
+    from tools.lib import init_flow
+
+    monkeypatch.setattr(init_flow, "run_foundation", lambda paths: 0)
+    monkeypatch.setattr(
+        init_flow,
+        "add_fleet_server",
+        lambda *args, **kwargs: pytest.fail("reuse path should not attach runtime"),
+    )
+
+    result = run_init(
+        RepoPaths(root=vaws_repo),
+        InitRequest(
+            server_host="10.0.0.12",
+            server_name="lab-a",
+            server_user="root",
+            server_auth_mode="password",
+            server_password_env="SERVER_PASSWORD",
+        ),
+    )
+
+    assert result == 0
+    auth = yaml.safe_load((vaws_repo / ".workspace.local" / "auth.yaml").read_text())
+    assert auth["ssh_auth"]["refs"]["default-server-auth"]["kind"] == "password"
+    assert auth["ssh_auth"]["refs"]["default-server-auth"]["username"] == "root"
+    assert auth["ssh_auth"]["refs"]["default-server-auth"]["password_env"] == "SERVER_PASSWORD"
+    assert "key_path" not in auth["ssh_auth"]["refs"]["default-server-auth"]
+
+
+def test_run_init_direct_preserves_requested_git_auth_settings(vaws_repo, monkeypatch):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+    monkeypatch.setattr("tools.lib.init_flow.run_foundation", lambda paths: 0)
+    monkeypatch.setattr(
+        "tools.lib.init_flow.add_fleet_server",
+        lambda *args, **kwargs: pytest.fail("local-only direct init should not attach runtime"),
+    )
+
+    result = run_init(
+        RepoPaths(root=vaws_repo),
+        InitRequest(
+            local_only=True,
+            vllm_ascend_origin_url="git@github.com:alice/vllm-ascend.git",
+            git_auth_mode="ssh-key",
+            git_key_path="/tmp/direct-git.key",
+        ),
+    )
+
+    assert result == 0
+    auth = yaml.safe_load((vaws_repo / ".workspace.local" / "auth.yaml").read_text())
+    assert auth["git_auth"]["refs"]["default-git-auth"]["kind"] == "ssh-key"
+    assert auth["git_auth"]["refs"]["default-git-auth"]["key_path"] == "/tmp/direct-git.key"
+
+
+def test_run_init_local_only_rejects_unstaged_git_token_before_preserving_auth(
+    vaws_repo, monkeypatch, capsys
+):
+    seed_overlay_files(vaws_repo)
+    _write_auth_overlay(vaws_repo)
+    monkeypatch.delenv("MISSING_GIT_TOKEN", raising=False)
+    monkeypatch.setattr("tools.lib.init_flow.run_foundation", lambda paths: 0)
+    monkeypatch.setattr(
+        "tools.lib.init_flow.add_fleet_server",
+        lambda *args, **kwargs: pytest.fail("local-only token validation failure should not attach runtime"),
+    )
+
+    result = run_init(
+        RepoPaths(root=vaws_repo),
+        InitRequest(
+            local_only=True,
+            vllm_ascend_origin_url="git@github.com:alice/vllm-ascend.git",
+            git_auth_mode="token",
+            git_token_env="MISSING_GIT_TOKEN",
+        ),
+    )
+
+    assert result == 1
+    output = capsys.readouterr().out.lower()
+    assert "git token" in output
+    assert "missing_git_token" in output
+
+    auth = yaml.safe_load((vaws_repo / ".workspace.local" / "auth.yaml").read_text())
+    default_git_auth = auth["git_auth"]["refs"].get("default-git-auth")
+    assert default_git_auth is None or default_git_auth.get("token_env") != "MISSING_GIT_TOKEN"
+
+
+def test_run_init_local_only_records_mode_without_attaching_runtime(
+    vaws_repo, monkeypatch
+):
+    from tools.lib import init_flow
+
+    monkeypatch.setattr(init_flow, "run_foundation", lambda paths: 0)
+    monkeypatch.setattr(init_flow, "git_profile", lambda paths, **kwargs: 0)
+    monkeypatch.setattr(
+        init_flow,
+        "ensure_bootstrap_secret_refs",
+        lambda **kwargs: pytest.fail("local-only should not enforce server secret refs"),
+    )
+    monkeypatch.setattr(
+        init_flow,
+        "add_fleet_server",
+        lambda *args, **kwargs: pytest.fail("local-only should not attach runtime"),
+    )
+
+    result = run_init(
+        RepoPaths(root=vaws_repo),
+        InitRequest(
+            server_host="10.0.0.12",
+            local_only=True,
+            server_user="root",
+            vllm_ascend_origin_url="git@github.com:alice/vllm-ascend.git",
+        ),
+    )
+
+    assert result == 0
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["lifecycle"]["requested_mode"] == "local-only"
+    assert "current_target" not in state
+    assert "runtime" not in state
+
+
+def test_run_init_local_only_preserves_legacy_success_without_git_profile_input(
+    vaws_repo, monkeypatch, capsys
+):
+    from tools.lib import init_flow
+
+    monkeypatch.setattr(init_flow, "run_foundation", lambda paths: 0)
+    monkeypatch.setattr(
+        init_flow,
+        "add_fleet_server",
+        lambda *args, **kwargs: pytest.fail("local-only compatibility path should not attach runtime"),
+    )
+
+    result = run_init(
+        RepoPaths(root=vaws_repo),
+        InitRequest(local_only=True),
+    )
+
+    assert result == 0
+    output = capsys.readouterr().out.lower()
+    assert "git-profile: needs_input" in output
+    assert "init: ready (local-only)" in output
+
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["lifecycle"]["requested_mode"] == "local-only"
+
+
+def test_run_init_local_only_rejects_unrelated_git_profile_failure(
+    vaws_repo, monkeypatch, capsys
+):
+    from tools.lib import init_flow
+
+    monkeypatch.setattr(init_flow, "run_foundation", lambda paths: 0)
+
+    def fake_git_profile(paths, **kwargs):
+        print("git-profile: failed: invalid auth overlay")
+        return 1
+
+    monkeypatch.setattr(init_flow, "git_profile", fake_git_profile)
+    monkeypatch.setattr(
+        init_flow,
+        "add_fleet_server",
+        lambda *args, **kwargs: pytest.fail("local-only error path should not attach runtime"),
+    )
+
+    result = run_init(
+        RepoPaths(root=vaws_repo),
+        InitRequest(local_only=True),
+    )
+
+    assert result == 1
+    output = capsys.readouterr().out.lower()
+    assert "git-profile: failed" in output
+    assert "init: ready" not in output
+
+
+def test_run_init_rejects_missing_env_backed_server_auth(vaws_repo, monkeypatch, capsys):
+    from tools.lib import init_flow
+
+    monkeypatch.setattr(init_flow, "run_foundation", lambda paths: 0)
+    monkeypatch.setattr(init_flow, "git_profile", lambda paths, **kwargs: 0)
+    monkeypatch.setattr(
+        init_flow,
+        "add_fleet_server",
+        lambda *args, **kwargs: pytest.fail("fleet add should not run when secret validation fails"),
+    )
+
+    result = run_init(
+        RepoPaths(root=vaws_repo),
+        InitRequest(
+            server_host="10.0.0.12",
+            server_user="root",
+            server_auth_mode="password",
+            server_password_env="MISSING_SERVER_PASSWORD",
+            vllm_ascend_origin_url="git@github.com:alice/vllm-ascend.git",
+        ),
+    )
+
+    assert result == 1
+    output = capsys.readouterr().out.lower()
+    assert "server password" in output
+    assert "missing_server_password" in output

--- a/tests/test_vaws_init_bootstrap.py
+++ b/tests/test_vaws_init_bootstrap.py
@@ -1,7 +1,9 @@
-import sys
+import json
 import subprocess
+import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -12,16 +14,14 @@ from conftest import run_vaws
 from tools.lib import bootstrap
 from tools.lib import preflight
 from tools.lib.config import RepoPaths
-from tools.lib.preflight import PreflightReport
 from tools.lib.remote import (
     CredentialGroup,
     HostSpec,
     RuntimeSpec,
     TargetContext,
     _ssh_base_command,
-    resolve_server_context,
-    resolve_target_context,
 )
+from tools.vaws import build_parser
 
 
 def _remote_url(repo, relative_path, remote_name):
@@ -36,236 +36,241 @@ def _remote_url(repo, relative_path, remote_name):
     return result.stdout.strip()
 
 
-def test_init_bootstrap_writes_overlay_and_configures_repo_remotes(vaws_repo):
-    result = run_vaws(
-        vaws_repo,
-        "init",
-        "--bootstrap",
-        "--server-host",
-        "173.125.1.2",
-        "--server-user",
-        "root",
-        "--vllm-ascend-origin-url",
-        "git@github.com:alice/vllm-ascend.git",
-        "--vllm-origin-url",
-        "git@github.com:alice/vllm.git",
-        "--git-auth-mode",
-        "ssh-agent",
+def test_bootstrap_request_from_args_preserves_legacy_surface():
+    parser = build_parser()
+
+    args = parser.parse_args(
+        [
+            "init",
+            "--bootstrap",
+            "--server-host",
+            "173.125.1.2",
+            "--server-port",
+            "2201",
+            "--server-user",
+            "root",
+            "--server-auth-mode",
+            "password",
+            "--server-password-env",
+            "SERVER_PASSWORD",
+            "--target-name",
+            "single-default",
+            "--host-name",
+            "host-a",
+            "--runtime-image",
+            "example/runtime:latest",
+            "--runtime-container",
+            "workspace-a",
+            "--runtime-ssh-port",
+            "63270",
+            "--runtime-workspace-root",
+            "/workspace-root",
+            "--vllm-origin-url",
+            "git@github.com:alice/vllm.git",
+            "--vllm-ascend-origin-url",
+            "git@github.com:alice/vllm-ascend.git",
+            "--git-auth-mode",
+            "ssh-agent",
+        ]
     )
 
-    assert result.returncode == 0
+    request = bootstrap.bootstrap_request_from_args(args)
 
-    repos = yaml.safe_load((vaws_repo / ".workspace.local" / "repos.yaml").read_text())
-    assert repos["submodules"]["vllm"]["upstream_url"] == "https://github.com/vllm-project/vllm.git"
-    assert repos["submodules"]["vllm"]["origin_url"] == "git@github.com:alice/vllm.git"
-    assert repos["submodules"]["vllm-ascend"]["upstream_url"] == "https://github.com/vllm-project/vllm-ascend.git"
-    assert repos["submodules"]["vllm-ascend"]["origin_url"] == "git@github.com:alice/vllm-ascend.git"
-
-    auth = yaml.safe_load((vaws_repo / ".workspace.local" / "auth.yaml").read_text())
-    assert auth["version"] == 1
-    assert auth["ssh_auth"]["refs"]["default-server-auth"]["kind"] == "ssh-key"
-    assert auth["ssh_auth"]["refs"]["default-server-auth"]["username"] == "root"
-    assert auth["git_auth"]["refs"]["default-git-auth"]["kind"] == "ssh-agent"
-
-    servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
-    assert servers["version"] == 1
-    assert servers["bootstrap"]["completed"] is True
-    assert servers["bootstrap"]["mode"] == "remote-first"
-    assert servers["servers"]["host-a"]["host"] == "173.125.1.2"
-    assert servers["servers"]["host-a"]["status"] == "ready"
-    assert servers["servers"]["host-a"]["ssh_auth_ref"] == "default-server-auth"
-    assert servers["servers"]["host-a"]["verification"]["status"] == "ready"
-    assert servers["servers"]["host-a"]["verification"]["checks"][0]["name"] == "inventory"
-    assert servers["servers"]["host-a"]["runtime"]["image_ref"] == "quay.nju.edu.cn/ascend/vllm-ascend:latest"
-    assert servers["servers"]["host-a"]["runtime"]["bootstrap_mode"] == "host-then-container"
-    assert servers["servers"]["host-a"]["runtime"]["host_workspace_path"] == "/root/.vaws/targets/single-default/workspace"
-
-    targets = yaml.safe_load(
-        (vaws_repo / ".workspace.local" / "targets.yaml").read_text()
-    )
-    assert targets["hosts"]["host-a"]["host"] == "173.125.1.2"
-    assert targets["hosts"]["host-a"]["ssh_auth_ref"] == "default-server-auth"
-    assert "auth_group" not in targets["hosts"]["host-a"]
-    assert targets["targets"]["single-default"]["runtime"]["workspace_root"] == "/vllm-workspace"
-    assert targets["targets"]["single-default"]["runtime"]["host_workspace_path"] == "/root/.vaws/targets/single-default/workspace"
-
-    assert _remote_url(vaws_repo, "vllm", "origin") == "git@github.com:alice/vllm.git"
-    assert _remote_url(vaws_repo, "vllm", "upstream") == "https://github.com/vllm-project/vllm.git"
-    assert _remote_url(vaws_repo, "vllm-ascend", "origin") == "git@github.com:alice/vllm-ascend.git"
-    assert _remote_url(vaws_repo, "vllm-ascend", "upstream") == "https://github.com/vllm-project/vllm-ascend.git"
-
-    target_result = run_vaws(vaws_repo, "target", "ensure", "single-default")
-    assert target_result.returncode == 0
-    state = yaml.safe_load((vaws_repo / ".workspace.local" / "state.json").read_text())
-    assert state["schema_version"] == 1
-    assert state["bootstrap"]["completed"] is True
-    assert state["bootstrap"]["mode"] == "remote-first"
-    assert state["current_target"] == "single-default"
-    assert state["server_verifications"]["host-a"]["status"] == "ready"
+    assert request.server_host == "173.125.1.2"
+    assert request.server_port == 2201
+    assert request.server_user == "root"
+    assert request.server_auth_mode == "password"
+    assert request.server_password_env == "SERVER_PASSWORD"
+    assert request.target_name == "single-default"
+    assert request.host_name == "host-a"
+    assert request.runtime_image == "example/runtime:latest"
+    assert request.runtime_container == "workspace-a"
+    assert request.runtime_ssh_port == 63270
+    assert request.runtime_workspace_root == "/workspace-root"
+    assert request.vllm_origin_url == "git@github.com:alice/vllm.git"
+    assert request.vllm_ascend_origin_url == "git@github.com:alice/vllm-ascend.git"
+    assert request.git_auth_mode == "ssh-agent"
 
 
-def test_init_bootstrap_rolls_back_finalization_failure(vaws_repo, monkeypatch):
-    def fail_finalize(*args, **kwargs):
-        raise bootstrap.BootstrapError("finalization failed")
+def test_bootstrap_init_routes_compat_request_into_staged_init(vaws_repo, monkeypatch):
+    captured = {}
 
-    monkeypatch.setattr(bootstrap, "_write_bootstrap_state", fail_finalize)
+    def fail_legacy_bootstrap_path():
+        pytest.fail("bootstrap compatibility path should delegate into staged init")
+
+    def fake_run_staged_init(paths, request):
+        captured["paths"] = paths
+        captured["request"] = request
+        return 17
+
+    monkeypatch.setattr(bootstrap, "_ensure_overlay", lambda *_args, **_kwargs: fail_legacy_bootstrap_path())
+    monkeypatch.setattr(bootstrap, "_run_staged_init", fake_run_staged_init, raising=False)
 
     result = bootstrap.bootstrap_init(
         RepoPaths(root=vaws_repo),
         bootstrap.BootstrapRequest(
             server_host="173.125.1.2",
             server_user="root",
+            server_port=2201,
+            server_auth_mode="password",
+            server_password_env="SERVER_PASSWORD",
+            server_key_path="/tmp/server.key",
+            target_name="single-default",
+            host_name="host-a",
+            runtime_image="example/runtime:latest",
+            runtime_container="workspace-a",
+            runtime_ssh_port=63270,
+            runtime_workspace_root="/workspace-root",
+            vllm_origin_url="git@github.com:alice/vllm.git",
             vllm_ascend_origin_url="git@github.com:alice/vllm-ascend.git",
+            git_auth_mode="ssh-key",
+            git_key_path="/tmp/git.key",
+            git_token_env="GIT_TOKEN",
         ),
     )
 
-    assert result == 1
-    servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
-    assert servers["bootstrap"]["completed"] is False
-    assert servers["bootstrap"]["mode"] == "remote-first"
-
-    state = yaml.safe_load((vaws_repo / ".workspace.local" / "state.json").read_text())
-    assert state.get("bootstrap", {}).get("completed") is False
-
-
-def test_init_bootstrap_refuses_rerun_after_baseline(vaws_repo):
-    first = run_vaws(
-        vaws_repo,
-        "init",
-        "--bootstrap",
-        "--server-host",
-        "173.125.1.2",
-        "--server-user",
-        "root",
-        "--vllm-ascend-origin-url",
-        "git@github.com:alice/vllm-ascend.git",
+    assert result == 17
+    assert captured["paths"].root == vaws_repo
+    assert captured["request"].server_host == "173.125.1.2"
+    assert captured["request"].server_name == "host-a"
+    assert captured["request"].local_only is False
+    assert captured["request"].server_user == "root"
+    assert captured["request"].server_port == 2201
+    assert captured["request"].server_auth_mode == "password"
+    assert captured["request"].server_password_env == "SERVER_PASSWORD"
+    assert captured["request"].server_key_path == "/tmp/server.key"
+    assert captured["request"].runtime_image == "example/runtime:latest"
+    assert captured["request"].runtime_container == "workspace-a"
+    assert captured["request"].runtime_ssh_port == 63270
+    assert captured["request"].runtime_workspace_root == "/workspace-root"
+    assert captured["request"].vllm_origin_url == "git@github.com:alice/vllm.git"
+    assert (
+        captured["request"].vllm_ascend_origin_url
+        == "git@github.com:alice/vllm-ascend.git"
     )
-    assert first.returncode == 0
-
-    second = run_vaws(
-        vaws_repo,
-        "init",
-        "--bootstrap",
-        "--server-host",
-        "173.125.1.2",
-        "--server-user",
-        "root",
-        "--vllm-ascend-origin-url",
-        "git@github.com:alice/vllm-ascend.git",
-    )
-
-    assert second.returncode == 1
-    output = (second.stdout + second.stderr).lower()
-    assert "bootstrap baseline" in output
-    assert "fleet" in output
-    assert "traceback" not in output
+    assert captured["request"].git_auth_mode == "ssh-key"
+    assert captured["request"].git_key_path == "/tmp/git.key"
+    assert captured["request"].git_token_env == "GIT_TOKEN"
 
 
-def test_init_bootstrap_supports_local_only_mode(vaws_repo):
-    overlay = vaws_repo / ".workspace.local"
-    overlay.mkdir()
-    (overlay / "servers.yaml").write_text(
-        "\n".join(
-            [
-                "version: 1",
-                "bootstrap:",
-                "  completed: false",
-                "  mode: remote-first",
-                "servers:",
-                "  host-a:",
-                "    host: 173.125.1.2",
-                "    port: 22",
-                "    login_user: root",
-                "    ssh_auth_ref: default-server-auth",
-                "    status: pending",
-                "    runtime:",
-                "      image_ref: quay.nju.edu.cn/ascend/vllm-ascend:latest",
-                "      container_name: vaws-workspace",
-                "      ssh_port: 63269",
-                "      workspace_root: /vllm-workspace",
-                "      bootstrap_mode: host-then-container",
-                "",
-            ]
-        ),
-        encoding="utf-8",
-    )
-    (overlay / "targets.yaml").write_text(
-        "\n".join(
-            [
-                "version: 1",
-                "hosts:",
-                "  host-a:",
-                "    host: 173.125.1.2",
-                "    port: 22",
-                "    login_user: root",
-                "    ssh_auth_ref: default-server-auth",
-                "targets:",
-                "  single-default:",
-                "    hosts:",
-                "      - host-a",
-                "    runtime:",
-                "      image_ref: quay.nju.edu.cn/ascend/vllm-ascend:latest",
-                "      container_name: vaws-workspace",
-                "      ssh_port: 63269",
-                "      workspace_root: /vllm-workspace",
-                "      bootstrap_mode: host-then-container",
-                "",
-            ]
-        ),
-        encoding="utf-8",
-    )
-    (overlay / "auth.yaml").write_text(
-        "\n".join(
-            [
-                "version: 1",
-                "ssh_auth:",
-                "  refs:",
-                "    default-server-auth:",
-                "      kind: ssh-key",
-                "      username: root",
-                "git_auth:",
-                "  refs:",
-                "    default-git-auth:",
-                "      kind: ssh-agent",
-                "",
-            ]
-        ),
-        encoding="utf-8",
-    )
-    (overlay / "repos.yaml").write_text(
-        "version: 1\nworkspace: {}\nsubmodules: {}\n",
-        encoding="utf-8",
-    )
-    (overlay / "state.json").write_text('{"schema_version": 1}\n', encoding="utf-8")
+def test_bootstrap_init_does_not_swallow_unexpected_runtime_error(vaws_repo, monkeypatch):
+    def fake_run_staged_init(paths, request):
+        raise RuntimeError("unexpected staged init bug")
 
+    monkeypatch.setattr(bootstrap, "_run_staged_init", fake_run_staged_init, raising=False)
+
+    with pytest.raises(RuntimeError, match="unexpected staged init bug"):
+        bootstrap.bootstrap_init(
+            RepoPaths(root=vaws_repo),
+            bootstrap.BootstrapRequest(
+                server_host="173.125.1.2",
+                server_user="root",
+                vllm_ascend_origin_url="git@github.com:alice/vllm-ascend.git",
+            ),
+        )
+
+
+def test_init_bootstrap_local_only_runs_staged_init_flow(vaws_repo):
     result = run_vaws(
         vaws_repo,
         "init",
         "--bootstrap",
+        "--server-user",
+        "root",
         "--vllm-ascend-origin-url",
         "git@github.com:alice/vllm-ascend.git",
     )
 
     assert result.returncode == 0
-    output = result.stdout.lower()
-    assert "bootstrap ready" in output
+    output = (result.stdout + result.stderr).lower()
+    assert "foundation:" in output
+    assert "git-profile: ready" in output
+    assert "init: ready (local-only)" in output
 
-    servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
-    assert servers["bootstrap"]["completed"] is True
-    assert servers["bootstrap"]["mode"] == "local-only"
-    assert servers["servers"] == {}
-
-    targets = yaml.safe_load((vaws_repo / ".workspace.local" / "targets.yaml").read_text())
-    assert targets["hosts"] == {}
-    assert targets["targets"] == {}
+    repos = yaml.safe_load((vaws_repo / ".workspace.local" / "repos.yaml").read_text())
+    assert "origin_url" not in repos["submodules"]["vllm"]
+    assert (
+        repos["submodules"]["vllm-ascend"]["origin_url"]
+        == "git@github.com:alice/vllm-ascend.git"
+    )
+    assert _remote_url(vaws_repo, "vllm", "origin") == "https://github.com/vllm-project/vllm.git"
+    assert _remote_url(vaws_repo, "vllm", "upstream") == "https://github.com/vllm-project/vllm.git"
 
     auth = yaml.safe_load((vaws_repo / ".workspace.local" / "auth.yaml").read_text())
     assert auth["ssh_auth"]["refs"] == {}
-    assert auth["git_auth"]["refs"] == {}
+    assert auth["git_auth"]["refs"]["default-git-auth"]["kind"] == "ssh-key"
 
-    state = yaml.safe_load((vaws_repo / ".workspace.local" / "state.json").read_text())
-    assert state["bootstrap"]["completed"] is True
-    assert state["bootstrap"]["mode"] == "local-only"
+    servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
+    assert servers["servers"] == {}
+    assert "bootstrap" not in servers
+
+    state = json.loads((vaws_repo / ".workspace.local" / "state.json").read_text())
+    assert state["schema_version"] == 1
+    assert state["lifecycle"]["requested_mode"] == "local-only"
+    assert state["lifecycle"]["git_profile"]["status"] == "ready"
+    assert "bootstrap" not in state
+    assert "current_target" not in state
+    assert "runtime" not in state
+
+
+def test_init_bootstrap_preserves_requested_git_auth_settings(vaws_repo):
+    result = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--server-user",
+        "root",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+        "--git-auth-mode",
+        "ssh-key",
+        "--git-key-path",
+        "/tmp/bootstrap-git.key",
+    )
+
+    assert result.returncode == 0
+
+    auth = yaml.safe_load((vaws_repo / ".workspace.local" / "auth.yaml").read_text())
+    assert auth["git_auth"]["refs"]["default-git-auth"]["kind"] == "ssh-key"
+    assert auth["git_auth"]["refs"]["default-git-auth"]["key_path"] == "/tmp/bootstrap-git.key"
+
+
+def test_init_bootstrap_preserves_default_requested_git_auth_mode(vaws_repo):
+    result = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--server-user",
+        "root",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+
+    assert result.returncode == 0
+
+    auth = yaml.safe_load((vaws_repo / ".workspace.local" / "auth.yaml").read_text())
+    assert auth["git_auth"]["refs"]["default-git-auth"]["kind"] == "ssh-key"
+    assert "key_path" not in auth["git_auth"]["refs"]["default-git-auth"]
+    assert "token_env" not in auth["git_auth"]["refs"]["default-git-auth"]
+
+
+def test_init_bootstrap_local_only_overlay_stays_doctor_compatible(vaws_repo):
+    result = run_vaws(
+        vaws_repo,
+        "init",
+        "--bootstrap",
+        "--server-user",
+        "root",
+        "--vllm-ascend-origin-url",
+        "git@github.com:alice/vllm-ascend.git",
+    )
+
+    assert result.returncode == 0
+
+    doctor_result = run_vaws(vaws_repo, "doctor")
+
+    assert doctor_result.returncode == 0
+    assert "doctor: ok" in doctor_result.stdout.lower()
 
 
 def test_preflight_reports_missing_and_optional_tools(monkeypatch):
@@ -283,81 +288,6 @@ def test_preflight_reports_missing_and_optional_tools(monkeypatch):
     assert report.missing_required == ()
     assert report.installed_recommended == ()
     assert report.missing_recommended == ("gh",)
-
-
-def test_init_bootstrap_reports_degraded_preflight_state(vaws_repo, monkeypatch, capsys):
-    monkeypatch.setattr(
-        bootstrap,
-        "ensure_local_control_plane_deps",
-        lambda: PreflightReport(
-            status="degraded",
-            installed_required=("git", "ssh", "python3"),
-            missing_required=(),
-            installed_recommended=(),
-            missing_recommended=("gh",),
-        ),
-    )
-
-    request = bootstrap.BootstrapRequest(
-        server_host="173.125.1.2",
-        server_user="root",
-        vllm_ascend_origin_url="git@github.com:alice/vllm-ascend.git",
-    )
-
-    result = bootstrap.bootstrap_init(RepoPaths(root=vaws_repo), request)
-    output = capsys.readouterr().out.lower()
-
-    assert result == 0
-    assert "preflight degraded" in output
-    assert "gh" in output
-    assert "bootstrap ready" in output
-
-
-def test_init_bootstrap_records_needs_repair_when_verification_needs_repair(
-    vaws_repo,
-    monkeypatch,
-    capsys,
-):
-    class FakeVerificationResult:
-        status = "needs_repair"
-        summary = "runtime probe failed"
-
-        def to_mapping(self):
-            return {
-                "status": self.status,
-                "summary": self.summary,
-                "checks": [
-                    {
-                        "name": "runtime_state",
-                        "status": "needs_repair",
-                        "detail": "probe failed",
-                    }
-                ],
-            }
-
-    monkeypatch.setattr(bootstrap, "verify_runtime", lambda *args, **kwargs: FakeVerificationResult(), raising=False)
-
-    request = bootstrap.BootstrapRequest(
-        server_host="173.125.1.2",
-        server_user="root",
-        vllm_ascend_origin_url="git@github.com:alice/vllm-ascend.git",
-    )
-
-    result = bootstrap.bootstrap_init(RepoPaths(root=vaws_repo), request)
-    output = capsys.readouterr().out.lower()
-
-    assert result == 0
-    assert "needs_repair" in output
-
-    servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
-    host_a = servers["servers"]["host-a"]
-    assert host_a["status"] == "needs_repair"
-    assert host_a["verification"]["status"] == "needs_repair"
-    assert host_a["verification"]["checks"][0]["detail"] == "probe failed"
-
-    state = yaml.safe_load((vaws_repo / ".workspace.local" / "state.json").read_text())
-    assert state["server_verifications"]["host-a"]["status"] == "needs_repair"
-    assert state["bootstrap"]["completed"] is True
 
 
 def test_preflight_reports_blocked_when_required_tool_missing(monkeypatch):
@@ -389,31 +319,6 @@ def test_preflight_treats_running_python_as_installed_python3(monkeypatch):
     assert report.status == "ready"
     assert "python3" in report.installed_required
     assert report.missing_required == ()
-
-
-def test_init_bootstrap_creates_overlay_compatible_with_doctor(vaws_repo):
-    result = run_vaws(
-        vaws_repo,
-        "init",
-        "--bootstrap",
-        "--server-host",
-        "173.125.1.2",
-        "--server-user",
-        "root",
-        "--vllm-ascend-origin-url",
-        "git@github.com:alice/vllm-ascend.git",
-        "--vllm-origin-url",
-        "git@github.com:alice/vllm.git",
-        "--git-auth-mode",
-        "ssh-agent",
-    )
-
-    assert result.returncode == 0
-
-    doctor_result = run_vaws(vaws_repo, "doctor")
-
-    assert doctor_result.returncode == 0
-    assert "doctor: ok" in doctor_result.stdout.lower()
 
 
 def test_ssh_base_command_honors_server_key_path():
@@ -504,30 +409,8 @@ def test_init_bootstrap_fails_cleanly_for_unsupported_state_schema_version(vaws_
     assert "unsupported" in output or "invalid" in output
     assert "traceback" not in output
     servers = yaml.safe_load((vaws_repo / ".workspace.local" / "servers.yaml").read_text())
-    assert servers["bootstrap"]["completed"] is False
-    assert servers["bootstrap"]["mode"] == "remote-first"
-
-
-def test_init_bootstrap_allows_missing_vllm_origin_url(vaws_repo):
-    result = run_vaws(
-        vaws_repo,
-        "init",
-        "--bootstrap",
-        "--server-host",
-        "173.125.1.2",
-        "--server-user",
-        "root",
-        "--vllm-ascend-origin-url",
-        "git@github.com:alice/vllm-ascend.git",
-    )
-
-    assert result.returncode == 0
-
-    repos = yaml.safe_load((vaws_repo / ".workspace.local" / "repos.yaml").read_text())
-    assert "origin_url" not in repos["submodules"]["vllm"]
-    assert repos["submodules"]["vllm-ascend"]["origin_url"] == "git@github.com:alice/vllm-ascend.git"
-    assert _remote_url(vaws_repo, "vllm", "origin") == "https://github.com/vllm-project/vllm.git"
-    assert _remote_url(vaws_repo, "vllm", "upstream") == "https://github.com/vllm-project/vllm.git"
+    assert servers["servers"] == {}
+    assert "bootstrap" not in servers
 
 
 def test_init_bootstrap_requires_vllm_ascend_origin_url(vaws_repo):
@@ -545,45 +428,6 @@ def test_init_bootstrap_requires_vllm_ascend_origin_url(vaws_repo):
     output = (result.stdout + result.stderr).lower()
     assert "vllm-ascend" in output
     assert "origin" in output
-
-
-def test_init_bootstrap_defaults_to_local_only_without_server_host(vaws_repo):
-    result = run_vaws(
-        vaws_repo,
-        "init",
-        "--bootstrap",
-        "--server-user",
-        "root",
-        "--vllm-ascend-origin-url",
-        "git@github.com:alice/vllm-ascend.git",
-    )
-
-    assert result.returncode == 0
-    output = result.stdout.lower()
-    assert "local-only" in output
-    assert "bootstrap ready" in output
-
-
-def test_bootstrap_target_and_server_resolution_share_workspace_root(vaws_repo):
-    result = run_vaws(
-        vaws_repo,
-        "init",
-        "--bootstrap",
-        "--server-host",
-        "173.125.1.2",
-        "--server-user",
-        "root",
-        "--vllm-ascend-origin-url",
-        "git@github.com:alice/vllm-ascend.git",
-    )
-
-    assert result.returncode == 0
-
-    paths = RepoPaths(root=vaws_repo)
-    target_context = resolve_target_context(paths, "single-default")
-    server_context = resolve_server_context(paths, "host-a")
-
-    assert target_context.runtime.host_workspace_path == server_context.runtime.host_workspace_path
 
 
 def test_init_bootstrap_rejects_missing_pre_staged_password_handle(vaws_repo):

--- a/tests/test_vaws_reset.py
+++ b/tests/test_vaws_reset.py
@@ -14,6 +14,7 @@ if str(ROOT) not in sys.path:
 from conftest import run_vaws
 from tools.lib import reset
 from tools.lib.config import RepoPaths
+from tools.lib.lifecycle_state import LEGACY_TARGET_HANDOFF_KIND
 from tools.lib.remote import (
     CredentialGroup,
     HostSpec,
@@ -42,38 +43,43 @@ def _remote_url(repo: Path, relative_path: str, remote_name: str) -> str:
     return result.stdout.strip()
 
 
-def seed_reset_workspace(vaws_repo: Path, target_name: str = "single-default") -> Path:
+def seed_reset_workspace(
+    vaws_repo: Path,
+    target_name: str = "single-default",
+    use_modern_auth: bool = False,
+) -> Path:
     simulation_root = vaws_repo.parent / "simulation-runtime"
     overlay = vaws_repo / ".workspace.local"
     overlay.mkdir(exist_ok=True)
 
-    (overlay / "auth.yaml").write_text(
-        yaml.safe_dump(
-            {
-                "host_auth": {
-                    "mode": "local-simulation",
-                    "credential_groups": {
-                        "shared-lab-a": {
-                            "username": "root",
-                            "simulation_root": str(simulation_root),
-                        }
-                    },
+    auth_config = (
+        {
+            "ssh_auth": {
+                "refs": {
+                    "shared-lab-a": {
+                        "kind": "local-simulation",
+                        "username": "root",
+                        "simulation_root": str(simulation_root),
+                    }
                 }
-                ,
-                "ssh_auth": {
-                    "refs": {
-                        "shared-lab-a": {
-                            "kind": "local-simulation",
-                            "username": "root",
-                            "simulation_root": str(simulation_root),
-                        }
+            },
+            "git_auth": {"refs": {}},
+        }
+        if use_modern_auth
+        else {
+            "host_auth": {
+                "mode": "local-simulation",
+                "credential_groups": {
+                    "shared-lab-a": {
+                        "username": "root",
+                        "simulation_root": str(simulation_root),
                     }
                 },
-                "git_auth": {"refs": {}},
-            }
-        ),
-        encoding="utf-8",
+            },
+            "git_auth": {"refs": {}},
+        }
     )
+    (overlay / "auth.yaml").write_text(yaml.safe_dump(auth_config), encoding="utf-8")
     (overlay / "repos.yaml").write_text(
         yaml.safe_dump(
             {
@@ -106,13 +112,17 @@ def seed_reset_workspace(vaws_repo: Path, target_name: str = "single-default") -
         yaml.safe_dump(
             {
                 "hosts": {
-                    "host-a": {
-                        "host": "127.0.0.1",
-                        "port": 22,
-                        "login_user": "root",
-                        "auth_group": "shared-lab-a",
-                    }
-                },
+                "host-a": {
+                    "host": "127.0.0.1",
+                    "port": 22,
+                    "login_user": "root",
+                    **(
+                        {"ssh_auth_ref": "shared-lab-a"}
+                        if use_modern_auth
+                        else {"auth_group": "shared-lab-a"}
+                    ),
+                }
+            },
                 "targets": {
                     target_name: {
                         "hosts": ["host-a"],
@@ -236,6 +246,16 @@ def add_competing_target(vaws_repo: Path, target_name: str = "single-backup") ->
     targets_path.write_text(yaml.safe_dump(targets_config), encoding="utf-8")
 
 
+def _remove_current_target_kind(vaws_repo: Path) -> None:
+    overlay = vaws_repo / ".workspace.local"
+    state = read_json(overlay / "state.json")
+    state.pop("current_target_kind", None)
+    (overlay / "state.json").write_text(
+        json.dumps(state, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
 def prepare_reset_confirmation(vaws_repo: Path):
     overlay = vaws_repo / ".workspace.local"
     result = run_vaws(vaws_repo, "reset", "--prepare")
@@ -244,7 +264,9 @@ def prepare_reset_confirmation(vaws_repo: Path):
     output = result.stdout + result.stderr
     lowered = output.lower()
     assert "wipe local workspace identity" in lowered
-    assert "remote runtime context" in lowered
+    assert "managed servers" in lowered
+    assert "approved target" in lowered or "approved-target" in lowered
+    assert "managed-server cleanup" in lowered or "approved-target cleanup" in lowered
     assert "overlay" in lowered
     assert "I authorize wiping local workspace identity and remote runtime" in output
 
@@ -285,10 +307,10 @@ def test_reset_prepare_prints_destruction_summary_and_creates_confirmation_recor
     confirmation_id, output = prepare_reset_confirmation(vaws_repo)
     lowered = output.lower()
     assert confirmation_id in output
-    assert "task 2" not in lowered
-    assert "only clear local overlay state" not in lowered
-    assert "wipe local workspace identity" in lowered
-    assert "remote runtime context" in lowered
+    assert "managed servers" in lowered
+    assert "approved target" in lowered or "approved-target" in lowered
+    assert "managed-server cleanup" in lowered or "approved-target cleanup" in lowered
+    assert "active bootstrap target" not in lowered
     assert (vaws_repo / ".workspace.local" / "reset-request.json").exists()
 
 
@@ -299,6 +321,35 @@ def test_reset_prepare_records_approved_target_in_confirmation_record(vaws_repo)
     request_data = read_json(vaws_repo / ".workspace.local" / "reset-request.json")
 
     assert request_data["approved_target"] == "single-default"
+    assert request_data["approved_target_kind"] == LEGACY_TARGET_HANDOFF_KIND
+
+
+def test_reset_execute_refuses_malformed_servers_inventory_and_leaves_local_state_intact(
+    vaws_repo,
+):
+    seed_initialized_reset_state(vaws_repo)
+    confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
+
+    overlay = vaws_repo / ".workspace.local"
+    (overlay / "servers.yaml").write_text("not: [valid", encoding="utf-8")
+    state_before = read_json(overlay / "state.json")
+
+    result = run_vaws(
+        vaws_repo,
+        "reset",
+        "--execute",
+        "--confirmation-id",
+        confirmation_id,
+        "--confirm",
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "servers.yaml" in output
+    assert "invalid" in output
+    assert (overlay / "reset-request.json").exists()
+    assert read_json(overlay / "state.json") == state_before
 
 
 def test_reset_prepare_fails_closed_on_invalid_runtime_state(vaws_repo):
@@ -432,6 +483,45 @@ def test_reset_execute_rejects_confirmation_phrase_with_outer_whitespace(vaws_re
     assert "exact" in output or "match" in output
 
 
+def test_reset_execute_cleans_remote_before_local(vaws_repo, monkeypatch):
+    overlay = vaws_repo / ".workspace.local"
+    overlay.mkdir(exist_ok=True)
+    (overlay / "reset-request.json").write_text(
+        json.dumps(
+            {
+                "confirmation_id": "reset-1",
+                "status": "pending",
+                "confirmation_phrase": reset.CONFIRMATION_PHRASE,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    calls = []
+    monkeypatch.setattr(
+        reset,
+        "_cleanup_remote_state",
+        lambda request, paths: calls.append("remote") or [],
+    )
+    monkeypatch.setattr(
+        reset,
+        "_cleanup_local_state",
+        lambda paths: calls.append("local"),
+    )
+    monkeypatch.setattr(reset, "_restore_public_repo_remotes", lambda paths: None)
+
+    result = reset.execute_reset(
+        RepoPaths(root=vaws_repo),
+        "reset-1",
+        reset.CONFIRMATION_PHRASE,
+    )
+
+    assert result == 0
+    assert calls == ["remote", "local"]
+
+
 def test_reset_execute_removes_local_and_remote_state(vaws_repo):
     seed_initialized_reset_state(vaws_repo)
     confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
@@ -458,6 +548,10 @@ def test_reset_execute_removes_local_and_remote_state(vaws_repo):
     assert read_json(overlay / "state.json") == {"schema_version": 1}
     assert not (overlay / "sessions").exists()
     assert (overlay / "targets.yaml").read_text(encoding="utf-8") == ""
+    assert yaml.safe_load((overlay / "servers.yaml").read_text(encoding="utf-8")) == {
+        "version": 1,
+        "servers": {},
+    }
     assert (overlay / "auth.yaml").read_text(encoding="utf-8") == ""
     assert (overlay / "repos.yaml").read_text(encoding="utf-8") == ""
     assert not runtime_root.exists()
@@ -467,6 +561,110 @@ def test_reset_execute_removes_local_and_remote_state(vaws_repo):
     assert _remote_url(vaws_repo, "vllm", "upstream") == COMMUNITY_VLLM_URL
     assert _remote_url(vaws_repo, "vllm-ascend", "origin") == COMMUNITY_VLLM_ASCEND_URL
     assert _remote_url(vaws_repo, "vllm-ascend", "upstream") == COMMUNITY_VLLM_ASCEND_URL
+
+
+def test_reset_execute_removes_remote_runtime_for_legacy_host_auth_managed_server(
+    vaws_repo,
+):
+    simulation_root = seed_reset_workspace(vaws_repo)
+    assert run_vaws(vaws_repo, "target", "ensure", "single-default").returncode == 0
+
+    overlay = vaws_repo / ".workspace.local"
+    auth = yaml.safe_load((overlay / "auth.yaml").read_text(encoding="utf-8"))
+    auth.pop("ssh_auth", None)
+    (overlay / "auth.yaml").write_text(
+        yaml.safe_dump(auth, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    (overlay / "servers.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "bootstrap": {
+                    "completed": True,
+                    "mode": "remote-first",
+                },
+                "servers": {
+                    "host-a": {
+                        "host": "127.0.0.1",
+                        "port": 22,
+                        "login_user": "root",
+                        "auth_group": "shared-lab-a",
+                        "status": "ready",
+                        "runtime": {
+                            "image_ref": "registry.example.com/ascend/vllm-ascend:test",
+                            "container_name": "vaws-owner",
+                            "ssh_port": 63269,
+                            "workspace_root": "/vllm-workspace",
+                            "bootstrap_mode": "host-then-container",
+                            "host_workspace_path": "/root/.vaws/targets/single-default/workspace",
+                        },
+                    },
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
+
+    result = run_vaws(
+        vaws_repo,
+        "reset",
+        "--execute",
+        "--confirmation-id",
+        confirmation_id,
+        "--confirm",
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+
+    assert result.returncode == 0
+    output = (result.stdout + result.stderr).lower()
+    assert "host-a" in output
+    assert "removed" in output
+    runtime_root = simulation_root / "host-a" / "vllm-workspace"
+    assert not runtime_root.exists()
+
+
+def test_reset_execute_surfaces_managed_server_auth_failure_without_fallback(
+    vaws_repo,
+):
+    simulation_root = seed_reset_workspace_with_servers(vaws_repo)
+    assert run_vaws(vaws_repo, "target", "ensure", "single-default").returncode == 0
+
+    overlay = vaws_repo / ".workspace.local"
+    auth = yaml.safe_load((overlay / "auth.yaml").read_text(encoding="utf-8"))
+    auth.pop("ssh_auth", None)
+    (overlay / "auth.yaml").write_text(
+        yaml.safe_dump(auth, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
+
+    result = run_vaws(
+        vaws_repo,
+        "reset",
+        "--execute",
+        "--confirmation-id",
+        confirmation_id,
+        "--confirm",
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+
+    assert result.returncode == 0
+    output = (result.stdout + result.stderr).lower()
+    assert "host-a" in output
+    assert "host-b" in output
+    assert "cleanup_failed" in output
+    assert "missing ssh_auth.refs map" in output
+    assert "unknown target" not in output
+    assert "single-default" in output
+    assert "removed" in output
+    runtime_root = simulation_root / "host-a" / "vllm-workspace"
+    assert not runtime_root.exists()
 
 
 def test_reset_execute_keeps_cleanup_pinned_to_prepared_target_after_live_target_changes(
@@ -566,6 +764,67 @@ def test_reset_execute_attempts_cleanup_for_all_managed_servers(
     capsys,
 ):
     seed_reset_workspace_with_servers(vaws_repo)
+    overlay = vaws_repo / ".workspace.local"
+    confirmation_id = "reset-managed"
+    (overlay / "reset-request.json").write_text(
+        json.dumps(
+            {
+                "confirmation_id": confirmation_id,
+                "status": "pending",
+                "confirmation_phrase": reset.CONFIRMATION_PHRASE,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    calls = []
+
+    class FakeCleanupResult:
+        def __init__(self, server_name: str):
+            self.server_name = server_name
+            self.status = "removed"
+            self.detail = "removed"
+
+        def to_mapping(self):
+            return {
+                "server_name": self.server_name,
+                "status": self.status,
+                "detail": self.detail,
+            }
+
+    def fake_cleanup_server_runtime(paths, server_name):
+        calls.append(server_name)
+        return FakeCleanupResult(server_name)
+
+    monkeypatch.setattr(
+        reset,
+        "_cleanup_managed_server_runtime",
+        fake_cleanup_server_runtime,
+        raising=False,
+    )
+
+    result = reset.execute_reset(
+        RepoPaths(root=vaws_repo),
+        confirmation_id,
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+    output = capsys.readouterr().out.lower()
+
+    assert result == 0
+    assert calls == ["host-a", "host-b"]
+    assert "host-a" in output
+    assert "host-b" in output
+    assert "removed" in output
+
+
+def test_reset_execute_attempts_cleanup_for_managed_servers_and_approved_target(
+    vaws_repo,
+    monkeypatch,
+    capsys,
+):
+    seed_reset_workspace_with_servers(vaws_repo)
     assert run_vaws(vaws_repo, "target", "ensure", "single-default").returncode == 0
     confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
 
@@ -588,7 +847,18 @@ def test_reset_execute_attempts_cleanup_for_all_managed_servers(
         calls.append(server_name)
         return FakeCleanupResult(server_name)
 
-    monkeypatch.setattr(reset, "cleanup_server_runtime", fake_cleanup_server_runtime, raising=False)
+    monkeypatch.setattr(
+        reset,
+        "_cleanup_managed_server_runtime",
+        fake_cleanup_server_runtime,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        reset,
+        "cleanup_target_runtime",
+        fake_cleanup_server_runtime,
+        raising=False,
+    )
 
     result = reset.execute_reset(
         RepoPaths(root=vaws_repo),
@@ -598,10 +868,224 @@ def test_reset_execute_attempts_cleanup_for_all_managed_servers(
     output = capsys.readouterr().out.lower()
 
     assert result == 0
-    assert calls == ["host-a", "host-b"]
+    assert calls == ["host-a", "host-b", "single-default"]
     assert "host-a" in output
     assert "host-b" in output
+    assert "single-default" in output
     assert "removed" in output
+
+
+def test_reset_execute_cleans_prepared_managed_target_even_if_removed_from_inventory(
+    vaws_repo,
+    monkeypatch,
+    capsys,
+):
+    seed_reset_workspace_with_servers(vaws_repo)
+    overlay = vaws_repo / ".workspace.local"
+    (overlay / "reset-request.json").write_text(
+        json.dumps(
+            {
+                "confirmation_id": "reset-managed-approved",
+                "status": "pending",
+                "confirmation_phrase": reset.CONFIRMATION_PHRASE,
+                "approved_target": "host-c",
+                "approved_target_kind": "managed_server",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    calls = []
+
+    class FakeCleanupResult:
+        def __init__(self, server_name: str):
+            self.server_name = server_name
+            self.status = "removed"
+            self.detail = "removed"
+
+        def to_mapping(self):
+            return {
+                "server_name": self.server_name,
+                "status": self.status,
+                "detail": self.detail,
+            }
+
+    def fake_cleanup_managed_server_runtime(paths, server_name):
+        calls.append(server_name)
+        return FakeCleanupResult(server_name)
+
+    monkeypatch.setattr(
+        reset,
+        "_cleanup_managed_server_runtime",
+        fake_cleanup_managed_server_runtime,
+        raising=False,
+    )
+
+    result = reset.execute_reset(
+        RepoPaths(root=vaws_repo),
+        "reset-managed-approved",
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+    output = capsys.readouterr().out.lower()
+
+    assert result == 0
+    assert calls == ["host-a", "host-b", "host-c"]
+    assert "host-c" in output
+    assert "removed" in output
+
+
+def test_reset_execute_cleans_managed_server_and_legacy_target_collision_separately(
+    vaws_repo,
+    monkeypatch,
+    capsys,
+):
+    simulation_root = seed_reset_workspace(vaws_repo, target_name="shared-name")
+    overlay = vaws_repo / ".workspace.local"
+    (overlay / "servers.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "bootstrap": {
+                    "completed": True,
+                    "mode": "remote-first",
+                },
+                "servers": {
+                    "shared-name": {
+                        "host": "127.0.0.1",
+                        "port": 22,
+                        "login_user": "root",
+                        "ssh_auth_ref": "shared-lab-a",
+                        "status": "ready",
+                        "runtime": {
+                            "image_ref": "registry.example.com/ascend/vllm-ascend:test",
+                            "container_name": "server-owner",
+                            "ssh_port": 63270,
+                            "workspace_root": "/vllm-workspace",
+                            "bootstrap_mode": "host-then-container",
+                            "host_workspace_path": "/root/.vaws/targets/shared-name/workspace",
+                        },
+                    }
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    assert run_vaws(vaws_repo, "target", "ensure", "shared-name").returncode == 0
+    confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
+
+    calls = []
+
+    class FakeCleanupResult:
+        def __init__(self, server_name: str, status: str):
+            self.server_name = server_name
+            self.status = status
+            self.detail = status
+
+        def to_mapping(self):
+            return {
+                "server_name": self.server_name,
+                "status": self.status,
+                "detail": self.detail,
+            }
+
+    def fake_cleanup_managed_server_runtime(paths, server_name):
+        calls.append(("managed", server_name))
+        return FakeCleanupResult(server_name, "removed")
+
+    def fake_cleanup_target_runtime(paths, target_name):
+        calls.append(("legacy", target_name))
+        return FakeCleanupResult(target_name, "removed")
+
+    monkeypatch.setattr(reset, "_cleanup_managed_server_runtime", fake_cleanup_managed_server_runtime, raising=False)
+    monkeypatch.setattr(reset, "cleanup_target_runtime", fake_cleanup_target_runtime, raising=False)
+
+    result = reset.execute_reset(
+        RepoPaths(root=vaws_repo),
+        confirmation_id,
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+    output = capsys.readouterr().out.lower()
+
+    assert result == 0
+    assert calls == [("managed", "shared-name"), ("legacy", "shared-name")]
+    assert "shared-name" in output
+    assert "removed" in output
+
+
+def test_reset_execute_infers_missing_current_target_kind_for_modern_auth_collision(
+    vaws_repo,
+):
+    simulation_root = seed_reset_workspace(
+        vaws_repo,
+        target_name="shared-name",
+        use_modern_auth=True,
+    )
+    overlay = vaws_repo / ".workspace.local"
+    (overlay / "servers.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "bootstrap": {
+                    "completed": True,
+                    "mode": "remote-first",
+                },
+                "servers": {
+                    "shared-name": {
+                        "host": "127.0.0.1",
+                        "port": 22,
+                        "login_user": "root",
+                        "ssh_auth_ref": "shared-lab-a",
+                        "status": "ready",
+                        "runtime": {
+                            "image_ref": "registry.example.com/ascend/vllm-ascend:test",
+                            "container_name": "server-owner",
+                            "ssh_port": 63270,
+                            "workspace_root": "/vllm-workspace",
+                            "bootstrap_mode": "host-then-container",
+                            "host_workspace_path": "/root/.vaws/targets/shared-name/workspace",
+                        },
+                    }
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    assert run_vaws(vaws_repo, "target", "ensure", "shared-name").returncode == 0
+    _remove_current_target_kind(vaws_repo)
+
+    confirmation_id, _ = prepare_reset_confirmation(vaws_repo)
+    request_path = overlay / "reset-request.json"
+    request_data = read_json(request_path)
+    assert request_data["approved_target"] == "shared-name"
+    assert request_data["approved_target_kind"] == LEGACY_TARGET_HANDOFF_KIND
+    request_data.pop("approved_target_kind")
+    request_path.write_text(json.dumps(request_data, indent=2) + "\n", encoding="utf-8")
+
+    result = run_vaws(
+        vaws_repo,
+        "reset",
+        "--execute",
+        "--confirmation-id",
+        confirmation_id,
+        "--confirm",
+        "I authorize wiping local workspace identity and remote runtime",
+    )
+
+    assert result.returncode == 0
+    output = (result.stdout + result.stderr).lower()
+    assert "shared-name" in output
+    assert "ok" in output or "complete" in output
+    target_runtime_root = simulation_root / "host-a" / "vllm-workspace"
+    server_runtime_root = simulation_root / "shared-name" / "vllm-workspace"
+    assert not target_runtime_root.exists()
+    assert not server_runtime_root.exists()
+    assert read_json(overlay / "state.json") == {"schema_version": 1}
 
 
 def test_reset_execute_reports_unreachable_servers_but_continues_cleanup(
@@ -627,12 +1111,17 @@ def test_reset_execute_reports_unreachable_servers_but_continues_cleanup(
                 "detail": self.detail,
             }
 
-    def fake_cleanup_server_runtime(paths, server_name):
+    def fake_cleanup_managed_server_runtime(paths, server_name):
         if server_name == "host-a":
             return FakeCleanupResult(server_name, "removed", "removed")
         return FakeCleanupResult(server_name, "unreachable", "ssh probe failed")
 
-    monkeypatch.setattr(reset, "cleanup_server_runtime", fake_cleanup_server_runtime, raising=False)
+    monkeypatch.setattr(
+        reset,
+        "_cleanup_managed_server_runtime",
+        fake_cleanup_managed_server_runtime,
+        raising=False,
+    )
 
     result = reset.execute_reset(
         RepoPaths(root=vaws_repo),

--- a/tests/test_vaws_session.py
+++ b/tests/test_vaws_session.py
@@ -1,9 +1,25 @@
 import json
 from pathlib import Path
+import sys
 
 import yaml
 
 from conftest import run_vaws
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.lib import fleet, session as session_lib
+from tools.lib.config import RepoPaths
+from tools.lib.remote import (
+    CredentialGroup,
+    HostSpec,
+    RuntimeSpec,
+    TargetContext,
+    VerificationCheck,
+    VerificationResult,
+)
 
 
 def read_json(path: Path):
@@ -14,26 +30,36 @@ def read_yaml(path: Path):
     return yaml.safe_load(path.read_text(encoding="utf-8"))
 
 
-def seed_overlay(vaws_repo, target_name="single-default") -> Path:
+def seed_overlay(vaws_repo, target_name="single-default", use_modern_auth=False) -> Path:
     overlay = vaws_repo / ".workspace.local"
     overlay.mkdir(exist_ok=True)
     simulation_root = vaws_repo.parent / "simulation-runtime"
-    (overlay / "auth.yaml").write_text(
-        yaml.safe_dump(
-            {
-                "host_auth": {
-                    "mode": "local-simulation",
-                    "credential_groups": {
-                        "shared-lab-a": {
-                            "username": "root",
-                            "simulation_root": str(simulation_root),
-                        }
-                    },
+    auth_config = (
+        {
+            "ssh_auth": {
+                "refs": {
+                    "shared-lab-a": {
+                        "kind": "local-simulation",
+                        "username": "root",
+                        "simulation_root": str(simulation_root),
+                    }
                 }
             }
-        ),
-        encoding="utf-8",
+        }
+        if use_modern_auth
+        else {
+            "host_auth": {
+                "mode": "local-simulation",
+                "credential_groups": {
+                    "shared-lab-a": {
+                        "username": "root",
+                        "simulation_root": str(simulation_root),
+                    }
+                },
+            }
+        }
     )
+    (overlay / "auth.yaml").write_text(yaml.safe_dump(auth_config), encoding="utf-8")
     (overlay / "repos.yaml").write_text(
         yaml.safe_dump(
             {
@@ -60,13 +86,17 @@ def seed_overlay(vaws_repo, target_name="single-default") -> Path:
         yaml.safe_dump(
             {
                 "hosts": {
-                    "host-a": {
-                        "host": "127.0.0.1",
-                        "port": 22,
-                        "login_user": "root",
-                        "auth_group": "shared-lab-a",
-                    }
-                },
+                "host-a": {
+                    "host": "127.0.0.1",
+                    "port": 22,
+                    "login_user": "root",
+                    **(
+                        {"ssh_auth_ref": "shared-lab-a"}
+                        if use_modern_auth
+                        else {"auth_group": "shared-lab-a"}
+                    ),
+                }
+            },
                 "targets": {
                     target_name: {
                         "hosts": ["host-a"],
@@ -93,8 +123,105 @@ def ensure_target(vaws_repo, target_name="single-default") -> Path:
     return simulation_root
 
 
+def ensure_fleet_handoff(vaws_repo, server_name="host-b"):
+    simulation_root = seed_overlay(vaws_repo)
+    overlay = vaws_repo / ".workspace.local"
+    (overlay / "servers.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "bootstrap": {
+                    "completed": False,
+                    "mode": "remote-first",
+                },
+                "servers": {},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    auth = yaml.safe_load((overlay / "auth.yaml").read_text(encoding="utf-8"))
+    auth["ssh_auth"] = {
+        "refs": {
+            "shared-lab-a": {
+                "kind": "local-simulation",
+                "username": "root",
+                "simulation_root": str(simulation_root),
+            }
+        }
+    }
+    (overlay / "auth.yaml").write_text(
+        yaml.safe_dump(auth, sort_keys=False),
+        encoding="utf-8",
+    )
+    state = read_json(overlay / "state.json")
+    state["lifecycle"] = {
+        "foundation": {"status": "degraded"},
+        "git_profile": {"status": "ready"},
+    }
+    (overlay / "state.json").write_text(
+        json.dumps(state, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = run_vaws(
+        vaws_repo,
+        "fleet",
+        "add",
+        server_name,
+        "--server-host",
+        "10.0.0.12",
+    )
+    assert result.returncode == 0
+    return simulation_root, server_name
+
+
+def _write_colliding_server(vaws_repo, server_name="shared-name") -> None:
+    overlay = vaws_repo / ".workspace.local"
+    (overlay / "servers.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "bootstrap": {
+                    "completed": True,
+                    "mode": "remote-first",
+                },
+                "servers": {
+                    server_name: {
+                        "host": "127.0.0.1",
+                        "port": 22,
+                        "login_user": "root",
+                        "ssh_auth_ref": "shared-lab-a",
+                        "status": "ready",
+                        "runtime": {
+                            "image_ref": "registry.example.com/ascend/vllm-ascend:test",
+                            "container_name": "server-owner",
+                            "ssh_port": 63270,
+                            "workspace_root": "/vllm-workspace",
+                            "bootstrap_mode": "host-then-container",
+                            "host_workspace_path": f"/root/.vaws/targets/{server_name}/workspace",
+                        },
+                    }
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _remove_current_target_kind(vaws_repo) -> None:
+    overlay = vaws_repo / ".workspace.local"
+    state = read_json(overlay / "state.json")
+    state.pop("current_target_kind", None)
+    (overlay / "state.json").write_text(
+        json.dumps(state, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
 def test_session_create_builds_local_and_remote_manifests_and_worktrees(vaws_repo):
-    simulation_root = ensure_target(vaws_repo)
+    simulation_root, current_target = ensure_fleet_handoff(vaws_repo)
 
     result = run_vaws(vaws_repo, "session", "create", "feat_x")
 
@@ -103,13 +230,13 @@ def test_session_create_builds_local_and_remote_manifests_and_worktrees(vaws_rep
         vaws_repo / ".workspace.local" / "sessions" / "feat_x" / "manifest.yaml"
     )
     assert local_manifest["name"] == "feat_x"
-    assert local_manifest["target"] == "single-default"
+    assert local_manifest["target"] == current_target
     assert local_manifest["workspace_ref"]["branch"] == "feature/feat_x"
     assert local_manifest["workspace_ref"]["base_ref"] == "origin/main"
     assert local_manifest["vllm_ref"]["branch"] == "feature/feat_x"
     assert local_manifest["vllm_ascend_ref"]["branch"] == "feature/feat_x"
 
-    runtime_root = simulation_root / "host-a" / "vllm-workspace"
+    runtime_root = simulation_root / current_target / "vllm-workspace"
     remote_manifest = read_yaml(
         runtime_root / ".vaws" / "sessions" / "feat_x" / "manifest.yaml"
     )
@@ -120,8 +247,98 @@ def test_session_create_builds_local_and_remote_manifests_and_worktrees(vaws_rep
     ).exists()
 
 
+def test_session_create_and_switch_use_legacy_target_handoff_kind_when_name_collides(
+    vaws_repo,
+    monkeypatch,
+):
+    seed_overlay(vaws_repo, target_name="shared-name")
+    _write_colliding_server(vaws_repo, "shared-name")
+    assert run_vaws(vaws_repo, "target", "ensure", "shared-name").returncode == 0
+
+    calls = {"target": [], "server": [], "create": [], "switch": []}
+
+    def fake_resolve_server_context(paths, server_name):
+        calls["server"].append(server_name)
+        raise AssertionError("server resolver should not be used for legacy target handoff")
+
+    def fake_resolve_target_context(paths, target_name):
+        calls["target"].append(target_name)
+        return TargetContext(
+            name=target_name,
+            host=HostSpec(
+                name="host-a",
+                host="127.0.0.1",
+                port=22,
+                login_user="root",
+                auth_group="shared-lab-a",
+            ),
+            credential=CredentialGroup(mode="local-simulation", username="root"),
+            runtime=RuntimeSpec(
+                image_ref="registry.example.com/ascend/vllm-ascend:test",
+                container_name="legacy-owner",
+                ssh_port=63269,
+                workspace_root="/vllm-workspace",
+                bootstrap_mode="host-then-container",
+                host_workspace_path=f"/root/.vaws/targets/{target_name}/workspace",
+                docker_run_args=[],
+            ),
+        )
+
+    def fake_create_remote_session(paths, ctx, manifest, transport):
+        calls["create"].append((ctx.name, transport, manifest["target"]))
+
+    def fake_switch_remote_session(ctx, session_name, transport):
+        calls["switch"].append((ctx.name, transport, session_name))
+
+    monkeypatch.setattr(session_lib, "resolve_server_context", fake_resolve_server_context)
+    monkeypatch.setattr(session_lib, "resolve_target_context", fake_resolve_target_context)
+    monkeypatch.setattr(session_lib, "create_remote_session", fake_create_remote_session)
+    monkeypatch.setattr(session_lib, "switch_remote_session", fake_switch_remote_session)
+
+    paths = RepoPaths(root=vaws_repo)
+    assert session_lib.create_session(paths, "feat_collision") == 0
+    assert session_lib.switch_session(paths, "feat_collision") == 0
+
+    assert calls["server"] == []
+    assert calls["target"] == ["shared-name", "shared-name"]
+    assert calls["create"] == [("shared-name", "simulation", "shared-name")]
+    assert calls["switch"] == [("shared-name", "simulation", "feat_collision")]
+
+
+def test_session_create_and_switch_infer_missing_current_target_kind_for_modern_auth_collision(
+    vaws_repo,
+):
+    simulation_root = seed_overlay(
+        vaws_repo,
+        target_name="shared-name",
+        use_modern_auth=True,
+    )
+    _write_colliding_server(vaws_repo, "shared-name")
+    assert run_vaws(vaws_repo, "target", "ensure", "shared-name").returncode == 0
+    _remove_current_target_kind(vaws_repo)
+
+    result = run_vaws(vaws_repo, "session", "create", "feat_inferred")
+    assert result.returncode == 0
+    result = run_vaws(vaws_repo, "session", "switch", "feat_inferred")
+    assert result.returncode == 0
+
+    target_runtime_root = simulation_root / "host-a" / "vllm-workspace"
+    server_runtime_root = simulation_root / "shared-name" / "vllm-workspace"
+    assert (
+        target_runtime_root / ".vaws" / "sessions" / "feat_inferred" / "manifest.yaml"
+    ).exists()
+    assert (
+        target_runtime_root / ".vaws" / "current"
+    ).resolve() == target_runtime_root / ".vaws" / "sessions" / "feat_inferred"
+    assert not (
+        server_runtime_root / ".vaws" / "sessions" / "feat_inferred" / "manifest.yaml"
+    ).exists()
+    state = read_json(vaws_repo / ".workspace.local" / "state.json")
+    assert state["current_session"] == "feat_inferred"
+
+
 def test_session_switch_updates_current_pointer_and_runtime_symlinks(vaws_repo):
-    simulation_root = ensure_target(vaws_repo)
+    simulation_root, current_target = ensure_fleet_handoff(vaws_repo)
     assert run_vaws(vaws_repo, "session", "create", "feat_x").returncode == 0
     assert run_vaws(vaws_repo, "session", "create", "feat_y").returncode == 0
 
@@ -131,14 +348,114 @@ def test_session_switch_updates_current_pointer_and_runtime_symlinks(vaws_repo):
     current = read_json(vaws_repo / ".workspace.local" / "state.json")
     assert current["schema_version"] == 1
     assert current["current_session"] == "feat_y"
-    assert current["current_target"] == "single-default"
-    runtime_root = simulation_root / "host-a" / "vllm-workspace"
+    assert current["current_target"] == current_target
+    runtime_root = simulation_root / current_target / "vllm-workspace"
     assert (runtime_root / ".vaws" / "current").is_symlink()
     assert (runtime_root / ".vaws" / "current").resolve().name == "feat_y"
     assert (runtime_root / "vllm").is_symlink()
     assert (runtime_root / "vllm").resolve().name == "vllm"
     assert (runtime_root / "vllm-ascend").is_symlink()
     assert (runtime_root / "vllm-ascend").resolve().name == "vllm-ascend"
+
+
+def test_session_switch_clears_stale_current_session_after_fleet_handoff(
+    vaws_repo,
+    monkeypatch,
+):
+    simulation_root, _current_target = ensure_fleet_handoff(vaws_repo)
+    assert run_vaws(vaws_repo, "session", "create", "feat_x").returncode == 0
+    assert run_vaws(vaws_repo, "session", "switch", "feat_x").returncode == 0
+
+    overlay = vaws_repo / ".workspace.local"
+    servers = read_yaml(overlay / "servers.yaml")
+    servers["servers"]["host-c"] = {
+        "host": "10.0.0.13",
+        "port": 22,
+        "login_user": "root",
+        "ssh_auth_ref": "shared-lab-a",
+        "status": "ready",
+        "runtime": {
+            "image_ref": "registry.example.com/ascend/vllm-ascend:test",
+            "container_name": "vaws-owner",
+            "ssh_port": 63271,
+            "workspace_root": "/vllm-workspace",
+            "bootstrap_mode": "host-then-container",
+            "host_workspace_path": "/root/.vaws/targets/host-c/workspace",
+        },
+    }
+    overlay.joinpath("servers.yaml").write_text(
+        yaml.safe_dump(servers, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    def fake_verify_runtime(paths, ctx):
+        return VerificationResult.ready(
+            summary="runtime verified",
+            runtime={
+                "host_name": ctx.name,
+                "host": ctx.host.host,
+                "host_port": ctx.host.port,
+                "login_user": ctx.host.login_user,
+                "transport": "simulation",
+                "container_endpoint": f"simulation://{ctx.name}/vllm-workspace",
+                "workspace_root": ctx.runtime.workspace_root,
+                "ssh_port": ctx.runtime.ssh_port,
+                "container_name": ctx.runtime.container_name,
+                "image_ref": ctx.runtime.image_ref,
+                "bootstrap_mode": ctx.runtime.bootstrap_mode,
+                "host_workspace_path": ctx.runtime.host_workspace_path,
+            },
+            checks=[
+                VerificationCheck(
+                    name="runtime_state",
+                    status="ready",
+                    detail="runtime state available",
+                )
+            ],
+        )
+
+    monkeypatch.setattr(fleet, "verify_runtime", fake_verify_runtime)
+
+    assert fleet.verify_fleet_server(RepoPaths(root=vaws_repo), "host-c") == 0
+
+    state = read_json(overlay / "state.json")
+    assert state["current_target"] == "host-c"
+    assert "current_session" not in state
+    assert state["runtime"]["host_name"] == "host-c"
+
+
+def test_session_create_reports_fleet_handoff_precondition_when_current_target_is_missing(
+    vaws_repo,
+):
+    seed_overlay(vaws_repo)
+
+    result = run_vaws(vaws_repo, "session", "create", "feat_x")
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "current target" in output
+    assert "fleet" in output
+    assert "target ensure" not in output
+
+
+def test_session_create_surfaces_server_auth_config_errors_after_fleet_handoff(
+    vaws_repo,
+):
+    ensure_fleet_handoff(vaws_repo)
+    overlay = vaws_repo / ".workspace.local"
+    auth = read_yaml(overlay / "auth.yaml")
+    auth.pop("ssh_auth", None)
+    (overlay / "auth.yaml").write_text(
+        yaml.safe_dump(auth, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = run_vaws(vaws_repo, "session", "create", "feat_x")
+
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "missing ssh_auth.refs map" in output
+    assert "unknown target" not in output
 
 
 def test_session_switch_fails_cleanly_when_state_schema_version_is_unsupported(vaws_repo):

--- a/tests/test_vaws_target.py
+++ b/tests/test_vaws_target.py
@@ -1,47 +1,73 @@
+"""Compatibility tests for the deprecated `vaws target` shim."""
+
 import json
 from pathlib import Path
+import sys
 
+import pytest
 import yaml
 
 from conftest import run_vaws
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.lib.config import RepoPaths
+from tools.lib.remote import RemoteError, resolve_server_context
 
 
 def read_json(path):
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def seed_overlay(vaws_repo, target_name="single-default") -> Path:
+def seed_overlay(vaws_repo, target_name="single-default", use_modern_auth=False) -> Path:
     overlay = vaws_repo / ".workspace.local"
     overlay.mkdir()
     (overlay / "repos.yaml").write_text("", encoding="utf-8")
     simulation_root = vaws_repo.parent / "simulation-runtime"
-    (overlay / "auth.yaml").write_text(
-        yaml.safe_dump(
-            {
-                "host_auth": {
-                    "mode": "local-simulation",
-                    "credential_groups": {
-                        "shared-lab-a": {
-                            "username": "root",
-                            "simulation_root": str(simulation_root),
-                        }
-                    },
+    auth_config = (
+        {
+            "ssh_auth": {
+                "refs": {
+                    "shared-lab-a": {
+                        "kind": "local-simulation",
+                        "username": "root",
+                        "simulation_root": str(simulation_root),
+                    }
                 }
             }
-        ),
-        encoding="utf-8",
+        }
+        if use_modern_auth
+        else {
+            "host_auth": {
+                "mode": "local-simulation",
+                "credential_groups": {
+                    "shared-lab-a": {
+                        "username": "root",
+                        "simulation_root": str(simulation_root),
+                    }
+                },
+            }
+        }
     )
+    (overlay / "auth.yaml").write_text(yaml.safe_dump(auth_config), encoding="utf-8")
     (overlay / "state.json").write_text("{}\n", encoding="utf-8")
+
+    host_config = {
+        "host": "10.0.0.11",
+        "port": 22,
+        "login_user": "root",
+        "labels": ["a3", "8npu"],
+    }
+    if use_modern_auth:
+        host_config["ssh_auth_ref"] = "shared-lab-a"
+    else:
+        host_config["auth_group"] = "shared-lab-a"
 
     targets = {
         "hosts": {
-            "host-a": {
-                "host": "10.0.0.11",
-                "port": 22,
-                "login_user": "root",
-                "auth_group": "shared-lab-a",
-                "labels": ["a3", "8npu"],
-            }
+            "host-a": host_config,
         },
         "targets": {
             target_name: {
@@ -60,38 +86,36 @@ def seed_overlay(vaws_repo, target_name="single-default") -> Path:
     return simulation_root
 
 
-def test_target_ensure_records_runtime_endpoint(vaws_repo):
-    simulation_root = seed_overlay(vaws_repo, target_name="single-default")
+def test_target_ensure_reports_deprecation_and_routing(vaws_repo):
+    seed_overlay(vaws_repo, target_name="single-default")
+
     result = run_vaws(vaws_repo, "target", "ensure", "single-default")
+
+    assert result.returncode == 0
+    output = (result.stdout + result.stderr).lower()
+    assert "deprecated" in output
+    assert "fleet" in output
+
+
+def test_target_ensure_supports_modern_auth_compatibility(vaws_repo):
+    simulation_root = seed_overlay(
+        vaws_repo,
+        target_name="single-default",
+        use_modern_auth=True,
+    )
+
+    result = run_vaws(vaws_repo, "target", "ensure", "single-default")
+
     assert result.returncode == 0
     state = read_json(vaws_repo / ".workspace.local" / "state.json")
     assert state["schema_version"] == 1
     assert state["current_target"] == "single-default"
-    assert state["runtime"]["workspace_root"] == "/vllm-workspace"
-    assert state["runtime"]["ssh_port"] == 63269
-    assert state["runtime"]["container_endpoint"].startswith("simulation://")
+    assert state["current_target_kind"] == "legacy_target"
     runtime_root = simulation_root / "host-a" / "vllm-workspace"
     assert (runtime_root / ".vaws" / "runtime.json").exists()
-    assert (runtime_root / "workspace").is_symlink()
 
 
-def test_target_ensure_reuses_existing_runtime_container(vaws_repo):
-    simulation_root = seed_overlay(vaws_repo, target_name="single-default")
-
-    first = run_vaws(vaws_repo, "target", "ensure", "single-default")
-    second = run_vaws(vaws_repo, "target", "ensure", "single-default")
-
-    assert first.returncode == 0
-    assert second.returncode == 0
-    state = read_json(vaws_repo / ".workspace.local" / "state.json")
-    assert state["schema_version"] == 1
-    runtime_root = simulation_root / "host-a" / "vllm-workspace"
-    runtime_state = read_json(runtime_root / ".vaws" / "runtime.json")
-    assert runtime_state["container"]["created"] is True
-    assert runtime_state["container"]["reused"] is True
-
-
-def test_target_ensure_fails_cleanly_when_state_schema_version_is_unsupported(vaws_repo):
+def test_target_ensure_rejects_unsupported_state_schema_version(vaws_repo):
     seed_overlay(vaws_repo, target_name="single-default")
     (vaws_repo / ".workspace.local" / "state.json").write_text(
         '{"schema_version": 2}\n',
@@ -107,170 +131,107 @@ def test_target_ensure_fails_cleanly_when_state_schema_version_is_unsupported(va
     assert "traceback" not in output
 
 
-def test_target_ensure_fails_when_target_is_missing(vaws_repo):
-    seed_overlay(vaws_repo, target_name="single-default")
-    result = run_vaws(vaws_repo, "target", "ensure", "unknown")
-    assert result.returncode == 1
-    output = (result.stdout + result.stderr).lower()
-    assert "unknown" in output
-    assert "target" in output
-
-
-def test_target_ensure_fails_when_targets_yaml_is_invalid_utf8(vaws_repo):
-    seed_overlay(vaws_repo, target_name="single-default")
-    (vaws_repo / ".workspace.local" / "targets.yaml").write_bytes(b"\xff\xfe")
-
-    result = run_vaws(vaws_repo, "target", "ensure", "single-default")
-
-    assert result.returncode == 1
-    output = (result.stdout + result.stderr).lower()
-    assert "invalid target config" in output
-    assert "traceback" not in output
-
-
-def test_target_ensure_fails_when_target_runtime_mapping_is_missing(vaws_repo):
-    seed_overlay(vaws_repo, target_name="single-default")
-
-    targets_without_runtime = {
-        "hosts": {
-            "host-a": {
-                "host": "10.0.0.11",
-                "port": 22,
-                "login_user": "root",
-                "auth_group": "shared-lab-a",
-                "labels": ["a3", "8npu"],
-            }
-        },
-        "targets": {
-            "single-default": {
-                "hosts": ["host-a"],
-            }
-        },
-    }
-    (vaws_repo / ".workspace.local" / "targets.yaml").write_text(
-        yaml.safe_dump(targets_without_runtime), encoding="utf-8"
-    )
-
-    result = run_vaws(vaws_repo, "target", "ensure", "single-default")
-
-    assert result.returncode == 1
-    output = (result.stdout + result.stderr).lower()
-    assert "runtime" in output
-
-
-def test_target_ensure_fails_when_target_runtime_mapping_is_incomplete(vaws_repo):
-    seed_overlay(vaws_repo, target_name="single-default")
-
-    targets_with_incomplete_runtime = {
-        "hosts": {
-            "host-a": {
-                "host": "10.0.0.11",
-                "port": 22,
-                "login_user": "root",
-                "auth_group": "shared-lab-a",
-                "labels": ["a3", "8npu"],
-            }
-        },
-        "targets": {
-            "single-default": {
-                "hosts": ["host-a"],
-                "runtime": {
-                    "workspace_root": "/vllm-workspace",
+def test_target_ensure_keeps_legacy_target_overlay_when_server_auth_exists(vaws_repo):
+    simulation_root = seed_overlay(vaws_repo, target_name="single-default")
+    overlay = vaws_repo / ".workspace.local"
+    (overlay / "servers.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "bootstrap": {
+                    "completed": False,
+                    "mode": "remote-first",
                 },
-            }
-        },
-    }
-    (vaws_repo / ".workspace.local" / "targets.yaml").write_text(
-        yaml.safe_dump(targets_with_incomplete_runtime), encoding="utf-8"
+                "servers": {
+                    "host-a": {
+                        "host": "10.0.0.11",
+                        "port": 22,
+                        "login_user": "root",
+                        "ssh_auth_ref": "shared-lab-a",
+                        "status": "ready",
+                        "runtime": {
+                            "image_ref": "registry.example.com/ascend/vllm-ascend:server",
+                            "container_name": "fleet-owner",
+                            "ssh_port": 63301,
+                            "workspace_root": "/vllm-workspace",
+                            "bootstrap_mode": "host-then-container",
+                            "host_workspace_path": "/root/.vaws/targets/host-a/workspace",
+                        },
+                    },
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
     )
 
-    result = run_vaws(vaws_repo, "target", "ensure", "single-default")
-
-    assert result.returncode == 1
-    output = (result.stdout + result.stderr).lower()
-    assert "runtime" in output
-    assert "incomplete" in output
-
-
-def test_target_ensure_fails_when_target_runtime_ssh_port_is_bool(vaws_repo):
-    seed_overlay(vaws_repo, target_name="single-default")
-
-    targets = yaml.safe_load(
-        (vaws_repo / ".workspace.local" / "targets.yaml").read_text(encoding="utf-8")
+    targets = yaml.safe_load((overlay / "targets.yaml").read_text(encoding="utf-8"))
+    targets["targets"]["single-default"]["runtime"]["ssh_port"] = 63269
+    targets["targets"]["single-default"]["runtime"]["container_name"] = "legacy-owner"
+    (overlay / "targets.yaml").write_text(
+        yaml.safe_dump(targets, sort_keys=False),
+        encoding="utf-8",
     )
-    targets["targets"]["single-default"]["runtime"]["ssh_port"] = True
-    (vaws_repo / ".workspace.local" / "targets.yaml").write_text(
-        yaml.safe_dump(targets), encoding="utf-8"
-    )
-
-    result = run_vaws(vaws_repo, "target", "ensure", "single-default")
-
-    assert result.returncode == 1
-    output = (result.stdout + result.stderr).lower()
-    assert "ssh_port" in output
-
-
-def test_target_ensure_fails_when_target_runtime_ssh_port_is_out_of_range(vaws_repo):
-    seed_overlay(vaws_repo, target_name="single-default")
-
-    targets = yaml.safe_load(
-        (vaws_repo / ".workspace.local" / "targets.yaml").read_text(encoding="utf-8")
-    )
-    targets["targets"]["single-default"]["runtime"]["ssh_port"] = 70000
-    (vaws_repo / ".workspace.local" / "targets.yaml").write_text(
-        yaml.safe_dump(targets), encoding="utf-8"
-    )
-
-    result = run_vaws(vaws_repo, "target", "ensure", "single-default")
-
-    assert result.returncode == 1
-    output = (result.stdout + result.stderr).lower()
-    assert "ssh_port" in output
-
-
-def test_target_ensure_defaults_blank_workspace_root(vaws_repo):
-    seed_overlay(vaws_repo, target_name="single-default")
-
-    targets = yaml.safe_load(
-        (vaws_repo / ".workspace.local" / "targets.yaml").read_text(encoding="utf-8")
-    )
-    targets["targets"]["single-default"]["runtime"]["workspace_root"] = ""
-    (vaws_repo / ".workspace.local" / "targets.yaml").write_text(
-        yaml.safe_dump(targets), encoding="utf-8"
-    )
-
-    result = run_vaws(vaws_repo, "target", "ensure", "single-default")
-
-    assert result.returncode == 0
-    state = read_json(vaws_repo / ".workspace.local" / "state.json")
-    assert state["runtime"]["workspace_root"] == "/vllm-workspace"
-
-
-def test_target_ensure_fails_when_auth_group_is_missing(vaws_repo):
-    seed_overlay(vaws_repo, target_name="single-default")
-
-    targets = yaml.safe_load(
-        (vaws_repo / ".workspace.local" / "targets.yaml").read_text(encoding="utf-8")
-    )
-    targets["hosts"]["host-a"]["auth_group"] = "missing-group"
-    (vaws_repo / ".workspace.local" / "targets.yaml").write_text(
-        yaml.safe_dump(targets), encoding="utf-8"
-    )
-
-    result = run_vaws(vaws_repo, "target", "ensure", "single-default")
-
-    assert result.returncode == 1
-    output = (result.stdout + result.stderr).lower()
-    assert "auth" in output
-    assert "missing-group" in output
-
-
-def test_target_ensure_reports_deprecation_and_routing(vaws_repo):
-    seed_overlay(vaws_repo, target_name="single-default")
 
     result = run_vaws(vaws_repo, "target", "ensure", "single-default")
 
     assert result.returncode == 0
     output = (result.stdout + result.stderr).lower()
     assert "deprecated" in output
-    assert "fleet" in output
+    state = read_json(vaws_repo / ".workspace.local" / "state.json")
+    assert state["current_target"] == "single-default"
+    assert state["runtime"]["ssh_port"] == 63269
+    assert state["runtime"]["container_name"] == "legacy-owner"
+    runtime_root = simulation_root / "host-a" / "vllm-workspace"
+    assert (runtime_root / ".vaws" / "runtime.json").exists()
+
+
+def test_resolve_server_context_rejects_legacy_host_auth(vaws_repo):
+    overlay = vaws_repo / ".workspace.local"
+    simulation_root = seed_overlay(vaws_repo, target_name="single-default")
+    (overlay / "servers.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "servers": {
+                    "host-a": {
+                        "host": "10.0.0.11",
+                        "port": 22,
+                        "login_user": "root",
+                        "ssh_auth_ref": "shared-lab-a",
+                        "status": "ready",
+                        "runtime": {
+                            "image_ref": "registry.example.com/ascend/vllm-ascend:test",
+                            "container_name": "fleet-owner",
+                            "ssh_port": 63301,
+                            "workspace_root": "/vllm-workspace",
+                            "bootstrap_mode": "host-then-container",
+                            "host_workspace_path": "/root/.vaws/targets/host-a/workspace",
+                        },
+                    },
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (overlay / "auth.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "host_auth": {
+                    "mode": "local-simulation",
+                    "credential_groups": {
+                        "shared-lab-a": {
+                            "username": "root",
+                            "simulation_root": str(simulation_root),
+                        }
+                    },
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RemoteError, match="missing ssh_auth\\.refs map"):
+        resolve_server_context(RepoPaths(root=vaws_repo), "host-a")

--- a/tests/test_workspace_adapter_contracts.py
+++ b/tests/test_workspace_adapter_contracts.py
@@ -16,7 +16,9 @@ def test_first_class_adapter_files_exist():
 
 def test_adapters_route_to_all_first_class_workspace_skills():
     expected_routes = (
-        ".agents/skills/workspace-bootstrap/skill.md",
+        ".agents/skills/workspace-init/skill.md",
+        ".agents/skills/workspace-foundation/skill.md",
+        ".agents/skills/workspace-git-profile/skill.md",
         ".agents/skills/workspace-fleet/skill.md",
         ".agents/skills/workspace-reset/skill.md",
         ".agents/skills/workspace-session-switch/skill.md",
@@ -31,6 +33,8 @@ def test_adapters_route_to_all_first_class_workspace_skills():
 def test_adapters_do_not_link_to_internal_routing_files_or_procedure_tokens():
     forbidden_terms = (
         "internal-routing.md",
+        "workspace-bootstrap",
+        "bootstrap",
         "init --bootstrap",
         "fleet add",
         "fleet verify",

--- a/tests/test_workspace_skill_contracts.py
+++ b/tests/test_workspace_skill_contracts.py
@@ -3,17 +3,32 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 FIRST_CLASS_SKILLS = {
-    "workspace-bootstrap": {
+    "workspace-init": {
         "intent_groups": (
-            ("first usable workspace baseline", "initialize this workspace for the first time"),
-            ("first development server", "development server attached"),
+            ("first-time initialization", "first usable workspace baseline"),
+            ("staged re-initialization", "recovering after reset"),
+            ("examples include, but are not limited to:",),
+        ),
+    },
+    "workspace-foundation": {
+        "intent_groups": (
+            ("local prerequisite", "control-plane readiness"),
+            ("foundation checks", "missing gh"),
+            ("examples include, but are not limited to:",),
+        ),
+    },
+    "workspace-git-profile": {
+        "intent_groups": (
+            ("git identity", "fork topology"),
+            ("repo remotes", "personalized git setup"),
             ("examples include, but are not limited to:",),
         ),
     },
     "workspace-fleet": {
         "intent_groups": (
             ("additional managed server", "additional server"),
-            ("post-bootstrap", "after baseline"),
+            ("first server handoff", "post-bootstrap"),
+            ("foundation and git-profile readiness",),
             ("examples include, but are not limited to:",),
         ),
     },
@@ -28,6 +43,7 @@ FIRST_CLASS_SKILLS = {
         "intent_groups": (
             ("create a new feature session", "new feature session"),
             ("switch the active session", "active session"),
+            ("compatible legacy target handoff",),
             ("examples include, but are not limited to:",),
         ),
     },
@@ -35,6 +51,15 @@ FIRST_CLASS_SKILLS = {
         "intent_groups": (
             ("sync repository or session state", "repository or session state"),
             ("check current sync status", "current sync status"),
+            ("examples include, but are not limited to:",),
+        ),
+    },
+}
+COMPATIBILITY_SKILLS = {
+    "workspace-bootstrap": {
+        "intent_groups": (
+            ("compatibility alias", "legacy bootstrap"),
+            ("route that request to workspace-init", "workspace-init"),
             ("examples include, but are not limited to:",),
         ),
     },
@@ -60,11 +85,14 @@ FORBIDDEN_DESCRIPTION_TERMS = (
     "fleet verify",
     "session create",
     "session switch",
+    "./sync",
+    "./setup",
 )
 PUBLIC_BODY_FORBIDDEN_TERMS = (
     "tools/vaws.py ",
     "./sync",
     "./setup",
+    "workspace-bootstrap",
 )
 
 
@@ -142,3 +170,11 @@ def test_never_expose_sections_contain_concrete_hidden_items():
         body = _section_body(skill_name, "## Never Expose").lower()
         assert "-" in body
         assert "raw" in body or "internal" in body or "overlay" in body or "secret" in body
+
+
+def test_bootstrap_is_only_a_compatibility_alias():
+    text = _skill_text("workspace-bootstrap").lower()
+    assert "compatibility alias" in text
+    assert "workspace-init" in text
+    assert "first usable workspace baseline" not in text
+    assert "first baseline" not in text

--- a/tests/test_workspace_skill_pressure.py
+++ b/tests/test_workspace_skill_pressure.py
@@ -3,20 +3,40 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCENARIOS = {
-    "workspace-bootstrap": {
+    "workspace-init": {
         "intent_groups": (
-            ("first usable workspace baseline", "initialize this workspace for the first time"),
-            ("first development server", "development server attached"),
+            ("first usable workspace baseline", "first-time initialization"),
+            ("staged re-initialization", "recovering after reset"),
         ),
         "pressure_only_variants": (
             "把第一套开发环境先搭起来",
             "先把仓库基础环境准备好",
         ),
     },
+    "workspace-foundation": {
+        "intent_groups": (
+            ("local prerequisite", "control-plane readiness"),
+            ("foundation checks", "missing gh"),
+        ),
+        "pressure_only_variants": (
+            "先检查本地前置依赖",
+            "把控制平面依赖状态看一下",
+        ),
+    },
+    "workspace-git-profile": {
+        "intent_groups": (
+            ("git identity", "fork topology"),
+            ("repo remotes", "personalized git setup"),
+        ),
+        "pressure_only_variants": (
+            "把这套仓库的 fork 和远端配置好",
+            "先把 Git 侧身份和 topology 准备好",
+        ),
+    },
     "workspace-fleet": {
         "intent_groups": (
             ("additional managed server", "additional server"),
-            ("post-bootstrap", "after baseline"),
+            ("first server handoff", "post-bootstrap"),
         ),
         "pressure_only_variants": (
             "把另一台开发机挂上来",

--- a/tools/lib/bootstrap.py
+++ b/tools/lib/bootstrap.py
@@ -9,12 +9,8 @@ import yaml
 
 from .config import RepoPaths
 from .overlay import ensure_overlay_layout
-from .preflight import PreflightError, ensure_local_control_plane_deps
-from .secret_boundary import SecretBoundaryError, ensure_bootstrap_secret_refs
 from .remote import DEFAULT_HOST_WORKSPACE_BASE
-from .remote import RemoteError
-from .remote import VerificationCheck, VerificationResult, persist_server_verification
-from .remote import resolve_server_context
+from .remote import VerificationCheck, VerificationResult
 from .remote import TargetContext
 from .runtime import read_state, write_state
 
@@ -128,6 +124,53 @@ def _bootstrap_host_workspace_path(request: BootstrapRequest) -> str:
     return f"{DEFAULT_HOST_WORKSPACE_BASE}/{request.target_name}/workspace"
 
 
+def _staged_init_request(request: BootstrapRequest) -> Any:
+    from .init_flow import InitRequest
+
+    return InitRequest(
+        server_host=request.server_host,
+        server_name=request.host_name if request.server_host is not None else None,
+        local_only=request.server_host is None,
+        server_user=request.server_user,
+        server_port=request.server_port,
+        server_auth_mode=request.server_auth_mode,
+        server_password_env=request.server_password_env,
+        server_key_path=request.server_key_path,
+        runtime_image=request.runtime_image,
+        runtime_container=request.runtime_container,
+        runtime_ssh_port=request.runtime_ssh_port,
+        runtime_workspace_root=request.runtime_workspace_root,
+        runtime_bootstrap_mode=DEFAULT_RUNTIME_BOOTSTRAP_MODE,
+        vllm_origin_url=request.vllm_origin_url,
+        vllm_ascend_origin_url=request.vllm_ascend_origin_url,
+        git_auth_mode=request.git_auth_mode,
+        git_key_path=request.git_key_path,
+        git_token_env=request.git_token_env,
+    )
+
+
+def _run_staged_init(paths: RepoPaths, request: Any) -> int:
+    from .init_flow import run_init
+
+    return run_init(paths, request)
+
+
+def _preserve_requested_git_auth(paths: RepoPaths, request: BootstrapRequest) -> None:
+    if (
+        request.git_key_path is None
+        and request.git_token_env is None
+        and request.git_auth_mode not in {"token"}
+    ):
+        return
+
+    write_git_auth_ref(
+        paths,
+        git_auth_mode=request.git_auth_mode,
+        git_key_path=request.git_key_path,
+        git_token_env=request.git_token_env,
+    )
+
+
 def verify_runtime(_paths: RepoPaths, context: TargetContext) -> VerificationResult:
     runtime = {
         "image_ref": context.runtime.image_ref,
@@ -198,6 +241,166 @@ def _auth_ref_payload(kind: str, **fields: Any) -> Dict[str, Any]:
     return payload
 
 
+def _load_auth_mapping(paths: RepoPaths) -> Dict[str, Any]:
+    return _load_yaml_mapping(paths.local_auth_file)
+
+
+def _auth_namespace_refs(auth: Dict[str, Any], namespace: str) -> Dict[str, Any]:
+    section = auth.get(namespace)
+    if section is None:
+        section = {"refs": {}}
+        auth[namespace] = section
+    if not isinstance(section, dict):
+        raise BootstrapError(f"invalid auth file: .workspace.local/auth.yaml {namespace}")
+
+    refs = section.get("refs")
+    if refs is None:
+        refs = {}
+        section["refs"] = refs
+    if not isinstance(refs, dict):
+        raise BootstrapError(f"invalid auth file: .workspace.local/auth.yaml {namespace}.refs")
+    return refs
+
+
+def _repo_topology_payload(
+    *,
+    vllm_origin_url: Optional[str],
+    vllm_ascend_origin_url: str,
+) -> Dict[str, Any]:
+    topology: Dict[str, Any] = {
+        "version": 1,
+        "workspace": {
+            "path": ".",
+            "default_branch": "main",
+            "protected_branches": ["main"],
+            "push_remote": "origin",
+            "upstream_remote": "upstream",
+        },
+        "submodules": {
+            "vllm": {
+                "path": "vllm",
+                "default_branch": "main",
+                "push_remote": "origin",
+                "upstream_remote": "upstream",
+                "upstream_url": COMMUNITY_UPSTREAM_URLS["vllm"],
+            },
+            "vllm-ascend": {
+                "path": "vllm-ascend",
+                "default_branch": "main",
+                "push_remote": "origin",
+                "upstream_remote": "upstream",
+                "upstream_url": COMMUNITY_UPSTREAM_URLS["vllm-ascend"],
+                "origin_url": vllm_ascend_origin_url,
+            },
+        },
+    }
+    if vllm_origin_url:
+        topology["submodules"]["vllm"]["origin_url"] = vllm_origin_url
+    return topology
+
+
+def load_existing_repo_topology(paths: RepoPaths) -> Dict[str, Any]:
+    return _load_yaml_mapping(paths.local_repos_file)
+
+
+def topology_is_ready(paths: RepoPaths) -> bool:
+    topology = load_existing_repo_topology(paths)
+    if not topology:
+        return False
+
+    workspace = topology.get("workspace")
+    submodules = topology.get("submodules")
+    if not isinstance(workspace, dict) or not isinstance(submodules, dict):
+        return False
+
+    for repo_name in ("vllm", "vllm-ascend"):
+        repo_config = submodules.get(repo_name)
+        if not isinstance(repo_config, dict):
+            return False
+
+        repo_path_value = repo_config.get("path")
+        if not isinstance(repo_path_value, str) or not repo_path_value.strip():
+            return False
+
+        repo_path = paths.root / repo_path_value.strip()
+        if not repo_path.is_dir():
+            return False
+
+        expected_upstream = repo_config.get("upstream_url")
+        if not isinstance(expected_upstream, str) or not expected_upstream.strip():
+            return False
+
+        if _git_remote_url(repo_path, "upstream") != expected_upstream.strip():
+            return False
+        expected_origin = repo_config.get("origin_url")
+        if repo_name == "vllm" and expected_origin is None:
+            continue
+        if (
+            repo_name == "vllm-ascend"
+            and expected_origin == COMMUNITY_UPSTREAM_URLS["vllm-ascend"]
+        ):
+            return False
+        if not isinstance(expected_origin, str) or not expected_origin.strip():
+            return False
+        if _git_remote_url(repo_path, "origin") != expected_origin.strip():
+            return False
+
+    return True
+
+
+def write_repo_topology(
+    paths: RepoPaths,
+    *,
+    vllm_origin_url: Optional[str],
+    vllm_ascend_origin_url: str,
+) -> None:
+    _write_yaml(
+        paths.local_repos_file,
+        _repo_topology_payload(
+            vllm_origin_url=vllm_origin_url,
+            vllm_ascend_origin_url=vllm_ascend_origin_url,
+        ),
+    )
+
+
+def write_server_auth_ref(
+    paths: RepoPaths,
+    *,
+    server_auth_mode: str,
+    server_user: str,
+    server_password_env: Optional[str],
+    server_key_path: Optional[str],
+) -> None:
+    auth = _load_auth_mapping(paths)
+    auth.setdefault("version", 1)
+    ssh_refs = _auth_namespace_refs(auth, "ssh_auth")
+    ssh_refs[DEFAULT_SERVER_AUTH_REF] = _auth_ref_payload(
+        server_auth_mode,
+        username=server_user,
+        password_env=server_password_env,
+        key_path=server_key_path,
+    )
+    _write_yaml(paths.local_auth_file, auth)
+
+
+def write_git_auth_ref(
+    paths: RepoPaths,
+    *,
+    git_auth_mode: str,
+    git_key_path: Optional[str],
+    git_token_env: Optional[str],
+) -> None:
+    auth = _load_auth_mapping(paths)
+    auth.setdefault("version", 1)
+    git_refs = _auth_namespace_refs(auth, "git_auth")
+    git_refs[DEFAULT_GIT_AUTH_REF] = _auth_ref_payload(
+        git_auth_mode,
+        key_path=git_key_path,
+        token_env=git_token_env,
+    )
+    _write_yaml(paths.local_auth_file, auth)
+
+
 def _run_git(repo_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", *args],
@@ -206,6 +409,13 @@ def _run_git(repo_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         check=False,
     )
+
+
+def _git_remote_url(repo_path: Path, remote_name: str) -> Optional[str]:
+    probe = _run_git(repo_path, "remote", "get-url", remote_name)
+    if probe.returncode != 0:
+        return None
+    return probe.stdout.strip()
 
 
 def _ensure_git_remote(repo_path: Path, remote_name: str, url: str) -> None:
@@ -226,41 +436,11 @@ def _ensure_git_remote(repo_path: Path, remote_name: str, url: str) -> None:
 
 
 def _write_repos_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
-    _write_yaml(
-        paths.local_repos_file,
-        {
-            "version": 1,
-            "workspace": {
-                "path": ".",
-                "default_branch": "main",
-                "protected_branches": ["main"],
-                "push_remote": "origin",
-                "upstream_remote": "upstream",
-            },
-            "submodules": {
-                "vllm": {
-                    "path": "vllm",
-                    "default_branch": "main",
-                    "push_remote": "origin",
-                    "upstream_remote": "upstream",
-                    "upstream_url": COMMUNITY_UPSTREAM_URLS["vllm"],
-                },
-                "vllm-ascend": {
-                    "path": "vllm-ascend",
-                    "default_branch": "main",
-                    "push_remote": "origin",
-                    "upstream_remote": "upstream",
-                    "upstream_url": COMMUNITY_UPSTREAM_URLS["vllm-ascend"],
-                    "origin_url": request.vllm_ascend_origin_url,
-                },
-            },
-        },
+    write_repo_topology(
+        paths,
+        vllm_origin_url=request.vllm_origin_url,
+        vllm_ascend_origin_url=request.vllm_ascend_origin_url,
     )
-    if request.vllm_origin_url:
-        repos_path = paths.local_repos_file
-        config = _load_yaml_mapping(repos_path)
-        config["submodules"]["vllm"]["origin_url"] = request.vllm_origin_url
-        _write_yaml(repos_path, config)
 
 
 def _bootstrap_servers_config(
@@ -354,30 +534,18 @@ def _write_auth_yaml(paths: RepoPaths, request: BootstrapRequest) -> None:
         )
         return
 
-    _write_yaml(
-        auth_path,
-        {
-            "version": 1,
-            "ssh_auth": {
-                "refs": {
-                    DEFAULT_SERVER_AUTH_REF: _auth_ref_payload(
-                        request.server_auth_mode,
-                        username=request.server_user,
-                        password_env=request.server_password_env,
-                        key_path=request.server_key_path,
-                    ),
-                },
-            },
-            "git_auth": {
-                "refs": {
-                    DEFAULT_GIT_AUTH_REF: _auth_ref_payload(
-                        request.git_auth_mode,
-                        key_path=request.git_key_path,
-                        token_env=request.git_token_env,
-                    ),
-                },
-            },
-        },
+    write_server_auth_ref(
+        paths,
+        server_auth_mode=request.server_auth_mode,
+        server_user=request.server_user,
+        server_password_env=request.server_password_env,
+        server_key_path=request.server_key_path,
+    )
+    write_git_auth_ref(
+        paths,
+        git_auth_mode=request.git_auth_mode,
+        git_key_path=request.git_key_path,
+        git_token_env=request.git_token_env,
     )
 
 
@@ -453,17 +621,22 @@ def _finalize_bootstrap(paths: RepoPaths, request: BootstrapRequest) -> None:
         raise BootstrapError(str(exc)) from exc
 
 
-def _configure_repo_remotes(paths: RepoPaths, request: BootstrapRequest) -> None:
+def configure_repo_remotes(
+    paths: RepoPaths,
+    *,
+    vllm_origin_url: Optional[str],
+    vllm_ascend_origin_url: str,
+) -> None:
     repo_targets = {
         "vllm": {
             "path": paths.root / "vllm",
             "upstream": COMMUNITY_UPSTREAM_URLS["vllm"],
-            "origin": request.vllm_origin_url,
+            "origin": vllm_origin_url,
         },
         "vllm-ascend": {
             "path": paths.root / "vllm-ascend",
             "upstream": COMMUNITY_UPSTREAM_URLS["vllm-ascend"],
-            "origin": request.vllm_ascend_origin_url,
+            "origin": vllm_ascend_origin_url,
         },
     }
 
@@ -473,47 +646,16 @@ def _configure_repo_remotes(paths: RepoPaths, request: BootstrapRequest) -> None
         origin_url = config["origin"]
         if origin_url:
             _ensure_git_remote(repo_path, "origin", origin_url)
-        elif repo_name == "vllm":
-            _ensure_git_remote(repo_path, "origin", config["upstream"])
 
 
 def bootstrap_init(paths: RepoPaths, request: BootstrapRequest) -> int:
     try:
-        preflight_report = ensure_local_control_plane_deps()
-        _ensure_overlay(paths)
-        _ensure_bootstrap_not_completed(paths)
-        ensure_bootstrap_secret_refs(
-            server_auth_mode=request.server_auth_mode,
-            server_password_env=request.server_password_env,
-            git_auth_mode=request.git_auth_mode,
-            git_token_env=request.git_token_env,
-        )
-        _write_repos_yaml(paths, request)
-        _write_servers_yaml(paths, request, completed=False)
-        _write_targets_yaml(paths, request)
-        _write_auth_yaml(paths, request)
-        _configure_repo_remotes(paths, request)
-        verification: Optional[VerificationResult] = None
-        if request.server_host is not None:
-            context = resolve_server_context(paths, request.host_name)
-            verification = verify_runtime(paths, context)
-            persist_server_verification(paths, request.host_name, verification)
-        _finalize_bootstrap(paths, request)
-    except (PreflightError, SecretBoundaryError) as exc:
-        print(str(exc))
-        return 1
+        staged_request = _staged_init_request(request)
+        result = _run_staged_init(paths, staged_request)
+        if result != 0:
+            return result
+        _preserve_requested_git_auth(paths, request)
+        return 0
     except BootstrapError as exc:
         print(str(exc))
         return 1
-    except (RemoteError, RuntimeError) as exc:
-        print(str(exc))
-        return 1
-
-    if preflight_report.status == "degraded":
-        missing = ", ".join(preflight_report.missing_recommended)
-        print(f"init: preflight degraded: missing recommended tools: {missing}")
-    bootstrap_status = (
-        verification.status if request.server_host is not None else "ready"
-    )
-    print(f"init: bootstrap {bootstrap_status} ({_bootstrap_mode(request)})")
-    return 0

--- a/tools/lib/doctor.py
+++ b/tools/lib/doctor.py
@@ -52,6 +52,14 @@ def _missing_submodules(root: Path, prefix: Optional[Path] = None):
     return missing
 
 
+def _validate_lifecycle_shape(state: dict) -> None:
+    lifecycle = state.get("lifecycle")
+    if lifecycle is not None and not isinstance(lifecycle, dict):
+        raise ValueError(
+            "invalid state file: .workspace.local/state.json lifecycle must be an object"
+        )
+
+
 def doctor(paths: RepoPaths) -> int:
     if not paths.local_overlay.exists():
         print("missing local overlay: .workspace.local/")
@@ -101,6 +109,12 @@ def doctor(paths: RepoPaths) -> int:
 
     if not isinstance(state, dict):
         print("invalid state file: .workspace.local/state.json must be a JSON object")
+        return 1
+
+    try:
+        _validate_lifecycle_shape(state)
+    except ValueError as exc:
+        print(str(exc))
         return 1
 
     schema_version = state.get("schema_version")

--- a/tools/lib/fleet.py
+++ b/tools/lib/fleet.py
@@ -11,10 +11,10 @@ from .bootstrap import (
     DEFAULT_SERVER_PORT,
     DEFAULT_RUNTIME_SSH_PORT,
     DEFAULT_RUNTIME_WORKSPACE_ROOT,
-    DEFAULT_SERVER_AUTH_REF,
     DEFAULT_SERVER_STATUS,
 )
 from .config import RepoPaths
+from .lifecycle_state import MANAGED_SERVER_HANDOFF_KIND, record_runtime_handoff
 from .remote import (
     DEFAULT_HOST_WORKSPACE_BASE,
     RemoteError,
@@ -24,6 +24,7 @@ from .remote import (
     resolve_server_context,
     verify_runtime,
 )
+from .runtime import read_state
 
 
 class FleetError(RuntimeError):
@@ -33,7 +34,9 @@ class FleetError(RuntimeError):
 def _read_servers_config(paths: RepoPaths) -> Dict[str, Any]:
     servers_file = paths.local_servers_file
     if not servers_file.is_file():
-        raise FleetError("missing server inventory: run `vaws init --bootstrap` first")
+        raise FleetError(
+            "missing server inventory: run staged init or `vaws foundation` first"
+        )
 
     try:
         loaded = yaml.safe_load(servers_file.read_text(encoding="utf-8"))
@@ -54,28 +57,39 @@ def _write_servers_config(paths: RepoPaths, config: Dict[str, Any]) -> None:
     )
 
 
-def _require_bootstrap_completed(config: Dict[str, Any]) -> None:
-    bootstrap = config.get("bootstrap")
-    if not isinstance(bootstrap, dict) or bootstrap.get("completed") is not True:
-        raise FleetError("missing bootstrap baseline: run `vaws init --bootstrap` first")
-
-
 def _require_non_empty_string(value: Any, message: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise FleetError(message)
     return value.strip()
 
 
-def _require_int(value: Any, message: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise FleetError(message)
-    return value
-
-
 def _require_port(value: Any, message: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 1 or value > 65535:
         raise FleetError(message)
     return value
+
+
+def _require_lifecycle_ready(paths: RepoPaths) -> None:
+    state = read_state(paths)
+    lifecycle = state.get("lifecycle")
+    if not isinstance(lifecycle, dict):
+        raise FleetError(
+            "missing lifecycle readiness: run `vaws foundation` and `vaws git-profile` first"
+        )
+
+    foundation = lifecycle.get("foundation")
+    foundation_status = foundation.get("status") if isinstance(foundation, dict) else None
+    if foundation_status not in {"ready", "degraded"}:
+        raise FleetError(
+            "foundation lifecycle must be ready or degraded before `vaws fleet add`"
+        )
+
+    git_profile = lifecycle.get("git_profile")
+    git_profile_status = git_profile.get("status") if isinstance(git_profile, dict) else None
+    if git_profile_status != "ready":
+        raise FleetError(
+            "git_profile lifecycle must be ready before `vaws fleet add`"
+        )
 
 
 def _single_auth_ref_name(ref_names: list[str]) -> str:
@@ -96,21 +110,7 @@ def _resolve_ssh_auth_ref(paths: RepoPaths, ssh_auth_ref: Optional[str]) -> str:
     auth = _load_auth_config(paths)
     ssh_auth = auth.get("ssh_auth")
     if not isinstance(ssh_auth, dict):
-        host_auth = auth.get("host_auth")
-        if not isinstance(host_auth, dict):
-            raise FleetError("invalid auth config: missing ssh_auth.refs map")
-
-        credential_groups = host_auth.get("credential_groups")
-        if not isinstance(credential_groups, dict):
-            raise FleetError("invalid auth config: missing host_auth.credential_groups map")
-
-        ref_names = sorted(
-            ref_name.strip()
-            for ref_name in credential_groups
-            if isinstance(ref_name, str) and ref_name.strip()
-        )
-        return _single_auth_ref_name(ref_names)
-
+        raise FleetError("invalid auth config: missing ssh_auth.refs map")
     refs = ssh_auth.get("refs")
     if not isinstance(refs, dict):
         raise FleetError("invalid auth config: missing ssh_auth.refs map")
@@ -188,10 +188,10 @@ def add_fleet_server(
         runtime_ssh_port = _require_port(runtime_ssh_port, "invalid runtime ssh port")
 
         config = _read_servers_config(paths)
-        _require_bootstrap_completed(config)
         servers = config.get("servers")
         if not isinstance(servers, dict):
             raise FleetError("invalid server config: missing 'servers' map")
+        _require_lifecycle_ready(paths)
         ssh_auth_ref = _resolve_ssh_auth_ref(paths, ssh_auth_ref)
 
         servers[server_name] = {
@@ -217,6 +217,16 @@ def add_fleet_server(
         ensure_runtime(paths, context)
         verification = verify_runtime(paths, context)
         persist_server_verification(paths, server_name, verification)
+        if verification.status == "ready":
+            record_runtime_handoff(
+                paths,
+                current_target=server_name,
+                handoff_kind=MANAGED_SERVER_HANDOFF_KIND,
+                runtime=verification.runtime,
+            )
+        else:
+            print(f"fleet add: {verification.status} ({server_name})")
+            return 1
     except (FleetError, RuntimeError, OSError) as exc:
         print(str(exc))
         return 1
@@ -229,6 +239,17 @@ def verify_fleet_server(paths: RepoPaths, server_name: str) -> int:
     try:
         context = resolve_server_context(paths, server_name)
         verification = verify_runtime(paths, context)
+        persist_server_verification(paths, server_name, verification)
+        if verification.status == "ready":
+            record_runtime_handoff(
+                paths,
+                current_target=server_name,
+                handoff_kind=MANAGED_SERVER_HANDOFF_KIND,
+                runtime=verification.runtime,
+            )
+        else:
+            print(f"fleet verify: {verification.status} ({server_name})")
+            return 1
     except (RemoteError, RuntimeError) as exc:
         print(str(exc))
         return 1

--- a/tools/lib/foundation.py
+++ b/tools/lib/foundation.py
@@ -1,0 +1,14 @@
+from .config import RepoPaths
+from .lifecycle_state import record_foundation_status
+from .preflight import check_local_control_plane_deps
+
+
+def run_foundation(paths: RepoPaths) -> int:
+    try:
+        report = check_local_control_plane_deps()
+        record_foundation_status(paths, report.status)
+    except RuntimeError as exc:
+        print(str(exc))
+        return 1
+    print(f"foundation: {report.status}")
+    return 1 if report.status == "blocked" else 0

--- a/tools/lib/git_profile.py
+++ b/tools/lib/git_profile.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from .bootstrap import (
+    BootstrapError,
+    _ensure_overlay,
+    configure_repo_remotes,
+    load_existing_repo_topology,
+    topology_is_ready,
+    write_git_auth_ref,
+    write_repo_topology,
+)
+from .config import RepoPaths
+from .lifecycle_state import record_git_profile_status
+
+
+def git_profile(
+    paths: RepoPaths,
+    *,
+    vllm_origin_url: str | None = None,
+    vllm_ascend_origin_url: str | None = None,
+) -> int:
+    try:
+        _ensure_overlay(paths)
+        existing_topology = load_existing_repo_topology(paths)
+        if existing_topology and topology_is_ready(paths):
+            write_git_auth_ref(
+                paths,
+                git_auth_mode="ssh-agent",
+                git_key_path=None,
+                git_token_env=None,
+            )
+            record_git_profile_status(paths, "ready")
+            print("git-profile: ready")
+            return 0
+
+        if not vllm_ascend_origin_url:
+            record_git_profile_status(paths, "needs_input")
+            print("git-profile: needs_input: missing vllm-ascend origin url")
+            return 1
+
+        resolved_vllm_origin_url = vllm_origin_url
+        resolved_vllm_ascend_origin_url = vllm_ascend_origin_url
+
+        write_repo_topology(
+            paths,
+            vllm_origin_url=resolved_vllm_origin_url,
+            vllm_ascend_origin_url=resolved_vllm_ascend_origin_url,
+        )
+        configure_repo_remotes(
+            paths,
+            vllm_origin_url=resolved_vllm_origin_url,
+            vllm_ascend_origin_url=resolved_vllm_ascend_origin_url,
+        )
+        write_git_auth_ref(
+            paths,
+            git_auth_mode="ssh-agent",
+            git_key_path=None,
+            git_token_env=None,
+        )
+        record_git_profile_status(paths, "ready")
+        print("git-profile: ready")
+        return 0
+    except BootstrapError as exc:
+        print(str(exc))
+        return 1
+    except RuntimeError as exc:
+        print(str(exc))
+        return 1

--- a/tools/lib/init_flow.py
+++ b/tools/lib/init_flow.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import yaml
+
+from .bootstrap import (
+    BOOTSTRAP_MODE_LOCAL_ONLY,
+    BOOTSTRAP_MODE_REMOTE_FIRST,
+    BootstrapError,
+    DEFAULT_RUNTIME_BOOTSTRAP_MODE,
+    DEFAULT_RUNTIME_CONTAINER,
+    DEFAULT_RUNTIME_IMAGE,
+    DEFAULT_RUNTIME_SSH_PORT,
+    DEFAULT_RUNTIME_WORKSPACE_ROOT,
+    DEFAULT_SERVER_AUTH_REF,
+    DEFAULT_SERVER_PORT,
+    _ensure_overlay,
+    write_git_auth_ref,
+    write_server_auth_ref,
+)
+from .config import RepoPaths
+from .fleet import add_fleet_server
+from .foundation import run_foundation
+from .git_profile import git_profile
+from .lifecycle_state import (
+    MANAGED_SERVER_HANDOFF_KIND,
+    record_requested_mode,
+    record_runtime_handoff,
+)
+from .secret_boundary import (
+    SecretBoundaryError,
+    ensure_bootstrap_secret_refs,
+    require_pre_staged_env_handle,
+)
+from .runtime import read_state
+
+
+@dataclass(frozen=True)
+class InitRequest:
+    server_host: Optional[str] = None
+    server_name: Optional[str] = None
+    local_only: bool = False
+    server_user: str = "root"
+    server_port: int = DEFAULT_SERVER_PORT
+    server_auth_mode: str = "ssh-key"
+    server_password_env: Optional[str] = None
+    server_key_path: Optional[str] = None
+    runtime_image: str = DEFAULT_RUNTIME_IMAGE
+    runtime_container: str = DEFAULT_RUNTIME_CONTAINER
+    runtime_ssh_port: int = DEFAULT_RUNTIME_SSH_PORT
+    runtime_workspace_root: str = DEFAULT_RUNTIME_WORKSPACE_ROOT
+    runtime_bootstrap_mode: str = DEFAULT_RUNTIME_BOOTSTRAP_MODE
+    vllm_origin_url: Optional[str] = None
+    vllm_ascend_origin_url: Optional[str] = None
+    git_auth_mode: str = "ssh-key"
+    git_key_path: Optional[str] = None
+    git_token_env: Optional[str] = None
+
+
+def _optional_non_empty(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def init_request_from_args(args: Any) -> InitRequest:
+    return InitRequest(
+        server_host=_optional_non_empty(args.server_host),
+        server_name=_optional_non_empty(getattr(args, "server_name", None)),
+        local_only=bool(getattr(args, "local_only", False)),
+        server_user=args.server_user,
+        server_port=args.server_port,
+        server_auth_mode=args.server_auth_mode,
+        server_password_env=args.server_password_env,
+        server_key_path=args.server_key_path,
+        runtime_image=args.runtime_image,
+        runtime_container=args.runtime_container,
+        runtime_ssh_port=args.runtime_ssh_port,
+        runtime_workspace_root=args.runtime_workspace_root,
+        runtime_bootstrap_mode=DEFAULT_RUNTIME_BOOTSTRAP_MODE,
+        vllm_origin_url=_optional_non_empty(args.vllm_origin_url),
+        vllm_ascend_origin_url=_optional_non_empty(args.vllm_ascend_origin_url),
+        git_auth_mode=args.git_auth_mode,
+        git_key_path=args.git_key_path,
+        git_token_env=args.git_token_env,
+    )
+
+
+def _requested_mode(request: InitRequest) -> str:
+    if request.local_only or request.server_host is None:
+        return BOOTSTRAP_MODE_LOCAL_ONLY
+    return BOOTSTRAP_MODE_REMOTE_FIRST
+
+
+def _resolved_server_name(request: InitRequest) -> Optional[str]:
+    if _requested_mode(request) != BOOTSTRAP_MODE_REMOTE_FIRST:
+        return None
+    return _optional_non_empty(request.server_name) or request.server_host
+
+
+def _read_yaml_mapping(path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
+        raise BootstrapError(f"invalid init state: {path.name}") from exc
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        raise BootstrapError(f"invalid init state: {path.name}")
+    return loaded
+
+
+def _server_is_ready(paths: RepoPaths, *, server_name: str, server_host: str) -> bool:
+    servers_config = _read_yaml_mapping(paths.local_servers_file)
+    servers = servers_config.get("servers")
+    if not isinstance(servers, dict):
+        return False
+
+    server = servers.get(server_name)
+    if not isinstance(server, dict):
+        return False
+    if server.get("host") != server_host:
+        return False
+
+    verification = server.get("verification")
+    server_status = server.get("status")
+    verification_status = (
+        verification.get("status") if isinstance(verification, dict) else None
+    )
+    if server_status != "ready" or verification_status != "ready":
+        return False
+
+    state = read_state(paths)
+    server_verifications = state.get("server_verifications")
+    if not isinstance(server_verifications, dict):
+        return False
+    persisted = server_verifications.get(server_name)
+    if not isinstance(persisted, dict):
+        return False
+    return persisted.get("status") == "ready"
+
+
+def _server_matches_request(
+    paths: RepoPaths,
+    *,
+    server_name: str,
+    request: InitRequest,
+) -> bool:
+    if request.server_host is None:
+        return False
+
+    servers_config = _read_yaml_mapping(paths.local_servers_file)
+    servers = servers_config.get("servers")
+    if not isinstance(servers, dict):
+        return False
+
+    server = servers.get(server_name)
+    if not isinstance(server, dict):
+        return False
+
+    if server.get("host") != request.server_host:
+        return False
+    if server.get("port") != request.server_port:
+        return False
+    if server.get("login_user") != request.server_user:
+        return False
+
+    runtime = server.get("runtime")
+    if not isinstance(runtime, dict):
+        return False
+    if runtime.get("image_ref") != request.runtime_image:
+        return False
+    if runtime.get("container_name") != request.runtime_container:
+        return False
+    if runtime.get("ssh_port") != request.runtime_ssh_port:
+        return False
+    if runtime.get("workspace_root") != request.runtime_workspace_root:
+        return False
+    if runtime.get("bootstrap_mode") != request.runtime_bootstrap_mode:
+        return False
+    return True
+
+
+def _resolved_ready_server_name(
+    paths: RepoPaths,
+    *,
+    server_name: Optional[str],
+    request: InitRequest,
+) -> Optional[str]:
+    explicit_server_name = _optional_non_empty(server_name)
+    if explicit_server_name is not None:
+        if _server_is_ready(
+            paths,
+            server_name=explicit_server_name,
+            server_host=request.server_host or "",
+        ) and _server_matches_request(
+            paths,
+            server_name=explicit_server_name,
+            request=request,
+        ):
+            return explicit_server_name
+        return None
+
+    servers_config = _read_yaml_mapping(paths.local_servers_file)
+    servers = servers_config.get("servers")
+    if not isinstance(servers, dict):
+        return None
+
+    for existing_name in sorted(servers):
+        if not isinstance(existing_name, str) or not existing_name.strip():
+            continue
+        if _server_is_ready(
+            paths,
+            server_name=existing_name,
+            server_host=request.server_host or "",
+        ) and _server_matches_request(
+            paths,
+            server_name=existing_name,
+            request=request,
+        ):
+            return existing_name
+    return None
+
+
+def _runtime_for_ready_server(paths: RepoPaths, server_name: str) -> Dict[str, Any]:
+    state = read_state(paths)
+    server_verifications = state.get("server_verifications")
+    if isinstance(server_verifications, dict):
+        persisted = server_verifications.get(server_name)
+        if isinstance(persisted, dict):
+            runtime = persisted.get("runtime")
+            if isinstance(runtime, dict):
+                return dict(runtime)
+
+    servers_config = _read_yaml_mapping(paths.local_servers_file)
+    servers = servers_config.get("servers")
+    if isinstance(servers, dict):
+        server = servers.get(server_name)
+        if isinstance(server, dict):
+            verification = server.get("verification")
+            if isinstance(verification, dict):
+                runtime = verification.get("runtime")
+                if isinstance(runtime, dict):
+                    return dict(runtime)
+
+    raise BootstrapError(f"missing ready runtime handoff for existing server: {server_name}")
+
+
+def _requested_server_auth_matches(paths: RepoPaths, request: InitRequest) -> bool:
+    auth_config = _read_yaml_mapping(paths.local_auth_file)
+    ssh_auth = auth_config.get("ssh_auth")
+    if not isinstance(ssh_auth, dict):
+        return False
+    refs = ssh_auth.get("refs")
+    if not isinstance(refs, dict):
+        return False
+    auth_ref = refs.get(DEFAULT_SERVER_AUTH_REF)
+    if not isinstance(auth_ref, dict):
+        return False
+    return (
+        auth_ref.get("kind") == request.server_auth_mode
+        and auth_ref.get("username") == request.server_user
+        and auth_ref.get("password_env") == request.server_password_env
+        and auth_ref.get("key_path") == request.server_key_path
+    )
+
+
+def _preserve_requested_git_auth(paths: RepoPaths, request: InitRequest) -> None:
+    write_git_auth_ref(
+        paths,
+        git_auth_mode=request.git_auth_mode,
+        git_key_path=request.git_key_path,
+        git_token_env=request.git_token_env,
+    )
+
+
+def _ensure_requested_git_auth_secret_refs(request: InitRequest) -> None:
+    if request.git_auth_mode == "token":
+        require_pre_staged_env_handle(
+            request.git_token_env,
+            field_label="git token",
+        )
+
+
+def _git_profile_needs_input(paths: RepoPaths) -> bool:
+    state = read_state(paths)
+    lifecycle = state.get("lifecycle")
+    if not isinstance(lifecycle, dict):
+        return False
+    git_profile_state = lifecycle.get("git_profile")
+    if not isinstance(git_profile_state, dict):
+        return False
+    return git_profile_state.get("status") == "needs_input"
+
+
+def run_init(paths: RepoPaths, request: InitRequest) -> int:
+    try:
+        _ensure_overlay(paths)
+        requested_mode = _requested_mode(request)
+        record_requested_mode(paths, requested_mode)
+
+        if run_foundation(paths) != 0:
+            return 1
+
+        git_profile_result = git_profile(
+                paths,
+                vllm_origin_url=request.vllm_origin_url,
+                vllm_ascend_origin_url=request.vllm_ascend_origin_url,
+            )
+        if git_profile_result != 0:
+            if (
+                requested_mode == BOOTSTRAP_MODE_LOCAL_ONLY
+                and request.vllm_origin_url is None
+                and request.vllm_ascend_origin_url is None
+                and _git_profile_needs_input(paths)
+            ):
+                _ensure_requested_git_auth_secret_refs(request)
+                _preserve_requested_git_auth(paths, request)
+                print("init: ready (local-only)")
+                return 0
+            return 1
+
+        _ensure_requested_git_auth_secret_refs(request)
+        _preserve_requested_git_auth(paths, request)
+
+        if requested_mode == BOOTSTRAP_MODE_LOCAL_ONLY:
+            print("init: ready (local-only)")
+            return 0
+
+        if request.server_host is None:
+            raise BootstrapError("missing server host for remote-first init")
+        server_name = _resolved_server_name(request)
+        if server_name is None:
+            raise BootstrapError("missing server name for remote-first init")
+
+        ready_server_name = _resolved_ready_server_name(
+            paths,
+            server_name=request.server_name,
+            request=request,
+        )
+        if ready_server_name is not None:
+            if not _requested_server_auth_matches(paths, request):
+                ensure_bootstrap_secret_refs(
+                    server_auth_mode=request.server_auth_mode,
+                    server_password_env=request.server_password_env,
+                    git_auth_mode=request.git_auth_mode,
+                    git_token_env=request.git_token_env,
+                )
+                write_server_auth_ref(
+                    paths,
+                    server_auth_mode=request.server_auth_mode,
+                    server_user=request.server_user,
+                    server_password_env=request.server_password_env,
+                    server_key_path=request.server_key_path,
+                )
+            record_runtime_handoff(
+                paths,
+                current_target=ready_server_name,
+                handoff_kind=MANAGED_SERVER_HANDOFF_KIND,
+                runtime=_runtime_for_ready_server(paths, ready_server_name),
+            )
+            print(f"init: ready (existing {ready_server_name})")
+            return 0
+
+        ensure_bootstrap_secret_refs(
+            server_auth_mode=request.server_auth_mode,
+            server_password_env=request.server_password_env,
+            git_auth_mode=request.git_auth_mode,
+            git_token_env=request.git_token_env,
+        )
+        write_server_auth_ref(
+            paths,
+            server_auth_mode=request.server_auth_mode,
+            server_user=request.server_user,
+            server_password_env=request.server_password_env,
+            server_key_path=request.server_key_path,
+        )
+        return add_fleet_server(
+            paths,
+            server_name,
+            request.server_host,
+            ssh_auth_ref=DEFAULT_SERVER_AUTH_REF,
+            server_user=request.server_user,
+            server_port=request.server_port,
+            runtime_image=request.runtime_image,
+            runtime_container=request.runtime_container,
+            runtime_ssh_port=request.runtime_ssh_port,
+            runtime_workspace_root=request.runtime_workspace_root,
+            runtime_bootstrap_mode=request.runtime_bootstrap_mode,
+        )
+    except (BootstrapError, SecretBoundaryError, RuntimeError) as exc:
+        print(str(exc))
+        return 1

--- a/tools/lib/lifecycle_state.py
+++ b/tools/lib/lifecycle_state.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, Tuple
+
+from .config import RepoPaths
+from .runtime import read_state, write_state
+
+MANAGED_SERVER_HANDOFF_KIND = "managed_server"
+LEGACY_TARGET_HANDOFF_KIND = "legacy_target"
+
+
+def _load_state_with_lifecycle(paths: RepoPaths) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    state = read_state(paths)
+    lifecycle = state.get("lifecycle")
+    if not isinstance(lifecycle, dict):
+        lifecycle = {}
+        state["lifecycle"] = lifecycle
+    return state, lifecycle
+
+
+def get_lifecycle_state(paths: RepoPaths) -> Dict[str, Any]:
+    state = read_state(paths)
+    lifecycle = state.get("lifecycle")
+    if not isinstance(lifecycle, dict):
+        return {}
+    return lifecycle
+
+
+def record_requested_mode(paths: RepoPaths, requested_mode: str) -> None:
+    state, lifecycle = _load_state_with_lifecycle(paths)
+    lifecycle["requested_mode"] = requested_mode
+    write_state(paths, state)
+
+
+def _record_profile_status(paths: RepoPaths, profile_name: str, status: str) -> None:
+    state, lifecycle = _load_state_with_lifecycle(paths)
+    profile = lifecycle.get(profile_name)
+    if not isinstance(profile, dict):
+        profile = {}
+        lifecycle[profile_name] = profile
+    profile["status"] = status
+    write_state(paths, state)
+
+
+def record_foundation_status(paths: RepoPaths, status: str) -> None:
+    _record_profile_status(paths, "foundation", status)
+
+
+def record_git_profile_status(paths: RepoPaths, status: str) -> None:
+    _record_profile_status(paths, "git_profile", status)
+
+
+def record_runtime_handoff(
+    paths: RepoPaths,
+    *,
+    current_target: str,
+    handoff_kind: str,
+    runtime: Dict[str, Any],
+) -> None:
+    state, _lifecycle = _load_state_with_lifecycle(paths)
+    state["current_target"] = current_target
+    state["current_target_kind"] = handoff_kind
+    state["runtime"] = deepcopy(runtime)
+    state.pop("current_session", None)
+    write_state(paths, state)
+
+
+def _runtime_matches_context(runtime: Dict[str, Any], context: Any) -> bool:
+    context_runtime = getattr(context, "runtime", None)
+    context_host = getattr(context, "host", None)
+    if context_runtime is None or context_host is None:
+        return False
+
+    expected = {
+        "container_name": context_runtime.container_name,
+        "ssh_port": context_runtime.ssh_port,
+        "workspace_root": context_runtime.workspace_root,
+        "bootstrap_mode": context_runtime.bootstrap_mode,
+        "host_name": context_host.name,
+        "host": context_host.host,
+        "host_port": context_host.port,
+        "login_user": context_host.login_user,
+    }
+    for key, expected_value in expected.items():
+        actual_value = runtime.get(key)
+        if actual_value is not None and actual_value != expected_value:
+            return False
+    return True
+
+
+def infer_current_target_kind(
+    paths: RepoPaths,
+    current_target: str,
+    runtime: Any,
+):
+    from .remote import RemoteError, resolve_server_context, resolve_target_context
+
+    candidates = []
+    for handoff_kind, resolver in (
+        (MANAGED_SERVER_HANDOFF_KIND, resolve_server_context),
+        (LEGACY_TARGET_HANDOFF_KIND, resolve_target_context),
+    ):
+        try:
+            context = resolver(paths, current_target)
+        except RemoteError:
+            continue
+        candidates.append((handoff_kind, context))
+
+    if not candidates:
+        return None
+
+    if isinstance(runtime, dict):
+        matching = [
+            handoff_kind
+            for handoff_kind, context in candidates
+            if _runtime_matches_context(runtime, context)
+        ]
+        if len(matching) == 1:
+            return matching[0]
+        return None
+
+    if len(candidates) == 1:
+        return candidates[0][0]
+    return None

--- a/tools/lib/preflight.py
+++ b/tools/lib/preflight.py
@@ -69,7 +69,6 @@ def ensure_local_control_plane_deps() -> PreflightReport:
     report = check_local_control_plane_deps()
     if report.status == "blocked":
         raise PreflightError(
-            "missing local control-plane dependencies: "
-            + ", ".join(report.missing_required)
+            f"missing local control-plane dependencies: {', '.join(report.missing_required)}"
         )
     return report

--- a/tools/lib/remote.py
+++ b/tools/lib/remote.py
@@ -22,6 +22,15 @@ class RemoteError(RuntimeError):
     """Remote bootstrap or runtime materialization failure."""
 
 
+def can_fallback_to_legacy_target(exc: "RemoteError") -> bool:
+    message = str(exc)
+    return (
+        message.startswith("unknown server:")
+        or message.startswith("invalid server config: .workspace.local/servers.yaml")
+        or message.startswith("invalid server config: missing 'servers' map")
+    )
+
+
 @dataclass(frozen=True)
 class CredentialGroup:
     mode: str
@@ -209,6 +218,45 @@ def _host_auth_ref(host_config: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+def _host_ssh_auth_ref(host_config: Dict[str, Any]) -> Optional[str]:
+    auth_ref = host_config.get("ssh_auth_ref")
+    if isinstance(auth_ref, str) and auth_ref.strip():
+        return auth_ref.strip()
+    return None
+
+
+def _modern_auth_ref_names(auth: Dict[str, Any]) -> List[str]:
+    ssh_auth = auth.get("ssh_auth")
+    if not isinstance(ssh_auth, dict):
+        return []
+
+    refs = ssh_auth.get("refs")
+    if not isinstance(refs, dict):
+        return []
+
+    return sorted(
+        ref_name.strip()
+        for ref_name in refs
+        if isinstance(ref_name, str) and ref_name.strip()
+    )
+
+
+def _legacy_auth_ref_names(auth: Dict[str, Any]) -> List[str]:
+    host_auth = auth.get("host_auth")
+    if not isinstance(host_auth, dict):
+        return []
+
+    credential_groups = host_auth.get("credential_groups")
+    if not isinstance(credential_groups, dict):
+        return []
+
+    return sorted(
+        ref_name.strip()
+        for ref_name in credential_groups
+        if isinstance(ref_name, str) and ref_name.strip()
+    )
+
+
 def _credential_group_from_ref(
     ref: Dict[str, Any],
     ref_name: str,
@@ -241,6 +289,30 @@ def _credential_group_from_ref(
         key_path=ref.get("key_path"),
         token_env=ref.get("token_env"),
         simulation_root=simulation_root_path,
+    )
+
+
+def _modern_credential_group_from_auth(
+    auth: Dict[str, Any],
+    host: HostSpec,
+    ssh_auth_ref: str,
+) -> CredentialGroup:
+    ssh_auth_refs = _modern_auth_ref_names(auth)
+    if not ssh_auth_refs:
+        raise RemoteError("invalid auth config: missing ssh_auth.refs map")
+
+    ssh_auth = auth.get("ssh_auth")
+    assert isinstance(ssh_auth, dict)
+    ssh_refs = ssh_auth.get("refs")
+    assert isinstance(ssh_refs, dict)
+    credential_config = ssh_refs.get(ssh_auth_ref)
+    if not isinstance(credential_config, dict):
+        raise RemoteError(f"invalid auth config: unknown ssh auth ref '{ssh_auth_ref}'")
+
+    return _credential_group_from_ref(
+        credential_config,
+        ssh_auth_ref,
+        host.login_user,
     )
 
 
@@ -295,8 +367,13 @@ def _context_from_inventory_record(
     host_name: str,
     host_config: Dict[str, Any],
     runtime: Dict[str, Any],
+    *,
+    legacy_auth: bool = False,
 ) -> TargetContext:
-    ssh_auth_ref = _host_auth_ref(host_config)
+    explicit_ssh_auth_ref = _host_ssh_auth_ref(host_config)
+    ssh_auth_ref = explicit_ssh_auth_ref
+    if not ssh_auth_ref and legacy_auth:
+        ssh_auth_ref = _host_auth_ref(host_config)
     if not ssh_auth_ref:
         raise RemoteError(
             f"invalid {record_kind} config: {record_kind} '{record_name}' missing ssh_auth_ref"
@@ -363,25 +440,12 @@ def _context_from_inventory_record(
         )
 
     auth = _load_auth_config(paths)
-    ssh_auth_ref = host.ssh_auth_ref or host.auth_group
-    ssh_auth = auth.get("ssh_auth")
-    if isinstance(ssh_auth, dict):
-        ssh_refs = ssh_auth.get("refs")
-        if not isinstance(ssh_refs, dict):
-            raise RemoteError("invalid auth config: missing ssh_auth.refs map")
-
-        credential_config = ssh_refs.get(ssh_auth_ref)
-        if not isinstance(credential_config, dict):
-            raise RemoteError(
-                f"invalid auth config: unknown ssh auth ref '{ssh_auth_ref}'"
-            )
-        credential = _credential_group_from_ref(
-            credential_config,
-            ssh_auth_ref,
-            host.login_user,
-        )
-    else:
+    if legacy_auth and explicit_ssh_auth_ref:
+        credential = _modern_credential_group_from_auth(auth, host, explicit_ssh_auth_ref)
+    elif legacy_auth:
         credential = _legacy_credential_group_from_auth(auth, host)
+    else:
+        credential = _modern_credential_group_from_auth(auth, host, ssh_auth_ref)
 
     return TargetContext(
         name=record_name,
@@ -469,6 +533,7 @@ def _resolve_legacy_target_context(paths: RepoPaths, target_name: str) -> Target
         host_name,
         host_config,
         runtime,
+        legacy_auth=True,
     )
 
 
@@ -499,13 +564,12 @@ def resolve_server_context(paths: RepoPaths, server_name: str) -> TargetContext:
 
 
 def list_managed_server_names(paths: RepoPaths) -> List[str]:
-    try:
-        config = _load_servers_config(paths)
-    except RemoteError:
+    if not paths.local_servers_file.exists():
         return []
+    config = _load_servers_config(paths)
     servers = config.get("servers")
     if not isinstance(servers, dict):
-        return []
+        raise RemoteError("invalid server config: missing 'servers' map")
     return sorted(
         name.strip()
         for name in servers
@@ -514,19 +578,7 @@ def list_managed_server_names(paths: RepoPaths) -> List[str]:
 
 
 def resolve_target_context(paths: RepoPaths, target_name: str) -> TargetContext:
-    legacy_error: Optional[RemoteError] = None
-    try:
-        return _resolve_legacy_target_context(paths, target_name)
-    except RemoteError as exc:
-        legacy_error = exc
-        if str(exc) != f"unknown target: {target_name}":
-            raise
-
-    try:
-        return resolve_server_context(paths, target_name)
-    except RemoteError:
-        assert legacy_error is not None
-        raise legacy_error
+    return _resolve_legacy_target_context(paths, target_name)
 
 
 def persist_server_verification(

--- a/tools/lib/reset.py
+++ b/tools/lib/reset.py
@@ -9,9 +9,15 @@ from typing import Any, Dict, List, Optional
 
 from .bootstrap import COMMUNITY_UPSTREAM_URLS
 from .config import RepoPaths
+from .lifecycle_state import (
+    LEGACY_TARGET_HANDOFF_KIND,
+    MANAGED_SERVER_HANDOFF_KIND,
+    infer_current_target_kind,
+)
 from .remote import (
     CleanupResult,
     RemoteError,
+    can_fallback_to_legacy_target,
     cleanup_runtime,
     list_managed_server_names,
     resolve_server_context,
@@ -63,10 +69,56 @@ def _current_target_from_state(paths: RepoPaths) -> Optional[str]:
     return None
 
 
+def _current_target_kind_from_state(paths: RepoPaths) -> Optional[str]:
+    state = read_state(paths)
+    current_target_kind = state.get("current_target_kind")
+    if isinstance(current_target_kind, str) and current_target_kind.strip():
+        return current_target_kind.strip()
+    current_target = state.get("current_target")
+    if not isinstance(current_target, str) or not current_target.strip():
+        return None
+    runtime = state.get("runtime")
+    inferred_kind = infer_current_target_kind(
+        paths,
+        current_target.strip(),
+        runtime if isinstance(runtime, dict) else None,
+    )
+    if inferred_kind is None:
+        raise RuntimeError(
+            "missing current target handoff kind: rerun `vaws fleet add <server>` or `vaws target ensure <target>`"
+        )
+    return inferred_kind
+def _cleanup_managed_server_runtime(paths: RepoPaths, server_name: str) -> CleanupResult:
+    context = resolve_server_context(paths, server_name)
+    return cleanup_runtime(context)
+
+
+def cleanup_target_runtime(paths: RepoPaths, target_name: str) -> CleanupResult:
+    context = resolve_target_context(paths, target_name)
+    return cleanup_runtime(context)
+
+
+def _cleanup_approved_target_runtime(
+    paths: RepoPaths,
+    target_name: str,
+    *,
+    handoff_kind: Optional[str],
+) -> CleanupResult:
+    if handoff_kind == MANAGED_SERVER_HANDOFF_KIND:
+        return _cleanup_managed_server_runtime(paths, target_name)
+    if handoff_kind == LEGACY_TARGET_HANDOFF_KIND:
+        return cleanup_target_runtime(paths, target_name)
+    return cleanup_server_runtime(paths, target_name)
+
+
 def _print_prepare_summary(confirmation_id: str) -> None:
-    print("reset prepare: this request records approval to wipe local workspace identity and remote runtime context")
-    print("reset prepare: reset execute will clean the active remote runtime first, then clear local overlay state")
-    print("reset prepare: local overlay state includes .workspace.local/state.json, .workspace.local/sessions/, .workspace.local/targets.yaml, .workspace.local/auth.yaml, and .workspace.local/repos.yaml")
+    print(
+        "reset prepare: this request records approval to wipe local workspace identity, managed servers, and approved-target cleanup"
+    )
+    print(
+        "reset prepare: reset execute will perform managed-server cleanup first, then approved-target cleanup if needed, before clearing local overlay state"
+    )
+    print("reset prepare: local overlay state includes .workspace.local/state.json, .workspace.local/sessions/, .workspace.local/servers.yaml, .workspace.local/targets.yaml, .workspace.local/auth.yaml, and .workspace.local/repos.yaml")
     print(f"reset prepare: confirmation id: {confirmation_id}")
     print(f"reset prepare: confirm with: {CONFIRMATION_PHRASE}")
 
@@ -81,8 +133,11 @@ def prepare_reset(paths: RepoPaths) -> int:
             "confirmation_phrase": CONFIRMATION_PHRASE,
         }
         approved_target = _current_target_from_state(paths)
+        approved_target_kind = _current_target_kind_from_state(paths)
         if approved_target:
             request["approved_target"] = approved_target
+        if approved_target_kind:
+            request["approved_target_kind"] = approved_target_kind
         paths.reset_request_file.write_text(
             json.dumps(request, indent=2) + "\n",
             encoding="utf-8",
@@ -106,6 +161,7 @@ def _cleanup_local_state(paths: RepoPaths) -> None:
             raise RuntimeError("failed to clean local workspace: .workspace.local/sessions is not a directory")
         shutil.rmtree(sessions_path)
     paths.local_targets_file.write_text("", encoding="utf-8")
+    paths.local_servers_file.write_text("version: 1\nservers: {}\n", encoding="utf-8")
     paths.local_auth_file.write_text("", encoding="utf-8")
     paths.local_repos_file.write_text("", encoding="utf-8")
 
@@ -113,22 +169,30 @@ def _cleanup_local_state(paths: RepoPaths) -> None:
 def cleanup_server_runtime(paths: RepoPaths, server_name: str) -> CleanupResult:
     try:
         context = resolve_server_context(paths, server_name)
-    except RemoteError:
+    except RemoteError as exc:
+        if not can_fallback_to_legacy_target(exc):
+            raise
         context = resolve_target_context(paths, server_name)
     return cleanup_runtime(context)
 
 
 def _cleanup_remote_state(request: Dict[str, Any], paths: RepoPaths) -> List[CleanupResult]:
     server_names = list_managed_server_names(paths)
-    if not server_names:
-        approved_target = request.get("approved_target")
-        if isinstance(approved_target, str) and approved_target.strip():
-            server_names = [approved_target.strip()]
+    approved_target = request.get("approved_target")
+    approved_target_kind = request.get("approved_target_kind")
+    if isinstance(approved_target, str) and approved_target.strip():
+        approved_target = approved_target.strip()
+    if isinstance(approved_target_kind, str) and approved_target_kind.strip():
+        approved_target_kind = approved_target_kind.strip()
+    else:
+        approved_target_kind = _current_target_kind_from_state(paths)
 
     results: List[CleanupResult] = []
+    cleaned_managed_servers = set()
     for server_name in server_names:
         try:
-            results.append(cleanup_server_runtime(paths, server_name))
+            results.append(_cleanup_managed_server_runtime(paths, server_name))
+            cleaned_managed_servers.add(server_name)
         except (RemoteError, RuntimeError) as exc:
             results.append(
                 CleanupResult(
@@ -137,6 +201,41 @@ def _cleanup_remote_state(request: Dict[str, Any], paths: RepoPaths) -> List[Cle
                     detail=str(exc),
                 )
             )
+    if isinstance(approved_target, str) and approved_target.strip():
+        if approved_target_kind is None:
+            raise RuntimeError(
+                "missing approved target handoff kind: rerun `vaws reset --prepare` first"
+            )
+        if approved_target_kind == MANAGED_SERVER_HANDOFF_KIND:
+            if approved_target not in cleaned_managed_servers:
+                try:
+                    results.append(_cleanup_managed_server_runtime(paths, approved_target))
+                except (RemoteError, RuntimeError) as exc:
+                    results.append(
+                        CleanupResult(
+                            server_name=approved_target,
+                            status="cleanup_failed",
+                            detail=str(exc),
+                        )
+                    )
+            return results
+        if approved_target_kind == LEGACY_TARGET_HANDOFF_KIND:
+            try:
+                results.append(
+                    _cleanup_approved_target_runtime(
+                        paths,
+                        approved_target,
+                        handoff_kind=approved_target_kind,
+                    )
+                )
+            except (RemoteError, RuntimeError) as exc:
+                results.append(
+                    CleanupResult(
+                        server_name=approved_target,
+                        status="cleanup_failed",
+                        detail=str(exc),
+                    )
+                )
     return results
 
 
@@ -215,7 +314,11 @@ def execute_reset(
         print("reset execute: confirmation phrase must exactly match the approved phrase")
         return 1
 
-    remote_results = _cleanup_remote_state(request, paths)
+    try:
+        remote_results = _cleanup_remote_state(request, paths)
+    except (RemoteError, RuntimeError) as exc:
+        print(f"reset execute: failed to clean remote runtime: {exc}")
+        return 1
     for result in remote_results:
         detail = f" ({result.detail})" if result.detail else ""
         print(f"reset execute: server {result.server_name}: {result.status}{detail}")

--- a/tools/lib/session.py
+++ b/tools/lib/session.py
@@ -7,8 +7,19 @@ import yaml
 
 from .config import RepoPaths
 from .gitflow import base_ref_for_repo
-from .remote import RemoteError, create_remote_session, resolve_target_context, switch_remote_session
+from .remote import (
+    RemoteError,
+    create_remote_session,
+    resolve_server_context,
+    resolve_target_context,
+    switch_remote_session,
+)
 from .runtime import read_state, write_state
+from .lifecycle_state import (
+    LEGACY_TARGET_HANDOFF_KIND,
+    MANAGED_SERVER_HANDOFF_KIND,
+    infer_current_target_kind,
+)
 
 
 def _session_manifest_path(paths: RepoPaths, session_name: str) -> Path:
@@ -50,9 +61,7 @@ def _read_state_for_session(paths: RepoPaths):
 
 
 def _build_manifest(paths: RepoPaths, session_name: str, state: Dict[str, Any]) -> Dict[str, Any]:
-    current_target = state.get("current_target")
-    if not isinstance(current_target, str) or not current_target.strip():
-        raise RemoteError("no current target: run `vaws target ensure <target>` first")
+    current_target = _current_target_from_state(state)
 
     runtime = state.get("runtime")
     workspace_root = "/vllm-workspace"
@@ -98,10 +107,40 @@ def _build_manifest(paths: RepoPaths, session_name: str, state: Dict[str, Any]) 
 
 
 def _target_context_from_state(paths: RepoPaths, state: Dict[str, Any]):
+    target_name = _current_target_from_state(state)
+    handoff_kind = _current_target_kind_from_state(paths, state)
+    if handoff_kind == MANAGED_SERVER_HANDOFF_KIND:
+        return resolve_server_context(paths, target_name)
+    if handoff_kind == LEGACY_TARGET_HANDOFF_KIND:
+        return resolve_target_context(paths, target_name)
+    raise RemoteError(
+        "missing current target handoff kind: rerun `vaws fleet add <server>` or `vaws target ensure <target>`"
+    )
+
+
+def _current_target_from_state(state: Dict[str, Any]) -> str:
     current_target = state.get("current_target")
     if not isinstance(current_target, str) or not current_target.strip():
-        raise RemoteError("no current target: run `vaws target ensure <target>` first")
-    return resolve_target_context(paths, current_target)
+        raise RemoteError("no current target: run `vaws fleet add <server>` first")
+    return current_target.strip()
+
+
+def _current_target_kind_from_state(paths: RepoPaths, state: Dict[str, Any]) -> str:
+    current_target_kind = state.get("current_target_kind")
+    if not isinstance(current_target_kind, str) or not current_target_kind.strip():
+        current_target = _current_target_from_state(state)
+        runtime = state.get("runtime")
+        inferred_kind = infer_current_target_kind(
+            paths,
+            current_target,
+            runtime if isinstance(runtime, dict) else None,
+        )
+        if inferred_kind is None:
+            raise RemoteError(
+                "missing current target handoff kind: rerun `vaws fleet add <server>` or `vaws target ensure <target>`"
+            )
+        return inferred_kind
+    return current_target_kind.strip()
 
 
 def create_session(paths: RepoPaths, session_name: str) -> int:

--- a/tools/lib/targets.py
+++ b/tools/lib/targets.py
@@ -1,41 +1,27 @@
 from .config import RepoPaths
+from .lifecycle_state import LEGACY_TARGET_HANDOFF_KIND, record_runtime_handoff
 from .remote import (
     RemoteError,
     ensure_runtime,
-    resolve_server_context,
     resolve_target_context,
     verify_runtime,
 )
-from .runtime import read_state, write_state
 
 
 def ensure_target(paths: RepoPaths, target_name: str) -> int:
     print(
-        "target ensure: deprecated shim; use `vaws fleet` for server inventory management"
+        "target ensure: deprecated compatibility shim; use `vaws fleet add <server>` for server handoff"
     )
     try:
-        routed_via = "legacy target config"
         context = resolve_target_context(paths, target_name)
-        try:
-            server_context = resolve_server_context(paths, context.host.name)
-        except RemoteError:
-            server_context = None
-
-        if server_context is not None:
-            context = server_context
-            routed_via = "fleet verification behavior"
-            try:
-                verification = verify_runtime(paths, context)
-                if verification.status != "ready":
-                    persisted_runtime = ensure_runtime(paths, context)
-                    verification = verify_runtime(paths, context)
-                persisted_runtime = verification.runtime
-            except RemoteError:
-                persisted_runtime = ensure_runtime(paths, context)
-                persisted_runtime = verify_runtime(paths, context).runtime
-        else:
-            persisted_runtime = ensure_runtime(paths, context)
-        state = read_state(paths)
+        ensure_runtime(paths, context)
+        verification = verify_runtime(paths, context)
+        record_runtime_handoff(
+            paths,
+            current_target=target_name,
+            handoff_kind=LEGACY_TARGET_HANDOFF_KIND,
+            runtime=verification.runtime,
+        )
     except RemoteError as exc:
         print(str(exc))
         return 1
@@ -43,13 +29,5 @@ def ensure_target(paths: RepoPaths, target_name: str) -> int:
         print(str(exc))
         return 1
 
-    state["current_target"] = target_name
-    state["runtime"] = persisted_runtime
-    try:
-        write_state(paths, state)
-    except RuntimeError as exc:
-        print(str(exc))
-        return 1
-    print(f"target ensure: routed via {routed_via}")
     print(f"target ensure: ok ({target_name})")
     return 0

--- a/tools/vaws.py
+++ b/tools/vaws.py
@@ -8,9 +8,12 @@ if __package__ in (None, ""):
 
 from tools.lib.bootstrap import bootstrap_init, bootstrap_request_from_args
 from tools.lib.config import RepoPaths
+from tools.lib.git_profile import git_profile
+from tools.lib.foundation import run_foundation
 from tools.lib.fleet import add_fleet_server, list_fleet, verify_fleet_server
-from tools.lib.doctor import doctor, init
+from tools.lib.doctor import doctor
 from tools.lib.gitflow import default_base_ref
+from tools.lib.init_flow import init_request_from_args, run_init
 from tools.lib.reset import execute_reset, prepare_reset
 from tools.lib.session import create_session, status_session, switch_session
 from tools.lib.targets import ensure_target
@@ -20,6 +23,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="vaws")
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("doctor")
+    subparsers.add_parser("foundation")
     init_parser = subparsers.add_parser("init")
     init_parser.add_argument("--bootstrap", action="store_true")
     init_parser.add_argument("--target-name", default="single-default")
@@ -28,12 +32,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--server-host",
         help="bootstrap server host; omit for local-only baseline",
     )
+    init_parser.add_argument("--server-name")
     init_parser.add_argument("--server-user", default="root")
     init_parser.add_argument("--server-port", type=int, default=22)
     init_parser.add_argument("--server-auth-mode", default="ssh-key")
     init_parser.add_argument("--server-auth-group", default="default")
     init_parser.add_argument("--server-password-env")
     init_parser.add_argument("--server-key-path")
+    init_parser.add_argument("--local-only", action="store_true")
     init_parser.add_argument(
         "--runtime-image",
         default="quay.nju.edu.cn/ascend/vllm-ascend:latest",
@@ -49,6 +55,9 @@ def build_parser() -> argparse.ArgumentParser:
     init_parser.add_argument("--git-auth-mode", default="ssh-key")
     init_parser.add_argument("--git-key-path")
     init_parser.add_argument("--git-token-env")
+    git_profile_parser = subparsers.add_parser("git-profile")
+    git_profile_parser.add_argument("--vllm-origin-url")
+    git_profile_parser.add_argument("--vllm-ascend-origin-url")
     sync_parser = subparsers.add_parser("sync")
     sync_subparsers = sync_parser.add_subparsers(dest="sync_command")
     sync_start_parser = sync_subparsers.add_parser("start")
@@ -120,6 +129,8 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     if args.command == "doctor":
         return doctor(paths)
+    if args.command == "foundation":
+        return run_foundation(paths)
     if args.command == "init":
         if args.bootstrap:
             try:
@@ -128,7 +139,13 @@ def main(argv: Optional[List[str]] = None) -> int:
                 print(str(exc))
                 return 1
             return bootstrap_init(paths, request)
-        return init(paths)
+        return run_init(paths, init_request_from_args(args))
+    if args.command == "git-profile":
+        return git_profile(
+            paths,
+            vllm_origin_url=args.vllm_origin_url,
+            vllm_ascend_origin_url=args.vllm_ascend_origin_url,
+        )
     if args.command == "sync":
         if args.sync_command in (None, "status"):
             return status_session(paths)


### PR DESCRIPTION
## Summary
- split the overloaded bootstrap lifecycle into staged init, foundation, git-profile, and fleet flows
- move first-server runtime attachment under fleet and preserve bootstrap compatibility routing
- rewrite workspace-local skills and adapters around the new first-class skill family

## Compatibility Notes
- `vaws fleet add` now requires modern `ssh_auth.refs` in `.workspace.local/auth.yaml`; legacy `host_auth.credential_groups` remains supported only through deprecated compatibility paths such as `vaws target ensure` and reset/session fallback handling.

## Verification
- python3 -m pytest tests/test_lifecycle_state.py tests/test_vaws_foundation.py tests/test_vaws_git_profile.py tests/test_vaws_init.py tests/test_vaws_init_bootstrap.py tests/test_vaws_fleet.py tests/test_vaws_reset.py tests/test_vaws_session.py tests/test_vaws_target.py tests/test_workspace_skill_contracts.py tests/test_workspace_adapter_contracts.py tests/test_repo_layout.py -v
- python3 -m pytest -q
- python3 tools/vaws.py init --help
- python3 tools/vaws.py foundation --help
- python3 tools/vaws.py git-profile --help
- python3 tools/vaws.py fleet --help