### PR TITLE
chore: sync local agent skills and scaffolding

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -6,11 +6,13 @@ This directory contains the repository-local skill layer for Codex, Claude Code,
 
 - `.agents/skills/repo-init/` is the source-of-truth skill package for repository initialization.
 - `.agents/skills/machine-management/` is the source-of-truth skill package for remote machine attach, verify, repair, and removal workflows.
+- `.agents/scripts/workspace_profile.py` is the shared helper for the local workspace machine profile.
+- `.agents/lib/vaws_local_state.py` is the shared library for untracked local runtime state.
 - `AGENTS.md` carries repository-wide routing and operating rules.
 
 ## Script-first convention
 
-When a workflow has deterministic shell, SSH, or Git mechanics, prefer the helper under `scripts/` instead of rebuilding the command inline in the conversation.
+When a workflow has deterministic shell, SSH, Git, or local-state mechanics, prefer the helper script instead of rebuilding the command inline in the conversation.
 
 Current primary helpers:
 
@@ -18,8 +20,18 @@ Current primary helpers:
 - `repo-init/scripts/repo_topology.py`
 - `machine-management/scripts/inventory.py`
 - `machine-management/scripts/manage_machine.py`
+- `../scripts/workspace_profile.py`
 
 Reference files under `references/` are fallback detail, not the default execution path.
+
+## Local runtime state
+
+Untracked workspace-local state lives under `.vaws-local/`:
+
+- `.vaws-local/machine-profile.json`
+- `.vaws-local/machine-inventory.json`
+
+The legacy repo-root `.machine-inventory.json` is compatibility input only and should not be reintroduced as the primary path.
 
 ## Maintenance rule
 
@@ -28,11 +40,13 @@ If you change `repo-init`, update these together:
 - `.agents/skills/repo-init/SKILL.md`
 - `.agents/skills/repo-init/references/`
 - `.agents/skills/repo-init/scripts/`
+- shared helpers when the workflow depends on local profile state
 
 If you change `machine-management`, update these together:
 
 - `.agents/skills/machine-management/SKILL.md`
 - `.agents/skills/machine-management/references/`
 - `.agents/skills/machine-management/scripts/`
+- shared helpers when the workflow depends on local profile or inventory state
 
 Keep the files under `.agents/skills/` as the canonical supporting files for repo-local skills.

--- a/.agents/lib/vaws_local_state.py
+++ b/.agents/lib/vaws_local_state.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Local untracked state helpers for vllm-ascend-workspace.
+
+This module centralizes repo-local runtime state that should never be tracked.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import secrets
+import string
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+STATE_DIRNAME = ".vaws-local"
+PROFILE_FILENAME = "machine-profile.json"
+INVENTORY_FILENAME = "machine-inventory.json"
+LEGACY_INVENTORY_FILENAME = ".machine-inventory.json"
+PROFILE_SCHEMA_VERSION = 1
+CONTAINER_PREFIX = "vaws-"
+USERNAME_PATTERN = re.compile(r"^[a-z0-9]{3,32}$")
+RANDOM_ALPHABET = string.ascii_lowercase + string.digits
+
+ROOT = Path(__file__).resolve().parents[2]
+STATE_DIR = ROOT / STATE_DIRNAME
+PROFILE_PATH = STATE_DIR / PROFILE_FILENAME
+INVENTORY_PATH = STATE_DIR / INVENTORY_FILENAME
+LEGACY_INVENTORY_PATH = ROOT / LEGACY_INVENTORY_FILENAME
+
+
+class WorkspaceStateError(RuntimeError):
+    """Raised for deterministic user-facing local-state failures."""
+
+
+def utc_now_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def ensure_state_dir(path: Path = STATE_DIR) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def same_path(left: Path, right: Path) -> bool:
+    return left.expanduser().resolve() == right.expanduser().resolve()
+
+
+def normalize_machine_username(value: str) -> str:
+    normalized = value.strip().lower()
+    if not normalized:
+        raise WorkspaceStateError("machine username must be non-empty")
+    if not USERNAME_PATTERN.fullmatch(normalized):
+        raise WorkspaceStateError(
+            "machine username must be 3-32 characters of English letters and digits only"
+        )
+    return normalized
+
+
+validate_machine_username = normalize_machine_username
+
+
+def generate_machine_username(
+    *,
+    prefix: str = "agent",
+    suffix_length: int = 6,
+    existing: set[str] | None = None,
+) -> str:
+    cleaned_prefix = "".join(ch for ch in prefix.lower() if ch.isalnum()) or "agent"
+    cleaned_prefix = cleaned_prefix[: max(1, 32 - suffix_length)]
+    existing = existing or set()
+    for _ in range(128):
+        suffix = "".join(secrets.choice(RANDOM_ALPHABET) for _ in range(suffix_length))
+        candidate = f"{cleaned_prefix}{suffix}"
+        if candidate not in existing and USERNAME_PATTERN.fullmatch(candidate):
+            return candidate
+    raise WorkspaceStateError("unable to generate a unique machine username")
+
+
+def default_container_name(machine_username: str) -> str:
+    return f"{CONTAINER_PREFIX}{normalize_machine_username(machine_username)}"
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise WorkspaceStateError(f"invalid JSON in {path}: {exc}") from exc
+
+
+def _save_json(path: Path, data: Any) -> None:
+    ensure_state_dir(path.parent)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _validate_profile(profile: Any, *, where: str = "profile") -> dict[str, Any]:
+    if not isinstance(profile, dict):
+        raise WorkspaceStateError(f"{where} must be an object")
+    if profile.get("schema_version") != PROFILE_SCHEMA_VERSION:
+        raise WorkspaceStateError(
+            f"unsupported profile schema_version in {where}: {profile.get('schema_version')!r}"
+        )
+    machine_username = normalize_machine_username(str(profile.get("machine_username", "")))
+    container_name = profile.get("container_name")
+    expected_container_name = default_container_name(machine_username)
+    if container_name is None:
+        container_name = expected_container_name
+    if not isinstance(container_name, str) or container_name != expected_container_name:
+        raise WorkspaceStateError(
+            f"{where}.container_name must be {expected_container_name!r}"
+        )
+    source = profile.get("source")
+    if source is not None and source not in {"user", "generated"}:
+        raise WorkspaceStateError(f"{where}.source must be 'user' or 'generated' when present")
+    for field in ("created_at", "updated_at"):
+        value = profile.get(field)
+        if value is not None and not isinstance(value, str):
+            raise WorkspaceStateError(f"{where}.{field} must be a string when present")
+    normalized: dict[str, Any] = dict(profile)
+    normalized["machine_username"] = machine_username
+    normalized["container_name"] = container_name
+    return normalized
+
+
+def load_profile(path: Path = PROFILE_PATH) -> dict[str, Any] | None:
+    path = path.expanduser().resolve()
+    if not path.exists():
+        return None
+    data = _load_json(path)
+    return _validate_profile(data, where=str(path))
+
+
+def save_profile(profile: dict[str, Any], path: Path = PROFILE_PATH) -> dict[str, Any]:
+    path = path.expanduser().resolve()
+    normalized = _validate_profile(profile, where="profile")
+    _save_json(path, normalized)
+    return normalized
+
+
+def ensure_profile(
+    *,
+    path: Path = PROFILE_PATH,
+    machine_username: str | None = None,
+    allow_update: bool = False,
+) -> tuple[dict[str, Any], str]:
+    path = path.expanduser().resolve()
+    existing = load_profile(path)
+    if existing is not None:
+        if machine_username is None:
+            return existing, "existing"
+        normalized_name = normalize_machine_username(machine_username)
+        if existing["machine_username"] == normalized_name:
+            return existing, "existing"
+        if not allow_update:
+            raise WorkspaceStateError(
+                "machine profile already exists; rerun with --allow-update to change it"
+            )
+        updated = dict(existing)
+        updated["machine_username"] = normalized_name
+        updated["container_name"] = default_container_name(normalized_name)
+        updated["source"] = "user"
+        updated["updated_at"] = utc_now_iso()
+        return save_profile(updated, path=path), "updated"
+
+    existing_names: set[str] = set()
+    normalized_name = (
+        normalize_machine_username(machine_username)
+        if machine_username is not None
+        else generate_machine_username(existing=existing_names)
+    )
+    now = utc_now_iso()
+    profile = {
+        "schema_version": PROFILE_SCHEMA_VERSION,
+        "machine_username": normalized_name,
+        "container_name": default_container_name(normalized_name),
+        "source": "user" if machine_username is not None else "generated",
+        "created_at": now,
+        "updated_at": now,
+    }
+    return save_profile(profile, path=path), "created"
+
+
+def profile_summary(path: Path = PROFILE_PATH) -> dict[str, Any]:
+    path = path.expanduser().resolve()
+    summary: dict[str, Any] = {
+        "state_dir": str(path.parent),
+        "profile_path": str(path),
+        "inventory_path": str(INVENTORY_PATH),
+        "legacy_inventory_path": str(LEGACY_INVENTORY_PATH),
+        "exists": path.exists(),
+        "machine_username": None,
+        "container_name": None,
+        "source": None,
+        "created_at": None,
+        "updated_at": None,
+    }
+    if not path.exists():
+        return summary
+    profile = load_profile(path)
+    if profile is None:
+        return summary
+    summary.update(
+        {
+            "machine_username": profile["machine_username"],
+            "container_name": profile["container_name"],
+            "source": profile.get("source"),
+            "created_at": profile.get("created_at"),
+            "updated_at": profile.get("updated_at"),
+        }
+    )
+    return summary
+
+
+def resolve_inventory_read_path(preferred_path: Path = INVENTORY_PATH) -> Path:
+    preferred_path = preferred_path.expanduser().resolve()
+    if same_path(preferred_path, INVENTORY_PATH) and not preferred_path.exists() and LEGACY_INVENTORY_PATH.exists():
+        return LEGACY_INVENTORY_PATH.expanduser().resolve()
+    return preferred_path

