### PR TITLE
Apply vaws skill fix v5

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -6,7 +6,7 @@ This directory contains the repository-local skill layer for Codex, Claude Code,
 
 - `.agents/skills/repo-init/` is the source-of-truth skill package for repository initialization.
 - `.agents/skills/machine-management/` is the source-of-truth skill package for remote machine attach, verify, repair, and removal workflows.
-- `.agents/scripts/workspace_profile.py` is the shared helper for the local workspace machine profile.
+- `.agents/scripts/workspace_profile.py` is the shared low-level helper for the local workspace machine profile.
 - `.agents/lib/vaws_local_state.py` is the shared library for untracked local runtime state.
 - `AGENTS.md` carries repository-wide routing rules and mandatory decision gates.
 
@@ -19,6 +19,7 @@ When you add or revise a helper script, keep the CLI alias-tolerant and give saf
 Current primary helpers:
 
 - `repo-init/scripts/repo_init_probe.py`
+- `repo-init/scripts/repo_init_profile.py`
 - `repo-init/scripts/repo_topology.py`
 - `machine-management/scripts/machine_add.py`
 - `machine-management/scripts/machine_verify.py`
@@ -45,6 +46,7 @@ The legacy repo-root `.machine-inventory.json` is compatibility input only and s
 Key guardrail:
 
 - on a missing machine profile, `workspace_profile.py ensure` now requires either `--username` or `--generate`
+- broad init should normally go through `repo-init/scripts/repo_init_profile.py`, which narrows the machine-username choice to: detected Git username, random `agent#####`, or custom
 - this prevents silent default usernames during broad init or first machine attach
 
 ## Maintenance rule

--- a/.agents/lib/vaws_local_state.py
+++ b/.agents/lib/vaws_local_state.py
@@ -21,7 +21,9 @@ LEGACY_INVENTORY_FILENAME = ".machine-inventory.json"
 PROFILE_SCHEMA_VERSION = 1
 CONTAINER_PREFIX = "vaws-"
 USERNAME_PATTERN = re.compile(r"^[a-z0-9]{3,32}$")
-RANDOM_ALPHABET = string.ascii_lowercase + string.digits
+RANDOM_ALPHABET = string.digits
+DEFAULT_RANDOM_PREFIX = "agent"
+DEFAULT_RANDOM_SUFFIX_LENGTH = 5
 
 ROOT = Path(__file__).resolve().parents[2]
 STATE_DIR = ROOT / STATE_DIRNAME
@@ -68,15 +70,16 @@ validate_machine_username = normalize_machine_username
 
 def generate_machine_username(
     *,
-    prefix: str = "agent",
-    suffix_length: int = 6,
+    prefix: str = DEFAULT_RANDOM_PREFIX,
+    suffix_length: int = DEFAULT_RANDOM_SUFFIX_LENGTH,
     existing: set[str] | None = None,
+    alphabet: str = RANDOM_ALPHABET,
 ) -> str:
     cleaned_prefix = "".join(ch for ch in prefix.lower() if ch.isalnum()) or "agent"
     cleaned_prefix = cleaned_prefix[: max(1, 32 - suffix_length)]
     existing = existing or set()
     for _ in range(128):
-        suffix = "".join(secrets.choice(RANDOM_ALPHABET) for _ in range(suffix_length))
+        suffix = "".join(secrets.choice(alphabet) for _ in range(suffix_length))
         candidate = f"{cleaned_prefix}{suffix}"
         if candidate not in existing and USERNAME_PATTERN.fullmatch(candidate):
             return candidate
@@ -202,6 +205,7 @@ def profile_summary(path: Path = PROFILE_PATH) -> dict[str, Any]:
         "exists": path.exists(),
         "choice_required": not path.exists(),
         "username_rules": "3-32 chars, lowercase English letters and digits only",
+        "default_generated_pattern": "agent + 5 digits",
         "machine_username": None,
         "container_name": None,
         "source": None,

