### PR TITLE
[codex] Fix runtime bootstrap and simplify discovery routing

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -21,7 +21,7 @@ This directory contains the shared workspace-local contract layer for agents wor
 ## Discovery
 
 - Read the matched public `SKILL.md` first.
-- When the skill leaves tool selection open, start at `.agents/discovery/README.md` before reading internal libraries.
+- Open `.agents/discovery/README.md` only when the matched skill or its linked reference does not identify the next tool, or when probe results disagree and the next step is ambiguous.
 
 ## Boundary
 

--- a/.agents/discovery/README.md
+++ b/.agents/discovery/README.md
@@ -1,27 +1,15 @@
 # Agent Tool Discovery
 
-Start here when a public skill identifies the problem class but does not name the exact atomic tool to run.
+Use this file only when a matched public skill or its linked reference does not already identify the next atomic tool.
 
-## How To Use This Directory
+## Read This File When
 
-1. Open `index.yaml`.
-2. Match the current problem class to a family manifest.
-3. Read the family manifest before running a tool.
-4. Respect `action_kind` before execution:
-   - `probe` means read-only
-   - `repair`, `bootstrap`, `cleanup`, and `execute` mutate state or produce durable outputs
-5. Use recipe metadata as advisory guidance, not hidden workflow authority.
+1. The public skill names the problem class but not the next tool.
+2. Probe results disagree and the next family is unclear.
+3. You are maintaining routing contracts or discovery manifests.
 
-## Current Scope
+## Do Not Read This File When
 
-- `workspace-foundation` is the workspace-init discovery surface for overlay validity, auth, repo topology, submodules, and live repo targets.
-- `workspace-diagnostics` is the pure diagnostics family behind `doctor`, covering overlay diagnosis and live workspace diagnosis without generic state residue checks.
-- `machine-inventory` is the explicit inventory-only family for registering, inspecting, listing, and removing server records before runtime verification.
-- `reset-cleanup` is the explicit destructive family for reset request recording, remote cleanup, overlay cleanup, known_hosts cleanup, and public remote restoration.
-- `machine-runtime` is the Phase 1 reference family.
-- `serving-lifecycle` is the Phase 3 reference family for service launch, readiness probing, inspection, and stop.
-- `benchmark-execution` is the explicit benchmark family for preset inspection, existing-service benchmark execution, and result inspection.
-
-## Namespace Rule
-
-`vaws` is still present for compatibility, but it is not the discovery surface for new atomic tools and it must not gain new hidden workflows.
+- the matched `SKILL.md` already names the next probe or repair tool
+- you have not yet run the first named probe in the public skill
+- you are looking for permission to read implementation files before the failing stage is known

--- a/.agents/skills/benchmark/references/internal-routing.md
+++ b/.agents/skills/benchmark/references/internal-routing.md
@@ -3,6 +3,7 @@
 Public contract: `../SKILL.md`
 
 This file is a maintainer backstop. The public `SKILL.md` is the normal execution surface, and agents should not need this file to understand the default public recipe.
+Use this file only for ambiguous routing, routing-maintenance work, or contract audits. Normal execution should stop at the public `SKILL.md` unless the next tool is genuinely unclear.
 
 ## Sanctioned Adapter Surface
 

--- a/.agents/skills/machine-management/SKILL.md
+++ b/.agents/skills/machine-management/SKILL.md
@@ -7,7 +7,7 @@ description: Use when the user wants after setup or ongoing machine attach, veri
 
 ## Overview
 
-Manage machines for this workspace after setup. This skill is the public skill behind machine add, verify, repair, and remove intent, and machine ready does not imply service ready.
+Manage machines after setup. Covers machine add, machine verify, and removal intent. Machine ready does not imply service ready.
 
 ## When to Use
 
@@ -16,14 +16,10 @@ Manage machines for this workspace after setup. This skill is the public skill b
 - The user wants to attach a machine to this workspace.
 - The user wants to verify whether a machine is ready.
 - The user wants to remove a machine or its bound container.
-- The user wants ongoing machine attach or verification work after setup.
 
 ### Examples Include, But Are Not Limited To:
 
 - `把这台机器接进来`
-- `看这台机器现在能不能用`
-- `把这台机器删掉`
-- `attach a machine to this workspace`
 
 ## Quick Triage
 