--- a/.agents/scripts/workspace_profile.py
+++ b/.agents/scripts/workspace_profile.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Manage the local workspace machine profile.
+
+The profile is untracked local state used to derive container names and other
+collision-sensitive identifiers for machine-management.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_local_state import (  # noqa: E402
+    PROFILE_PATH,
+    WorkspaceStateError,
+    default_container_name,
+    ensure_profile,
+    profile_summary,
+    validate_machine_username,
+)
+
+
+def print_json(data: dict[str, object]) -> None:
+    print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def cmd_summary(args: argparse.Namespace) -> int:
+    payload = profile_summary(path=args.profile_path)
+    print_json(payload)
+    return 0
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    normalized = validate_machine_username(args.username)
+    print_json(
+        {
+            "success": True,
+            "input": args.username,
+            "machine_username": normalized,
+            "container_name": default_container_name(normalized),
+        }
+    )
+    return 0
+
+
+def cmd_ensure(args: argparse.Namespace) -> int:
+    profile, action = ensure_profile(
+        path=args.profile_path,
+        machine_username=args.username,
+        allow_update=args.allow_update,
+    )
+    payload = {
+        "success": True,
+        "action": action,
+        **profile_summary(path=args.profile_path),
+        "machine_username": profile["machine_username"],
+        "container_name": profile["container_name"],
+        "source": profile.get("source"),
+    }
+    print_json(payload)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile-path",
+        type=Path,
+        default=PROFILE_PATH,
+        help=f"profile path (default: {PROFILE_PATH})",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    summary = subparsers.add_parser("summary", help="print the current workspace machine profile summary")
+    summary.set_defaults(func=cmd_summary)
+
+    validate = subparsers.add_parser("validate", help="validate one proposed machine username")
+    validate.add_argument("username", help="letters and digits only; case-insensitive")
+    validate.set_defaults(func=cmd_validate)
+
+    ensure = subparsers.add_parser(
+        "ensure",
+        help="ensure the local workspace machine profile exists; generates a default when --username is omitted",
+    )
+    ensure.add_argument("--username", help="letters and digits only; case-insensitive")
+    ensure.add_argument(
+        "--allow-update",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="allow replacing an existing machine username",
+    )
+    ensure.set_defaults(func=cmd_ensure)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except WorkspaceStateError as exc:
+        print_json({"success": False, "error": str(exc)})
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/machine-management/SKILL.md
+++ b/.agents/skills/machine-management/SKILL.md
@@ -18,10 +18,12 @@ Ready does **not** imply code sync, rebuild, serving, or benchmark readiness.
 
 A successful run leaves the workspace in a predictable local state:
 
-- `.machine-inventory.json` records the managed machine locally.
+- `.vaws-local/machine-profile.json` records the stable local machine username / namespace.
+- `.vaws-local/machine-inventory.json` records the managed machine locally.
 - host SSH uses key auth after the initial bootstrap.
 - the managed container uses host networking and `/vllm-workspace`.
 - the managed container accepts direct SSH as `root@HOST -p CONTAINER_SSH_PORT`.
+- the managed container name is collision-safe, derived from the local machine profile, for example `vaws-alice123`.
 - the managed container passes the NPU smoke test.
 - peer managed containers are mesh-connected when reachable.
 
@@ -31,6 +33,7 @@ A successful run leaves the workspace in a predictable local state:
 - the user asks whether a managed machine is ready
 - the user asks to repair host SSH, container SSH, or managed-container drift
 - the user asks to remove a managed machine
+- repo-init was skipped and the local machine profile is still missing
 
 ## Do not use this skill when
 
@@ -45,23 +48,39 @@ A successful run leaves the workspace in a predictable local state:
 - Be idempotent and conservative.
 - Keep mutations bounded to the requested machine.
 - Treat the bare-metal host as a maintenance plane, not a developer workspace.
-- Prefer helper scripts in `scripts/` over ad-hoc SSH heredocs.
+- Prefer helper scripts in `scripts/` and `.agents/scripts/` over ad-hoc SSH heredocs.
 - Never use `scp`, `sftp`, `sshpass`, or `expect` in this workflow.
 - Never write secrets or passwords to disk.
+- Never pass host passwords through shell arguments, env vars, or temporary files.
 
 ## Local state
 
-Local machine state lives only in the repo-root file `.machine-inventory.json`.
+Local workspace-machine state lives under `.vaws-local/`:
+
+- `.vaws-local/machine-profile.json`
+- `.vaws-local/machine-inventory.json`
+
+Compatibility note:
+
+- the helper still reads legacy repo-root `.machine-inventory.json` when the new path does not exist yet
+- the next successful inventory write migrates state to `.vaws-local/machine-inventory.json`
 
 Inspect it first:
 
 ```bash
+python3 .agents/scripts/workspace_profile.py summary
 python3 .agents/skills/machine-management/scripts/inventory.py summary
 ```
 
-Prefer helper-script writes over hand-editing. Canonical stored `bootstrap_method` values are `ssh` and `password-once`. The helper also accepts `key` as a compatibility alias and normalizes it to `ssh`.
+Prefer helper-script writes over hand-editing. Canonical stored `bootstrap_method` values are `ssh` and `password-once`. The inventory helper also accepts `key` as a compatibility alias and normalizes it to `ssh`.
 
 ## Script-first entry points
+
+Shared profile helper:
+
+- `python3 .agents/scripts/workspace_profile.py summary`
+- `python3 .agents/scripts/workspace_profile.py ensure --username <letters-or-digits>`
+- `python3 .agents/scripts/workspace_profile.py ensure`  # auto-generate if missing
 
 Inventory helper:
 
@@ -73,7 +92,8 @@ Inventory helper:
 Remote-machine helper:
 
 - `python3 .agents/skills/machine-management/scripts/manage_machine.py probe-host --host <ip>`
-- `python3 .agents/skills/machine-management/scripts/manage_machine.py bootstrap-container --host <ip> --container-name <name> --container-ssh-port <port>`
+- `python3 .agents/skills/machine-management/scripts/manage_machine.py bootstrap-host-key --host <ip>`
+- `python3 .agents/skills/machine-management/scripts/manage_machine.py bootstrap-container --host <ip> --container-name <name> --container-ssh-port <port> --namespace <machine-username>`
 - `python3 .agents/skills/machine-management/scripts/manage_machine.py smoke --host <ip> --container-ssh-port <port>`
 - `python3 .agents/skills/machine-management/scripts/manage_machine.py verify-machine --host <ip> --container-ssh-port <port>`
 - `python3 .agents/skills/machine-management/scripts/manage_machine.py mesh-export-key ...`
@@ -114,10 +134,28 @@ Classify the request as one of:
 
 Resolve the target by alias or host IP. If an inventory record already exists for the same alias or host IP, pivot from blind add to verify-or-repair instead of creating a duplicate record.
 
-### 2. Probe first
+### 2. Ensure the local machine profile
+
+Inspect the local workspace machine profile first.
+
+Rules:
+
+- if a profile already exists, reuse it
+- if it is missing and the user is doing machine setup, ask once whether they want a specific machine username
+- accept English letters and digits only
+- normalize to lowercase
+- reject symbols and spaces
+- if the user leaves it blank or does not care, auto-generate one with `workspace_profile.py ensure`
+
+Use the resulting machine username as the stable namespace for collision-sensitive identifiers. For new containers, derive the name from that profile, for example `vaws-alice123`.
+
+If inventory already records a container name for the target machine, keep using the recorded name even if the current local profile later changes.
+
+### 3. Probe first
 
 Before any mutation, inspect:
 
+- local machine profile state
 - local inventory state
 - whether a local public key already exists
 - whether host SSH by key already works
@@ -125,35 +163,44 @@ Before any mutation, inspect:
 - whether a free high SSH port exists
 - whether a managed container already exists
 
-Use `inventory.py` and `manage_machine.py probe-host` for these checks.
+Use `workspace_profile.py`, `inventory.py`, and `manage_machine.py probe-host` for these checks.
 
-### 3. Host auth boundary
+### 4. Host auth boundary
 
 Password policy:
 
-- Allowed: one bare-metal password-authenticated SSH session during the first add of a new machine.
-- Forbidden: repeated server password prompts after the initial bootstrap, any container password prompt, or any password automation.
+- allowed: one bare-metal password-authenticated SSH session during the first add of a new machine
+- forbidden: repeated server password prompts after the initial bootstrap, any container password prompt, or any password automation
 
 If host key auth already works, do not use the password even if the user provided one.
 
 If host key auth does not work and the request is verify-only, stop with `needs_input` instead of mutating.
 
-### 4. Add or attach workflow
+When password bootstrap is required:
+
+- prefer `manage_machine.py bootstrap-host-key`
+- let the terminal prompt handle the password interactively
+- do not echo the password back to the user
+- do not pass the password through shell args, env vars, or heredocs
+- if the environment cannot surface an interactive prompt, use `bootstrap-host-key --print-command` and ask the user to run that exact foreground command once
+
+### 5. Add or attach workflow
 
 Proceed in this order:
 
-1. Ensure a local public key exists.
-2. If needed, do the single interactive host bootstrap to append the local public key to `root`’s `authorized_keys` on the host.
-3. Run `manage_machine.py probe-host`.
-4. Decide the container name and high SSH port.
-5. Run `manage_machine.py bootstrap-container`.
-6. Run `manage_machine.py smoke`.
-7. Persist the record with `inventory.py put`.
-8. Best-effort mesh the new container with existing managed containers.
+1. ensure a local machine profile exists
+2. ensure a local public key exists
+3. if needed, do the single interactive host bootstrap with `bootstrap-host-key`
+4. run `manage_machine.py probe-host`
+5. decide the container name from the local machine profile and choose a free high SSH port
+6. run `manage_machine.py bootstrap-container`
+7. run `manage_machine.py smoke`
+8. persist the record with `inventory.py put`
+9. best-effort mesh the new container with existing managed containers
 
 After direct local -> container SSH works, stop using the bare-metal host except when container SSH later breaks.
 
-### 5. Verify workflow
+### 6. Verify workflow
 
 For verify-only requests:
 