--- a/.agents/skills/repo-init/SKILL.md
+++ b/.agents/skills/repo-init/SKILL.md
@@ -32,9 +32,13 @@ This skill is optional. Do not treat it as a prerequisite for unrelated work.
 - Never write secrets or user-specific remotes into tracked files.
 - Keep local runtime state only under `.vaws-local/`.
 - Prefer helper scripts in `scripts/` and `.agents/scripts/` over ad-hoc shell pipelines.
-- For a missing machine profile, never call `workspace_profile.py ensure` bare. Use either:
-  - `--username <letters-or-digits>` after the user chose a name
-  - `--generate` only after the user explicitly accepted the default/random option
+- During broad init, do not call `workspace_profile.py ensure` directly for a missing profile. Use `repo_init_profile.py`.
+- The machine-username checkpoint must use exactly three options when the profile is missing:
+  - current Git username
+  - random `agent#####`
+  - custom username
+- If the user selects custom, stop again and ask for the literal username before any mutation.
+- Never infer a custom username from `gh` login, Git remotes, or the local OS account.
 
 ## Cross-platform launcher rule
 
@@ -48,9 +52,17 @@ Start with the probe script:
 - POSIX: `python3 .agents/skills/repo-init/scripts/repo_init_probe.py --compact`
 - Windows: `py -3 .agents/skills/repo-init/scripts/repo_init_probe.py --compact`
 
-Shared profile helper:
+Public machine-profile wrapper for broad init:
+
+- `python3 .agents/skills/repo-init/scripts/repo_init_profile.py plan`
+- `python3 .agents/skills/repo-init/scripts/repo_init_profile.py apply --choice git-username`
+- `python3 .agents/skills/repo-init/scripts/repo_init_profile.py apply --choice random`
+- `python3 .agents/skills/repo-init/scripts/repo_init_profile.py apply --choice custom --custom-username <letters-or-digits>`
+
+Low-level shared profile helper, mainly for maintenance and debugging:
 
 - `python3 .agents/scripts/workspace_profile.py summary`
+- `python3 .agents/scripts/workspace_profile.py validate <letters-or-digits>`
 - `python3 .agents/scripts/workspace_profile.py ensure --username <letters-or-digits>`
 - `python3 .agents/scripts/workspace_profile.py ensure --generate`
 
@@ -73,10 +85,12 @@ After the probe and before any mutation, stop once and ask a grouped question wh
 That checkpoint must cover:
 
 1. machine username choice when `.vaws-local/machine-profile.json` is missing
-   - allowed: English letters and digits only
-   - normalize to lowercase
+   - ask exactly these three options: `git-username`, `random`, `custom`
+   - allowed usernames are English letters and digits only
+   - normalize usernames to lowercase
    - reject spaces and symbols
-   - blank / default is allowed, but only after the user explicitly says default/random is okay
+   - random mode means `agent#####`
+   - custom mode is not complete until the user provides the literal username in a second question
 2. repo topology choice
    - keep current remotes
    - recommended fork mode
@@ -108,13 +122,25 @@ Run the compact probe and summarize only the facts that matter:
 - what each repo currently uses for `origin` and `upstream`
 - whether the local machine profile exists and whether user choice is still required
 
-### 2. Stop for the decision checkpoint
+### 2. Resolve the machine-profile branch when relevant
+
+If the request is broad init and the profile is missing:
+
+- run `repo_init_profile.py plan`
+- use its fixed three-option payload for the username part of the grouped checkpoint
+- if the user chose `git-username`, run `repo_init_profile.py apply --choice git-username`
+- if the user chose `random`, run `repo_init_profile.py apply --choice random`
+- if the user chose `custom`, ask one extra free-text question and only then run `repo_init_profile.py apply --choice custom --custom-username ...`
+
+Do not silently fall back from `custom` to the detected Git username.
+
+### 3. Stop for the decision checkpoint
 
 Do not mutate in the same step as the first probe summary for broad init.
 
 If the request was just “初始化仓库” or similarly broad, do not silently assume a generated username or the recommended remotes.
 
-### 3. Apply approved changes by category
+### 4. Apply approved changes by category
 
 Typical categories:
 
@@ -126,7 +152,7 @@ Typical categories:
 - branch tracking updates
 - optional fork sync
 