@@ -31,15 +27,17 @@ Manage machines for this workspace after setup. This skill is the public skill b
 - Probe host access with `machine.probe_host_ssh` before deciding that repair is required.
 - Probe container transport with `runtime.probe_container_transport` before assuming bootstrap is necessary.
 - Keep `code_parity` and `runtime_env` as reusable-machine prerequisites, not as reasons to skip probe-first verification.
-- If the real issue is service lifecycle rather than machine readiness, stop and hand off to `serving`.
+- Do not start at `.agents/discovery/README.md` when the verify or repair ladder is already named here.
+- Do not read `tools/lib/*.py` until a named atomic tool fails and the stage is known.
 
 ## Default Recipe
 
-- Discovery families: `.agents/discovery/families/machine-inventory.yaml` and `.agents/discovery/families/machine-runtime.yaml`
 - Inventory-first inspection: `machine.describe_server` or `machine.list_servers`
 - Verify-first ladder: `machine.probe_host_ssh` -> `runtime.probe_container_transport`
 - Repair ladder only when probes fail: `machine.bootstrap_host_ssh` -> `machine.sync_workspace_mirror` -> `runtime.reconcile_container` -> `runtime.bootstrap_container_transport`
 - Removal path when the user explicitly wants cleanup: `runtime.cleanup_server`
+- Detailed routing map: `references/internal-routing.md`
+- Runtime bootstrap failure triage: `references/runtime-bootstrap-triage.md`
 
 ## Stop Conditions
 
@@ -51,14 +49,12 @@ Manage machines for this workspace after setup. This skill is the public skill b
 ## User-Visible Output Contract
 
 - Report whether the requested machine is `ready`, `needs_input`, `needs_repair`, or `blocked`.
-- Explain whether the machine is attached, reusable, or removed.
-- Keep the result framed as machine readiness, not as raw inventory mutation.
-- Make it explicit that machine ready does not imply service ready.
+- Explain whether the machine is attached, reusable, or removed, keep the result framed as machine readiness, and make it explicit that machine ready does not imply service ready.
 
 ## Auth Boundary
 
-- Allowed: one bare-metal password bootstrap when establishing host key-based access for a newly added machine.
-- Forbidden: GitHub login prompts, repeated server password prompts after bootstrap, and any container password prompt.
+- Allowed: one bare-metal password bootstrap when establishing host key-based access for a new machine.
+- Forbidden: GitHub login prompts, repeated server password prompts after password bootstrap, and any container password prompt.
 - On any unexpected auth prompt, fail closed with `needs_input` or `needs_repair`.
 
 ## Never Expose
@@ -78,9 +74,7 @@ Manage machines for this workspace after setup. This skill is the public skill b
 ## Common Mistakes
 
 - Treating machine maintenance as a generic SSH wrapper.
-- Re-attaching a machine instead of verifying an existing one.
 - Mixing verify and bootstrap until the user loses track of what mutated.
-- Treating a machine-ready result as if it also guaranteed service readiness.
 
 ## Red Flags
 

--- a/.agents/skills/machine-management/references/internal-routing.md
+++ b/.agents/skills/machine-management/references/internal-routing.md
@@ -3,6 +3,7 @@
 Public contract: `../SKILL.md`
 
 This file is a maintainer backstop. The public `SKILL.md` is the normal execution surface, and agents should not need this file to understand the default public recipe.
+Use this file only for ambiguous routing, routing-maintenance work, or contract audits. Normal execution should stop at the public `SKILL.md` unless the next tool is genuinely unclear.
 
 ## Sanctioned Adapter Surface
 

--- a/.agents/skills/machine-management/references/runtime-bootstrap-triage.md
+++ b/.agents/skills/machine-management/references/runtime-bootstrap-triage.md
@@ -1,0 +1,16 @@
+# Runtime Bootstrap Triage
+
+Use this file only after `runtime.bootstrap_container_transport` fails.
+
+## Triage Order
+
+1. Read the tool result first. Record `status`, `reason`, and whether a return code is present.
+2. If the failure text contains `rc=143`, inspect process-kill patterns before assuming package or network failure.
+3. Read `tools/atomic/runtime_bootstrap_container_transport.py`, then `tools/lib/runtime_transport.py`.
+4. Read `tools/lib/runtime_container.py` only if the failing stage is still ambiguous after `runtime_transport.py`.
+
+## Do Not Do
+
+- Do not start with `.agents/discovery/README.md`.
+- Do not fan out into sibling `tools/lib/*.py` modules before the failing stage is known.
+- Do not treat SSH banner text or package-manager warnings as root cause without a return code.