@@ -161,7 +208,7 @@ For verify-only requests:
 - prefer `manage_machine.py verify-machine`
 - do not silently repair drift
 
-### 6. Repair workflow
+### 7. Repair workflow
 
 Prefer non-destructive repair:
 
@@ -170,7 +217,7 @@ Prefer non-destructive repair:
 - rerun `smoke`
 - do not recreate or delete a container unless the user explicitly asked for destructive repair
 
-### 7. Remove workflow
+### 8. Remove workflow
 
 Proceed in this order:
 
@@ -190,10 +237,11 @@ Do not remove host firewall rules or host-level `authorized_keys` entries.
 - Preseed `PATH` and `LD_LIBRARY_PATH` before sourcing env scripts under `set -u`.
 - Prefix `LD_LIBRARY_PATH` with `/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/driver/lib64`.
 - Do not add Ascend `devlib` paths by default; they caused ABI drift in the recorded session.
+- New containers should label the namespace so later inspection stays explainable.
 
 ## Output discipline
 
 - Prefer helper-script JSON over long raw logs.
 - Redirect noisy package-manager output to a temp log and show only a short failure tail.
 - Summarize banners and repetitive SSH noise instead of replaying them.
-- Keep the final report compact: outcome, evidence, inventory state, and remaining manual action.
+- Keep the final report compact: outcome, evidence, local profile state, inventory state, and remaining manual action.

--- a/.agents/skills/machine-management/references/acceptance.md
+++ b/.agents/skills/machine-management/references/acceptance.md
@@ -25,43 +25,53 @@ These should not trigger `machine-management` unless machine readiness is the ob
 
 ### Universal
 
-- The skill reads local inventory before mutating remote state.
-- The skill uses `.machine-inventory.json` as the local state file.
-- The skill prefers helper scripts over long inline SSH heredocs.
-- The skill does not use `scp`, `sftp`, `sshpass`, or `expect`.
-- The final report is compact and evidence-based.
+- the skill reads local profile and inventory state before mutating remote state
+- the skill uses `.vaws-local/` as the canonical local runtime-state directory
+- the skill prefers helper scripts over long inline SSH heredocs
+- the skill does not use `scp`, `sftp`, `sshpass`, or `expect`
+- the final report is compact and evidence-based
+
+### Local machine profile
+
+- the skill reuses or creates `.vaws-local/machine-profile.json`
+- new machine usernames accept letters and digits only
+- usernames normalize to lowercase
+- blank input generates a default namespace
+- new managed container names derive from that namespace instead of a single global fixed name
 
 ### Add / attach
 
-- The skill prefers host key SSH first and uses a password only for the first bootstrap of a new machine.
-- The skill checks Docker and required Ascend/NPU prerequisites before container creation.
-- The managed container uses host networking, required devices, required Ascend mounts, and `/vllm-workspace` as the workdir.
-- The skill configures a dedicated container `sshd` on a high port without brittle inline edits to `/etc/ssh/sshd_config`.
-- The skill verifies direct local -> container SSH.
-- The skill runs the smoke test successfully before claiming readiness.
-- The skill persists final alias, host identity, container name, image, and SSH port into inventory.
+- the skill prefers host key SSH first and uses a password only for the first bootstrap of a new machine
+- password bootstrap uses `bootstrap-host-key` or an equivalent single foreground interactive step
+- the skill never passes the password via shell args, files, env vars, or password automation
+- the skill checks Docker and required Ascend/NPU prerequisites before container creation
+- the managed container uses host networking, required devices, required Ascend mounts, and `/vllm-workspace` as the workdir
+- the skill configures a dedicated container `sshd` on a high port without brittle inline edits to `/etc/ssh/sshd_config`
+- the skill verifies direct local -> container SSH
+- the skill runs the smoke test successfully before claiming readiness
+- the skill persists final alias, namespace, host identity, container name, image, and SSH port into inventory
 
 ### Verify
 
-- Verify-only runs are read-only.
-- A `ready` report requires host SSH, container SSH, and a passing smoke test.
-- The skill does not silently repair drift during verify-only requests.
+- verify-only runs are read-only
+- a `ready` report requires host SSH, container SSH, and a passing smoke test
+- the skill does not silently repair drift during verify-only requests
 
 ### Repair
 
-- The skill prefers non-destructive repairs first.
-- The skill uses the bare-metal host only when container SSH is broken.
-- The skill does not recreate or delete a container unless the user explicitly asked for destructive repair.
-- The smoke path stays dynamic: no pinned Python patch version, no unconditional vendor `set_env.bash`, no default `devlib` injection.
+- the skill prefers non-destructive repairs first
+- the skill uses the bare-metal host only when container SSH is broken
+- the skill does not recreate or delete a container unless the user explicitly asked for destructive repair
+- the smoke path stays dynamic: no pinned Python patch version, no unconditional vendor `set_env.bash`, no default `devlib` injection
 
 ### Remove
 
-- The skill removes only the container recorded in inventory as skill-managed.
-- If the recorded container is already absent, removal still succeeds as drift cleanup.
-- The skill removes the local endpoint from `known_hosts`.
-- The skill best-effort removes the departing mesh key and endpoint from peers.
-- The skill removes the machine record from inventory.
-- The skill does not remove host firewall rules or host-level `authorized_keys` entries.
+- the skill removes only the container recorded in inventory as skill-managed
+- if the recorded container is already absent, removal still succeeds as drift cleanup
+- the skill removes the local endpoint from `known_hosts`
+- the skill best-effort removes the departing mesh key and endpoint from peers
+- the skill removes the machine record from inventory
+- the skill does not remove host firewall rules or host-level `authorized_keys` entries
 
 ## Manual regression checklist
 
@@ -73,3 +83,5 @@ Review these files together after every substantial skill edit:
 - `.agents/skills/machine-management/references/acceptance.md`
 - `.agents/skills/machine-management/scripts/manage_machine.py`
 - `.agents/skills/machine-management/scripts/inventory.py`
+- `.agents/scripts/workspace_profile.py`
+- `.agents/lib/vaws_local_state.py`

--- a/.agents/skills/machine-management/references/behavior.md
+++ b/.agents/skills/machine-management/references/behavior.md
@@ -6,6 +6,7 @@ This file is the detailed contract for the `machine-management` skill.
 
 This skill owns the remote-machine layer for this workspace:
 
+- ensure the local workspace machine profile exists when needed
 - add a host to local inventory
 - create or adopt one managed workspace container on that host
 - verify readiness
@@ -21,7 +22,7 @@ It does **not** own:
 
 ## Local state contract
 
-`.machine-inventory.json` is the canonical local state file.
+Repo-local runtime state lives under `.vaws-local/`.
 
 Rules:
 
@@ -29,7 +30,18 @@ Rules:
 - read it before mutating remote state
 - write it after successful add, identity-changing repair, or remove
 - alias and host IP must not resolve to different records
+- machine username must be letters and digits only, normalized to lowercase
 - v1 supports one managed workspace container per host
+
+Relevant files:
+
+- `.vaws-local/machine-profile.json`
+- `.vaws-local/machine-inventory.json`
+
+Compatibility rule:
+
+- read legacy repo-root `.machine-inventory.json` when the new path is still absent
+- migrate to `.vaws-local/machine-inventory.json` on the next successful inventory write
 
 `inventory.py` stores canonical `bootstrap_method` values as:
 
@@ -37,6 +49,19 @@ Rules:
 - `password-once`
 
 For compatibility, `inventory.py put --bootstrap-method key` normalizes to `ssh`.
+
+## Namespace and container naming contract
+
+The local machine profile provides a stable workspace machine username / namespace.
+
+Rules:
+
+- create or reuse the profile before new-machine setup
+- accept letters and digits only
+- normalize to lowercase
+- blank input means auto-generate a default such as `agent7k2p9x`
+- derive new container names from the namespace, for example `vaws-alice123`
+- if inventory already records a container name for a managed machine, keep using the recorded name for that machine
 
 ## Ready vs not-ready
 
@@ -54,8 +79,9 @@ All of the following are true:
 Use this when the request is blocked by missing input or by an auth boundary the skill is not allowed to bypass, for example:
 
 - no local public key exists
-- password bootstrap is needed but no password was provided
+- password bootstrap is needed but no interactive terminal is available
 - verify-only was requested, but repair would be required
+- the user wants a specific machine username but has not chosen one yet
 
 ### `needs_repair`
 
@@ -81,7 +107,17 @@ After host key auth is established:
 
 - stop using the password
 - never use a container password
-- never automate passwords with `sshpass`, `expect`, files, or env scripts
+- never automate passwords with `sshpass`, `expect`, files, env vars, or heredoc injection
+
+Preferred helper:
+
+- `manage_machine.py bootstrap-host-key`
+
+Rules for that step:
+
+- run it in the foreground so the terminal can prompt for the password
+- do not echo the password into the transcript
+- if interactive execution is impossible, use `--print-command` and ask the user to run it once themselves
 
 ## Container SSH contract
 

--- a/.agents/skills/machine-management/references/command-recipes.md
+++ b/.agents/skills/machine-management/references/command-recipes.md
@@ -1,12 +1,20 @@
 # Machine-management command recipes
 
-These are fallback patterns. Prefer the helper scripts in `scripts/` when possible.
+These are fallback patterns. Prefer the helper scripts in `scripts/` and `.agents/scripts/` when possible.
 
-## Inventory
+## Local profile and inventory
 
 ```bash
+python3 .agents/scripts/workspace_profile.py summary
 python3 .agents/skills/machine-management/scripts/inventory.py summary
-python3 .agents/skills/machine-management/scripts/inventory.py get 173.125.1.2
+```
+
+Create or reuse a collision-safe local machine profile:
+
+```bash
+python3 .agents/scripts/workspace_profile.py ensure --username alice123
+# or
+python3 .agents/scripts/workspace_profile.py ensure
 ```
 
 ## Probe one host