-### 4. Finish compactly
+### 5. Finish compactly
 
 Report:
 

--- a/.agents/skills/repo-init/references/acceptance.md
+++ b/.agents/skills/repo-init/references/acceptance.md
@@ -38,16 +38,23 @@ A successful run should satisfy all applicable items below.
   - machine username choice if the profile is missing
   - repo topology choice
   - submodule-init choice
+- the machine-username branch uses exactly three options:
+  - `git-username`
+  - `random`
+  - `custom`
 - the skill does not silently assume a generated username for broad init
 - the skill does not silently apply the recommended topology when the user only asked for generic init
+- if the user picks `custom`, the skill asks one follow-up text question for the literal username before mutating
+- the skill does not silently replace `custom` with the detected Git username
 
 ### Local machine profile
 
 - broad workspace init reuses or creates `.vaws-local/machine-profile.json`
 - machine usernames accept English letters and digits only
 - profile creation normalizes usernames to lowercase
-- default/random creation happens only after explicit user consent
-- `workspace_profile.py ensure` on a missing profile fails unless `--username` or `--generate` is provided
+- random/default creation uses the `agent#####` format
+- `repo_init_profile.py plan` returns the fixed-choice question when the profile is missing
+- `repo_init_profile.py apply --choice custom` without `--custom-username` returns `needs_input`
 - narrow Git-only tasks do not force profile creation
 
 ### Tooling and auth
@@ -73,6 +80,8 @@ Review these files together after every substantial skill edit:
 - `.agents/skills/repo-init/references/behavior.md`
 - `.agents/skills/repo-init/references/command-recipes.md`
 - `.agents/skills/repo-init/references/acceptance.md`
+- `.agents/skills/repo-init/scripts/_profile_choice_common.py`
+- `.agents/skills/repo-init/scripts/repo_init_profile.py`
 - `.agents/skills/repo-init/scripts/repo_init_probe.py`
 - `.agents/skills/repo-init/scripts/repo_topology.py`
 - `.agents/scripts/workspace_profile.py`

--- a/.agents/skills/repo-init/references/behavior.md
+++ b/.agents/skills/repo-init/references/behavior.md
@@ -26,9 +26,9 @@ Rules:
 - create the machine profile during broad workspace init, not for every narrow Git-only task
 - machine usernames must be letters and digits only
 - normalize machine usernames to lowercase
-- blank / default is valid only after the user explicitly accepts the default/random option
+- the random/default format is `agent#####`
 - do not rewrite an existing machine profile unless the user explicitly asked for that change
-- on a missing profile, `workspace_profile.py ensure` must use either `--username` or `--generate`
+- during broad init, prefer `repo_init_profile.py` over calling `workspace_profile.py ensure` directly
 
 ## Stage model
 
@@ -58,15 +58,27 @@ That question must cover:
 - repo topology mode: keep current, recommended fork mode, or community-only
 - whether to initialize submodules now
 
-Do not silently generate a username and do not silently rewire remotes when the user only asked for generic init.
+For the machine username branch, use the fixed three-option model from `repo_init_profile.py plan`:
+
+- `git-username`
+- `random`
+- `custom`
+
+Rules:
+
+- do not silently generate a username when the user only asked for generic init
+- do not silently rewire remotes when the user only asked for generic init
+- do not treat `custom` as permission to reuse the detected Git username
+- if the user selects `custom`, stop again and ask for the literal username before any mutation
 
 ### Stage 3: ensure local machine profile when relevant
 
 During broad workspace init:
 
-- inspect the profile first with `workspace_profile.py summary`
-- if missing and the user chose a specific name, call `workspace_profile.py ensure --username ...`
-- if missing and the user explicitly accepted the default/random option, call `workspace_profile.py ensure --generate`
+- inspect the profile first with `repo_init_profile.py plan`
+- if missing and the user chose `git-username`, call `repo_init_profile.py apply --choice git-username`
+- if missing and the user explicitly accepted the default/random option, call `repo_init_profile.py apply --choice random`
+- if missing and the user chose `custom`, first ask for the literal username, then call `repo_init_profile.py apply --choice custom --custom-username ...`
 - do not change an existing profile unless the user explicitly asked to change it
 
 For narrow Git-only tasks, skip this stage.
