### PR TITLE
Apply remote code parity current repo patch

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -6,6 +6,7 @@ This directory contains the repository-local skill layer for Codex, Claude Code,
 
 - `.agents/skills/repo-init/` is the source-of-truth skill package for repository initialization.
 - `.agents/skills/machine-management/` is the source-of-truth skill package for remote machine attach, verify, repair, and removal workflows.
+- `.agents/skills/remote-code-parity/` is the source-of-truth skill package for remote code parity before remote execution.
 - `.agents/scripts/workspace_profile.py` is the shared low-level helper for the local workspace machine profile.
 - `.agents/lib/vaws_local_state.py` is the shared library for untracked local runtime state.
 - `AGENTS.md` carries repository-wide routing rules and mandatory decision gates.
@@ -25,6 +26,9 @@ Current primary helpers:
 - `machine-management/scripts/machine_verify.py`
 - `machine-management/scripts/machine_repair.py`
 - `machine-management/scripts/machine_remove.py`
+- `remote-code-parity/scripts/remote_code_parity.py`
+- `remote-code-parity/scripts/install_consent.py`
+- `remote-code-parity/scripts/gc_runtime_cache.py`
 - `../scripts/workspace_profile.py`
 
 Low-level machine-management helpers remain available for implementation work and debugging:
@@ -40,6 +44,8 @@ Untracked workspace-local state lives under `.vaws-local/`:
 
 - `.vaws-local/machine-profile.json`
 - `.vaws-local/machine-inventory.json`
+- `.vaws-local/remote-code-parity/install-consents.json`
+- `.vaws-local/remote-code-parity/runtime-state.json`
 
 The legacy repo-root `.machine-inventory.json` is compatibility input only and should not be reintroduced as the primary path.
 
@@ -64,5 +70,12 @@ If you change `machine-management`, update these together:
 - `.agents/skills/machine-management/references/`
 - `.agents/skills/machine-management/scripts/`
 - shared helpers when the workflow depends on local profile or inventory state
+
+If you change `remote-code-parity`, update these together:
+
+- `.agents/skills/remote-code-parity/SKILL.md`
+- `.agents/skills/remote-code-parity/references/`
+- `.agents/skills/remote-code-parity/scripts/`
+- `AGENTS.md` and this file when routing or local-state behavior changes
 
 Keep the files under `.agents/skills/` as the canonical supporting files for repo-local skills.

--- a/.agents/skills/remote-code-parity/SKILL.md
+++ b/.agents/skills/remote-code-parity/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: remote-code-parity
+description: Ensure a ready remote runtime runs the exact current local workspace state before any remote smoke, service launch, or benchmark. Use automatically immediately before remote execution when SCP is unavailable and local uncommitted changes must be reflected remotely. Do not use for initial machine attach, generic Git topology work, or unrelated local-only coding.
+---
+
+# Remote Code Parity
+
+Keep a **ready** remote runtime in exact code parity with the local `vllm-ascend-workspace` checkout.
+
+## Use this skill when
+
+- a remote smoke, service launch, or benchmark is about to start
+- `machine-management` already proved host SSH and direct local -> container SSH by key
+- the request depends on local uncommitted changes, untracked files, or ignored-but-allowed files
+- `scp` is unavailable or disallowed
+- the user expects “run the latest local code remotely” rather than “run the latest pushed commit remotely”
+
+## Do not use this skill when
+
+- the main task is adding or repairing a machine, SSH, or container bootstrap
+- the task is generic fork / remote topology setup
+- the task is ordinary local coding with no remote execution
+- the runtime cannot yet accept direct key-based login
+- the user only wants a Git commit, push, or PR
+
+## Critical rules
+
+- Treat the **local working tree** as the source of truth: committed + staged + unstaged + untracked.
+- Do **not** require the user to commit or push before parity.
+- Do **not** use `scp`, `sftp`, `rsync`, `sshpass`, or `expect`.
+- Do **not** require GitHub credentials on the remote host or in the container.
+- Prefer **host-local bare mirror repos** over push-to-GitHub / pull-from-GitHub.
+- Use synthetic snapshot refs so dirty working trees can be mirrored through Git transport.
+- Keep remote cache / lock / manifest / log paths isolated by `workspace_id`.
+- Reuse the first validated `storage_root` for a given host unless it becomes invalid.
+- Reject shared or undersized storage roots.
+- Fail closed if parity cannot be proven.
+- First replacement of image-provided `vllm` / `vllm-ascend` inside a container requires explicit user consent for that **container identity**.
+- Once the user approved reinstall for a given container identity, later parity runs on the same container do not ask again.
+- Keep local runtime state only under `.vaws-local/remote-code-parity/`.
+
+## Preconditions
+
+This skill assumes an upper skill already proved:
+
+- host SSH works by key
+- container SSH works by key
+- the runtime root path is known
+- recursive submodules are initialized and populated
+- the target machine / container is the intended execution target
+
+If any of those are still uncertain, stop and route back to `machine-management` or `repo-init`.
+
+## Local state
+
+Keep local untracked state here:
+
+- `.vaws-local/remote-code-parity/install-consents.json`
+- `.vaws-local/remote-code-parity/runtime-state.json`
+
+Recommended remote host cache layout under `storage_root`:
+
+- `remote-code-parity/workspaces/<workspace_id>/mirrors/`
+- `remote-code-parity/workspaces/<workspace_id>/locks/`
+- `remote-code-parity/workspaces/<workspace_id>/manifests/`
+- `remote-code-parity/workspaces/<workspace_id>/logs/`
+
+## Cross-platform launcher rule
+
+- macOS / Linux / WSL: `python3 ...`
+- Windows: `py -3 ...`
+
+Remote host and runtime commands in this skill assume Linux shells.
+
+## Script-first entry points
+
+Primary orchestration:
+
+- POSIX: `python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py plan ...`
+- POSIX: `python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py sync ...`
+- Windows: `py -3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py plan ...`
+- Windows: `py -3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py sync ...`
+
+Consent helper:
+
+- POSIX: `python3 .agents/skills/remote-code-parity/scripts/install_consent.py resolve ...`
+- POSIX: `python3 .agents/skills/remote-code-parity/scripts/install_consent.py set ...`
+- POSIX: `python3 .agents/skills/remote-code-parity/scripts/install_consent.py batch-set --input FILE.json`
+
+Cache cleanup helper:
+
+- POSIX: `python3 .agents/skills/remote-code-parity/scripts/gc_runtime_cache.py --storage-root ... --workspace-id ...`
+
+Reference files:
+
+- `.agents/skills/remote-code-parity/references/behavior.md`
+- `.agents/skills/remote-code-parity/references/command-recipes.md`
+- `.agents/skills/remote-code-parity/references/acceptance.md`
+
+## Workflow
+
+### 1. Confirm scope and preconditions
+
+Collect:
+
+- `workspace_root`
+- `workspace_id`
+- host SSH endpoint
+- container SSH endpoint
+- runtime root inside the container
+- container identity
+- either a known `storage_root` or a probe candidate list
+
+Stop if the request is not actually about an imminent remote execution.
+
+### 2. Resolve `storage_root`
+
+Rules:
+
+- if local state already records a validated `storage_root` for the host, reuse it
+- otherwise probe candidates on the host and select the first path that is:
+  - writable
+  - not on a rejected shared filesystem type
+  - above the hard free-space threshold
+- persist the chosen `storage_root` locally for future parity runs
+
+Thresholds:
+
+- hard fail below **512 MiB**
+- for a first-time uninstall + editable reinstall, fail below **4 GiB**
+
+### 3. Capture synthetic snapshot refs
+
+Create synthetic Git commits for the workspace repo and nested submodules in **postorder**:
+
+1. leaf submodules first
+2. then parent submodules
+3. workspace root last
+
+For each repo:
+
+- build a temporary index from `HEAD`
+- stage the full current working tree with `git add -A -f`
+- exclude local-only denylist paths
+- replace child submodule gitlinks with the child synthetic snapshot commit ids
+- write a synthetic commit
+
+This is the key step that allows Git transport to represent dirty working trees.
+
+### 4. Publish mirrors to the host
+
+For each repo in scope:
+
+- ensure the host-local bare mirror repo exists under `storage_root`
+- push the synthetic commit to a stable parity ref such as `refs/parity/<workspace_id>/current`
+- write a compact manifest for this sync attempt under `manifests/`
+
+Preferred scope:
+
+- workspace root
+- `vllm/`
+- `vllm-ascend/`
+- recursive nested populated submodules if discovered
+
+### 5. Materialize the mirrors inside the runtime container
+
+Inside the container:
+
+- fetch each repo from the host-local mirror path
+- force the runtime repo to the synthetic parity ref
+- rewrite submodule URLs to local mirror paths
+- initialize / update submodules against those mirror paths
+- ensure the checked-out commits match the manifest
+
+Do not claim success before the container-side commit ids match the snapshot manifest.
+
+### 6. Handle first-time runtime replacement
+
+If this container identity has never been approved:
+
+- resolve the consent state from `.vaws-local/remote-code-parity/install-consents.json`
+- if there is no `allow`, stop with `status == blocked`
+- do **not** silently continue with the image-provided packages
+
+If the user already approved this container identity:
+
+- best-effort uninstall image-provided `vllm` / `vllm-ascend`
+- rebuild/install from the mirrored runtime tree
+
+Use these commands inside the container when required:
+
+### `vllm`
+
+```bash
+export VLLM_TARGET_DEVICE=empty
+pip install -e . --no-build-isolation
+```
+
+### `vllm-ascend`
+
+```bash
+pip install -r requirements.txt
+pip install -v -e . --no-build-isolation
+```
+
+Default environment preamble before install / import smoke:
+
+```bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh 2>/dev/null || true
+source /usr/local/Ascend/nnal/atb/set_env.sh 2>/dev/null || true
+source /vllm-workspace/vllm-ascend/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/bin/set_env.bash 2>/dev/null || true
+export PATH=/usr/local/python3.11.14/bin:$PATH
+export PYTHON=/usr/local/python3.11.14/bin/python3
+export PIP=/usr/local/python3.11.14/bin/pip
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export OMP_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+```
+
+### 7. Reinstall trigger matrix after first install
+
+After the first approved replacement, reinstall only when matching paths changed.
+
+Conservative defaults:
+
+- `vllm`: `requirements*`, `pyproject.toml`, `setup.*`, `CMake*`, `cmake/**`, `csrc/**`, and common native-source suffixes
+- `vllm-ascend`: same as `vllm`, plus `vllm_ascend/_cann_ops_custom/**`
+- pure Python, docs, configs, tests, and ordinary scripts: parity only, no rebuild
+
+### 8. Finish with proof, not assumptions
+
+Return a compact JSON summary that includes:
+
+- final `status`
+- `storage_root` used
+- synthetic snapshot commit ids
+- observed runtime commit ids
+- whether reinstall ran or was blocked
+- the reason when the skill stopped early
+
+Success means `status == ready` and runtime commit ids match the synthetic snapshot ids exactly.