@@ -16,13 +24,42 @@ python3 .agents/skills/machine-management/scripts/manage_machine.py probe-host \
   --host 173.125.1.2
 ```
 
+## First interactive host bootstrap
+
+Preferred helper:
+
+```bash
+python3 .agents/skills/machine-management/scripts/manage_machine.py bootstrap-host-key \
+  --host 173.125.1.2
+```
+
+If the execution environment cannot surface an interactive password prompt, print the exact command instead:
+
+```bash
+python3 .agents/skills/machine-management/scripts/manage_machine.py bootstrap-host-key \
+  --host 173.125.1.2 \
+  --print-command
+```
+
+Raw fallback only when the helper is unavailable:
+
+```bash
+ssh -p 22 root@173.125.1.2
+mkdir -p /root/.ssh && chmod 700 /root/.ssh
+cat >> /root/.ssh/authorized_keys <<'KEY'
+<LOCAL_PUBLIC_KEY_LINE>
+KEY
+chmod 600 /root/.ssh/authorized_keys
+```
+
 ## Bootstrap or repair one managed container
 
 ```bash
 python3 .agents/skills/machine-management/scripts/manage_machine.py bootstrap-container \
   --host 173.125.1.2 \
-  --container-name vaws-maoxx241 \
-  --container-ssh-port 46671
+  --container-name vaws-alice123 \
+  --container-ssh-port 46671 \
+  --namespace alice123
 ```
 
 ## Run the smoke test
@@ -46,8 +83,9 @@ python3 .agents/skills/machine-management/scripts/manage_machine.py verify-machi
 ```bash
 python3 .agents/skills/machine-management/scripts/inventory.py put \
   --alias 173.125.1.2 \
+  --namespace alice123 \
   --host-ip 173.125.1.2 \
-  --container-name vaws-maoxx241 \
+  --container-name vaws-alice123 \
   --container-ssh-port 46671 \
   --bootstrap-method ssh \
   --last-verified-at "2026-04-04T09:22:03Z"
@@ -99,22 +137,9 @@ python3 .agents/skills/machine-management/scripts/manage_machine.py mesh-remove-
 ```bash
 python3 .agents/skills/machine-management/scripts/manage_machine.py remove-container \
   --host 173.125.1.2 \
-  --container-name vaws-maoxx241 \
+  --container-name vaws-alice123 \
   --container-ssh-port 46671 \
   --clean-local-known-hosts
 
 python3 .agents/skills/machine-management/scripts/inventory.py remove 173.125.1.2
-```
-
-## Only fallback raw step: first interactive host bootstrap
-
-Use a single interactive SSH session only when host key auth is not ready yet and the request is adding a new machine.
-
-```bash
-ssh -p 22 root@173.125.1.2
-mkdir -p /root/.ssh && chmod 700 /root/.ssh
-cat >> /root/.ssh/authorized_keys <<'KEY'
-<LOCAL_PUBLIC_KEY_LINE>
-KEY
-chmod 600 /root/.ssh/authorized_keys
 ```

--- a/.agents/skills/machine-management/scripts/inventory.py
+++ b/.agents/skills/machine-management/scripts/inventory.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Manage local machine inventory for vllm-ascend-workspace.
 