--- a/.agents/skills/serving/references/internal-routing.md
+++ b/.agents/skills/serving/references/internal-routing.md
@@ -3,6 +3,7 @@
 Public contract: `../SKILL.md`
 
 This file is a maintainer backstop. The public `SKILL.md` is the normal execution surface, and agents should not need this file to understand the default public recipe.
+Use this file only for ambiguous routing, routing-maintenance work, or contract audits. Normal execution should stop at the public `SKILL.md` unless the next tool is genuinely unclear.
 
 ## Sanctioned Adapter Surface
 

--- a/.agents/skills/workspace-init/SKILL.md
+++ b/.agents/skills/workspace-init/SKILL.md
@@ -7,7 +7,7 @@ description: Use when the user wants first-time setup, recovery setup after rese
 
 ## Overview
 
-Prepare this workspace for development as one user-visible baseline. `workspace-init` owns first-time setup and recovery setup, with local foundation probes first and optional first-machine handling only when the user explicitly asked for a first machine.
+Prepare one usable baseline. Start local, then add first-machine work only when asked.
 
 ## When to Use
 
@@ -16,29 +16,26 @@ Prepare this workspace for development as one user-visible baseline. `workspace-
 - The user wants first-time setup for this workspace.
 - The user wants to prepare this repo for development.
 - The user wants the repo foundation established first and an optional first machine checked afterward.
-- The user wants recovery setup after reset or partial failure.
 
 ### Examples Include, But Are Not Limited To:
 
 - `初始化这个 workspace`
-- `把这个仓库准备成可开发状态`
-- `先把仓库基础配好，再看第一台机器`
-- `prepare this repo for development`
 
 ## Quick Triage
 
 - Start with `workspace.probe_config_validity`, `workspace.probe_git_auth`, `workspace.probe_repo_topology`, and `workspace.probe_submodules`.
 - Use `workspace.diagnose_workspace` when local foundation probes disagree or only partial residue is visible.
-- If the user asked for a first machine, inspect inventory first with `machine.describe_server` or `machine.list_servers` before inventing new machine state.
-- Treat optional first-machine setup as a second stage after the local foundation is ready.
+- If the user asked for a first machine, inspect inventory first with `machine.describe_server` or `machine.list_servers`.
+- Do not start at `.agents/discovery/README.md` when the next probe is already named here.
+- Do not read `tools/lib/*.py` until a named atomic tool fails and the stage is known.
 
 ## Default Recipe
 
-- Discovery families: `.agents/discovery/families/workspace-foundation.yaml`, `.agents/discovery/families/workspace-diagnostics.yaml`, and when a first machine is requested `.agents/discovery/families/machine-inventory.yaml` plus `.agents/discovery/families/machine-runtime.yaml`
 - Local baseline ladder: `workspace.probe_config_validity` -> `workspace.probe_git_auth` -> `workspace.probe_repo_topology` -> `workspace.probe_submodules` -> `workspace.describe_repo_targets`
 - Diagnose ambiguous or partial local failures with `workspace.diagnose_workspace`.
-- Optional first-machine ladder when the user explicitly wants it: `machine.register_server` -> `machine.probe_host_ssh` -> `runtime.probe_container_transport`
-- Repair the first-machine path only after failing probes: `machine.bootstrap_host_ssh` -> `machine.sync_workspace_mirror` -> `runtime.reconcile_container` -> `runtime.bootstrap_container_transport`
+- Optional first-machine verify ladder: `machine.register_server` -> `machine.probe_host_ssh` -> `runtime.probe_container_transport`
+- Optional first-machine repair ladder: `machine.bootstrap_host_ssh` -> `machine.sync_workspace_mirror` -> `runtime.reconcile_container` -> `runtime.bootstrap_container_transport`
+- Detailed routing map: `references/internal-routing.md`
 
 ## Stop Conditions
 
@@ -49,12 +46,11 @@ Prepare this workspace for development as one user-visible baseline. `workspace-
 ## User-Visible Output Contract
 
 - Report whether initialization is `ready`, `needs_input`, `needs_repair`, or `blocked`.
-- Explain whether Git setup and any requested first machine setup are complete.
-- Say plainly what missing input or repair step is still preventing a usable development baseline.
+- Explain whether Git setup and any requested first machine setup are complete, and what missing input or repair step still blocks a usable baseline.
 
 ## Auth Boundary
 
-- Allowed: GitHub login bootstrap, plus an optional first-machine bare-metal server password bootstrap when init is explicitly establishing the first machine.
+- Allowed: GitHub login bootstrap, plus an optional first-machine bare-metal server password bootstrap when init is establishing that path.
 - Forbidden: server password prompts outside the optional first-machine path, repeated GitHub login prompts after success, and any container auth prompt.
 - On any unexpected auth prompt, fail closed with `needs_input` or `needs_repair`.
 
@@ -75,8 +71,7 @@ Prepare this workspace for development as one user-visible baseline. `workspace-
 ## Common Mistakes
 
 - Treating init as a command wrapper instead of a baseline-establishing skill.
-- Starting first machine work before `git_auth` and `repo_topology` are ready.
-- Pretending partial setup is a complete development baseline.
+- Reading discovery or implementation files before the first named probe runs.
 
 ## Red Flags
 

--- a/.agents/skills/workspace-init/references/internal-routing.md
+++ b/.agents/skills/workspace-init/references/internal-routing.md
@@ -3,6 +3,7 @@
 Public contract: `../SKILL.md`
 
 This file is a maintainer backstop. The public `SKILL.md` is the normal execution surface, and agents should not need this file to understand the default public recipe.
+Use this file only for ambiguous routing, routing-maintenance work, or contract audits. Normal execution should stop at the public `SKILL.md` unless the next tool is genuinely unclear.
 
 ## Sanctioned Adapter Surface
 
@@ -30,6 +31,7 @@ This file is a maintainer backstop. The public `SKILL.md` is the normal executio
   - local foundation ladder: `workspace.probe_config_validity` -> `workspace.probe_git_auth` -> `workspace.probe_repo_topology` -> `workspace.probe_submodules` -> `workspace.describe_repo_targets`
 - `first-time Git setup and first-machine setup`
   - discovery families: `.agents/discovery/families/workspace-foundation.yaml`, `.agents/discovery/families/machine-inventory.yaml`, `.agents/discovery/families/machine-runtime.yaml`
+  - inventory probes: `machine.describe_server`, `machine.list_servers`
   - first-machine ladder: `machine.register_server` -> `machine.probe_host_ssh` -> `runtime.probe_container_transport`
   - repair ladder: `machine.bootstrap_host_ssh` -> `machine.sync_workspace_mirror` -> `runtime.reconcile_container` -> `runtime.bootstrap_container_transport`
 - `diagnose why init cannot finish`

--- a/.agents/skills/workspace-reset/references/internal-routing.md
+++ b/.agents/skills/workspace-reset/references/internal-routing.md
@@ -3,6 +3,7 @@
 Public contract: `../SKILL.md`
 
 This file is a maintainer backstop. The public `SKILL.md` is the normal execution surface, and agents should not need this file to understand the default public recipe.
+Use this file only for ambiguous routing, routing-maintenance work, or contract audits. Normal execution should stop at the public `SKILL.md` unless the next tool is genuinely unclear.
 
 ## Sanctioned Adapter Surface
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -8,7 +8,7 @@
 - Treat `.agents/skills/benchmark/SKILL.md` as the benchmark contract.
 - Treat `.agents/skills/workspace-reset/SKILL.md` as the destructive teardown contract.
 - Read the matched public `SKILL.md` first.
-- When the skill leaves tool selection open, start at `.agents/discovery/README.md` before reading internal libraries.
+- Open `.agents/discovery/README.md` only when the matched skill or its linked reference does not identify the next tool, or when probe results disagree and the next step is ambiguous.
 - Treat skill-local routing references as internal execution notes, not public workflow steps.
 - Never expose overlay file paths as public workflow steps.
 - Never emit shell commands that inline raw secret values.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ This repository is an agent-first scaffold for vLLM Ascend development work.
 ## Discovery
 
 - Read the matched public `SKILL.md` first.
-- When the skill leaves tool selection open, start at `.agents/discovery/README.md` before reading internal libraries.
+- Open `.agents/discovery/README.md` only when the matched skill or its linked reference does not identify the next tool, or when probe results disagree and the next step is ambiguous.
 
 ## Skill Boundary
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ This repository keeps its workflow contract inside the workspace.
 ## Discovery
 
 - Read the matched public `SKILL.md` first.
-- When the skill leaves tool selection open, start at `.agents/discovery/README.md` before reading internal libraries.
+- Open `.agents/discovery/README.md` only when the matched skill or its linked reference does not identify the next tool, or when probe results disagree and the next step is ambiguous.
 
 ## Adapter Boundary
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Public workspace-local scaffold for coordinating vLLM and vLLM-Ascend developmen
 ## Agent Discovery
 
 - Read the matched public `SKILL.md` first.
-- When the skill leaves tool selection open, start at `.agents/discovery/README.md` before reading internal libraries.
+- Open `.agents/discovery/README.md` only when the matched skill or its linked reference does not identify the next tool, or when probe results disagree and the next step is ambiguous.
 
 ## Adapters
 

--- a/tests/test_host_access.py
+++ b/tests/test_host_access.py
@@ -8,7 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from tools.lib.host_access import ensure_host_ssh_access, run_host_command
+from tools.lib.host_access import ensure_host_ssh_access, run_host_command, ssh_base_command
 from tools.lib.remote_types import CredentialGroup, HostSpec, RuntimeSpec, TargetContext
 
 
@@ -87,3 +87,18 @@ def test_run_host_command_uses_public_ensure_host_access(monkeypatch):
     assert captured["ensure"] is False
     assert "ssh" in captured["command"][0]
     assert result.returncode == 0
+
+
+def test_ssh_base_command_uses_error_only_logging():
+    command = ssh_base_command(_ctx())
+
+    assert command[:8] == [
+        "ssh",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "LogLevel=ERROR",
+        "-p",
+    ]

--- a/tests/test_remote_runtime.py
+++ b/tests/test_remote_runtime.py
@@ -89,6 +89,24 @@ def test_container_bootstrap_writes_key_only_sshd_config(monkeypatch):
     assert "PermitRootLogin prohibit-password" in script
 
 
+def test_container_bootstrap_uses_absolute_sshd_binary(monkeypatch):
+    ctx = _host_ctx()
+    recorded = {}
+
+    def fake_run_docker_exec(_ctx, script):
+        recorded["script"] = script
+        return subprocess.CompletedProcess(["docker"], 0, "", "")
+
+    monkeypatch.setattr("tools.lib.runtime_transport.run_docker_exec", fake_run_docker_exec)
+    monkeypatch.setattr("tools.lib.runtime_transport.probe_container_ssh", lambda _ctx: True)
+
+    transport = bootstrap_container_runtime(ctx)
+
+    assert transport == "container-ssh"
+    assert "/usr/sbin/sshd -t" in recorded["script"]
+    assert "pkill -f" not in recorded["script"]
+
+
 def test_verify_runtime_does_not_claim_ready_when_all_host_transports_fail(
     monkeypatch, tmp_path
 ):

--- a/tests/test_runtime_transport.py
+++ b/tests/test_runtime_transport.py
@@ -4,11 +4,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from tools.lib.remote_types import CredentialGroup, HostSpec, RuntimeSpec, TargetContext
+from tools.lib.remote_types import CredentialGroup, HostSpec, RemoteError, RuntimeSpec, TargetContext
 from tools.lib.runtime_transport import (
     bootstrap_container_runtime,
     probe_container_ssh_transport,
@@ -70,6 +72,59 @@ def test_bootstrap_container_runtime_returns_container_ssh_when_probe_succeeds(m
 
     assert bootstrap_container_runtime(_ctx()) == "container-ssh"
     assert "PasswordAuthentication no" in recorded["script"]
+
+
+def test_bootstrap_container_runtime_uses_precise_sshd_kill_and_absolute_path(monkeypatch):
+    recorded: dict[str, str] = {}
+    monkeypatch.setattr(
+        "tools.lib.runtime_transport.find_public_key_path",
+        lambda: Path("/tmp/id_rsa.pub"),
+    )
+    monkeypatch.setattr(
+        "pathlib.Path.read_text",
+        lambda self, encoding="utf-8": "ssh-ed25519 AAAA test",
+    )
+
+    def fake_run_docker_exec(_ctx, script):
+        recorded["script"] = script
+        return subprocess.CompletedProcess(["docker"], 0, "", "")
+
+    monkeypatch.setattr("tools.lib.runtime_transport.run_docker_exec", fake_run_docker_exec)
+    monkeypatch.setattr("tools.lib.runtime_transport.probe_container_ssh", lambda _ctx: True)
+
+    assert bootstrap_container_runtime(_ctx()) == "container-ssh"
+    assert "pkill -f" not in recorded["script"]
+    assert "pgrep -a -x sshd" in recorded["script"]
+    assert "/usr/sbin/sshd -t" in recorded["script"]
+    assert "sshd -t && sshd -p" not in recorded["script"]
+
+
+def test_bootstrap_container_runtime_reports_return_code_and_streams(monkeypatch):
+    monkeypatch.setattr(
+        "tools.lib.runtime_transport.find_public_key_path",
+        lambda: Path("/tmp/id_rsa.pub"),
+    )
+    monkeypatch.setattr(
+        "pathlib.Path.read_text",
+        lambda self, encoding="utf-8": "ssh-ed25519 AAAA test",
+    )
+    monkeypatch.setattr(
+        "tools.lib.runtime_transport.run_docker_exec",
+        lambda _ctx, script: subprocess.CompletedProcess(
+            ["docker"],
+            143,
+            "stdout marker",
+            "stderr marker",
+        ),
+    )
+
+    with pytest.raises(RemoteError) as excinfo:
+        bootstrap_container_runtime(_ctx())
+
+    message = str(excinfo.value)
+    assert "rc=143" in message
+    assert "stderr=stderr marker" in message
+    assert "stdout=stdout marker" in message
 
 
 def test_resolve_available_runtime_transport_prefers_container_ssh(monkeypatch):

--- a/tests/test_tool_discovery.py
+++ b/tests/test_tool_discovery.py
@@ -121,7 +121,9 @@ def test_benchmark_family_recipe_requires_explicit_service_and_no_temporary_serv
     assert "weights_path" not in manifest
 
 
-def test_first_contact_surface_points_agents_to_discovery_readme():
+def test_first_contact_surface_points_to_discovery_as_fallback_only():
     for relative_path in ("AGENTS.md", "CLAUDE.md", ".cursorrules", "README.md", ".agents/README.md"):
         text = (ROOT / relative_path).read_text(encoding="utf-8").lower()
         assert ".agents/discovery/readme.md" in text
+        assert "only when" in text
+        assert "start at .agents/discovery/readme.md" not in text

--- a/tests/test_workspace_adapter_contracts.py
+++ b/tests/test_workspace_adapter_contracts.py
@@ -24,7 +24,7 @@ LEGACY_PUBLIC_VOCAB = (
 )
 SKILL_FIRST_MARKERS = (
     "read the matched public `skill.md` first",
-    "when the skill leaves tool selection open",
+    "only when the matched skill or its linked reference does not identify the next tool",
 )
 
 

--- a/tests/test_workspace_agent_entry_contracts.py
+++ b/tests/test_workspace_agent_entry_contracts.py
@@ -34,7 +34,7 @@ FORBIDDEN_TERMS = (
 )
 SKILL_FIRST_MARKERS = (
     "read the matched public `skill.md` first",
-    "when the skill leaves tool selection open",
+    "only when the matched skill or its linked reference does not identify the next tool",
 )
 
 

--- a/tests/test_workspace_skill_contracts.py
+++ b/tests/test_workspace_skill_contracts.py
@@ -81,7 +81,6 @@ PUBLIC_BODY_FORBIDDEN_TERMS = (
     "workspace-fleet",
     "workspace-session-switch",
     "workspace-sync",
-    "internal-routing.md",
 )
 PUBLIC_SECTIONS_WITHOUT_INTERNALS = (
     "## Overview",
@@ -252,6 +251,18 @@ STOP_CONDITION_MARKERS = {
         "partial",
     ),
 }
+MINIMAL_READ_PATH_MARKERS = {
+    "workspace-init": (
+        "do not start at `.agents/discovery/readme.md`",
+        "references/internal-routing.md",
+        "do not read `tools/lib/*.py` until a named atomic tool fails",
+    ),
+    "machine-management": (
+        "do not start at `.agents/discovery/readme.md`",
+        "references/internal-routing.md",
+        "runtime-bootstrap-triage.md",
+    ),
+}
 
 
 def _skill_text(skill_name: str) -> str:
@@ -283,7 +294,6 @@ def _section_body(skill_name: str, header: str) -> str:
 def test_first_class_workspace_skills_share_judgment_sections():
     for skill_name in FIRST_CLASS_SKILLS:
         text = _skill_text(skill_name)
-        assert "internal-routing.md" not in text.lower()
         for section in REQUIRED_PUBLIC_SECTIONS:
             assert section in text, f"{skill_name} missing section: {section}"
 
@@ -393,3 +403,10 @@ def test_cross_skill_boundary_and_stop_conditions_encode_safe_handoffs():
             assert marker in stops, (
                 f"{skill_name} missing stop-condition marker: {marker}"
             )
+
+
+def test_public_skill_bodies_define_minimal_read_paths_and_discovery_fallback():
+    for skill_name, markers in MINIMAL_READ_PATH_MARKERS.items():
+        text = _skill_text(skill_name).lower()
+        for marker in markers:
+            assert marker.lower() in text, f"{skill_name} missing marker: {marker}"

--- a/tests/test_workspace_skill_pressure.py
+++ b/tests/test_workspace_skill_pressure.py
@@ -122,6 +122,17 @@ SCENARIOS = {
         ),
     },
 }
+EXTRA_PRESSURE_MARKERS = {
+    "workspace-init": (
+        "do not start at `.agents/discovery/readme.md`",
+        "do not read `tools/lib/*.py` until a named atomic tool fails",
+    ),
+    "machine-management": (
+        "do not start at `.agents/discovery/readme.md`",
+        "runtime-bootstrap-triage.md",
+        "do not read `tools/lib/*.py` until a named atomic tool fails",
+    ),
+}
 
 
 def _skill_text(skill_name: str) -> str:
@@ -171,3 +182,10 @@ def test_pressure_scenarios_require_usable_guidance_and_no_phrase_copying():
             assert phrase.lower() not in text, (
                 f"{skill_name} copied pressure-only variant {phrase!r} into the contract body"
             )
+
+
+def test_pressure_scenarios_guard_against_premature_discovery_and_source_fanout():
+    for skill_name, markers in EXTRA_PRESSURE_MARKERS.items():
+        text = _skill_text(skill_name)
+        for marker in markers:
+            assert marker in text, f"{skill_name} missing pressure guard: {marker}"

--- a/tests/test_workspace_skill_recipe_contracts.py
+++ b/tests/test_workspace_skill_recipe_contracts.py
@@ -86,10 +86,10 @@ DISCOVERY_BACKED_SKILL_RECIPES = {
 }
 
 
-def _skill_text(skill_name: str) -> str:
-    return (ROOT / ".agents" / "skills" / skill_name / "SKILL.md").read_text(
-        encoding="utf-8"
-    ).lower()
+def _routing_text(skill_name: str) -> str:
+    return (
+        ROOT / ".agents" / "skills" / skill_name / "references" / "internal-routing.md"
+    ).read_text(encoding="utf-8").lower()
 
 
 def _manifest(path: str) -> dict:
@@ -109,9 +109,9 @@ def test_discovery_backed_skill_recipe_manifests_cover_expected_tool_ids():
             )
 
 
-def test_public_skill_bodies_reference_discovery_families_and_tool_ids():
+def test_internal_routing_files_reference_discovery_families_and_tool_ids():
     for skill_name, recipe in DISCOVERY_BACKED_SKILL_RECIPES.items():
-        text = _skill_text(skill_name)
+        text = _routing_text(skill_name)
         for family_path in recipe["family_paths"]:
             assert family_path.lower() in text, (
                 f"{skill_name} missing discovery family path {family_path}"

--- a/tests/test_workspace_skill_routing_contracts.py
+++ b/tests/test_workspace_skill_routing_contracts.py
@@ -49,6 +49,14 @@ def test_internal_routing_files_declare_secondary_maintainer_role():
         assert "agents should not need this file" in lowered
 
 
+def test_internal_routing_files_are_detailed_backstops_not_first_hops():
+    for skill_name in FIRST_CLASS_SKILLS:
+        text = _routing_text(skill_name).lower()
+        assert "maintainer backstop" in text
+        assert "agents should not need this file" in text
+        assert "ambiguous routing" in text or "fallback" in text
+
+
 def test_action_routing_stays_on_truthful_compatibility_and_discovery_surfaces():
     for skill_name in FIRST_CLASS_SKILLS:
         body = _routing_section(skill_name, "## Action Routing").lower()

--- a/tests/test_workspace_skill_token_budget.py
+++ b/tests/test_workspace_skill_token_budget.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORD_BUDGETS = {
+    ".agents/skills/workspace-init/SKILL.md": 520,
+    ".agents/skills/machine-management/SKILL.md": 500,
+    ".agents/discovery/README.md": 180,
+}
+
+
+def test_frequently_loaded_skill_files_stay_within_word_budget():
+    for relative_path, budget in WORD_BUDGETS.items():
+        word_count = len((ROOT / relative_path).read_text(encoding="utf-8").split())
+        assert word_count <= budget, f"{relative_path} exceeded budget: {word_count} > {budget}"

--- a/tools/lib/host_access.py
+++ b/tools/lib/host_access.py
@@ -54,6 +54,8 @@ def ssh_base_command(
         "StrictHostKeyChecking=no",
         "-o",
         "UserKnownHostsFile=/dev/null",
+        "-o",
+        "LogLevel=ERROR",
         "-p",
         str(target_port),
     ]

--- a/tools/lib/runtime_transport.py
+++ b/tools/lib/runtime_transport.py
@@ -37,6 +37,17 @@ def probe_container_ssh(ctx: TargetContext) -> bool:
     return status == "ready"
 
 
+def _format_remote_failure(result: subprocess.CompletedProcess[str]) -> str:
+    parts = [f"rc={result.returncode}"]
+    stderr = (result.stderr or "").strip()
+    stdout = (result.stdout or "").strip()
+    if stderr:
+        parts.append(f"stderr={stderr}")
+    if stdout:
+        parts.append(f"stdout={stdout}")
+    return "; ".join(parts)
+
+
 def bootstrap_container_runtime(ctx: TargetContext) -> str:
     public_key = find_public_key_path().read_text(encoding="utf-8").strip()
     bootstrap_script = "\n".join(
@@ -70,15 +81,15 @@ def bootstrap_container_runtime(ctx: TargetContext) -> str:
             "PidFile /var/run/sshd.pid",
             "AuthorizedKeysFile .ssh/authorized_keys",
             "EOF",
-            f"pkill -f 'sshd -p {ctx.runtime.ssh_port}' >/dev/null 2>&1 || true",
-            f"(sshd -t && sshd -p {ctx.runtime.ssh_port}) >/dev/null 2>&1 || "
-            f"(/usr/sbin/sshd -t && /usr/sbin/sshd -p {ctx.runtime.ssh_port}) >/dev/null 2>&1",
+            f"pgrep -a -x sshd | grep ' -p {ctx.runtime.ssh_port}' | awk '{{print $1}}' | xargs -r kill 2>/dev/null || true",
+            "/usr/sbin/sshd -t",
+            f"/usr/sbin/sshd -p {ctx.runtime.ssh_port}",
         ]
     )
     result = run_docker_exec(ctx, bootstrap_script)
     if result.returncode != 0:
         raise RemoteError(
-            f"failed to bootstrap runtime inside container: {(result.stderr or result.stdout).strip()}"
+            f"failed to bootstrap runtime inside container: {_format_remote_failure(result)}"
         )
     if probe_container_ssh(ctx):
         return "container-ssh"


### PR DESCRIPTION
## Summary
- harden runtime bootstrap by replacing the self-killing `pkill -f` flow, using absolute-path `sshd`, and surfacing remote return codes and streams
- make public machine skills and entry docs discovery-fallback-only, add runtime bootstrap triage guidance, and enforce tighter word budgets
- add routing, pressure, and adapter contract tests to keep the new discovery boundary and token discipline in place

## Root Cause
The runtime bootstrap path could terminate its own `docker exec` shell via `pkill -f`, and the public skill/discovery contract pushed agents into repeated route rediscovery and noisy shell output instead of probe-first execution.

## Test Plan
- [x] `pytest -q`