--- a/.agents/skills/remote-code-parity/references/acceptance.md
+++ b/.agents/skills/remote-code-parity/references/acceptance.md
@@ -1,0 +1,90 @@
+# Remote-code-parity acceptance criteria
+
+## Trigger examples
+
+These should trigger `remote-code-parity` directly or as an automatic internal step:
+
+- “同步远端代码后再拉服务，包含我本地没 commit 的改动。”
+- “在 ready 的蓝区机器上启动 benchmark 前，确保跑的是我本地最新修改。”
+- “这台机器已经 ready 了，先把我本地 workspace 的最新改动同步进去再跑 smoke。”
+- “这个容器是新的，先批量确认允许第一次 editable install，再同步代码。”
+
+## Non-trigger examples
+
+These should not trigger `remote-code-parity` unless remote code parity is the obvious blocker:
+
+- “帮我配置一台远端 NPU 机器。”
+- “修一下这台机器的 SSH 和容器 ready。”
+- “只帮我把 remotes 配好并初始化 submodules。”
+- “把我本地这几个改动 commit 然后推到 GitHub。”
+- “解释一下这段代码。”
+
+## Success criteria
+
+### Universal
+
+- the skill treats the local working tree as the source of truth, including committed, staged, unstaged, and untracked files
+- the skill does not require the user to commit or push before parity
+- the skill does not use `scp`, `sftp`, `rsync`, `sshpass`, or `expect`
+- the skill does not require GitHub credentials on the remote host or in the container
+- the skill keeps local runtime state only under `.vaws-local/remote-code-parity/`
+- normal outcomes are reported as compact JSON with `status` equal to `ready`, `blocked`, or `failed`
+
+### Repo graph and snapshotting
+
+- the workspace root, `vllm/`, and `vllm-ascend/` all participate in parity
+- synthetic snapshots can represent dirty working trees without forcing a real commit
+- when `vllm` or `vllm-ascend` changed locally, the workspace-root synthetic snapshot also changes because the gitlinks are rewritten to the synthetic child commits
+- ignored-but-allowed files can be included in the snapshot
+- denylisted files such as `.vaws-local/*`, `.env*`, and local cache directories are excluded
+- if a required submodule path exists but is not populated, the skill fails closed with a clear error instead of producing a traceback-heavy Git failure
+
+### Consent and first install
+
+- first sync on a fresh container without recorded approval ends with `status == blocked`
+- first sync on a fresh container with `allow` recorded proceeds to uninstall image-provided packages best-effort and perform editable installs
+- later syncs on the same container do not ask again unless the container identity changed
+- batch approval supports mixed decisions across different servers or containers
+- a rebuilt or recreated container with a new identity requires consent again
+
+### Storage-root selection
+
+- if local state already records a validated `storage_root` for the server, the skill reuses it
+- if no `storage_root` is known yet, the skill can probe candidate paths and select the first acceptable one
+- shared filesystems such as NFS, CIFS, SSHFS, Lustre, Ceph, and GlusterFS are rejected
+- paths below 512 MiB free space fail closed before mirror publication
+- first editable reinstall below 4 GiB free space fails closed before runtime mutation
+
+### Runtime materialization and proof
+
+- the host-local bare mirrors are updated before the container fetches them
+- the runtime tree inside the container is forced to the synthetic snapshot commits rather than to a branch tip from GitHub
+- final `git rev-parse HEAD` values inside the container match the synthetic snapshot commits exactly
+- reinstall runs only when the trigger matrix says it should, except for the mandatory first approved replacement on a fresh container
+- a successful run ends with `status == ready`
+
+## Regression checklist from this patch
+
+These specific mistakes should no longer be part of the normal path:
+
+- Python helper files should not start with an extra leading backslash before the shebang
+- `command-recipes.md` should not tell the agent to pass unsupported `plan` arguments such as host or container SSH fields
+- repeated `plan` or `sync` runs should not accumulate unbounded local temporary parity refs
+- temporary parity index files should be cleaned up after snapshot construction
+- missing or unpopulated required submodules should return a compact failure payload instead of a raw `git add` traceback
+
+## Manual regression checklist
+
+Review these files together after every substantial skill edit:
+
+- `.agents/skills/remote-code-parity/SKILL.md`
+- `.agents/skills/remote-code-parity/references/behavior.md`
+- `.agents/skills/remote-code-parity/references/command-recipes.md`
+- `.agents/skills/remote-code-parity/references/acceptance.md`
+- `.agents/skills/remote-code-parity/scripts/common.py`
+- `.agents/skills/remote-code-parity/scripts/remote_code_parity.py`
+- `.agents/skills/remote-code-parity/scripts/install_consent.py`
+- `.agents/skills/remote-code-parity/scripts/gc_runtime_cache.py`
+- `AGENTS.md`
+- `.agents/README.md`
+- `README.md`