@@ -128,6 +140,7 @@ gh repo sync USER/REPO --source OWNER/REPO
 A successful run usually ends with:
 
 - the local machine profile present when broad init asked for it
+- the machine-profile branch used one of the fixed choices: `git-username`, `random`, or `custom`
 - `gh` installed or a fallback provided
 - GitHub auth valid
 - recursive submodules initialized when the user approved it

--- a/.agents/skills/repo-init/references/command-recipes.md
+++ b/.agents/skills/repo-init/references/command-recipes.md
@@ -16,7 +16,33 @@ Windows:
 py -3 .agents/skills/repo-init/scripts/repo_init_probe.py --compact
 ```
 
-## Local machine profile
+## Broad-init machine profile
+
+Get the exact three-option machine-username question:
+
+```bash
+python3 .agents/skills/repo-init/scripts/repo_init_profile.py plan
+```
+
+Apply the Git-username option:
+
+```bash
+python3 .agents/skills/repo-init/scripts/repo_init_profile.py apply --choice git-username
+```
+
+Apply the random `agent#####` option:
+
+```bash
+python3 .agents/skills/repo-init/scripts/repo_init_profile.py apply --choice random
+```
+
+Apply the custom option after the user gave the literal username:
+
+```bash
+python3 .agents/skills/repo-init/scripts/repo_init_profile.py apply --choice custom --custom-username alice123
+```
+
+## Low-level profile helper
 
 Validate one user-provided name:
 
@@ -24,16 +50,10 @@ Validate one user-provided name:
 python3 .agents/scripts/workspace_profile.py validate alice123
 ```
 
-Create a specific profile after the user chose a name:
+Read the current profile summary:
 
 ```bash
-python3 .agents/scripts/workspace_profile.py ensure --username alice123
-```
-
-Create a default/random profile only after the user explicitly accepted that option:
-
-```bash
-python3 .agents/scripts/workspace_profile.py ensure --generate
+python3 .agents/scripts/workspace_profile.py summary
 ```
 
 ## Submodules
@@ -56,25 +76,17 @@ python3 .agents/skills/repo-init/scripts/repo_topology.py compare-main --repo vl
 Workspace example:
 
 ```bash
-python3 .agents/skills/repo-init/scripts/repo_topology.py configure \
-  --repo . \
-  --origin-url git@github.com:USER/vllm-ascend-workspace.git \
-  --upstream-url git@github.com:maoxx241/vllm-ascend-workspace.git
+python3 .agents/skills/repo-init/scripts/repo_topology.py configure   --repo .   --origin-url git@github.com:USER/vllm-ascend-workspace.git   --upstream-url git@github.com:maoxx241/vllm-ascend-workspace.git
 ```
 
 `vllm-ascend` example:
 
 ```bash
-python3 .agents/skills/repo-init/scripts/repo_topology.py configure \
-  --repo vllm-ascend \
-  --origin-url git@github.com:USER/vllm-ascend.git \
-  --upstream-url git@github.com:vllm-project/vllm-ascend.git
+python3 .agents/skills/repo-init/scripts/repo_topology.py configure   --repo vllm-ascend   --origin-url git@github.com:USER/vllm-ascend.git   --upstream-url git@github.com:vllm-project/vllm-ascend.git
 ```
 
 ## Branch tracking
 
 ```bash