-This helper keeps the repo-root `.machine-inventory.json` file consistent.
-It is intentionally small and dependency-free so agent workflows can rely on it.
+The canonical inventory now lives under `.vaws-local/machine-inventory.json`.
+For compatibility, the helper will read the legacy repo-root
+`.machine-inventory.json` when the new path does not exist yet.
 """
 
 from __future__ import annotations
@@ -10,14 +11,23 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_local_state import (  # noqa: E402
+    INVENTORY_PATH as DEFAULT_PATH,
+    LEGACY_INVENTORY_PATH,
+    ensure_state_dir,
+    resolve_inventory_read_path,
+    same_path,
+    validate_machine_username,
+)
+
 SCHEMA_VERSION = 1
-DEFAULT_FILENAME = ".machine-inventory.json"
-ROOT = Path(__file__).resolve().parents[4]
-DEFAULT_PATH = ROOT / DEFAULT_FILENAME
 
 
 class InventoryError(RuntimeError):
@@ -33,13 +43,6 @@ BOOTSTRAP_METHOD_ALIASES = {
 }
 
 
-@dataclass(frozen=True)
-class MachineId:
-    alias: str
-    host_ip: str
-
-
-
 def normalize_bootstrap_method(value: str | None) -> str | None:
     if value is None:
         return None
@@ -52,7 +55,6 @@ def normalize_bootstrap_method(value: str | None) -> str | None:
 
 def _empty_inventory() -> dict[str, Any]:
     return {"schema_version": SCHEMA_VERSION, "machines": []}
-
 
 
 def load_inventory(path: Path) -> dict[str, Any]:
@@ -76,10 +78,9 @@ def load_inventory(path: Path) -> dict[str, Any]:
     return data
 
 
-
 def save_inventory(path: Path, inventory: dict[str, Any]) -> None:
+    ensure_state_dir(path.parent)
     path.write_text(json.dumps(inventory, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-
 
 
 def _validate_record(record: Any, where: str = "record") -> None:
@@ -88,6 +89,12 @@ def _validate_record(record: Any, where: str = "record") -> None:
     alias = record.get("alias")
     if not isinstance(alias, str) or not alias.strip():
         raise InventoryError(f"{where}.alias must be a non-empty string")
+
+    namespace = record.get("namespace")
+    if namespace is not None:
+        if not isinstance(namespace, str) or not namespace.strip():
+            raise InventoryError(f"{where}.namespace must be a non-empty string when present")
+        record["namespace"] = validate_machine_username(namespace)
 
     host = record.get("host")
     if not isinstance(host, dict):
@@ -132,19 +139,18 @@ def _validate_record(record: Any, where: str = "record") -> None:
         raise InventoryError(f"{where}.last_verified_at must be a string when present")
 
 
-
-def _iter_machine_ids(inventory: dict[str, Any]) -> list[MachineId]:
-    return [
-        MachineId(alias=record["alias"], host_ip=record["host"]["ip"])
-        for record in inventory["machines"]
-    ]
-
-
-
-def _find_matches(inventory: dict[str, Any], identifier: str | None = None, *, alias: str | None = None, host_ip: str | None = None) -> list[dict[str, Any]]:
+def _find_matches(
+    inventory: dict[str, Any],
+    identifier: str | None = None,
+    *,
+    alias: str | None = None,
+    host_ip: str | None = None,
+) -> list[dict[str, Any]]:
     matches: list[dict[str, Any]] = []
     for record in inventory["machines"]:
-        if identifier is not None and (record["alias"] == identifier or record["host"]["ip"] == identifier):
+        if identifier is not None and (
+            record["alias"] == identifier or record["host"]["ip"] == identifier
+        ):
             matches.append(record)
             continue
         if alias is not None and record["alias"] == alias:
@@ -155,15 +161,29 @@ def _find_matches(inventory: dict[str, Any], identifier: str | None = None, *, a
     return matches
 
 
+def preferred_inventory_path(path: Path) -> Path:
+    return path.expanduser().resolve()
+
+
+def read_inventory_path(path: Path) -> Path:
+    requested = preferred_inventory_path(path)
+    return resolve_inventory_read_path(requested)
+
 
 def cmd_summary(args: argparse.Namespace) -> int:
-    inventory = load_inventory(args.inventory)
+    requested_path = preferred_inventory_path(args.inventory)
+    active_path = read_inventory_path(requested_path)
+    inventory = load_inventory(active_path)
     summary = {
         "schema_version": inventory["schema_version"],
+        "inventory": str(active_path),
+        "preferred_inventory": str(requested_path),
+        "legacy_inventory": str(LEGACY_INVENTORY_PATH),
         "count": len(inventory["machines"]),
         "machines": [
             {
                 "alias": record["alias"],
+                "namespace": record.get("namespace"),
                 "host": f"{record['host']['user']}@{record['host']['ip']}:{record['host']['port']}",
                 "container": record["container"]["name"],
                 "container_ssh_port": record["container"]["ssh_port"],
@@ -177,9 +197,8 @@ def cmd_summary(args: argparse.Namespace) -> int:
     return 0
 
 
-
 def cmd_get(args: argparse.Namespace) -> int:
-    inventory = load_inventory(args.inventory)
+    inventory = load_inventory(read_inventory_path(args.inventory))
     matches = _find_matches(inventory, identifier=args.identifier)
     if not matches:
         raise InventoryError(f"no machine found for identifier: {args.identifier}")
@@ -191,9 +210,10 @@ def cmd_get(args: argparse.Namespace) -> int:
     return 0
 
 
-
 def cmd_put(args: argparse.Namespace) -> int:
-    inventory = load_inventory(args.inventory)
+    requested_path = preferred_inventory_path(args.inventory)
+    active_path = read_inventory_path(requested_path)
+    inventory = load_inventory(active_path)
     alias_matches = _find_matches(inventory, alias=args.alias)
     ip_matches = _find_matches(inventory, host_ip=args.host_ip)
 
@@ -205,8 +225,10 @@ def cmd_put(args: argparse.Namespace) -> int:
         )
 
     target = alias_record or ip_record
+    namespace = validate_machine_username(args.namespace) if args.namespace else None
     record = {
         "alias": args.alias,
+        "namespace": namespace,
         "host": {
             "ip": args.host_ip,
             "port": args.host_port,
@@ -223,6 +245,8 @@ def cmd_put(args: argparse.Namespace) -> int:
         "created_by_skill": args.created_by_skill,
         "last_verified_at": args.last_verified_at,
     }
+    if namespace is None:
+        record.pop("namespace")
     _validate_record(record)
 
     if target is None:
@@ -233,25 +257,25 @@ def cmd_put(args: argparse.Namespace) -> int:
         target.update(record)
         action = "updated"
 
-    save_inventory(args.inventory, inventory)
-    print(
-        json.dumps(
-            {
-                "result": action,
-                "alias": record["alias"],
-                "host_ip": record["host"]["ip"],
-                "inventory": str(args.inventory),
-            },
-            indent=2,
-            ensure_ascii=False,
-        )
-    )
+    save_inventory(requested_path, inventory)
+    payload = {
+        "result": action,
+        "alias": record["alias"],
+        "namespace": record.get("namespace"),
+        "host_ip": record["host"]["ip"],
+        "inventory": str(requested_path),
+    }
+    if not same_path(active_path, requested_path):
+        payload["loaded_from"] = str(active_path)
+        payload["migrated_from_legacy"] = same_path(active_path, LEGACY_INVENTORY_PATH)
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
     return 0
 
 
-
 def cmd_remove(args: argparse.Namespace) -> int:
-    inventory = load_inventory(args.inventory)
+    requested_path = preferred_inventory_path(args.inventory)
+    active_path = read_inventory_path(requested_path)
+    inventory = load_inventory(active_path)
     matches = _find_matches(inventory, identifier=args.identifier)
     if not matches:
         raise InventoryError(f"no machine found for identifier: {args.identifier}")
@@ -261,21 +285,19 @@ def cmd_remove(args: argparse.Namespace) -> int:
         )
     target = matches[0]
     inventory["machines"] = [record for record in inventory["machines"] if record is not target]
-    save_inventory(args.inventory, inventory)
-    print(
-        json.dumps(
-            {
-                "result": "removed",
-                "alias": target["alias"],
-                "host_ip": target["host"]["ip"],
-                "inventory": str(args.inventory),
-            },
-            indent=2,
-            ensure_ascii=False,
-        )
-    )
+    save_inventory(requested_path, inventory)
+    payload = {
+        "result": "removed",
+        "alias": target["alias"],
+        "namespace": target.get("namespace"),
+        "host_ip": target["host"]["ip"],
+        "inventory": str(requested_path),
+    }
+    if not same_path(active_path, requested_path):
+        payload["loaded_from"] = str(active_path)
+        payload["migrated_from_legacy"] = same_path(active_path, LEGACY_INVENTORY_PATH)
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
     return 0
-
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -298,6 +320,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     put_cmd = subparsers.add_parser("put", help="insert or update one machine record")
     put_cmd.add_argument("--alias", required=True)
+    put_cmd.add_argument("--namespace", help="stable workspace machine username used for collision-safe naming")
     put_cmd.add_argument("--host-ip", required=True)
     put_cmd.add_argument("--host-port", type=int, default=22)
     put_cmd.add_argument("--host-user", default="root")
@@ -328,7 +351,6 @@ def build_parser() -> argparse.ArgumentParser:
     remove.set_defaults(func=cmd_remove)
 
     return parser
-
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/.agents/skills/machine-management/scripts/manage_machine.py
+++ b/.agents/skills/machine-management/scripts/manage_machine.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import shlex
+import shutil
 import subprocess
 from dataclasses import dataclass
 from typing import Any, Sequence
@@ -46,23 +48,43 @@ def run_local(
     input_text: str | None = None,
     check: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    proc = subprocess.run(
-        list(cmd),
-        input=input_text,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
+    try:
+        proc = subprocess.run(
+            list(cmd),
+            input=input_text,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except FileNotFoundError as exc:
+        raise MachineManagementError(f"required local command not found: {cmd[0]}") from exc
     if check and proc.returncode != 0:
         detail = proc.stderr.strip() or proc.stdout.strip() or "command failed"
         raise MachineManagementError(detail)
     return proc
 
 
-def ssh_command(target: SshTarget, *, batch_mode: bool = True) -> list[str]:
-    return [
+def run_local_interactive(cmd: Sequence[str]) -> int:
+    try:
+        proc = subprocess.run(list(cmd))
+    except FileNotFoundError as exc:
+        raise MachineManagementError(f"required local command not found: {cmd[0]}") from exc
+    return proc.returncode
+
+
+def shell_join(cmd: Sequence[str]) -> str:
+    return shlex.join(list(cmd))
+
+
+def ssh_command(
+    target: SshTarget,
+    *,
+    batch_mode: bool = True,
+    extra_options: Sequence[str] = (),
+) -> list[str]:
+    command = [
         "ssh",
         "-o",
         f"BatchMode={'yes' if batch_mode else 'no'}",
@@ -72,10 +94,11 @@ def ssh_command(target: SshTarget, *, batch_mode: bool = True) -> list[str]:
         "LogLevel=ERROR",
         "-o",
         "ConnectTimeout=10",
-        "-p",
-        str(target.port),
-        f"{target.user}@{target.host}",
     ]
+    for option in extra_options:
+        command.extend(["-o", option])
+    command.extend(["-p", str(target.port), f"{target.user}@{target.host}"])
+    return command
 
 
 @dataclass
@@ -116,13 +139,28 @@ def run_remote_script(
     )
 
 
+def compact_failure_tail(text: str, *, max_lines: int = 20, max_chars: int = 1600) -> str:
+    stripped = text.strip()
+    if not stripped:
+        return ""
+    lines = stripped.splitlines()
+    tail = "\n".join(lines[-max_lines:])
+    if len(tail) > max_chars:
+        tail = tail[-max_chars:]
+    return tail
+
+
 def assert_remote_success(result: RemoteResult, *, require_payload: bool = True) -> dict[str, Any]:
     if require_payload and result.payload is None:
         detail = result.stderr.strip() or result.stdout.strip() or "remote command produced no JSON payload"
         raise MachineManagementError(detail)
     if result.returncode != 0:
+        stderr_tail = compact_failure_tail(result.stderr)
         if result.payload and result.payload.get("error"):
-            raise MachineManagementError(str(result.payload["error"]))
+            base = str(result.payload["error"])
+            if stderr_tail:
+                raise MachineManagementError(f"{base}\n--- stderr tail ---\n{stderr_tail}")
+            raise MachineManagementError(base)
         detail = result.stderr.strip() or result.stdout.strip() or "remote command failed"
         raise MachineManagementError(detail)
     return result.payload or {}
@@ -295,6 +333,7 @@ port="$2"
 image="$3"
 workdir="$4"
 pubkey="$5"
+namespace="${6:-}"
 
 emit_json() {
   python3 - "$1" <<'PY'
@@ -377,6 +416,7 @@ else
     --label com.vaws.managed=true \
     --label com.vaws.container_ssh_port="$port" \
     --label com.vaws.workdir="$workdir" \
+    --label com.vaws.namespace="$namespace" \
     -w "$workdir" \
     --device=/dev/davinci_manager \
     --device=/dev/hisi_hdc \
@@ -422,6 +462,7 @@ if ! grep -qxF "$pubkey" /root/.ssh/authorized_keys 2>/dev/null; then
   printf '%s\n' "$pubkey" >> /root/.ssh/authorized_keys
 fi
 chmod 600 /root/.ssh/authorized_keys
+install -d -m 0755 /run/sshd
 ssh-keygen -A >/dev/null 2>&1 || true
 cat > /etc/ssh/sshd_vaws_config <<EOF
 Port ${port}
@@ -466,16 +507,17 @@ elif command -v firewall-cmd >/dev/null 2>&1 && firewall-cmd --state >/dev/null 
   firewall="firewalld"
 fi
 
-payload=$(python3 - <<'PY' "$container" "$port" "$image" "$workdir" "$created" "$started" "$pulled" "$installed_ssh" "$firewall" "${actions[*]}"
+payload=$(python3 - <<'PY' "$container" "$port" "$image" "$workdir" "$namespace" "$created" "$started" "$pulled" "$installed_ssh" "$firewall" "${actions[*]}"
 import json
 import sys
-container, port, image, workdir, created, started, pulled, installed_ssh, firewall, actions = sys.argv[1:]
+container, port, image, workdir, namespace, created, started, pulled, installed_ssh, firewall, actions = sys.argv[1:]
 print(json.dumps({
     "success": True,
     "container": container,
     "container_ssh_port": int(port),
     "image": image,
     "workdir": workdir,
+    "namespace": namespace or None,
     "created": created == "true",
     "started_existing": started == "true",
     "pulled_image": pulled == "true",
@@ -730,13 +772,128 @@ def host_target(args: argparse.Namespace) -> SshTarget:
 
 
 def check_direct_ssh(target: SshTarget) -> dict[str, Any]:
-    result = run_local(ssh_command(target, batch_mode=True) + ["printf", "ok"])
+    try:
+        result = run_local(ssh_command(target, batch_mode=True) + ["printf", "ok"])
+    except MachineManagementError as exc:
+        return {
+            "ok": False,
+            "returncode": None,
+            "stdout": "",
+            "stderr": str(exc),
+        }
     return {
         "ok": result.returncode == 0 and result.stdout.endswith("ok"),
         "returncode": result.returncode,
         "stdout": result.stdout.strip(),
         "stderr": result.stderr.strip(),
     }
+
+
+def build_bootstrap_host_key_command(
+    target: SshTarget,
+    *,
+    key_path: pathlib.Path,
+    public_key: str,
+) -> tuple[str, list[str]]:
+    if shutil.which("ssh-copy-id"):
+        return (
+            "ssh-copy-id",
+            [
+                "ssh-copy-id",
+                "-i",
+                str(key_path),
+                "-o",
+                "StrictHostKeyChecking=accept-new",
+                "-o",
+                "LogLevel=ERROR",
+                "-o",
+                "ConnectTimeout=10",
+                "-o",
+                "PreferredAuthentications=password,keyboard-interactive",
+                "-o",
+                "PubkeyAuthentication=no",
+                "-o",
+                "NumberOfPasswordPrompts=1",
+                "-p",
+                str(target.port),
+                f"{target.user}@{target.host}",
+            ],
+        )
+
+    quoted_key = shlex.quote(public_key)
+    remote_cmd = (
+        "umask 077; "
+        "mkdir -p ~/.ssh && touch ~/.ssh/authorized_keys; "
+        "chmod 700 ~/.ssh; "
+        "chmod 600 ~/.ssh/authorized_keys; "
+        f"grep -qxF {quoted_key} ~/.ssh/authorized_keys 2>/dev/null || "
+        f"printf '%s\\n' {quoted_key} >> ~/.ssh/authorized_keys"
+    )
+    command = ssh_command(
+        target,
+        batch_mode=False,
+        extra_options=(
+            "PreferredAuthentications=password,keyboard-interactive",
+            "PubkeyAuthentication=no",
+            "NumberOfPasswordPrompts=1",
+        ),
+    ) + ["sh", "-c", remote_cmd]
+    return "ssh", command
+
+
+def cmd_bootstrap_host_key(args: argparse.Namespace) -> int:
+    target = host_target(args)
+    key_path = find_public_key(args.public_key_file)
+    public_key = load_public_key(key_path)
+    before = check_direct_ssh(target)
+    tool_name, command = build_bootstrap_host_key_command(
+        target,
+        key_path=key_path,
+        public_key=public_key,
+    )
+    payload: dict[str, Any] = {
+        "target": {"host": target.host, "user": target.user, "host_port": target.port},
+        "public_key_file": str(key_path),
+        "precheck": before,
+        "interactive_tool": tool_name,
+        "interactive_command": shell_join(command),
+        "needs_interactive_terminal": True,
+    }
+    if before["ok"]:
+        payload.update({"success": True, "executed": False, "result": "already-configured"})
+        print_json(payload)
+        return 0
+
+    if args.print_command:
+        payload.update({
+            "success": True,
+            "executed": False,
+            "result": "command-preview",
+            "message": "run the interactive command in a terminal and enter the host password when prompted",
+        })
+        print_json(payload)
+        return 0
+
+    returncode = run_local_interactive(command)
+    after = check_direct_ssh(target)
+    payload.update(
+        {
+            "executed": True,
+            "command_returncode": returncode,
+            "postcheck": after,
+            "success": after["ok"],
+            "result": "bootstrapped" if after["ok"] else "failed",
+        }
+    )
+    if not after["ok"]:
+        payload["error"] = (
+            "interactive host bootstrap did not establish key-based SSH; verify the host password, username, and password-login policy"
+        )
+        print_json(payload)
+        return 2
+
+    print_json(payload)
+    return 0
 
 
 def cmd_probe_host(args: argparse.Namespace) -> int:
@@ -770,6 +927,7 @@ def cmd_bootstrap_container(args: argparse.Namespace) -> int:
             args.image,
             args.workdir,
             public_key,
+            args.namespace or "",
         ],
         batch_mode=True,
     )
@@ -781,6 +939,7 @@ def cmd_bootstrap_container(args: argparse.Namespace) -> int:
     payload.update(
         {
             "public_key_file": str(key_path),
+            "namespace": args.namespace or None,
             "direct_container_ssh": ssh_check,
             "target": {
                 "host": target.host,
@@ -983,12 +1142,30 @@ def build_parser() -> argparse.ArgumentParser:
     probe.add_argument("--managed-prefix", default="vaws-", help="managed container name prefix (default: vaws-)")
     probe.set_defaults(func=cmd_probe_host)
 
+    host_bootstrap = subparsers.add_parser(
+        "bootstrap-host-key",
+        help="run one interactive host-key bootstrap; the terminal prompts for the host password",
+    )
+    add_host_args(host_bootstrap)
+    host_bootstrap.add_argument(
+        "--public-key-file",
+        help="local SSH public key to install on the host; defaults to ~/.ssh/id_ed25519.pub if present",
+    )
+    host_bootstrap.add_argument(
+        "--print-command",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="print the exact interactive command instead of running it",
+    )
+    host_bootstrap.set_defaults(func=cmd_bootstrap_host_key)
+
     bootstrap = subparsers.add_parser("bootstrap-container", help="create or repair the managed container and dedicated sshd")
     add_host_args(bootstrap)
     bootstrap.add_argument("--container-name", required=True, help="container name to create or reuse")
     bootstrap.add_argument("--container-ssh-port", type=int, required=True, help="high non-default SSH port for the managed container")
     bootstrap.add_argument("--image", default=DEFAULT_IMAGE, help=f"image name (default: {DEFAULT_IMAGE})")
     bootstrap.add_argument("--workdir", default=DEFAULT_WORKDIR, help=f"container workdir (default: {DEFAULT_WORKDIR})")
+    bootstrap.add_argument("--namespace", help="stable workspace machine username used for collision-safe container naming")
     bootstrap.add_argument("--public-key-file", help="local SSH public key to add to the container; defaults to ~/.ssh/id_ed25519.pub if present")
     bootstrap.set_defaults(func=cmd_bootstrap_container)
 

--- a/.agents/skills/repo-init/SKILL.md
+++ b/.agents/skills/repo-init/SKILL.md
@@ -17,7 +17,8 @@ A successful run leaves the local clone in a recommended but editable state:
 - GitHub auth exists on `github.com`.
 - recursive submodules are initialized.
 - remotes and local tracking branches match the user’s chosen topology.
-- tracked files keep community URLs; user-specific topology remains local runtime state.
+- for broad workspace init, a local workspace machine profile exists under `.vaws-local/`.
+- tracked files keep community URLs; user-specific topology and machine profile state remain local runtime state.
 
 ## Use this skill when
 
@@ -26,12 +27,14 @@ A successful run leaves the local clone in a recommended but editable state:
 - the user asks to sign into GitHub
 - the user asks to initialize recursive submodules
 - the user asks to configure forks or remotes for the workspace, `vllm`, or `vllm-ascend`
+- the user asks for a broad workspace init and the local machine profile is missing
 - missing auth, missing recursive submodules, or obviously broken remote topology is the clear blocker
 
 ## Do not use this skill when
 
 - the task is ordinary coding, debugging, docs, serving, or benchmarking
 - the task is generic Git work unrelated to initial setup
+- the user only wants remote machine attach / repair; use `machine-management` instead
 
 ## Core rules
 
@@ -40,7 +43,32 @@ A successful run leaves the local clone in a recommended but editable state:
 - Allow partial completion if the user declines a step.
 - Preserve extra remotes such as `upstream2`.
 - Never write secrets or user-specific remotes into tracked files.
-- Prefer helper scripts in `scripts/` over ad-hoc shell pipelines.
+- Keep local runtime state only under `.vaws-local/`.
+- Prefer helper scripts in `scripts/` and `.agents/scripts/` over ad-hoc shell pipelines.
+
+## Local runtime state
+
+Workspace-local runtime state lives under the untracked directory `.vaws-local/`:
+
+- `.vaws-local/machine-profile.json`
+- `.vaws-local/machine-inventory.json`
+
+The machine profile stores the stable machine username / namespace used later by `machine-management` to derive collision-safe container names such as `vaws-alice123`.
+
+Inspect it first when the task is a broad workspace init:
+
+```bash
+python3 .agents/scripts/workspace_profile.py summary
+```
+
+If the profile is missing and the user is doing a broad init, ask once for the desired machine username:
+
+- allowed: English letters and digits only
+- normalize to lowercase
+- reject symbols and spaces
+- blank input means auto-generate a default such as `agent7k2p9x`
+
+For narrow Git-only tasks, do not force profile creation.
 
 ## Script-first entry points
 
@@ -48,6 +76,12 @@ Start with the probe script:
 
 - POSIX: `python3 .agents/skills/repo-init/scripts/repo_init_probe.py --compact`
 - Windows: `py -3 .agents/skills/repo-init/scripts/repo_init_probe.py --compact`
+
+Shared profile helper:
+
+- `python3 .agents/scripts/workspace_profile.py summary`
+- `python3 .agents/scripts/workspace_profile.py ensure --username <letters-or-digits>`
+- `python3 .agents/scripts/workspace_profile.py ensure`  # auto-generate if missing
 
 Prefer the topology helper for deterministic mutations and quiet comparisons:
 
@@ -83,11 +117,24 @@ Run the probe script and summarize only the compact facts that matter:
 - whether submodules are initialized
 - which forks exist
 - what each repo currently uses for `origin` and `upstream`
+- whether the local workspace machine profile already exists
 
-### 2. Ask by change category
+### 2. For broad init, ensure the local machine profile early
+
+If the request is a broad workspace init rather than a narrow Git-only task:
+
+1. inspect `.vaws-local/machine-profile.json`
+2. if it exists, reuse it
+3. if it is missing, ask once for the desired machine username
+4. if the user leaves it blank, auto-generate one with `workspace_profile.py ensure`
+
+Do not rewrite an existing machine profile unless the user explicitly asked to change it.
+
+### 3. Ask by change category
 
 Group approvals by category instead of asking one command at a time:
 
+- create or change the local machine profile
 - install or configure `gh`
 - authenticate GitHub
 - initialize recursive submodules
@@ -95,7 +142,7 @@ Group approvals by category instead of asking one command at a time:
 - move local branches or set tracking
 - sync a user fork from upstream
 
-### 3. Ensure `gh`
+### 4. Ensure `gh`
 
 Preferred install choices:
 
@@ -106,7 +153,7 @@ Preferred install choices:
 
 Never silently edit shell startup files or PATH.
 
-### 4. Ensure GitHub auth
+### 5. Ensure GitHub auth
 
 Preferred interactive flow:
 
@@ -123,7 +170,7 @@ gh api user --jq .login
 
 If SSH is requested and no key exists, ask before creating or uploading one.
 
-### 5. Initialize recursive submodules
+### 6. Initialize recursive submodules
 
 Use the recursive form for this repo:
 
@@ -132,7 +179,7 @@ git submodule sync --recursive
 git submodule update --init --recursive
 ```
 
-### 6. Configure remotes per repo
+### 7. Configure remotes per repo
 
 Decide `workspace`, `vllm`, and `vllm-ascend` independently.
 
@@ -140,12 +187,12 @@ Use `repo_topology.py configure` for deterministic remote mutations.
 
 Rules:
 
-- `workspace`: add community `upstream` when the current clone is already the user repo.
-- `vllm`: a user fork is optional.
-- `vllm-ascend`: a user fork is recommended for PR-oriented work.
-- If a user refuses a fork, community-only mode is still a successful outcome.
+- `workspace`: add community `upstream` when the current clone is already the user repo
+- `vllm`: a user fork is optional
+- `vllm-ascend`: a user fork is recommended for PR-oriented work
+- if a user refuses a fork, community-only mode is still a successful outcome
 
-### 7. Compare or sync forks quietly
+### 8. Compare or sync forks quietly
 
 Do not use `git fetch --prune` merely to inspect divergence. It can emit thousands of deleted refs.
 
@@ -155,7 +202,7 @@ Instead:
 - or use `git ls-remote --heads <remote> main`
 - use `gh repo sync USER/REPO --source OWNER/REPO` only after explicit approval
 
-### 8. Move local branches only when safe
+### 9. Move local branches only when safe
 
 Use `repo_topology.py ensure-main` for targeted `main` tracking.
 
@@ -166,14 +213,15 @@ Rules:
 - if the worktree is dirty, ask before switching branches or pulling
 - do not hard reset without explicit approval
 
-### 9. Optional `gh` default repo
+### 10. Optional `gh` default repo
 
 When both `origin` and `upstream` exist, prefer `gh repo set-default upstream` for PR-oriented flows unless the user asks otherwise.
 
-### 10. Finish with a compact status report
+### 11. Finish with a compact status report
 
 Report:
 
+- local machine profile state when relevant
 - tool install state
 - auth state
 - submodule state

--- a/.agents/skills/repo-init/references/acceptance.md
+++ b/.agents/skills/repo-init/references/acceptance.md
@@ -8,6 +8,7 @@ These should trigger `repo-init`:
 - “Set up GitHub CLI and sign me in.”
 - “Initialize submodules and point `vllm-ascend` to my fork.”
 - “Configure my remotes for PR work.”
+- “初始化这个仓库，顺便把后面远端机器要用的用户名也配好。”
 
 ## Non-trigger examples
 
@@ -17,6 +18,7 @@ These should not trigger `repo-init` unless setup is the obvious blocker:
 - “Explain how scheduling works.”
 - “Run the benchmark suite.”
 - “Update README wording.”
+- “帮我配置一台远端 NPU 机器。”
 
 ## Success criteria
 
@@ -27,31 +29,41 @@ A successful run should satisfy all applicable items below.
 - probes first before mutating
 - asks before each mutation category
 - allows partial completion
-- never writes personal remotes or credentials into tracked files
+- never writes personal remotes, secrets, or machine profile state into tracked files
 - preserves extra remotes
+
+### Local machine profile
+
+- broad workspace init reuses or creates `.vaws-local/machine-profile.json`
+- machine usernames accept English letters and digits only
+- profile creation normalizes usernames to lowercase
+- blank input generates a default machine username
+- narrow Git-only tasks do not force profile creation
 
 ### Tooling and auth
 
 - chooses the correct platform install path for `gh`
-- hands off the bundled fallback installer when privilege is missing
-- verifies GitHub auth with `gh auth status` and `gh api user --jq .login`
+- offers a no-admin fallback when needed
+- verifies GitHub auth after login
+- asks before generating or uploading SSH keys
 
-### Submodules and remotes
+### Submodules and topology
 
-- uses recursive submodule sync + init
-- configures remotes only after approval
-- preserves community-only mode when the user declines forks
-
-### Branching and sync
-
-- does not use `git fetch --prune` merely to inspect divergence
-- compares `main` heads quietly
-- moves local branches only after approval when worktree state makes that relevant
-- syncs a user fork only after explicit approval
+- initializes submodules recursively
+- preserves nonstandard remotes
+- keeps tracked files on community URLs
+- uses quiet remote comparison instead of broad prune-heavy fetches
+- moves local branches only with approval when worktrees are clean enough
 
 ## Manual regression checklist
 
-- Run `repo_init_probe.py` on a repo with uninitialized submodules.
-- Reconfigure a repo that already has extra remotes and ensure they remain.
-- Compare fork / upstream `main` without producing deleted-ref noise.
-- Ensure `ensure-main` works on both a detached submodule checkout and an existing local `main` branch.
+Review these files together after every substantial skill edit:
+
+- `.agents/skills/repo-init/SKILL.md`
+- `.agents/skills/repo-init/references/behavior.md`
+- `.agents/skills/repo-init/references/command-recipes.md`
+- `.agents/skills/repo-init/references/acceptance.md`
+- `.agents/skills/repo-init/scripts/repo_init_probe.py`
+- `.agents/skills/repo-init/scripts/repo_topology.py`
+- `.agents/scripts/workspace_profile.py`
+- `.agents/lib/vaws_local_state.py`

--- a/.agents/skills/repo-init/references/behavior.md
+++ b/.agents/skills/repo-init/references/behavior.md
@@ -7,15 +7,33 @@ This file defines the durable behavior of `repo-init`.
 - Probe first.
 - Ask before each mutation category.
 - Preserve user choices and extra remotes.
-- Keep user-specific topology local, not tracked.
+- Keep user-specific topology and machine profile state local, not tracked.
 - Prefer helper scripts to raw shell.
 - Prefer quiet single-branch comparisons over broad ref pruning.
+
+## Local-state contract
+
+Repo-local runtime state lives under `.vaws-local/`.
+
+Relevant files:
+
+- `.vaws-local/machine-profile.json`
+- `.vaws-local/machine-inventory.json`
+
+Rules:
+
+- keep the directory untracked
+- create the machine profile during broad workspace init, not for every narrow Git-only task
+- machine username must be letters and digits only
+- normalize machine usernames to lowercase
+- blank user input means generate a default such as `agent7k2p9x`
+- do not rewrite an existing machine profile unless the user explicitly asked for that change
 
 ## Stage model
 
 ### Stage 0: applicability
 
-Use `repo-init` only for workspace setup, GitHub auth / CLI setup, recursive submodules, and fork / remote topology.
+Use `repo-init` only for workspace setup, GitHub auth / CLI setup, recursive submodules, fork / remote topology, and the local machine profile during broad init.
 
 ### Stage 1: read-only probe
 
@@ -24,6 +42,7 @@ Use `repo_init_probe.py` to collect:
 - platform and package-manager availability
 - `gh` install state
 - GitHub auth state and login
+- local workspace machine profile state
 - submodule status
 - repo remote topology for `workspace`, `vllm`, and `vllm-ascend`
 - whether matching personal forks appear to exist
@@ -34,6 +53,7 @@ Before mutating, summarize only the compact state the user needs to approve the 
 
 Group approvals by:
 
+- local machine profile creation or change
 - `gh` install / upgrade
 - GitHub auth
 - recursive submodules
@@ -41,18 +61,30 @@ Group approvals by:
 - branch movement / tracking
 - fork sync
 
-### Stage 3: ensure tooling and auth
+### Stage 3: ensure local machine profile when relevant
+
+During broad workspace init:
+
+- inspect the profile first with `workspace_profile.py summary`
+- if missing, ask once for a machine username
+- if the user leaves it blank, call `workspace_profile.py ensure` with no username
+- if the user provided a valid value, call `workspace_profile.py ensure --username ...`
+- do not change an existing profile unless the user explicitly asked to change it
+
+For narrow Git-only tasks, skip this stage.
+
+### Stage 4: ensure tooling and auth
 
 - Prefer official install paths when privilege exists.
 - Use the bundled fallback installers when privilege does not exist.
 - Verify auth with `gh auth status` and `gh api user --jq .login`.
 - Prefer SSH for Git operations when feasible.
 
-### Stage 4: submodules
+### Stage 5: submodules
 
 Always use recursive sync + init for this repo.
 
-### Stage 5: topology
+### Stage 6: topology
 
 Use `repo_topology.py configure` for remote mutations.
 
@@ -63,7 +95,7 @@ Rules:
 - `vllm` user fork is optional
 - `vllm-ascend` user fork is recommended but not mandatory
 
-### Stage 6: main-branch comparison and tracking
+### Stage 7: main-branch comparison and tracking
 
 Use `repo_topology.py compare-main` for branch-head comparison.
 
@@ -76,7 +108,7 @@ Rules:
 - if the worktree is dirty, ask before switching branches or pulling
 - do not hard reset without explicit approval
 
-### Stage 7: optional fork sync
+### Stage 8: optional fork sync
 
 Only sync a user fork when the user explicitly approves it.
 
@@ -96,6 +128,7 @@ gh repo sync USER/REPO --source OWNER/REPO
 
 A successful run usually ends with:
 
+- the local machine profile present when broad init asked for it
 - `gh` installed or a fallback provided
 - GitHub auth valid
 - recursive submodules initialized

--- a/.agents/skills/repo-init/references/command-recipes.md
+++ b/.agents/skills/repo-init/references/command-recipes.md
@@ -1,11 +1,31 @@
 # Repo-init command recipes
 
-These are fallback patterns. Prefer the helper scripts in `scripts/` when possible.
+These are fallback patterns. Prefer the helper scripts when possible.
 
 ## Probe
 
 ```bash
 python3 .agents/skills/repo-init/scripts/repo_init_probe.py --compact
+```
+
+## Workspace machine profile
+
+Inspect the local profile:
+
+```bash
+python3 .agents/scripts/workspace_profile.py summary
+```
+
+Create it with an explicit user-chosen machine username:
+
+```bash
+python3 .agents/scripts/workspace_profile.py ensure --username alice123
+```
+
+Create it with an auto-generated default:
+
+```bash
+python3 .agents/scripts/workspace_profile.py ensure
 ```
 
 ## Quiet remote comparison

--- a/.agents/skills/repo-init/scripts/repo_init_probe.py
+++ b/.agents/skills/repo-init/scripts/repo_init_probe.py
@@ -24,6 +24,12 @@ import sys
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
+LIB_DIR = pathlib.Path(__file__).resolve().parents[3] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_local_state import profile_summary  # noqa: E402
+
 COMMUNITY = {
     "workspace": "maoxx241/vllm-ascend-workspace",
     "vllm": "vllm-project/vllm",
@@ -486,12 +492,19 @@ def compact_fork_summary(forks: Dict[str, Any]) -> Dict[str, Any]:
 
 def compact_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     gh = payload.get("gh") or {}
+    profile = payload.get("workspace_profile") or {}
     compact: Dict[str, Any] = {
         "platform": {
             "kind": payload.get("platform", {}).get("kind"),
             "machine": payload.get("platform", {}).get("machine"),
         },
         "repo_root": payload.get("repo_root"),
+        "workspace_profile": {
+            "exists": profile.get("exists"),
+            "machine_username": profile.get("machine_username"),
+            "container_name": profile.get("container_name"),
+            "source": profile.get("source"),
+        },
         "gh": {
             "installed": gh.get("installed"),
             "logged_in": gh.get("logged_in"),
@@ -532,6 +545,7 @@ def main() -> None:
     payload: Dict[str, Any] = {
         "platform": platform_info,
         "tools": tool_state(),
+        "workspace_profile": profile_summary(),
         "gh": gh_state,
         "gh_install_plan": gh_install_plan(platform_info),
         "repo_root": str(root) if root else None,

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+._*
 Thumbs.db
 __pycache__/
 *.py[cod]
@@ -14,3 +15,5 @@ venv/
 docs/superpowers/
 .claude/settings.local.json
 .codex/
+.vaws-local/
+.machine-inventory.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository is a composable scaffold for local `vllm` + `vllm-ascend` develo
 
 Repo-local skills live under `.agents/skills/`.
 
-- `repo-init`: initialize this workspace after clone, including `gh`, GitHub auth, recursive submodules, and optional fork / remote topology.
+- `repo-init`: initialize this workspace after clone, including `gh`, GitHub auth, recursive submodules, optional fork / remote topology, and the local workspace machine profile used later by machine-management.
 - `machine-management`: add, verify, repair, or remove a workspace-managed remote NPU machine and its managed container.
 
 Both skills are optional. Do not force them as a gate before normal coding, docs work, serving, benchmarking, or unrelated Git / SSH tasks.
@@ -20,11 +20,12 @@ Put detailed step-by-step workflows, long examples, fallback procedures, and com
 ## Repo-wide operating rules
 
 - Never write secrets, passwords, private keys, tokens, or user-specific machine metadata into tracked files.
-- Keep remote machine state only in the repo-root local inventory file `.machine-inventory.json`.
+- Keep repo-local runtime state only under the untracked directory `.vaws-local/`.
+- Treat the legacy repo-root `.machine-inventory.json` as compatibility input only.
 - Keep `.gitmodules` on community URLs:
   - `https://github.com/vllm-project/vllm.git`
   - `https://github.com/vllm-project/vllm-ascend.git`
-- Prefer helper scripts under `.agents/skills/*/scripts/` for deterministic work.
+- Prefer helper scripts under `.agents/skills/*/scripts/` and `.agents/scripts/` for deterministic work.
 - Prefer concise machine-readable summaries over long raw command logs.
 - When a command is noisy, capture the log and report only a compact summary plus a short failure tail.
 - Preserve user choices and extra remotes unless the user explicitly asks to replace them.
@@ -38,6 +39,7 @@ Use `repo-init` when the user explicitly asks to:
 - sign into GitHub
 - initialize recursive submodules
 - configure forks or remotes for the workspace, `vllm`, or `vllm-ascend`
+- create or confirm the local workspace machine profile during a broad init
 
 Use `machine-management` when the user explicitly asks to:
 
@@ -45,6 +47,7 @@ Use `machine-management` when the user explicitly asks to:
 - check whether a managed machine is ready
 - repair host SSH, container SSH, or managed-container drift
 - remove a managed machine from this workspace
+- create the local workspace machine profile when repo-init was skipped
 
 Do not use `machine-management` for code sync, source rebuilds, serving, benchmarking, or generic SSH work unrelated to workspace-managed machines.
 
@@ -57,3 +60,8 @@ When you change a skill, update the whole skill package together:
 - `references/behavior.md`
 - `references/command-recipes.md`
 - `references/acceptance.md`
+
+When the change affects shared local-state behavior, also update:
+
+- `.agents/scripts/workspace_profile.py`
+- `.agents/lib/vaws_local_state.py`

--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@
 - `vllm/`
 - `vllm-ascend/`
 
-The repository is intentionally **not** a mandatory workflow. Developers can use only the pieces they want. The only bundled skill in this package is `repo-init`, which prepares the local clone for development when the developer asks for it.
+The repository is intentionally **not** a mandatory workflow. Developers can use only the pieces they want. The bundled repo-local skills are:
+
+- `repo-init`
+- `machine-management`
 
 ## Design goals
 
 - Keep the tracked repository state public-safe and community-oriented.
-- Keep user-specific remotes, forks, auth state, and credentials in **local** machine state only.
+- Keep user-specific remotes, auth state, machine profile state, and managed-machine inventory in **local untracked state** only.
 - Make initialization optional, conservative, and repeatable.
 - Let agents drive setup in natural language instead of making the developer compose shell commands by hand.
 - Preserve user freedom to add custom remotes such as `upstream2`, keep community-only mode, or skip any suggested step.
@@ -25,11 +28,20 @@ This repository expects two Git submodules:
 
 The tracked `.gitmodules` file should always stay pointed at the community repositories on `main`. Personal forks are a **local runtime concern**, not a tracked file concern.
 
+## Local runtime state
+
+Untracked workspace-local state lives under `.vaws-local/`:
+
+- `.vaws-local/machine-profile.json`: the stable machine username / namespace used to derive collision-safe container names such as `vaws-alice123`
+- `.vaws-local/machine-inventory.json`: managed remote-machine records for this local clone
+
+The legacy repo-root `.machine-inventory.json` is compatibility input only.
+
 ## What `repo-init` does
 
 When invoked, `repo-init` can:
 
-1. detect the machine, shell, OS, package managers, GitHub CLI state, GitHub auth state, and current remote topology
+1. detect the machine, shell, OS, package managers, GitHub CLI state, GitHub auth state, local workspace machine profile state, and current remote topology
 2. install `gh` on macOS, Ubuntu, WSL, or Windows
 3. support headless auth flows and prefer SSH when possible
 4. initialize submodules recursively
@@ -39,7 +51,8 @@ When invoked, `repo-init` can:
    - `vllm-project/vllm-ascend`
 6. optionally create or adopt forks and wire local remotes into the recommended topology
 7. optionally sync user forks to the latest community `main`
-8. optionally place local `main` branches on the expected tracking branch for active development
+8. for broad workspace init, create the local machine profile that later machine-management will reuse
+9. optionally place local `main` branches on the expected tracking branch for active development
 
 `repo-init` is **idempotent** and **conservative**:
 - it asks before installing tools
@@ -48,24 +61,40 @@ When invoked, `repo-init` can:
 - it asks before forking repositories
 - it asks before renaming or replacing remotes
 - it asks before syncing forks or resetting branches
+- it asks before changing the local machine profile when one already exists
 
 If the developer declines any step, the skill should stop at the last safe state and report a partial but valid result.
 
+## What `machine-management` does
+
+When invoked, `machine-management` can:
+
+1. create or reuse the local workspace machine profile when repo-init was skipped
+2. bootstrap host key-based SSH with a single interactive password-authenticated step
+3. probe host prerequisites
+4. create or repair one managed host-network container per requested machine
+5. verify direct local -> container SSH and run a `torch` + `torch_npu` smoke test
+6. persist managed-machine state in local inventory
+7. mesh managed containers together on a best-effort basis
+8. remove a managed container and clean local trust state
+
+New managed containers should derive their name from the local machine profile rather than using one global shared name.
+
 ## Recommended remote topology
 
-The skill treats the following as the recommended end state, but never as a hard requirement.
+The skills treat the following as the recommended end state, but never as a hard requirement.
 
 | Repository | Recommended `origin` | Recommended `upstream` | Notes |
 | --- | --- | --- | --- |
 | workspace | user fork, if the user wants one | `maoxx241/vllm-ascend-workspace` | If the clone is already the user fork, offer to add `upstream`. |
-| `vllm` | user fork, if one exists and the user wants to use it | `vllm-project/vllm` | Community-only mode is valid. |
+| `vllm` | user fork, if one exists and the user wants it | `vllm-project/vllm` | Community-only mode is valid. |
 | `vllm-ascend` | user fork | `vllm-project/vllm-ascend` | A personal fork is recommended for PR-oriented work. |
 
 A user may keep extra remotes such as `upstream2`; `repo-init` must preserve them.
 
 ## Recommended branch placement
 
-The skill should optimize for the developer-facing state instead of preserving a detached submodule checkout forever.
+The skills should optimize for the developer-facing state instead of preserving a detached submodule checkout forever.
 
 - `workspace`: keep the current branch unless the user explicitly wants branch movement.
 - `vllm`: prefer a local `main` tracking the chosen working remote's `main`.
@@ -82,6 +111,9 @@ Example prompts for an agent:
 - “Only install GitHub CLI and log me in. Do not touch remotes.”
 - “Initialize submodules recursively and move `vllm-ascend` to my fork.”
 - “Run repo-init in community-only mode. Do not create any forks.”
+- “Configure this NPU machine for the current workspace.”
+- “Check whether the managed machine is ready.”
+- “Repair the container SSH on the managed host.”
 
 ## Repository layout
 
@@ -89,7 +121,15 @@ Example prompts for an agent:
 .
 ├── .agents/
 │   ├── README.md
+│   ├── lib/
+│   │   └── vaws_local_state.py
+│   ├── scripts/
+│   │   └── workspace_profile.py
 │   └── skills/
+│       ├── machine-management/
+│       │   ├── SKILL.md
+│       │   ├── references/
+│       │   └── scripts/
 │       └── repo-init/
 │           ├── SKILL.md
 │           ├── references/
@@ -101,5 +141,5 @@ Example prompts for an agent:
 
 ## Source of truth
 
-- Codex repo-local skills live under `.agents/skills/`.
-
+- Repo-local skills live under `.agents/skills/`.
+- Shared local-state helpers live under `.agents/lib/` and `.agents/scripts/`.


### PR DESCRIPTION
Consolidates and updates local agent skill docs/runtime files in one commit after recent scaffold alignment.

Includes updates to repo-init and machine-management SKILL docs + references, README/AGENTS tweaks, plus runtime helper scripts under .agents/lib and .agents/scripts.