--- a/.agents/skills/remote-code-parity/references/behavior.md
+++ b/.agents/skills/remote-code-parity/references/behavior.md
@@ -1,0 +1,260 @@
+# Remote-code-parity behavior reference
+
+This file defines the durable behavior of `remote-code-parity`.
+
+## Core contract
+
+- Treat the local working tree as the source of truth.
+- Use Git transport without requiring a real user commit.
+- Prefer host-local bare mirror repos over push-to-GitHub / pull-from-GitHub.
+- Keep all local parity state under `.vaws-local/remote-code-parity/`.
+- Fail closed when parity cannot be proven.
+- Prove the final container-side commit ids instead of trusting command exit status alone.
+
+## Scope and routing
+
+`remote-code-parity` is an internal execution skill. End users should not need to learn `sync`, `session`, or `fleet` vocabulary.
+
+Intended route:
+
+1. `machine-management` proves host + container reachability and key-based login.
+2. `remote-code-parity` proves code and runtime package parity.
+3. a higher-level serving / benchmark / smoke workflow executes the requested workload.
+
+## Preconditions
+
+Before this skill mutates anything remotely, confirm all of these:
+
+- the target host already accepts key-based SSH
+- the target container already accepts direct local -> container key-based SSH
+- the runtime root inside the container is known
+- the workspace submodules are initialized and populated
+- the target machine / container is already the intended execution target
+
+If a required submodule path exists but is not a populated Git worktree, fail closed with a clear instruction to initialize submodules first.
+
+## Why synthetic snapshots exist
+
+A plain `git push HEAD` is not enough because it misses:
+
+- staged-but-uncommitted changes
+- unstaged changes
+- untracked files
+- ignored-but-allowed local runtime inputs
+
+The load-bearing trick is to create synthetic commits from the local working tree without forcing the user to make a real commit. Git remains the transport layer, but the exported commit represents the live working tree rather than the checked-in branch tip.
+
+## Default repo scope
+
+Default scope is:
+
+- workspace root
+- `vllm/`
+- `vllm-ascend/`
+- recursively discovered nested populated submodules
+
+Why:
+
+- the workspace root carries gitlinks
+- `vllm` and `vllm-ascend` are both execution inputs
+- nested submodules can otherwise drift to commits the parent snapshot cannot materialize
+
+If recursive discovery finds an unpopulated child, fail closed. Do not silently ignore it.
+
+## Recommended denylist
+
+Ignored files are **not** the denylist.
+
+Recommended denylist for parity snapshots:
+
+- `.vaws-local/`
+- `.workspace.local/`
+- `.machine-inventory.json`
+- `.codex/`
+- `.claude/settings.local.json`
+- `.env`
+- `.env.*`
+- `.venv/`
+- `venv/`
+- `__pycache__/`
+- `.pytest_cache/`
+- `.mypy_cache/`
+- `.ruff_cache/`
+- `*.log`
+- `*.out`
+- `.DS_Store`
+- `._*`
+- `Thumbs.db`
+
+Everything else is allowed by default unless the repo later adds a stronger local-state boundary.
+
+## Local-state contract
+
+Store local parity state under `.vaws-local/remote-code-parity/`.
+
+### `install-consents.json`
+
+Suggested shape:
+
+```json
+{
+  "schema_version": 1,
+  "consents": {
+    "server-a": {
+      "containers": {
+        "container-id-123": {
+          "decision": "allow",
+          "updated_at": "2026-04-05T10:00:00Z",
+          "note": "approved by user"
+        }
+      }
+    }
+  }
+}
+```
+
+### `runtime-state.json`
+
+Suggested shape:
+
+```json
+{
+  "schema_version": 1,
+  "servers": {
+    "server-a": {
+      "storage_root": "/mnt/nvme/vaws",
+      "containers": {
+        "container-id-123": {
+          "runtime_root": "/vllm-workspace",
+          "last_sync_at": "2026-04-05T10:03:00Z",
+          "first_reinstall_completed": true,
+          "last_snapshot_commits": {
+            ".": "abc123",
+            "vllm": "def456",
+            "vllm-ascend": "ghi789"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The state is local and advisory. Proof of current parity still comes from the actual container-side commit ids.
+
+## Remote cache layout
+
+Recommended layout under `storage_root`:
+
+```text
+<storage_root>/
+  remote-code-parity/
+    workspaces/<workspace_id>/
+      locks/
+      manifests/
+      logs/
+      mirrors/
+        workspace.git
+        nested/<sanitized-relpath>.git
+```
+
+Keep the mirror cache on the **host local disk**, not on a shared filesystem.
+
+## Storage-root policy
+
+A chosen `storage_root` should satisfy all of these:
+
+- writable from the host
+- bind-mounted or otherwise visible inside the container
+- filesystem type not in the rejected set
+- enough free space for mirrors + manifests + rebuilds
+
+Suggested rejected filesystem markers:
+
+- `nfs`
+- `nfs4`
+- `cifs`
+- `smbfs`
+- `sshfs`
+- `fuse.sshfs`
+- `lustre`
+- `ceph`
+- `glusterfs`
+
+Thresholds:
+
+- hard fail below 512 MiB
+- fail closed for first-time editable reinstall below 4 GiB
+
+## First-time runtime replacement
+
+The first sync against a fresh container has a special rule.
+
+The container image may already include its own `vllm` / `vllm-ascend`. If the user wants remote execution to use the local workspace code, the image-provided packages must be replaced with editable installs from the mirrored runtime tree.
+
+That step is mutating and potentially slow, so:
+
+- require user consent once per container identity
+- support batch approval through the consent helper
+- fail closed if the user declines or has not approved yet
+
+After a container is rebuilt or recreated, treat it as a new identity and require consent again.
+
+## Reinstall trigger matrix
+
+Recommended conservative defaults:
+
+### `vllm`
+
+Trigger reinstall on changes matching:
+
+- `requirements*`
+- `pyproject.toml`
+- `setup.py`
+- `setup.cfg`
+- `CMakeLists.txt`
+- `cmake/**`
+- `csrc/**`
+- common native-source suffixes such as `*.cu`, `*.cuh`, `*.cpp`, `*.cc`, `*.h`, `*.hpp`
+
+### `vllm-ascend`
+
+Trigger reinstall on the same set as `vllm`, plus:
+
+- `vllm_ascend/_cann_ops_custom/**`
+
+Everything else defaults to “parity only, no reinstall”.
+
+## Exact proof to collect
+
+A trustworthy parity result records:
+
+- storage root actually used
+- pushed synthetic commit ids
+- fetched / checked-out commit ids in the container
+- whether `vllm` and `vllm-ascend` were reinstalled
+- whether first-time consent was consulted
+- any mismatch between the manifest and runtime state
+
+## Failure handling
+
+### Fail closed immediately
+
+- no usable `storage_root`
+- uninitialized or unpopulated required submodule
+- host mirror push failed
+- mirror path not visible inside the container
+- expected commit id not present in the runtime repo
+- reinstall required but blocked or failed
+
+### Recoverable but reportable
+
+- no reinstall needed
+- GC skipped
+- optional manifest upload skipped even though parity succeeded
+
+## Optional transport fallback
+
+The preferred path is host-local bare mirrors.
+
+If mirror publication is impossible but SSH stdin/stdout still works, a later implementation can stream `git bundle` files over plain `ssh` without using `scp`. That fallback should remain explicit and secondary so the normal path stays incremental and cache-friendly.

--- a/.agents/skills/remote-code-parity/references/command-recipes.md
+++ b/.agents/skills/remote-code-parity/references/command-recipes.md
@@ -1,0 +1,81 @@
+# Remote-code-parity command recipes
+
+Prefer the helper scripts in `scripts/` when possible.
+
+## Inspect the current consent state
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/install_consent.py resolve   --repo-root .   --server-name blue-a   --container-identity c-20260405-01
+```
+
+## Approve the first runtime replacement for one container
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/install_consent.py set   --repo-root .   --server-name blue-a   --container-identity c-20260405-01   --decision allow   --note "approved for first editable install"
+```
+
+## Bulk-approve several containers at once
+
+Input file example:
+
+```json
+[
+  {
+    "server_name": "blue-a",
+    "container_identity": "c-20260405-01",
+    "decision": "allow"
+  },
+  {
+    "server_name": "blue-b",
+    "container_identity": "c-20260405-09",
+    "decision": "deny",
+    "note": "leave image packages intact"
+  }
+]
+```
+
+Apply:
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/install_consent.py batch-set   --repo-root .   --input approvals.json
+```
+
+## Dry-run the local parity plan
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py plan   --workspace-root .   --workspace-id vaws-main   --server-name blue-a   --container-identity c-20260405-01   --runtime-root /vllm-workspace   --storage-root /mnt/nvme/vaws
+```
+
+## Full sync against an already-known storage root
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py sync   --workspace-root .   --workspace-id vaws-main   --server-name blue-a   --host lab.example.internal   --host-port 22   --host-user root   --container-host lab.example.internal   --container-port 41001   --container-user root   --container-identity c-20260405-01   --runtime-root /vllm-workspace   --storage-root /mnt/nvme/vaws
+```
+
+## Probe storage-root candidates on the first run
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py sync   --workspace-root .   --workspace-id vaws-main   --server-name blue-a   --host lab.example.internal   --host-port 22   --host-user root   --container-host lab.example.internal   --container-port 41001   --container-user root   --container-identity c-20260405-01   --runtime-root /vllm-workspace   --storage-root-candidate /mnt/nvme/vaws   --storage-root-candidate /mnt/data/vaws   --storage-root-candidate /data/vaws
+```
+
+## Force a dry-run without touching the host or container
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py sync   --workspace-root .   --workspace-id vaws-main   --server-name blue-a   --host lab.example.internal   --host-port 22   --host-user root   --container-host lab.example.internal   --container-port 41001   --container-user root   --container-identity c-20260405-01   --runtime-root /vllm-workspace   --storage-root /mnt/nvme/vaws   --dry-run
+```
+
+## Clean old parity artifacts
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/gc_runtime_cache.py   --storage-root /mnt/nvme/vaws   --workspace-id vaws-main   --keep-success 3   --keep-failure 1   --dry-run
+```
+
+## Recommended upper-skill routing rule
+
+When a serving / benchmark / smoke workflow is about to execute remotely:
+
+1. ensure `machine-management` already proved host + container SSH
+2. call `remote-code-parity`
+3. continue only if `status == ready`
+
+Do **not** continue on `blocked` or `failed`.

--- a/.agents/skills/remote-code-parity/scripts/common.py
+++ b/.agents/skills/remote-code-parity/scripts/common.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+STATE_SUBDIR = Path(".vaws-local/remote-code-parity")
+
+DEFAULT_DENYLIST = (
+    ".vaws-local/",
+    ".workspace.local/",
+    ".machine-inventory.json",
+    ".codex/",
+    ".claude/settings.local.json",
+    ".env",
+    ".env.*",
+    ".venv/",
+    "venv/",
+    "__pycache__/",
+    ".pytest_cache/",
+    ".mypy_cache/",
+    ".ruff_cache/",
+    "*.log",
+    "*.out",
+    ".DS_Store",
+    "._*",
+    "Thumbs.db",
+)
+
+DEFAULT_REJECTED_FS_TYPES = {
+    "nfs",
+    "nfs4",
+    "cifs",
+    "smbfs",
+    "sshfs",
+    "fuse.sshfs",
+    "lustre",
+    "ceph",
+    "glusterfs",
+}
+
+HARD_MIN_FREE_BYTES = 512 * 1024 * 1024
+FIRST_INSTALL_MIN_FREE_BYTES = 4 * 1024 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class SshEndpoint:
+    host: str
+    port: int
+    user: str
+
+    def destination(self) -> str:
+        return f"{self.user}@{self.host}"
+
+
+def run(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+    capture_output: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        env=env,
+        check=False,
+        capture_output=capture_output,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(
+            f"command failed ({result.returncode}): {' '.join(shlex.quote(part) for part in cmd)}\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    return result
+
+
+def git(repo: Path, args: list[str], *, env: dict[str, str] | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return run(["git", "-C", str(repo), *args], env=env, check=check)
+
+
+def repo_root_from(path: Path) -> Path:
+    current = path.resolve()
+    while True:
+        if (current / ".git").exists():
+            return current
+        if current.parent == current:
+            raise RuntimeError(f"could not find git repo root above {path}")
+        current = current.parent
+
+
+def state_dir(repo_root: Path) -> Path:
+    target = repo_root / STATE_SUBDIR
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def load_state(repo_root: Path, filename: str, default: Any) -> Any:
+    path = state_dir(repo_root) / filename
+    if not path.exists():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def save_state(repo_root: Path, filename: str, data: Any) -> Path:
+    path = state_dir(repo_root) / filename
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def now_utc() -> str:
+    import datetime as _dt
+
+    return _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def sanitize_repo_id(relpath: str) -> str:
+    return "workspace" if relpath in ("", ".") else relpath.replace("/", "__")
+
+
+def json_dump(data: Any) -> str:
+    return json.dumps(data, indent=2, sort_keys=True)
+
+
+def human_bytes(value: int) -> str:
+    units = ["B", "KiB", "MiB", "GiB", "TiB"]
+    size = float(value)
+    for unit in units:
+        if size < 1024.0 or unit == units[-1]:
+            return f"{size:.1f} {unit}"
+        size /= 1024.0
+    return f"{value} B"
+
+
+def quoted(script: str) -> str:
+    return shlex.quote(script)
+
+
+def ssh_exec(
+    endpoint: SshEndpoint,
+    script: str,
+    *,
+    check: bool = True,
+    capture_output: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-p",
+        str(endpoint.port),
+        endpoint.destination(),
+        "bash",
+        "-lc",
+        script,
+    ]
+    return run(cmd, check=check, capture_output=capture_output)
+
+
+def ssh_stream_to_file(endpoint: SshEndpoint, remote_path: str, payload: str) -> None:
+    cmd = [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-p",
+        str(endpoint.port),
+        endpoint.destination(),
+        "bash",
+        "-lc",
+        f"mkdir -p {quoted(str(Path(remote_path).parent))} && cat > {quoted(remote_path)}",
+    ]
+    result = subprocess.run(cmd, input=payload, text=True, capture_output=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"failed to stream payload to {remote_path}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+
+
+def is_git_worktree(path: Path) -> bool:
+    result = git(path, ["rev-parse", "--is-inside-work-tree"], check=False)
+    if result.returncode != 0 or result.stdout.strip() != "true":
+        return False
+    top = git(path, ["rev-parse", "--show-toplevel"], check=False)
+    if top.returncode != 0:
+        return False
+    try:
+        return Path(top.stdout.strip()).resolve() == path.resolve()
+    except FileNotFoundError:
+        return False
+
+def ensure_local_git_identity(repo: Path) -> tuple[str | None, str | None]:
+    name = git(repo, ["config", "--get", "user.name"], check=False).stdout.strip() or None
+    email = git(repo, ["config", "--get", "user.email"], check=False).stdout.strip() or None
+    return name, email
+
+
+def glob_match_any(path: str, patterns: Iterable[str]) -> bool:
+    import fnmatch
+
+    normalized = path.replace("\\", "/")
+    return any(fnmatch.fnmatch(normalized, pattern) for pattern in patterns)

--- a/.agents/skills/remote-code-parity/scripts/gc_runtime_cache.py
+++ b/.agents/skills/remote-code-parity/scripts/gc_runtime_cache.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+from common import json_dump, now_utc
+
+
+@dataclass
+class Candidate:
+    path: Path
+    category: str
+    modified_ns: int
+
+
+def list_candidates(workspace_root: Path) -> list[Candidate]:
+    candidates: list[Candidate] = []
+    for category in ("manifests", "logs"):
+        category_path = workspace_root / category
+        if not category_path.exists():
+            continue
+        for item in category_path.iterdir():
+            if item.is_file():
+                candidates.append(Candidate(item, category, item.stat().st_mtime_ns))
+    return sorted(candidates, key=lambda item: item.modified_ns, reverse=True)
+
+
+def run_gc(args: argparse.Namespace) -> int:
+    workspace_root = Path(args.storage_root) / "remote-code-parity" / "workspaces" / args.workspace_id
+    candidates = list_candidates(workspace_root)
+
+    kept: list[str] = []
+    removed: list[str] = []
+    keep_limit = {
+        "manifests": args.keep_success,
+        "logs": args.keep_failure,
+    }
+    counts = {"manifests": 0, "logs": 0}
+    for candidate in candidates:
+        counts[candidate.category] += 1
+        if counts[candidate.category] <= keep_limit[candidate.category]:
+            kept.append(str(candidate.path))
+            continue
+        removed.append(str(candidate.path))
+        if not args.dry_run:
+            candidate.path.unlink(missing_ok=True)
+
+    print(
+        json_dump(
+            {
+                "generated_at": now_utc(),
+                "workspace_root": str(workspace_root),
+                "dry_run": args.dry_run,
+                "kept": kept,
+                "removed": removed,
+            }
+        )
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prune old remote-code-parity manifests and logs.")
+    parser.add_argument("--storage-root", required=True)
+    parser.add_argument("--workspace-id", required=True)
+    parser.add_argument("--keep-success", type=int, default=3)
+    parser.add_argument("--keep-failure", type=int, default=1)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main() -> int:
+    return run_gc(build_parser().parse_args())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/remote-code-parity/scripts/install_consent.py
+++ b/.agents/skills/remote-code-parity/scripts/install_consent.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from common import json_dump, load_state, repo_root_from, save_state, now_utc
+
+
+FILENAME = "install-consents.json"
+
+
+def load_consent_state(repo_root: Path) -> dict[str, Any]:
+    return load_state(repo_root, FILENAME, {"schema_version": 1, "consents": {}})
+
+
+def save_consent_state(repo_root: Path, state: dict[str, Any]) -> Path:
+    return save_state(repo_root, FILENAME, state)
+
+
+def set_decision(state: dict[str, Any], server_name: str, container_identity: str, decision: str, note: str | None) -> None:
+    containers = state.setdefault("consents", {}).setdefault(server_name, {}).setdefault("containers", {})
+    containers[container_identity] = {
+        "decision": decision,
+        "updated_at": now_utc(),
+        "note": note or "",
+    }
+
+
+def run_resolve(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from(Path(args.repo_root))
+    state = load_consent_state(repo_root)
+    record = (
+        state.get("consents", {})
+        .get(args.server_name, {})
+        .get("containers", {})
+        .get(args.container_identity)
+    )
+    payload = {
+        "server_name": args.server_name,
+        "container_identity": args.container_identity,
+        "decision": record.get("decision") if record else "unknown",
+        "record": record,
+    }
+    print(json_dump(payload))
+    return 0
+
+
+def run_set(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from(Path(args.repo_root))
+    state = load_consent_state(repo_root)
+    set_decision(state, args.server_name, args.container_identity, args.decision, args.note)
+    path = save_consent_state(repo_root, state)
+    print(json_dump({"status": "updated", "path": str(path)}))
+    return 0
+
+
+def run_batch_set(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from(Path(args.repo_root))
+    state = load_consent_state(repo_root)
+    items = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    if not isinstance(items, list):
+        raise RuntimeError("batch-set input must be a JSON list")
+    for item in items:
+        if not isinstance(item, dict):
+            raise RuntimeError("each batch-set entry must be an object")
+        set_decision(
+            state,
+            item["server_name"],
+            item["container_identity"],
+            item["decision"],
+            item.get("note"),
+        )
+    path = save_consent_state(repo_root, state)
+    print(json_dump({"status": "updated", "count": len(items), "path": str(path)}))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Manage first-install consent for remote-code-parity.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    def add_common(target: argparse.ArgumentParser) -> None:
+        target.add_argument("--repo-root", default=".")
+        target.add_argument("--server-name", required=True)
+        target.add_argument("--container-identity", required=True)
+
+    resolve = subparsers.add_parser("resolve")
+    add_common(resolve)
+
+    set_parser = subparsers.add_parser("set")
+    add_common(set_parser)
+    set_parser.add_argument("--decision", required=True, choices=("allow", "deny"))
+    set_parser.add_argument("--note", default=None)
+
+    batch = subparsers.add_parser("batch-set")
+    batch.add_argument("--repo-root", default=".")
+    batch.add_argument("--input", required=True)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.command == "resolve":
+        return run_resolve(args)
+    if args.command == "set":
+        return run_set(args)
+    if args.command == "batch-set":
+        return run_batch_set(args)
+    parser.error(f"unsupported command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
+++ b/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
@@ -1,0 +1,906 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import tempfile
+import uuid
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any
+
+from common import (
+    DEFAULT_DENYLIST,
+    DEFAULT_REJECTED_FS_TYPES,
+    FIRST_INSTALL_MIN_FREE_BYTES,
+    HARD_MIN_FREE_BYTES,
+    SshEndpoint,
+    ensure_local_git_identity,
+    git,
+    glob_match_any,
+    human_bytes,
+    json_dump,
+    load_state,
+    now_utc,
+    quoted,
+    repo_root_from,
+    sanitize_repo_id,
+    save_state,
+    ssh_exec,
+    ssh_stream_to_file,
+    is_git_worktree,
+)
+
+
+VLLM_REINSTALL_PATTERNS = (
+    "requirements*",
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "CMakeLists.txt",
+    "cmake/**",
+    "csrc/**",
+    "**/*.cu",
+    "**/*.cuh",
+    "**/*.cpp",
+    "**/*.cc",
+    "**/*.h",
+    "**/*.hpp",
+)
+
+VLLM_ASCEND_REINSTALL_PATTERNS = VLLM_REINSTALL_PATTERNS + (
+    "vllm_ascend/_cann_ops_custom/**",
+)
+
+DEFAULT_ENV_PREAMBLE = (
+    "if [ -f /usr/local/Ascend/ascend-toolkit/set_env.sh ]; then source /usr/local/Ascend/ascend-toolkit/set_env.sh; fi",
+    "if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then source /usr/local/Ascend/nnal/atb/set_env.sh; fi",
+    "if [ -f /vllm-workspace/vllm-ascend/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/bin/set_env.bash ]; then source /vllm-workspace/vllm-ascend/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/bin/set_env.bash; fi",
+    "export PATH=/usr/local/python3.11.14/bin:$PATH",
+    "export PYTHON=/usr/local/python3.11.14/bin/python3",
+    "export PIP=/usr/local/python3.11.14/bin/pip",
+    "export VLLM_WORKER_MULTIPROC_METHOD=spawn",
+    "export OMP_NUM_THREADS=1",
+    "export MKL_NUM_THREADS=1",
+)
+
+
+@dataclass
+class SubmoduleEntry:
+    name: str
+    path: str
+
+
+@dataclass
+class RepoNode:
+    relpath: str
+    repo_path: Path
+    submodule_name: str | None
+    children: list["RepoNode"] = field(default_factory=list)
+
+
+@dataclass
+class SnapshotRecord:
+    relpath: str
+    repo_id: str
+    parent: str | None
+    commit: str
+    tree: str
+    ref: str
+    changed_paths: list[str]
+    submodules: list[dict[str, str]]
+
+
+def ensure_populated_worktree(repo: Path, relpath: str) -> None:
+    if not repo.exists():
+        raise RuntimeError(
+            f"required repo path {relpath} is missing; initialize submodules before remote-code-parity"
+        )
+    if not is_git_worktree(repo):
+        raise RuntimeError(
+            f"required repo path {relpath} is not a populated Git worktree; run repo-init or git submodule update --init --recursive before remote-code-parity"
+        )
+
+
+def list_submodules(repo: Path) -> list[SubmoduleEntry]:
+    gitmodules = repo / ".gitmodules"
+    if not gitmodules.exists():
+        return []
+    result = git(repo, ["config", "--file", str(gitmodules), "--get-regexp", r"^submodule\..*\.path$"], check=False)
+    entries: list[SubmoduleEntry] = []
+    if result.returncode != 0 or not result.stdout.strip():
+        return entries
+    for line in result.stdout.splitlines():
+        key, path = line.split(maxsplit=1)
+        name = key.removeprefix("submodule.").removesuffix(".path")
+        entries.append(SubmoduleEntry(name=name, path=path.strip()))
+    return entries
+
+
+def discover_repo_tree(repo: Path, relpath: str = ".", submodule_name: str | None = None) -> RepoNode:
+    ensure_populated_worktree(repo, relpath)
+    node = RepoNode(relpath=relpath, repo_path=repo, submodule_name=submodule_name)
+    for entry in list_submodules(repo):
+        child_repo = repo / entry.path
+        child_relpath = entry.path if relpath in ("", ".") else f"{relpath}/{entry.path}"
+        ensure_populated_worktree(child_repo, child_relpath)
+        node.children.append(discover_repo_tree(child_repo, child_relpath, entry.name))
+    return node
+
+
+def iter_postorder(node: RepoNode):
+    for child in node.children:
+        yield from iter_postorder(child)
+    yield node
+
+
+def git_head(repo: Path) -> str | None:
+    result = git(repo, ["rev-parse", "--verify", "HEAD"], check=False)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def git_current_branch(repo: Path) -> str | None:
+    result = git(repo, ["symbolic-ref", "--short", "HEAD"], check=False)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def exclude_pathspecs(node: RepoNode, denylist: tuple[str, ...]) -> list[str]:
+    specs: list[str] = []
+    for child in node.children:
+        specs.append(f":(exclude){child.repo_path.relative_to(node.repo_path).as_posix()}")
+    for pattern in denylist:
+        if any(ch in pattern for ch in "*?[]"):
+            specs.append(f":(glob,exclude){pattern}")
+        else:
+            specs.append(f":(exclude){pattern}")
+    return specs
+
+
+def synthetic_ref(workspace_id: str, snapshot_id: str, relpath: str) -> str:
+    repo_id = sanitize_repo_id(relpath)
+    return f"refs/parity/{workspace_id}/{snapshot_id}/{repo_id}"
+
+
+def commit_message(workspace_id: str, snapshot_id: str, relpath: str) -> str:
+    repo_id = sanitize_repo_id(relpath)
+    return f"remote-code-parity snapshot {workspace_id} {snapshot_id} {repo_id}"
+
+
+def build_synthetic_snapshot(
+    node: RepoNode,
+    *,
+    workspace_id: str,
+    snapshot_id: str,
+    denylist: tuple[str, ...],
+    child_commits: dict[str, SnapshotRecord],
+) -> SnapshotRecord:
+    repo = node.repo_path
+    parent = git_head(repo)
+    ref = synthetic_ref(workspace_id, snapshot_id, node.relpath)
+    temp_index = tempfile.NamedTemporaryFile(prefix="parity-index-", delete=False)
+    temp_index.close()
+    temp_index_path = Path(temp_index.name)
+    env = os.environ.copy()
+    env["GIT_INDEX_FILE"] = temp_index.name
+    env["GIT_OPTIONAL_LOCKS"] = "0"
+    author_name, author_email = ensure_local_git_identity(repo)
+    env.setdefault("GIT_AUTHOR_NAME", author_name or "remote-code-parity")
+    env.setdefault("GIT_AUTHOR_EMAIL", author_email or "remote-code-parity@example.invalid")
+    env.setdefault("GIT_COMMITTER_NAME", author_name or "remote-code-parity")
+    env.setdefault("GIT_COMMITTER_EMAIL", author_email or "remote-code-parity@example.invalid")
+
+    try:
+        if parent:
+            git(repo, ["read-tree", parent], env=env)
+        add_args = ["add", "-A", "-f", "--", "."]
+        add_args.extend(exclude_pathspecs(node, denylist))
+        git(repo, add_args, env=env)
+
+        submodule_records: list[dict[str, str]] = []
+        for child in node.children:
+            child_record = child_commits[child.relpath]
+            child_rel_to_repo = child.repo_path.relative_to(repo).as_posix()
+            git(
+                repo,
+                ["update-index", "--add", "--cacheinfo", f"160000,{child_record.commit},{child_rel_to_repo}"],
+                env=env,
+            )
+            submodule_records.append(
+                {
+                    "name": child.submodule_name or child_rel_to_repo,
+                    "path": child_rel_to_repo,
+                    "commit": child_record.commit,
+                    "repo_id": child_record.repo_id,
+                }
+            )
+
+        tree = git(repo, ["write-tree"], env=env).stdout.strip()
+        commit_args = ["commit-tree", tree]
+        if parent:
+            commit_args.extend(["-p", parent])
+        commit_args.extend(["-m", commit_message(workspace_id, snapshot_id, node.relpath)])
+        commit = git(repo, commit_args, env=env).stdout.strip()
+        git(repo, ["update-ref", ref, commit])
+
+        if parent:
+            diff = git(repo, ["diff", "--name-only", f"{parent}..{commit}"]).stdout.splitlines()
+        else:
+            diff = git(repo, ["show", "--pretty=", "--name-only", commit]).stdout.splitlines()
+
+        return SnapshotRecord(
+            relpath=node.relpath,
+            repo_id=sanitize_repo_id(node.relpath),
+            parent=parent,
+            commit=commit,
+            tree=tree,
+            ref=ref,
+            changed_paths=[path.strip() for path in diff if path.strip()],
+            submodules=submodule_records,
+        )
+    finally:
+        temp_index_path.unlink(missing_ok=True)
+
+
+
+def cleanup_synthetic_refs(workspace_root: Path, records: list[SnapshotRecord]) -> None:
+    for record in records:
+        repo = workspace_root if record.relpath in ("", ".") else workspace_root / record.relpath
+        git(repo, ["update-ref", "-d", record.ref], check=False)
+
+
+def load_runtime_state(repo_root: Path) -> dict[str, Any]:
+    return load_state(repo_root, "runtime-state.json", {"schema_version": 1, "servers": {}})
+
+
+def save_runtime_state(repo_root: Path, state: dict[str, Any]) -> Path:
+    return save_state(repo_root, "runtime-state.json", state)
+
+
+def choose_storage_root(
+    *,
+    repo_root: Path,
+    server_name: str,
+    host: SshEndpoint,
+    provided_root: str | None,
+    candidate_roots: list[str],
+    first_install: bool,
+    dry_run: bool,
+) -> tuple[str, dict[str, Any]]:
+    state = load_runtime_state(repo_root)
+    server_state = state.setdefault("servers", {}).setdefault(server_name, {})
+    threshold = FIRST_INSTALL_MIN_FREE_BYTES if first_install else HARD_MIN_FREE_BYTES
+
+    attempts: list[dict[str, Any]] = []
+    roots_to_try: list[str] = []
+    if provided_root:
+        roots_to_try.append(provided_root)
+    if server_state.get("storage_root") and server_state["storage_root"] not in roots_to_try:
+        roots_to_try.append(server_state["storage_root"])
+    roots_to_try.extend(root for root in candidate_roots if root not in roots_to_try)
+
+    if not roots_to_try:
+        raise RuntimeError("no storage root or storage-root candidates were supplied")
+
+    if dry_run:
+        chosen = roots_to_try[0]
+        attempts.append({"path": chosen, "status": "dry-run-assumed", "free_bytes": None, "fs_type": None})
+        return chosen, {"attempts": attempts, "threshold_bytes": threshold}
+
+    for root in roots_to_try:
+        script = (
+            f"mkdir -p {quoted(root)} && "
+            f"df -PT {quoted(root)} | tail -1 && "
+            f"python3 - <<'PY'\n"
+            f"import os\n"
+            f"st = os.statvfs({root!r})\n"
+            f"print(st.f_bavail * st.f_frsize)\n"
+            f"PY"
+        )
+        result = ssh_exec(host, script, check=False)
+        if result.returncode != 0:
+            attempts.append({"path": root, "status": "probe-failed", "stderr_tail": result.stderr[-400:]})
+            continue
+        lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        if len(lines) < 2:
+            attempts.append({"path": root, "status": "malformed-probe-output", "stdout": result.stdout})
+            continue
+        df_line = lines[-2]
+        free_line = lines[-1]
+        parts = df_line.split()
+        fs_type = parts[1].lower() if len(parts) >= 2 else "unknown"
+        try:
+            free_bytes = int(free_line)
+        except ValueError:
+            attempts.append({"path": root, "status": "invalid-free-byte-output", "stdout": result.stdout})
+            continue
+
+        if fs_type in DEFAULT_REJECTED_FS_TYPES:
+            attempts.append({"path": root, "status": "rejected-fs-type", "fs_type": fs_type, "free_bytes": free_bytes})
+            continue
+        if free_bytes < threshold:
+            attempts.append({"path": root, "status": "below-threshold", "fs_type": fs_type, "free_bytes": free_bytes})
+            continue
+
+        server_state["storage_root"] = root
+        save_runtime_state(repo_root, state)
+        attempts.append({"path": root, "status": "selected", "fs_type": fs_type, "free_bytes": free_bytes})
+        return root, {"attempts": attempts, "threshold_bytes": threshold}
+
+    raise RuntimeError("could not find a usable storage_root:\n" + json_dump({"attempts": attempts, "threshold_bytes": threshold}))
+
+
+def load_consent(repo_root: Path) -> dict[str, Any]:
+    return load_state(repo_root, "install-consents.json", {"schema_version": 1, "consents": {}})
+
+
+def resolve_install_consent(repo_root: Path, server_name: str, container_identity: str) -> str:
+    state = load_consent(repo_root)
+    decision = (
+        state.get("consents", {})
+        .get(server_name, {})
+        .get("containers", {})
+        .get(container_identity, {})
+        .get("decision")
+    )
+    return decision or "unknown"
+
+
+def ensure_remote_bare_repo(host: SshEndpoint, mirror_path: str, dry_run: bool) -> None:
+    if dry_run:
+        return
+    script = (
+        f"mkdir -p {quoted(str(Path(mirror_path).parent))} && "
+        f"if [ ! -d {quoted(mirror_path)} ]; then git init --bare {quoted(mirror_path)} >/dev/null; fi"
+    )
+    ssh_exec(host, script)
+
+
+def push_snapshot_to_mirror(
+    repo: Path,
+    *,
+    host: SshEndpoint,
+    mirror_path: str,
+    record: SnapshotRecord,
+    workspace_id: str,
+    dry_run: bool,
+) -> None:
+    ensure_remote_bare_repo(host, mirror_path, dry_run)
+    if dry_run:
+        return
+    remote_url = f"ssh://{host.user}@{host.host}:{host.port}{mirror_path}"
+    target_ref = f"refs/parity/{workspace_id}/current"
+    git(repo, ["push", "--force", remote_url, f"{record.commit}:{target_ref}"])
+
+
+def remote_workspace_root(storage_root: str, workspace_id: str) -> str:
+    return f"{storage_root.rstrip('/')}/remote-code-parity/workspaces/{workspace_id}"
+
+
+def mirror_path_for(storage_root: str, workspace_id: str, record: SnapshotRecord) -> str:
+    root = Path(remote_workspace_root(storage_root, workspace_id)) / "mirrors"
+    repo_id = record.repo_id
+    if repo_id == "workspace":
+        return str(root / "workspace.git")
+    return str(root / "nested" / f"{repo_id}.git")
+
+
+def host_manifest_path(storage_root: str, workspace_id: str, snapshot_id: str) -> str:
+    root = Path(remote_workspace_root(storage_root, workspace_id)) / "manifests"
+    return str(root / f"{snapshot_id}.json")
+
+
+def host_lock_path(storage_root: str, workspace_id: str, container_identity: str) -> str:
+    root = Path(remote_workspace_root(storage_root, workspace_id)) / "locks"
+    digest = hashlib.sha256(container_identity.encode("utf-8")).hexdigest()[:16]
+    return str(root / f"{digest}.lock")
+
+
+def acquire_host_lock(host: SshEndpoint, lock_path: str, dry_run: bool) -> None:
+    if dry_run:
+        return
+    script = (
+        f"mkdir -p {quoted(str(Path(lock_path).parent))} && "
+        f"mkdir {quoted(lock_path)}"
+    )
+    result = ssh_exec(host, script, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"could not acquire host lock {lock_path}: {result.stderr or result.stdout}")
+
+
+def release_host_lock(host: SshEndpoint, lock_path: str, dry_run: bool) -> None:
+    if dry_run:
+        return
+    ssh_exec(host, f"rmdir {quoted(lock_path)} >/dev/null 2>&1 || true", check=False)
+
+
+def upload_manifest(host: SshEndpoint, manifest_path: str, manifest: dict[str, Any], dry_run: bool) -> None:
+    if dry_run:
+        return
+    ssh_stream_to_file(host, manifest_path, json_dump(manifest) + "\n")
+
+
+def container_repo_paths(runtime_root: str, record: SnapshotRecord) -> str:
+    relpath = record.relpath
+    if relpath in ("", "."):
+        return runtime_root
+    return str(Path(runtime_root) / relpath)
+
+
+def materialize_runtime(
+    *,
+    container: SshEndpoint,
+    runtime_root: str,
+    container_storage_root: str,
+    workspace_id: str,
+    records: list[SnapshotRecord],
+    dry_run: bool,
+) -> None:
+    record_by_relpath = {record.relpath: record for record in records}
+    root_record = record_by_relpath["."]
+    # Top-down materialization so each repo can rewrite its child submodule URLs before update.
+    def render_repo_step(record: SnapshotRecord) -> list[str]:
+        repo_dir = container_repo_paths(runtime_root, record)
+        mirror_path = mirror_path_for(container_storage_root, workspace_id, record)
+        lines = [
+            f"mkdir -p {quoted(str(Path(repo_dir).parent))}",
+            f"if [ ! -d {quoted(repo_dir + '/.git')} ]; then rm -rf {quoted(repo_dir)} && git clone --no-checkout {quoted(mirror_path)} {quoted(repo_dir)} >/dev/null; fi",
+            f"git -C {quoted(repo_dir)} remote get-url parity >/dev/null 2>&1 || git -C {quoted(repo_dir)} remote add parity {quoted(mirror_path)}",
+            f"git -C {quoted(repo_dir)} remote set-url parity {quoted(mirror_path)}",
+            f"git -C {quoted(repo_dir)} fetch --force parity refs/parity/{workspace_id}/current >/dev/null",
+            f"git -C {quoted(repo_dir)} checkout -B parity/current FETCH_HEAD >/dev/null",
+            f"git -C {quoted(repo_dir)} reset --hard FETCH_HEAD >/dev/null",
+            f"git -C {quoted(repo_dir)} clean -ffd >/dev/null",
+        ]
+        for child in record.submodules:
+            child_record = record_by_relpath[child["path"] if record.relpath in ("", ".") else f'{record.relpath}/{child["path"]}']
+            child_mirror = mirror_path_for(container_storage_root, workspace_id, child_record)
+            lines.extend(
+                [
+                    f"git -C {quoted(repo_dir)} config submodule.{quoted(child['name'])}.url {quoted(child_mirror)}",
+                    f"git -C {quoted(repo_dir)} submodule sync -- {quoted(child['path'])} >/dev/null || true",
+                    f"git -C {quoted(repo_dir)} submodule update --init --checkout --force -- {quoted(child['path'])} >/dev/null",
+                ]
+            )
+        return lines
+
+    def walk(record: SnapshotRecord) -> list[str]:
+        lines = render_repo_step(record)
+        for child in record.submodules:
+            child_relpath = child["path"] if record.relpath in ("", ".") else f"{record.relpath}/{child['path']}"
+            lines.extend(walk(record_by_relpath[child_relpath]))
+        return lines
+
+    script_lines = ["set -eo pipefail", f"mkdir -p {quoted(runtime_root)}"]
+    script_lines.extend(walk(root_record))
+    script = "\n".join(script_lines)
+    if dry_run:
+        return
+    ssh_exec(container, script)
+
+
+def reinstall_required_for_repo(record: SnapshotRecord, patterns: tuple[str, ...]) -> bool:
+    return any(glob_match_any(path, patterns) for path in record.changed_paths)
+
+
+def runtime_install_script(
+    *,
+    runtime_root: str,
+    reinstall_vllm: bool,
+    reinstall_vllm_ascend: bool,
+    container_identity: str,
+) -> str:
+    lines = ["set -eo pipefail", f"cd {quoted(runtime_root)}"]
+    lines.extend(DEFAULT_ENV_PREAMBLE)
+    if reinstall_vllm or reinstall_vllm_ascend:
+        lines.append("$PIP uninstall -y vllm vllm-ascend vllm_ascend >/dev/null 2>&1 || true")
+    if reinstall_vllm:
+        lines.extend(
+            [
+                f"cd {quoted(str(Path(runtime_root) / 'vllm'))}",
+                "export VLLM_TARGET_DEVICE=empty",
+                "$PIP install -e . --no-build-isolation",
+            ]
+        )
+    if reinstall_vllm_ascend:
+        lines.extend(
+            [
+                f"cd {quoted(str(Path(runtime_root) / 'vllm-ascend'))}",
+                "$PIP install -r requirements.txt",
+                "$PIP install -v -e . --no-build-isolation",
+            ]
+        )
+    lines.extend(
+        [
+            "$PYTHON - <<'PY'",
+            "import importlib.util",
+            "import torch_npu  # noqa: F401",
+            "assert importlib.util.find_spec('vllm') is not None",
+            "assert importlib.util.find_spec('vllm_ascend') is not None",
+            "print('editable-import-smoke=ok')",
+            "PY",
+            f"mkdir -p {quoted(str(Path(runtime_root) / '.remote-code-parity'))}",
+            (
+                "cat > "
+                + quoted(str(Path(runtime_root) / ".remote-code-parity/runtime-install.json"))
+                + " <<'JSON'\n"
+                + json.dumps(
+                    {
+                        "container_identity": container_identity,
+                        "updated_at": now_utc(),
+                        "reinstall_vllm": reinstall_vllm,
+                        "reinstall_vllm_ascend": reinstall_vllm_ascend,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\nJSON"
+            ),
+        ]
+    )
+    return "\n".join(lines)
+
+
+def verify_runtime_commits(
+    *,
+    container: SshEndpoint,
+    runtime_root: str,
+    records: list[SnapshotRecord],
+    dry_run: bool,
+) -> dict[str, str]:
+    expected = {record.relpath: record.commit for record in records}
+    if dry_run:
+        return expected
+    lines = ["set -eo pipefail"]
+    for relpath, _commit in expected.items():
+        repo_dir = runtime_root if relpath in ("", ".") else str(Path(runtime_root) / relpath)
+        lines.append(f"printf '%s %s\\n' {quoted(relpath)} \"$(git -C {quoted(repo_dir)} rev-parse HEAD)\"")
+    result = ssh_exec(container, "\n".join(lines))
+    observed: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        relpath, commit = line.split(maxsplit=1)
+        observed[relpath] = commit
+    return observed
+
+
+def update_runtime_state(
+    *,
+    repo_root: Path,
+    server_name: str,
+    container_identity: str,
+    runtime_root: str,
+    storage_root: str,
+    records: list[SnapshotRecord],
+    first_reinstall_completed: bool,
+) -> None:
+    state = load_runtime_state(repo_root)
+    server_state = state.setdefault("servers", {}).setdefault(server_name, {})
+    server_state["storage_root"] = storage_root
+    containers = server_state.setdefault("containers", {})
+    containers[container_identity] = {
+        "runtime_root": runtime_root,
+        "last_sync_at": now_utc(),
+        "first_reinstall_completed": first_reinstall_completed,
+        "last_snapshot_commits": {record.relpath: record.commit for record in records},
+    }
+    save_runtime_state(repo_root, state)
+
+
+def make_manifest(
+    *,
+    workspace_root: Path,
+    workspace_id: str,
+    snapshot_id: str,
+    server_name: str,
+    container_identity: str,
+    runtime_root: str,
+    storage_root: str,
+    records: list[SnapshotRecord],
+    storage_probe: dict[str, Any],
+) -> dict[str, Any]:
+    git_name, git_email = ensure_local_git_identity(workspace_root)
+    return {
+        "schema_version": 1,
+        "generated_at": now_utc(),
+        "workspace_root": str(workspace_root),
+        "workspace_id": workspace_id,
+        "snapshot_id": snapshot_id,
+        "server_name": server_name,
+        "container_identity": container_identity,
+        "runtime_root": runtime_root,
+        "storage_root": storage_root,
+        "git_identity": {"name": git_name, "email": git_email},
+        "storage_probe": storage_probe,
+        "repos": [asdict(record) for record in records],
+    }
+
+
+def summary_payload(
+    *,
+    status: str,
+    server_name: str,
+    container_identity: str,
+    workspace_id: str,
+    storage_root: str | None,
+    records: list[SnapshotRecord],
+    reinstall_status: str,
+    reason: str | None,
+    observed_runtime_commits: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "server_name": server_name,
+        "container_identity": container_identity,
+        "workspace_id": workspace_id,
+        "storage_root": storage_root,
+        "snapshot_commits": {record.relpath: record.commit for record in records},
+        "runtime_commits": observed_runtime_commits,
+        "reinstall": reinstall_status,
+        "reason": reason,
+    }
+
+
+def build_snapshot_records(workspace_root: Path, workspace_id: str, snapshot_id: str, denylist: tuple[str, ...]) -> list[SnapshotRecord]:
+    tree = discover_repo_tree(workspace_root, ".", None)
+    child_records: dict[str, SnapshotRecord] = {}
+    ordered_records: list[SnapshotRecord] = []
+    for node in iter_postorder(tree):
+        record = build_synthetic_snapshot(
+            node,
+            workspace_id=workspace_id,
+            snapshot_id=snapshot_id,
+            denylist=denylist,
+            child_commits=child_records,
+        )
+        child_records[node.relpath] = record
+        ordered_records.append(record)
+    return ordered_records
+
+
+def run_plan(args: argparse.Namespace) -> int:
+    workspace_root = repo_root_from(Path(args.workspace_root))
+    snapshot_id = args.snapshot_id or now_utc().replace(":", "").replace("-", "")
+    records = build_snapshot_records(workspace_root, args.workspace_id, snapshot_id, tuple(DEFAULT_DENYLIST))
+    try:
+        manifest = make_manifest(
+            workspace_root=workspace_root,
+            workspace_id=args.workspace_id,
+            snapshot_id=snapshot_id,
+            server_name=args.server_name,
+            container_identity=args.container_identity,
+            runtime_root=args.runtime_root,
+            storage_root=args.storage_root or (args.storage_root_candidate[0] if args.storage_root_candidate else ""),
+            records=records,
+            storage_probe={"attempts": [], "threshold_bytes": HARD_MIN_FREE_BYTES},
+        )
+        print(json_dump(manifest))
+        return 0
+    finally:
+        cleanup_synthetic_refs(workspace_root, records)
+
+
+def run_sync(args: argparse.Namespace) -> int:
+    workspace_root = repo_root_from(Path(args.workspace_root))
+    snapshot_id = args.snapshot_id or now_utc().replace(":", "").replace("-", "") + "-" + uuid.uuid4().hex[:8]
+    host = SshEndpoint(host=args.host, port=args.host_port, user=args.host_user)
+    container = SshEndpoint(host=args.container_host, port=args.container_port, user=args.container_user)
+
+    records = build_snapshot_records(workspace_root, args.workspace_id, snapshot_id, tuple(DEFAULT_DENYLIST))
+    try:
+        record_map = {record.relpath: record for record in records}
+        reinstall_vllm = reinstall_required_for_repo(record_map["vllm"], VLLM_REINSTALL_PATTERNS) if "vllm" in record_map else False
+        reinstall_vllm_ascend = reinstall_required_for_repo(record_map["vllm-ascend"], VLLM_ASCEND_REINSTALL_PATTERNS) if "vllm-ascend" in record_map else False
+
+        runtime_state = load_runtime_state(workspace_root)
+        previous_container_state = (
+            runtime_state.get("servers", {})
+            .get(args.server_name, {})
+            .get("containers", {})
+            .get(args.container_identity, {})
+        )
+        first_install = not bool(previous_container_state.get("first_reinstall_completed"))
+        storage_root, storage_probe = choose_storage_root(
+            repo_root=workspace_root,
+            server_name=args.server_name,
+            host=host,
+            provided_root=args.storage_root,
+            candidate_roots=args.storage_root_candidate,
+            first_install=first_install,
+            dry_run=args.dry_run,
+        )
+
+        reinstall_status = "not-needed"
+        consent = resolve_install_consent(workspace_root, args.server_name, args.container_identity)
+        if first_install:
+            if consent != "allow":
+                manifest = make_manifest(
+                    workspace_root=workspace_root,
+                    workspace_id=args.workspace_id,
+                    snapshot_id=snapshot_id,
+                    server_name=args.server_name,
+                    container_identity=args.container_identity,
+                    runtime_root=args.runtime_root,
+                    storage_root=storage_root,
+                    records=records,
+                    storage_probe=storage_probe,
+                )
+                if args.print_manifest:
+                    print(json_dump(manifest))
+                summary = summary_payload(
+                    status="blocked",
+                    server_name=args.server_name,
+                    container_identity=args.container_identity,
+                    workspace_id=args.workspace_id,
+                    storage_root=storage_root,
+                    records=records,
+                    reinstall_status="blocked-by-consent",
+                    reason="first-time runtime replacement requires explicit consent",
+                )
+                print(json_dump(summary))
+                return 2
+            reinstall_vllm = True if "vllm" in record_map else reinstall_vllm
+            reinstall_vllm_ascend = True if "vllm-ascend" in record_map else reinstall_vllm_ascend
+
+        manifest = make_manifest(
+            workspace_root=workspace_root,
+            workspace_id=args.workspace_id,
+            snapshot_id=snapshot_id,
+            server_name=args.server_name,
+            container_identity=args.container_identity,
+            runtime_root=args.runtime_root,
+            storage_root=storage_root,
+            records=records,
+            storage_probe=storage_probe,
+        )
+
+        if args.print_manifest:
+            print(json_dump(manifest))
+
+        lock_path = host_lock_path(storage_root, args.workspace_id, args.container_identity)
+        try:
+            acquire_host_lock(host, lock_path, args.dry_run)
+            for record in records:
+                mirror_path = mirror_path_for(storage_root, args.workspace_id, record)
+                push_snapshot_to_mirror(
+                    record=record,
+                    repo=workspace_root if record.relpath in ("", ".") else workspace_root / record.relpath,
+                    host=host,
+                    mirror_path=mirror_path,
+                    workspace_id=args.workspace_id,
+                    dry_run=args.dry_run,
+                )
+            upload_manifest(host, host_manifest_path(storage_root, args.workspace_id, snapshot_id), manifest, args.dry_run)
+            materialize_runtime(
+                container=container,
+                runtime_root=args.runtime_root,
+                container_storage_root=args.container_storage_root or storage_root,
+                workspace_id=args.workspace_id,
+                records=records,
+                dry_run=args.dry_run,
+            )
+
+            if reinstall_vllm or reinstall_vllm_ascend:
+                reinstall_status = "performed"
+                if not args.dry_run:
+                    ssh_exec(
+                        container,
+                        runtime_install_script(
+                            runtime_root=args.runtime_root,
+                            reinstall_vllm=reinstall_vllm,
+                            reinstall_vllm_ascend=reinstall_vllm_ascend,
+                            container_identity=args.container_identity,
+                        ),
+                    )
+            observed_runtime_commits = verify_runtime_commits(
+                container=container,
+                runtime_root=args.runtime_root,
+                records=records,
+                dry_run=args.dry_run,
+            )
+            expected_runtime_commits = {record.relpath: record.commit for record in records}
+            if observed_runtime_commits != expected_runtime_commits:
+                summary = summary_payload(
+                    status="failed",
+                    server_name=args.server_name,
+                    container_identity=args.container_identity,
+                    workspace_id=args.workspace_id,
+                    storage_root=storage_root,
+                    records=records,
+                    reinstall_status=reinstall_status,
+                    reason="runtime commit verification mismatch",
+                    observed_runtime_commits=observed_runtime_commits,
+                )
+                print(json_dump(summary))
+                return 1
+
+            update_runtime_state(
+                repo_root=workspace_root,
+                server_name=args.server_name,
+                container_identity=args.container_identity,
+                runtime_root=args.runtime_root,
+                storage_root=storage_root,
+                records=records,
+                first_reinstall_completed=first_install or previous_container_state.get("first_reinstall_completed", False) or reinstall_status == "performed",
+            )
+            summary = summary_payload(
+                status="ready",
+                server_name=args.server_name,
+                container_identity=args.container_identity,
+                workspace_id=args.workspace_id,
+                storage_root=storage_root,
+                records=records,
+                reinstall_status=reinstall_status,
+                reason=None,
+                observed_runtime_commits=observed_runtime_commits,
+            )
+            print(json_dump(summary))
+            return 0
+        finally:
+            release_host_lock(host, lock_path, args.dry_run)
+    finally:
+        cleanup_synthetic_refs(workspace_root, records)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prepare or enforce remote code parity for a ready runtime.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    def add_shared_arguments(target: argparse.ArgumentParser) -> None:
+        target.add_argument("--workspace-root", required=True, help="Local workspace root.")
+        target.add_argument("--workspace-id", required=True, help="Stable workspace id used for remote cache namespacing.")
+        target.add_argument("--server-name", required=True)
+        target.add_argument("--runtime-root", required=True)
+        target.add_argument("--container-identity", required=True)
+        target.add_argument("--storage-root", default=None)
+        target.add_argument("--storage-root-candidate", action="append", default=[])
+
+    plan = subparsers.add_parser("plan", help="Build a synthetic snapshot manifest without remote mutations.")
+    add_shared_arguments(plan)
+    plan.add_argument("--snapshot-id", default=None)
+    plan.add_argument("--print-manifest", action="store_true")
+
+    sync = subparsers.add_parser("sync", help="Publish mirrors, materialize runtime state, and reinstall when required.")
+    add_shared_arguments(sync)
+    sync.add_argument("--snapshot-id", default=None)
+    sync.add_argument("--host", required=True)
+    sync.add_argument("--host-port", type=int, default=22)
+    sync.add_argument("--host-user", required=True)
+    sync.add_argument("--container-host", required=True)
+    sync.add_argument("--container-port", type=int, required=True)
+    sync.add_argument("--container-user", required=True)
+    sync.add_argument("--container-storage-root", default=None, help="Container-visible path for the host storage root. Defaults to --storage-root.")
+    sync.add_argument("--dry-run", action="store_true")
+    sync.add_argument("--print-manifest", action="store_true")
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        if args.command == "plan":
+            return run_plan(args)
+        if args.command == "sync":
+            return run_sync(args)
+        parser.error(f"unsupported command: {args.command}")
+        return 2
+    except Exception as exc:
+        payload: dict[str, Any] = {
+            "status": "failed",
+            "reason": str(exc),
+        }
+        for field in ("server_name", "container_identity", "workspace_id"):
+            if hasattr(args, field):
+                payload[field] = getattr(args, field)
+        print(json_dump(payload))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,15 @@ Repo-local skills live under `.agents/skills/`.
 
 - `repo-init`: initialize the workspace after clone, including `gh`, GitHub auth, recursive submodules, optional fork / remote topology, and the local workspace machine profile used later by machine-management.
 - `machine-management`: add, verify, repair, or remove a workspace-managed remote NPU machine and its managed container.
+- `remote-code-parity`: automatically ensure a ready remote runtime uses the exact current local workspace state before any remote smoke, service launch, or benchmark.
 
-Both skills are optional. Do not force them as a gate before normal coding, docs work, serving, benchmarking, or unrelated Git / SSH tasks.
+`repo-init` and `machine-management` are optional. `remote-code-parity` is an automatic pre-execution gate only for ready-machine remote execution. Do not force any of them as a gate before normal local coding, docs work, or unrelated Git / SSH tasks.
 
 ## Repo-wide operating rules
 
 - Never write secrets, passwords, private keys, tokens, or user-specific machine metadata into tracked files.
 - Keep repo-local runtime state only under the untracked directory `.vaws-local/`.
+- Keep remote-code-parity state only under `.vaws-local/remote-code-parity/`.
 - Treat the legacy repo-root `.machine-inventory.json` as compatibility input only.
 - Keep `.gitmodules` on community URLs:
   - `https://github.com/vllm-project/vllm.git`
@@ -43,6 +45,13 @@ Both skills are optional. Do not force them as a gate before normal coding, docs
 - Never treat a custom selection as permission to reuse the detected Git username.
 - During `machine-management`, if host key SSH is missing and the user already supplied the host password in the request, prefer a one-shot scripted bootstrap first. Do not immediately bounce the user to a manual terminal command.
 
+
+## Mandatory execution gate
+
+- When a ready managed machine is about to run a remote smoke, service launch, or benchmark, run `remote-code-parity` first.
+- Do not continue remote execution unless `remote-code-parity` returned `status == ready`.
+- If the first runtime replacement is blocked by missing consent, stop and get consent instead of silently using the image-provided packages.
+
 ## Skill routing
 
 Use `repo-init` when the user explicitly asks to:
@@ -64,6 +73,14 @@ Use `machine-management` when the user explicitly asks to:
 
 Do not use `machine-management` for code sync, source rebuilds, serving, benchmarking, or generic SSH work unrelated to workspace-managed machines.
 
+Use `remote-code-parity` automatically when:
+
+- a ready managed machine is about to run a remote smoke, service launch, or benchmark
+- the request depends on local uncommitted changes, untracked files, or ignored-but-allowed files being reflected remotely
+- the container already accepts direct local -> container key-based SSH
+
+Do not use `remote-code-parity` for initial machine attach, SSH repair, generic Git topology work, or unrelated local-only tasks.
+
 ## Maintenance rule
 
 When you change a skill, update the whole skill package together:
@@ -78,3 +95,11 @@ When the change affects shared local-state behavior, also update:
 
 - `.agents/scripts/workspace_profile.py`
 - `.agents/lib/vaws_local_state.py`
+
+If you change `remote-code-parity`, update these together:
+
+- `.agents/skills/remote-code-parity/SKILL.md`
+- `.agents/skills/remote-code-parity/scripts/`
+- `.agents/skills/remote-code-parity/references/`
+- `AGENTS.md` and `.agents/README.md` when routing or local-state behavior changes
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The repository is intentionally **not** a mandatory workflow. Developers can use
 
 - `repo-init`
 - `machine-management`
+- `remote-code-parity`
 
 ## Design goals
 
@@ -17,6 +18,7 @@ The repository is intentionally **not** a mandatory workflow. Developers can use
 - Keep user-specific remotes, auth state, machine profile state, and managed-machine inventory in **local untracked state** only.
 - Make initialization optional, conservative, and repeatable.
 - Let agents drive setup in natural language instead of making the developer compose shell commands by hand.
+- Make ready remote execution use the exact current local workspace state even when the developer has not committed or pushed yet.
 - Preserve user freedom to add custom remotes such as `upstream2`, keep community-only mode, or skip any suggested step.
 
 ## Tracked repository model
@@ -34,6 +36,8 @@ Untracked workspace-local state lives under `.vaws-local/`:
 
 - `.vaws-local/machine-profile.json`: the stable machine username / namespace used to derive collision-safe container names such as `vaws-alice123`
 - `.vaws-local/machine-inventory.json`: managed remote-machine records for this local clone
+- `.vaws-local/remote-code-parity/install-consents.json`: per-container approval state for the first replacement of image-provided `vllm` / `vllm-ascend`
+- `.vaws-local/remote-code-parity/runtime-state.json`: advisory parity state such as the last validated `storage_root` per server and the last synced synthetic commits
 
 The legacy repo-root `.machine-inventory.json` is compatibility input only.
 
@@ -80,6 +84,21 @@ When invoked, `machine-management` can:
 
 New managed containers should derive their name from the local machine profile rather than using one global shared name.
 
+
+## What `remote-code-parity` does
+
+When invoked automatically before remote execution, `remote-code-parity` can:
+
+1. treat the local working tree as the source of truth, including committed, staged, unstaged, and untracked files
+2. build synthetic Git snapshot commits for the workspace root, `vllm/`, `vllm-ascend/`, and any nested populated submodules without forcing a real commit
+3. publish those snapshots into host-local bare mirror repositories under a validated `storage_root`
+4. materialize the mirrored commits inside the ready runtime container so the checked-out code matches the local workspace exactly
+5. on the first sync for a fresh container, require explicit user consent before uninstalling image-provided `vllm` / `vllm-ascend` and reinstalling them from the mirrored source trees
+6. on later syncs, reinstall only when build-critical paths changed
+7. verify the final runtime commit ids instead of assuming success from command exit status alone
+
+`remote-code-parity` is not a machine-attach or SSH-repair workflow. It assumes `machine-management` already proved the target container is reachable by key-based SSH.
+
 ## Recommended remote topology
 
 The skills treat the following as the recommended end state, but never as a hard requirement.
@@ -114,6 +133,7 @@ Example prompts for an agent:
 - “Configure this NPU machine for the current workspace.”
 - “Check whether the managed machine is ready.”
 - “Repair the container SSH on the managed host.”
+- “On the ready machine, sync my latest local code before you launch the remote service.”
 
 ## Repository layout
 
@@ -127,6 +147,10 @@ Example prompts for an agent:
 │   │   └── workspace_profile.py
 │   └── skills/
 │       ├── machine-management/
+│       │   ├── SKILL.md
+│       │   ├── references/
+│       │   └── scripts/
+│       ├── remote-code-parity/
 │       │   ├── SKILL.md
 │       │   ├── references/
 │       │   └── scripts/


### PR DESCRIPTION
Add the remote-code-parity skill package (scripts, references, skill spec) and align AGENTS/repo docs for local-to-remote parity workflows, including synthetic snapshot parity, consent handling for image replacement, and runtime cache hygiene.