-python3 .agents/skills/repo-init/scripts/repo_topology.py ensure-main \
-  --repo vllm-ascend \
-  --remote origin
+python3 .agents/skills/repo-init/scripts/repo_topology.py ensure-main   --repo vllm-ascend   --remote origin
 ```

--- a/.agents/skills/repo-init/scripts/_profile_choice_common.py
+++ b/.agents/skills/repo-init/scripts/_profile_choice_common.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Shared machine-username choice helpers for repo-init.
+
+This module keeps the repo-init machine-profile question narrow and stable.
+The public repo-init flow should present exactly three options:
+- use the detected Git / GitHub username
+- generate a random ``agent#####`` username
+- let the user provide a custom username
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+LIB_DIR = pathlib.Path(__file__).resolve().parents[3] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_local_state import (  # noqa: E402
+    WorkspaceStateError,
+    generate_machine_username,
+    validate_machine_username,
+)
+
+REMOTE_PATTERNS = [
+    r"^git@github\.com:(?P<owner>[^/]+)/(?P<repo>[^/.]+?)(?:\.git)?$",
+    r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/.]+?)(?:\.git)?$",
+    r"^ssh://git@github\.com/(?P<owner>[^/]+)/(?P<repo>[^/.]+?)(?:\.git)?$",
+]
+
+
+def run(cmd: list[str], cwd: pathlib.Path | None = None) -> tuple[int, str, str]:
+    if cmd and cmd[0] == "git":
+        cmd = ["git", "-c", "safe.directory=*", *cmd[1:]]
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def which(name: str) -> str | None:
+    return shutil.which(name)
+
+
+def parse_remote_url(url: str) -> str | None:
+    for pattern in REMOTE_PATTERNS:
+        match = re.match(pattern, url)
+        if match:
+            return f"{match.group('owner')}/{match.group('repo')}"
+    return None
+
+
+def _normalize_candidate(value: str | None) -> str | None:
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        return validate_machine_username(value)
+    except WorkspaceStateError:
+        return None
+
+
+def _candidate_from_gh() -> dict[str, Any] | None:
+    if which("gh") is None:
+        return None
+    rc, _, _ = run(["gh", "auth", "status", "--hostname", "github.com"])
+    if rc != 0:
+        return None
+    rc, login, _ = run(["gh", "api", "user", "--jq", ".login"])
+    if rc != 0:
+        return None
+    candidate = _normalize_candidate(login)
+    if candidate is None:
+        return None
+    return {
+        "available": True,
+        "candidate": candidate,
+        "source": "gh-user-login",
+        "raw_value": login,
+    }
+
+
+def _candidate_from_origin(cwd: pathlib.Path | None = None) -> dict[str, Any] | None:
+    rc, origin_url, _ = run(["git", "remote", "get-url", "origin"], cwd=cwd)
+    if rc != 0 or not origin_url:
+        return None
+    repo = parse_remote_url(origin_url)
+    if repo is None:
+        return None
+    owner, _, _ = repo.partition("/")
+    candidate = _normalize_candidate(owner)
+    if candidate is None:
+        return None
+    return {
+        "available": True,
+        "candidate": candidate,
+        "source": "origin-owner",
+        "raw_value": owner,
+        "origin_repo": repo,
+    }
+
+
+def _candidate_from_git_config(cwd: pathlib.Path | None = None) -> dict[str, Any] | None:
+    rc, user_name, _ = run(["git", "config", "--get", "user.name"], cwd=cwd)
+    if rc == 0 and user_name:
+        candidate = _normalize_candidate(user_name)
+        if candidate is not None:
+            return {
+                "available": True,
+                "candidate": candidate,
+                "source": "git-config-user-name",
+                "raw_value": user_name,
+            }
+
+    rc, user_email, _ = run(["git", "config", "--get", "user.email"], cwd=cwd)
+    if rc == 0 and user_email:
+        local_part = user_email.split("@", 1)[0]
+        candidate = _normalize_candidate(local_part)
+        if candidate is not None:
+            return {
+                "available": True,
+                "candidate": candidate,
+                "source": "git-config-user-email-local-part",
+                "raw_value": user_email,
+            }
+    return None
+
+
+def detect_git_username_candidate(cwd: pathlib.Path | None = None) -> dict[str, Any]:
+    for resolver in (_candidate_from_gh, lambda: _candidate_from_origin(cwd), lambda: _candidate_from_git_config(cwd)):
+        result = resolver()
+        if result is not None:
+            return result
+    return {
+        "available": False,
+        "candidate": None,
+        "source": None,
+        "raw_value": None,
+    }
+
+
+def random_username_preview() -> str:
+    return generate_machine_username(prefix="agent", suffix_length=5)
+
+
+def fixed_machine_username_question(cwd: pathlib.Path | None = None) -> dict[str, Any]:
+    git_username = detect_git_username_candidate(cwd)
+    random_preview = random_username_preview()
+
+    git_description = (
+        f"使用当前检测到的 Git 用户名 {git_username['candidate']}"
+        if git_username["available"]
+        else "当前没有检测到可用的 Git 用户名；若选择此项，必须先让 agent 修复或确认 Git / GitHub 身份"
+    )
+
+    return {
+        "question": "你希望这台开发机使用哪个机器用户名？",
+        "mode": "single-choice",
+        "rules": "3-32 chars, lowercase English letters and digits only",
+        "fixed_options_only": True,
+        "followup_required_for": ["custom"],
+        "followup_question": "请输入你想使用的机器用户名（仅限英文和数字，3-32 位）",
+        "options": [
+            {
+                "id": "git-username",
+                "label": (
+                    f"使用当前 Git 用户名（{git_username['candidate']}）"
+                    if git_username["available"]
+                    else "使用当前 Git 用户名"
+                ),
+                "description": git_description,
+                "available": git_username["available"],
+                "candidate": git_username["candidate"],
+                "source": git_username["source"],
+            },
+            {
+                "id": "random",
+                "label": f"随机生成（{random_preview}）",
+                "description": "生成 agent + 5 位数字的用户名",
+                "available": True,
+                "pattern": "agent#####",
+            },
+            {
+                "id": "custom",
+                "label": "自定义",
+                "description": "用户输入什么就用什么；仅接受英文字母和数字。选择此项后必须再问一次具体用户名。",
+                "available": True,
+                "requires_followup_text": True,
+            },
+        ],
+    }

--- a/.agents/skills/repo-init/scripts/repo_init_probe.py
+++ b/.agents/skills/repo-init/scripts/repo_init_probe.py
@@ -30,6 +30,11 @@ if str(LIB_DIR) not in sys.path:
 
 from vaws_local_state import profile_summary  # noqa: E402
 
+from _profile_choice_common import (  # noqa: E402
+    detect_git_username_candidate,
+    fixed_machine_username_question,
+)
+
 COMMUNITY = {
     "workspace": "maoxx241/vllm-ascend-workspace",
     "vllm": "vllm-project/vllm",
@@ -44,6 +49,8 @@ REPO_PATHS = {
 
 
 def run(cmd: List[str], cwd: Optional[pathlib.Path] = None) -> Tuple[int, str, str]:
+    if cmd and cmd[0] == "git":
+        cmd = ["git", "-c", "safe.directory=*", *cmd[1:]]
     proc = subprocess.run(
         cmd,
         cwd=str(cwd) if cwd else None,
@@ -494,6 +501,10 @@ def compact_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     gh = payload.get("gh") or {}
     profile = payload.get("workspace_profile") or {}
     compact_submodules = compact_submodule_summary(payload.get("submodules") or [])
+    repo_root_value = payload.get("repo_root")
+    repo_root = pathlib.Path(repo_root_value) if isinstance(repo_root_value, str) and repo_root_value else None
+    machine_username_question = fixed_machine_username_question(repo_root)
+    detected_git_username = detect_git_username_candidate(repo_root)
     compact: Dict[str, Any] = {
         "platform": {
             "kind": payload.get("platform", {}).get("kind"),
@@ -504,6 +515,7 @@ def compact_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
             "exists": profile.get("exists"),
             "choice_required": profile.get("choice_required"),
             "username_rules": profile.get("username_rules"),
+            "default_generated_pattern": profile.get("default_generated_pattern"),
             "machine_username": profile.get("machine_username"),
             "container_name": profile.get("container_name"),
             "source": profile.get("source"),
@@ -529,8 +541,12 @@ def compact_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
             "machine_username": {
                 "required": bool(profile.get("choice_required")),
                 "username_rules": profile.get("username_rules"),
+                "default_generated_pattern": profile.get("default_generated_pattern"),
                 "default_random_allowed": True,
                 "default_random_requires_explicit_user_consent": True,
+                "fixed_options_only": True,
+                "detected_git_username": detected_git_username,
+                "question_template": machine_username_question,
             },
             "repo_topology": {
                 "required": True,

--- a/.agents/skills/repo-init/scripts/repo_init_profile.py
+++ b/.agents/skills/repo-init/scripts/repo_init_profile.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Agent-facing machine-profile workflow for repo-init.
+
+Prefer this wrapper during broad init instead of calling workspace_profile.py
+and inferring a username ad hoc from surrounding context.
+
+All outputs are JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+from typing import Any, Sequence
+
+LIB_DIR = pathlib.Path(__file__).resolve().parents[3] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_local_state import (  # noqa: E402
+    WorkspaceStateError,
+    ensure_profile,
+    load_profile,
+    profile_summary,
+    validate_machine_username,
+)
+
+from _profile_choice_common import detect_git_username_candidate, fixed_machine_username_question  # noqa: E402
+
+
+Status = str
+
+
+def print_json(data: dict[str, Any]) -> None:
+    print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def status_payload(
+    status: Status,
+    *,
+    success: bool,
+    action: str,
+    message: str | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "success": success,
+        "status": status,
+        "action": action,
+    }
+    if message is not None:
+        payload["message"] = message
+    payload.update(extra)
+    return payload
+
+
+def existing_profile_payload() -> dict[str, Any]:
+    summary = profile_summary()
+    return status_payload(
+        "ready",
+        success=True,
+        action="existing",
+        message="local machine profile already exists; broad init should reuse it unless the user explicitly asked to change it",
+        profile=summary,
+    )
+
+
+def needs_choice_payload(cwd: pathlib.Path | None = None) -> dict[str, Any]:
+    summary = profile_summary()
+    return status_payload(
+        "needs_input",
+        success=False,
+        action="choose-machine-username",
+        message="local machine profile is missing; ask exactly one fixed-choice question before continuing broad init",
+        profile=summary,
+        question=fixed_machine_username_question(cwd),
+    )
+
+
+def cmd_plan(args: argparse.Namespace) -> int:
+    summary = profile_summary()
+    if summary["exists"]:
+        print_json(existing_profile_payload())
+        return 0
+    print_json(needs_choice_payload(pathlib.Path.cwd()))
+    return 0
+
+
+def _create_profile_from_choice(choice: str, custom_username: str | None, cwd: pathlib.Path | None = None) -> dict[str, Any]:
+    if choice == "git-username":
+        detected = detect_git_username_candidate(cwd)
+        if not detected["available"] or not detected["candidate"]:
+            return status_payload(
+                "blocked",
+                success=False,
+                action="git-username-unavailable",
+                message="the Git username option is not currently available; choose random/custom or establish Git / GitHub identity first",
+                detected_git_username=detected,
+                profile=profile_summary(),
+                question=fixed_machine_username_question(cwd),
+            )
+        profile, action = ensure_profile(machine_username=detected["candidate"], allow_update=False, generate=False)
+        return status_payload(
+            "ready",
+            success=True,
+            action=action,
+            message="created the local machine profile from the detected Git username",
+            selection={
+                "choice": choice,
+                "machine_username": detected["candidate"],
+                "source": detected["source"],
+            },
+            profile={
+                **profile_summary(),
+                "machine_username": profile["machine_username"],
+                "container_name": profile["container_name"],
+                "source": profile.get("source"),
+            },
+        )
+
+    if choice == "random":
+        profile, action = ensure_profile(machine_username=None, allow_update=False, generate=True)
+        return status_payload(
+            "ready",
+            success=True,
+            action=action,
+            message="created the local machine profile with a random agent##### username",
+            selection={
+                "choice": choice,
+                "machine_username": profile["machine_username"],
+                "pattern": "agent#####",
+            },
+            profile={
+                **profile_summary(),
+                "machine_username": profile["machine_username"],
+                "container_name": profile["container_name"],
+                "source": profile.get("source"),
+            },
+        )
+
+    if custom_username is None:
+        return status_payload(
+            "needs_input",
+            success=False,
+            action="await-custom-machine-username",
+            message="custom mode was selected; ask one follow-up question for the literal username before mutating anything",
+            missing={
+                "name": "custom_machine_username",
+                "rules": profile_summary()["username_rules"],
+                "question": "请输入你想使用的机器用户名（仅限英文和数字，3-32 位）",
+            },
+            question=fixed_machine_username_question(cwd),
+        )
+
+    try:
+        normalized = validate_machine_username(custom_username)
+    except WorkspaceStateError as exc:
+        return status_payload(
+            "needs_input",
+            success=False,
+            action="invalid-custom-machine-username",
+            message=str(exc),
+            invalid_input=custom_username,
+            missing={
+                "name": "custom_machine_username",
+                "rules": profile_summary()["username_rules"],
+                "question": "请输入你想使用的机器用户名（仅限英文和数字，3-32 位）",
+            },
+            question=fixed_machine_username_question(cwd),
+        )
+
+    profile, action = ensure_profile(machine_username=normalized, allow_update=False, generate=False)
+    return status_payload(
+        "ready",
+        success=True,
+        action=action,
+        message="created the local machine profile from the explicit custom username",
+        selection={
+            "choice": choice,
+            "machine_username": normalized,
+        },
+        profile={
+            **profile_summary(),
+            "machine_username": profile["machine_username"],
+            "container_name": profile["container_name"],
+            "source": profile.get("source"),
+        },
+    )
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    current = load_profile()
+    if current is not None:
+        print_json(existing_profile_payload())
+        return 0
+
+    payload = _create_profile_from_choice(
+        choice=args.choice,
+        custom_username=args.custom_username,
+        cwd=pathlib.Path.cwd(),
+    )
+    print_json(payload)
+    return 0 if payload.get("success") else 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    plan = subparsers.add_parser("plan", help="summarize the exact machine-username choices for broad init")
+    plan.set_defaults(func=cmd_plan)
+
+    apply = subparsers.add_parser("apply", help="materialize one approved machine-username choice")
+    apply.add_argument(
+        "--choice",
+        required=True,
+        choices=["git-username", "random", "custom"],
+        help="approved fixed-choice username mode",
+    )
+    apply.add_argument(
+        "--custom-username",
+        help="required only when --choice custom; letters and digits only",
+    )
+    apply.set_defaults(func=cmd_apply)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except WorkspaceStateError as exc:
+        print_json(status_payload("blocked", success=False, action="failed", message=str(exc)))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/repo-init/scripts/repo_topology.py
+++ b/.agents/skills/repo-init/scripts/repo_topology.py
@@ -34,8 +34,11 @@ def run(
     check: bool = False,
     quiet: bool = False,
 ) -> subprocess.CompletedProcess[str]:
+    command = list(cmd)
+    if command and command[0] == "git":
+        command = ["git", "-c", "safe.directory=*", *command[1:]]
     proc = subprocess.run(
-        list(cmd),
+        command,
         cwd=str(cwd) if cwd else None,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,9 @@ Both skills are optional. Do not force them as a gate before normal coding, docs
   - machine username choice for broad init when the profile is missing
   - repo topology choice: keep current, recommended fork mode, or community-only
   - whether to initialize submodules now
+- For a missing broad-init machine profile, prefer `.agents/skills/repo-init/scripts/repo_init_profile.py` over calling `workspace_profile.py` directly.
+- The broad-init machine-username question should use exactly three options: detected Git username, random `agent#####`, or custom. If the user picks custom, ask one more text question and wait for the literal username before mutating.
+- Never treat a custom selection as permission to reuse the detected Git username.
 - During `machine-management`, if host key SSH is missing and the user already supplied the host password in the request, prefer a one-shot scripted bootstrap first. Do not immediately bounce the user to a manual terminal command.
 
 ## Skill routing


### PR DESCRIPTION
Apply the provided vaws-skill-fix-v5 patch for repo-init workflow refinements: add repo_init_profile entrypoint, enforce three-option machine username flow in broad init, and align local-state/defaults for numeric suffix username generation.