### PR TITLE
Apply container-only parity patch on main

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -26,6 +26,7 @@ Current primary helpers:
 - `machine-management/scripts/machine_verify.py`
 - `machine-management/scripts/machine_repair.py`
 - `machine-management/scripts/machine_remove.py`
+- `remote-code-parity/scripts/parity_sync.py`
 - `remote-code-parity/scripts/remote_code_parity.py`
 - `remote-code-parity/scripts/install_consent.py`
 - `remote-code-parity/scripts/gc_runtime_cache.py`
@@ -46,6 +47,8 @@ Untracked workspace-local state lives under `.vaws-local/`:
 - `.vaws-local/machine-inventory.json`
 - `.vaws-local/remote-code-parity/install-consents.json`
 - `.vaws-local/remote-code-parity/runtime-state.json`
+
+Remote-code-parity transport is container-only after machine attach: use machine inventory to resolve the target, then push synthetic refs directly into the container-local cache root.
 
 The legacy repo-root `.machine-inventory.json` is compatibility input only and should not be reintroduced as the primary path.
 
@@ -76,6 +79,6 @@ If you change `remote-code-parity`, update these together:
 - `.agents/skills/remote-code-parity/SKILL.md`
 - `.agents/skills/remote-code-parity/references/`
 - `.agents/skills/remote-code-parity/scripts/`
-- `AGENTS.md` and this file when routing or local-state behavior changes
+- `AGENTS.md`, `README.md`, and this file when routing, transport model, or local-state behavior changes
 
 Keep the files under `.agents/skills/` as the canonical supporting files for repo-local skills.

--- a/.agents/skills/remote-code-parity/SKILL.md
+++ b/.agents/skills/remote-code-parity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: remote-code-parity
-description: Ensure a ready remote runtime runs the exact current local workspace state before any remote smoke, service launch, or benchmark. Use automatically immediately before remote execution when SCP is unavailable and local uncommitted changes must be reflected remotely. Do not use for initial machine attach, generic Git topology work, or unrelated local-only coding.
+description: Ensure a ready remote runtime runs the exact current local workspace state before any remote smoke, service launch, or benchmark. Use automatically immediately before remote execution when direct local -> container SSH already works and local uncommitted changes must be reflected remotely. Do not use for initial machine attach, generic Git topology work, or unrelated local-only coding.
 ---
 
 # Remote Code Parity
@@ -10,10 +10,9 @@ Keep a **ready** remote runtime in exact code parity with the local `vllm-ascend
 ## Use this skill when
 
 - a remote smoke, service launch, or benchmark is about to start
-- `machine-management` already proved host SSH and direct local -> container SSH by key
-- the request depends on local uncommitted changes, untracked files, or ignored-but-allowed files
-- `scp` is unavailable or disallowed
-- the user expects “run the latest local code remotely” rather than “run the latest pushed commit remotely”
+- `machine-management` already proved direct local -> container SSH by key
+- the request depends on local committed, staged, unstaged, or untracked **non-ignored** files
+- the user expects “run my current local workspace remotely” instead of “run the latest pushed branch remotely”
 
 ## Do not use this skill when
 
@@ -25,31 +24,29 @@ Keep a **ready** remote runtime in exact code parity with the local `vllm-ascend
 
 ## Critical rules
 
-- Treat the **local working tree** as the source of truth: committed + staged + unstaged + untracked.
+- Treat the **local working tree** as the source of truth: committed + staged + unstaged + untracked non-ignored.
 - Do **not** require the user to commit or push before parity.
 - Do **not** use `scp`, `sftp`, `rsync`, `sshpass`, or `expect`.
-- Do **not** require GitHub credentials on the remote host or in the container.
-- Prefer **host-local bare mirror repos** over push-to-GitHub / pull-from-GitHub.
-- Use synthetic snapshot refs so dirty working trees can be mirrored through Git transport.
-- Keep remote cache / lock / manifest / log paths isolated by `workspace_id`.
-- Reuse the first validated `storage_root` for a given host unless it becomes invalid.
-- Reject shared or undersized storage roots.
+- Do **not** require GitHub credentials on the host or in the container.
+- Keep the sync path **container-only** after machine attach: no host storage root, no host mirror, no host lock.
+- Use synthetic snapshot refs so dirty working trees can move through Git transport.
+- Keep container cache / lock / manifest paths isolated by `workspace_id` under a container-local cache root.
+- Preserve runtime-private paths under `/vllm-workspace`, especially `Mooncake`.
 - Fail closed if parity cannot be proven.
-- First replacement of image-provided `vllm` / `vllm-ascend` inside a container requires explicit user consent for that **container identity**.
-- Once the user approved reinstall for a given container identity, later parity runs on the same container do not ask again.
+- First replacement of image-provided `vllm` / `vllm-ascend` requires explicit user consent for that logical container identity.
+- `install_consent.py set` and `batch-set` must include `--approved-by-user`.
 - Keep local runtime state only under `.vaws-local/remote-code-parity/`.
 
 ## Preconditions
 
 This skill assumes an upper skill already proved:
 
-- host SSH works by key
 - container SSH works by key
 - the runtime root path is known
 - recursive submodules are initialized and populated
 - the target machine / container is the intended execution target
 
-If any of those are still uncertain, stop and route back to `machine-management` or `repo-init`.
+If any of those are uncertain, stop and route back to `machine-management` or `repo-init`.
 
 ## Local state
 
@@ -58,38 +55,39 @@ Keep local untracked state here:
 - `.vaws-local/remote-code-parity/install-consents.json`
 - `.vaws-local/remote-code-parity/runtime-state.json`
 
-Recommended remote host cache layout under `storage_root`:
+Container-local cache layout under the cache root:
 
-- `remote-code-parity/workspaces/<workspace_id>/mirrors/`
-- `remote-code-parity/workspaces/<workspace_id>/locks/`
-- `remote-code-parity/workspaces/<workspace_id>/manifests/`
-- `remote-code-parity/workspaces/<workspace_id>/logs/`
+- `workspaces/<workspace_id>/mirrors/`
+- `workspaces/<workspace_id>/locks/`
+- `workspaces/<workspace_id>/manifests/`
 
 ## Cross-platform launcher rule
 
 - macOS / Linux / WSL: `python3 ...`
 - Windows: `py -3 ...`
 
-Remote host and runtime commands in this skill assume Linux shells.
+Container commands in this skill assume Linux shells.
 
 ## Script-first entry points
 
-Primary orchestration:
+Normal agent entrypoint:
 
-- POSIX: `python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py plan ...`
-- POSIX: `python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py sync ...`
-- Windows: `py -3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py plan ...`
-- Windows: `py -3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py sync ...`
+- POSIX: `python3 .agents/skills/remote-code-parity/scripts/parity_sync.py --machine <alias-or-ip> ...`
+- Windows: `py -3 .agents/skills/remote-code-parity/scripts/parity_sync.py --machine <alias-or-ip> ...`
 
 Consent helper:
 
 - POSIX: `python3 .agents/skills/remote-code-parity/scripts/install_consent.py resolve ...`
-- POSIX: `python3 .agents/skills/remote-code-parity/scripts/install_consent.py set ...`
-- POSIX: `python3 .agents/skills/remote-code-parity/scripts/install_consent.py batch-set --input FILE.json`
+- POSIX: `python3 .agents/skills/remote-code-parity/scripts/install_consent.py set ... --approved-by-user`
+- POSIX: `python3 .agents/skills/remote-code-parity/scripts/install_consent.py batch-set --input FILE.json --approved-by-user`
 
-Cache cleanup helper:
+Low-level helper:
 
-- POSIX: `python3 .agents/skills/remote-code-parity/scripts/gc_runtime_cache.py --storage-root ... --workspace-id ...`
+- POSIX: `python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py sync ...`
+
+Optional cache cleanup helper:
+
+- POSIX: `python3 .agents/skills/remote-code-parity/scripts/gc_runtime_cache.py ...`
 
 Reference files:
 
@@ -99,37 +97,21 @@ Reference files:
 
 ## Workflow
 
-### 1. Confirm scope and preconditions
+### 1. Resolve the ready target from inventory
 
-Collect:
+For normal agent work, start from `parity_sync.py`.
 
-- `workspace_root`
-- `workspace_id`
-- host SSH endpoint
+Collect from local machine inventory:
+
+- machine alias
 - container SSH endpoint
 - runtime root inside the container
-- container identity
-- either a known `storage_root` or a probe candidate list
+- logical container identity: `<container-name>@<runtime-root>`
+- workspace id
 
-Stop if the request is not actually about an imminent remote execution.
+Stop if the request is not actually about imminent remote execution.
 
-### 2. Resolve `storage_root`
-
-Rules:
-
-- if local state already records a validated `storage_root` for the host, reuse it
-- otherwise probe candidates on the host and select the first path that is:
-  - writable
-  - not on a rejected shared filesystem type
-  - above the hard free-space threshold
-- persist the chosen `storage_root` locally for future parity runs
-
-Thresholds:
-
-- hard fail below **512 MiB**
-- for a first-time uninstall + editable reinstall, fail below **4 GiB**
-
-### 3. Capture synthetic snapshot refs
+### 2. Capture synthetic snapshot refs
 
 Create synthetic Git commits for the workspace repo and nested submodules in **postorder**:
 
@@ -140,20 +122,21 @@ Create synthetic Git commits for the workspace repo and nested submodules in **p
 For each repo:
 
 - build a temporary index from `HEAD`
-- stage the full current working tree with `git add -A -f`
-- exclude local-only denylist paths
+- stage the full current working tree with `git add -A`
+- reset local-only denylist paths and child-submodule paths from that temporary index
 - replace child submodule gitlinks with the child synthetic snapshot commit ids
 - write a synthetic commit
 
-This is the key step that allows Git transport to represent dirty working trees.
+Ignored files stay ignored. The snapshot source of truth is tracked + untracked non-ignored.
 
-### 4. Publish mirrors to the host
+### 3. Publish mirrors directly into the container cache
 
 For each repo in scope:
 
-- ensure the host-local bare mirror repo exists under `storage_root`
-- push the synthetic commit to a stable parity ref such as `refs/parity/<workspace_id>/current`
+- ensure the container-local bare mirror repo exists under the cache root
+- push the synthetic commit to `refs/parity/<workspace_id>/current`
 - write a compact manifest for this sync attempt under `manifests/`
+- use a **container-local** lock while mutating cache or runtime state
 
 Preferred scope:
 
@@ -162,21 +145,11 @@ Preferred scope:
 - `vllm-ascend/`
 - recursive nested populated submodules if discovered
 
-### 5. Materialize the mirrors inside the runtime container
+### 4. Handle first-time runtime replacement
 
-Inside the container:
+Use a container-side marker under `/vllm-workspace/.remote-code-parity/` to detect whether editable replacement already happened.
 
-- fetch each repo from the host-local mirror path
-- force the runtime repo to the synthetic parity ref
-- rewrite submodule URLs to local mirror paths
-- initialize / update submodules against those mirror paths
-- ensure the checked-out commits match the manifest
-
-Do not claim success before the container-side commit ids match the snapshot manifest.
-
-### 6. Handle first-time runtime replacement
-
-If this container identity has never been approved:
+If the container identity has never been approved:
 
 - resolve the consent state from `.vaws-local/remote-code-parity/install-consents.json`
 - if there is no `allow`, stop with `status == blocked`
@@ -184,8 +157,33 @@ If this container identity has never been approved:
 
 If the user already approved this container identity:
 
-- best-effort uninstall image-provided `vllm` / `vllm-ascend`
-- rebuild/install from the mirrored runtime tree
+- uninstall image-provided `vllm` / `vllm-ascend` best-effort
+- delete `/vllm-workspace/vllm` and `/vllm-workspace/vllm-ascend`
+- do **not** delete the entire `/vllm-workspace`
+
+### 5. Materialize the mirrors in place inside `/vllm-workspace`
+
+Inside the container:
+
+- initialize the root repo in place if needed
+- fetch each repo from the container-local mirror path
+- force the runtime repo to the synthetic parity ref
+- rewrite submodule URLs to container-local mirror paths
+- initialize / update submodules against those mirror paths
+- preserve runtime-private paths such as `Mooncake` and `.remote-code-parity`
+- ensure the checked-out commits match the manifest
+
+Do not claim success before the container-side commit ids match the snapshot manifest.
+
+### 6. Reinstall only when required after first install
+
+After the first approved replacement, reinstall only when matching paths changed.
+
+Conservative defaults:
+
+- `vllm`: `requirements*`, `pyproject.toml`, `setup.*`, `CMake*`, `cmake/**`, `csrc/**`, and common native-source suffixes
+- `vllm-ascend`: same as `vllm`, plus `vllm_ascend/_cann_ops_custom/**`
+- pure Python, docs, configs, tests, and ordinary scripts: parity only, no rebuild
 
 Use these commands inside the container when required:
 
@@ -203,39 +201,16 @@ pip install -r requirements.txt
 pip install -v -e . --no-build-isolation
 ```
 
-Default environment preamble before install / import smoke:
-
-```bash
-source /usr/local/Ascend/ascend-toolkit/set_env.sh 2>/dev/null || true
-source /usr/local/Ascend/nnal/atb/set_env.sh 2>/dev/null || true
-source /vllm-workspace/vllm-ascend/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/bin/set_env.bash 2>/dev/null || true
-export PATH=/usr/local/python3.11.14/bin:$PATH
-export PYTHON=/usr/local/python3.11.14/bin/python3
-export PIP=/usr/local/python3.11.14/bin/pip
-export VLLM_WORKER_MULTIPROC_METHOD=spawn
-export OMP_NUM_THREADS=1
-export MKL_NUM_THREADS=1
-```
-
-### 7. Reinstall trigger matrix after first install
-
-After the first approved replacement, reinstall only when matching paths changed.
-
-Conservative defaults:
-
-- `vllm`: `requirements*`, `pyproject.toml`, `setup.*`, `CMake*`, `cmake/**`, `csrc/**`, and common native-source suffixes
-- `vllm-ascend`: same as `vllm`, plus `vllm_ascend/_cann_ops_custom/**`
-- pure Python, docs, configs, tests, and ordinary scripts: parity only, no rebuild
-
-### 8. Finish with proof, not assumptions
+### 7. Finish with proof, not assumptions
 
 Return a compact JSON summary that includes:
 
 - final `status`
-- `storage_root` used
+- `container_cache_root`
 - synthetic snapshot commit ids
 - observed runtime commit ids
 - whether reinstall ran or was blocked
+- whether this was the first install path
 - the reason when the skill stopped early
 
 Success means `status == ready` and runtime commit ids match the synthetic snapshot ids exactly.

--- a/.agents/skills/remote-code-parity/references/acceptance.md
+++ b/.agents/skills/remote-code-parity/references/acceptance.md
@@ -7,7 +7,7 @@ These should trigger `remote-code-parity` directly or as an automatic internal s
 - “同步远端代码后再拉服务，包含我本地没 commit 的改动。”
 - “在 ready 的蓝区机器上启动 benchmark 前，确保跑的是我本地最新修改。”
 - “这台机器已经 ready 了，先把我本地 workspace 的最新改动同步进去再跑 smoke。”
-- “这个容器是新的，先批量确认允许第一次 editable install，再同步代码。”
+- “这个容器是新的，先确认允许第一次 editable install，再同步代码。”
 
 ## Non-trigger examples
 
@@ -23,42 +23,41 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 
 ### Universal
 
-- the skill treats the local working tree as the source of truth, including committed, staged, unstaged, and untracked files
+- the skill treats the local working tree as the source of truth, including committed, staged, unstaged, and untracked **non-ignored** files
 - the skill does not require the user to commit or push before parity
 - the skill does not use `scp`, `sftp`, `rsync`, `sshpass`, or `expect`
-- the skill does not require GitHub credentials on the remote host or in the container
+- the skill does not require GitHub credentials on the host or in the container
 - the skill keeps local runtime state only under `.vaws-local/remote-code-parity/`
-- normal outcomes are reported as compact JSON with `status` equal to `ready`, `blocked`, or `failed`
+- normal outcomes are reported as compact JSON with `status` equal to `ready`, `blocked`, `failed`, or `dry-run`
 
 ### Repo graph and snapshotting
 
 - the workspace root, `vllm/`, and `vllm-ascend/` all participate in parity
 - synthetic snapshots can represent dirty working trees without forcing a real commit
 - when `vllm` or `vllm-ascend` changed locally, the workspace-root synthetic snapshot also changes because the gitlinks are rewritten to the synthetic child commits
-- ignored-but-allowed files can be included in the snapshot
+- ignored files are not added to the snapshot by default
 - denylisted files such as `.vaws-local/*`, `.env*`, and local cache directories are excluded
 - if a required submodule path exists but is not populated, the skill fails closed with a clear error instead of producing a traceback-heavy Git failure
+
+### Container-only cache path
+
+- the normal sync path does not require host storage, host lock directories, or `docker inspect`
+- container-local bare mirrors are populated directly through container SSH
+- the normal agent-facing entrypoint can resolve the target from machine inventory through `parity_sync.py`
+- the skill does not create or reuse a flat shared host path such as `/home/vaws`
 
 ### Consent and first install
 
 - first sync on a fresh container without recorded approval ends with `status == blocked`
-- first sync on a fresh container with `allow` recorded proceeds to uninstall image-provided packages best-effort and perform editable installs
-- later syncs on the same container do not ask again unless the container identity changed
+- consent writes require explicit `--approved-by-user`
+- first sync on a fresh container with `allow` recorded proceeds to uninstall image-provided packages best-effort, remove only `vllm` and `vllm-ascend`, and perform editable installs
+- later syncs on the same logical container identity do not ask again unless the marker or identity changed
 - batch approval supports mixed decisions across different servers or containers
-- a rebuilt or recreated container with a new identity requires consent again
-
-### Storage-root selection
-
-- if local state already records a validated `storage_root` for the server, the skill reuses it
-- if no `storage_root` is known yet, the skill can probe candidate paths and select the first acceptable one
-- shared filesystems such as NFS, CIFS, SSHFS, Lustre, Ceph, and GlusterFS are rejected
-- paths below 512 MiB free space fail closed before mirror publication
-- first editable reinstall below 4 GiB free space fails closed before runtime mutation
 
 ### Runtime materialization and proof
 
-- the host-local bare mirrors are updated before the container fetches them
-- the runtime tree inside the container is forced to the synthetic snapshot commits rather than to a branch tip from GitHub
+- `/vllm-workspace` is updated in place instead of being replaced wholesale
+- runtime-private paths such as `Mooncake` survive root cleanups
 - final `git rev-parse HEAD` values inside the container match the synthetic snapshot commits exactly
 - reinstall runs only when the trigger matrix says it should, except for the mandatory first approved replacement on a fresh container
 - a successful run ends with `status == ready`
@@ -68,10 +67,12 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 These specific mistakes should no longer be part of the normal path:
 
 - Python helper files should not start with an extra leading backslash before the shebang
-- `command-recipes.md` should not tell the agent to pass unsupported `plan` arguments such as host or container SSH fields
+- the normal path should not depend on host `storage_root` arguments
 - repeated `plan` or `sync` runs should not accumulate unbounded local temporary parity refs
 - temporary parity index files should be cleaned up after snapshot construction
-- missing or unpopulated required submodules should return a compact failure payload instead of a raw `git add` traceback
+- missing or unpopulated required submodules should return a compact failure payload instead of a raw Git traceback
+- the main snapshot path should not force ignored files into the synthetic snapshot
+- root cleanups inside `/vllm-workspace` should not delete `Mooncake`
 
 ## Manual regression checklist
 
@@ -83,6 +84,7 @@ Review these files together after every substantial skill edit:
 - `.agents/skills/remote-code-parity/references/acceptance.md`
 - `.agents/skills/remote-code-parity/scripts/common.py`
 - `.agents/skills/remote-code-parity/scripts/remote_code_parity.py`
+- `.agents/skills/remote-code-parity/scripts/parity_sync.py`
 - `.agents/skills/remote-code-parity/scripts/install_consent.py`
 - `.agents/skills/remote-code-parity/scripts/gc_runtime_cache.py`
 - `AGENTS.md`

--- a/.agents/skills/remote-code-parity/references/behavior.md
+++ b/.agents/skills/remote-code-parity/references/behavior.md
@@ -6,199 +6,112 @@ This file defines the durable behavior of `remote-code-parity`.
 
 - Treat the local working tree as the source of truth.
 - Use Git transport without requiring a real user commit.
-- Prefer host-local bare mirror repos over push-to-GitHub / pull-from-GitHub.
+- Keep sync container-only after machine attach.
 - Keep all local parity state under `.vaws-local/remote-code-parity/`.
 - Fail closed when parity cannot be proven.
 - Prove the final container-side commit ids instead of trusting command exit status alone.
 
 ## Scope and routing
 
-`remote-code-parity` is an internal execution skill. End users should not need to learn `sync`, `session`, or `fleet` vocabulary.
+`remote-code-parity` is an internal execution skill.
 
 Intended route:
 
-1. `machine-management` proves host + container reachability and key-based login.
+1. `machine-management` proves direct local -> container SSH and records the target in inventory.
 2. `remote-code-parity` proves code and runtime package parity.
 3. a higher-level serving / benchmark / smoke workflow executes the requested workload.
+
+Normal agent-facing entrypoint: `parity_sync.py`.
 
 ## Preconditions
 
 Before this skill mutates anything remotely, confirm all of these:
 
-- the target host already accepts key-based SSH
 - the target container already accepts direct local -> container key-based SSH
 - the runtime root inside the container is known
-- the workspace submodules are initialized and populated
-- the target machine / container is already the intended execution target
+- the workspace submodules required for execution are initialized and populated
+- the selected machine record in inventory is the intended runtime target
 
-If a required submodule path exists but is not a populated Git worktree, fail closed with a clear instruction to initialize submodules first.
+## Source of truth and snapshot semantics
 
-## Why synthetic snapshots exist
+The snapshot source of truth is:
 
-A plain `git push HEAD` is not enough because it misses:
+- tracked files
+- staged files
+- unstaged tracked changes
+- untracked non-ignored files
 
-- staged-but-uncommitted changes
-- unstaged changes
-- untracked files
-- ignored-but-allowed local runtime inputs
+The snapshot source of truth is **not**:
 
-The load-bearing trick is to create synthetic commits from the local working tree without forcing the user to make a real commit. Git remains the transport layer, but the exported commit represents the live working tree rather than the checked-in branch tip.
-
-## Default repo scope
-
-Default scope is:
-
-- workspace root
-- `vllm/`
-- `vllm-ascend/`
-- recursively discovered nested populated submodules
-
-Why:
-
-- the workspace root carries gitlinks
-- `vllm` and `vllm-ascend` are both execution inputs
-- nested submodules can otherwise drift to commits the parent snapshot cannot materialize
-
-If recursive discovery finds an unpopulated child, fail closed. Do not silently ignore it.
-
-## Recommended denylist
-
-Ignored files are **not** the denylist.
-
-Recommended denylist for parity snapshots:
-
+- ignored local caches
 - `.vaws-local/`
-- `.workspace.local/`
-- `.machine-inventory.json`
-- `.codex/`
-- `.claude/settings.local.json`
-- `.env`
-- `.env.*`
-- `.venv/`
-- `venv/`
-- `__pycache__/`
-- `.pytest_cache/`
-- `.mypy_cache/`
-- `.ruff_cache/`
-- `*.log`
-- `*.out`
-- `.DS_Store`
-- `._*`
-- `Thumbs.db`
+- temporary agent state
+- other denylisted local-only files
 
-Everything else is allowed by default unless the repo later adds a stronger local-state boundary.
+Implementation rule:
 
-## Local-state contract
+- stage with `git add -A`
+- then reset denylisted paths and child-submodule paths from the temporary index
+- do **not** use `git add -A -f` for the main snapshot path
 
-Store local parity state under `.vaws-local/remote-code-parity/`.
+## Cache and transport model
 
-### `install-consents.json`
+The sync path does not rely on host storage.
 
-Suggested shape:
+Container-local cache root defaults to:
 
-```json
-{
-  "schema_version": 1,
-  "consents": {
-    "server-a": {
-      "containers": {
-        "container-id-123": {
-          "decision": "allow",
-          "updated_at": "2026-04-05T10:00:00Z",
-          "note": "approved by user"
-        }
-      }
-    }
-  }
-}
-```
+- `/root/.cache/vaws/remote-code-parity`
 
-### `runtime-state.json`
-
-Suggested shape:
-
-```json
-{
-  "schema_version": 1,
-  "servers": {
-    "server-a": {
-      "storage_root": "/mnt/nvme/vaws",
-      "containers": {
-        "container-id-123": {
-          "runtime_root": "/vllm-workspace",
-          "last_sync_at": "2026-04-05T10:03:00Z",
-          "first_reinstall_completed": true,
-          "last_snapshot_commits": {
-            ".": "abc123",
-            "vllm": "def456",
-            "vllm-ascend": "ghi789"
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-The state is local and advisory. Proof of current parity still comes from the actual container-side commit ids.
-
-## Remote cache layout
-
-Recommended layout under `storage_root`:
+Per-workspace layout:
 
 ```text
-<storage_root>/
-  remote-code-parity/
-    workspaces/<workspace_id>/
+<cache-root>/
+  workspaces/
+    <workspace_id>/
+      mirrors/
       locks/
       manifests/
-      logs/
-      mirrors/
-        workspace.git
-        nested/<sanitized-relpath>.git
 ```
 
-Keep the mirror cache on the **host local disk**, not on a shared filesystem.
+Required behavior:
 
-## Storage-root policy
+- create bare mirror repos inside the container cache root
+- push synthetic refs directly from local -> container SSH
+- use a container-local lock while mutating cache or runtime state
+- do not create or reuse a shared flat host path such as `/home/vaws`
 
-A chosen `storage_root` should satisfy all of these:
+## Runtime materialization model
 
-- writable from the host
-- bind-mounted or otherwise visible inside the container
-- filesystem type not in the rejected set
-- enough free space for mirrors + manifests + rebuilds
+Runtime root defaults to `/vllm-workspace`.
 
-Suggested rejected filesystem markers:
+Materialization requirements:
 
-- `nfs`
-- `nfs4`
-- `cifs`
-- `smbfs`
-- `sshfs`
-- `fuse.sshfs`
-- `lustre`
-- `ceph`
-- `glusterfs`
-
-Thresholds:
-
-- hard fail below 512 MiB
-- fail closed for first-time editable reinstall below 4 GiB
+- initialize the root repo in place when `.git` is missing
+- force the root repo and submodules to the synthetic snapshot commits
+- rewrite submodule URLs to container-local mirror paths
+- preserve runtime-private sibling paths such as `Mooncake`
+- preserve `.remote-code-parity` so the container-side marker survives root cleanups
+- do not delete the entire runtime root as part of normal sync
 
 ## First-time runtime replacement
 
 The first sync against a fresh container has a special rule.
 
-The container image may already include its own `vllm` / `vllm-ascend`. If the user wants remote execution to use the local workspace code, the image-provided packages must be replaced with editable installs from the mirrored runtime tree.
+The container image may already include its own `vllm` / `vllm-ascend`. If the user wants remote execution to use the local workspace code, those image-provided packages must be replaced with editable installs from the synced source trees.
 
 That step is mutating and potentially slow, so:
 
-- require user consent once per container identity
-- support batch approval through the consent helper
+- require user consent once per logical container identity
+- require `--approved-by-user` before writing consent state
 - fail closed if the user declines or has not approved yet
+- use a container-side marker under `/vllm-workspace/.remote-code-parity/runtime-install.json` to detect whether first install already happened
 
-After a container is rebuilt or recreated, treat it as a new identity and require consent again.
+First-install mutation boundary:
+
+- uninstall image packages best-effort
+- delete `/vllm-workspace/vllm`
+- delete `/vllm-workspace/vllm-ascend`
+- keep the rest of `/vllm-workspace`, including `Mooncake`
 
 ## Reinstall trigger matrix
 
@@ -223,38 +136,15 @@ Trigger reinstall on the same set as `vllm`, plus:
 
 - `vllm_ascend/_cann_ops_custom/**`
 
-Everything else defaults to “parity only, no reinstall”.
+Everything else defaults to parity-only, no reinstall.
 
 ## Exact proof to collect
 
 A trustworthy parity result records:
 
-- storage root actually used
+- container cache root actually used
 - pushed synthetic commit ids
-- fetched / checked-out commit ids in the container
+- checked-out commit ids in the container
 - whether `vllm` and `vllm-ascend` were reinstalled
-- whether first-time consent was consulted
+- whether first-time consent was consulted or blocked
 - any mismatch between the manifest and runtime state
-
-## Failure handling
-
-### Fail closed immediately
-
-- no usable `storage_root`
-- uninitialized or unpopulated required submodule
-- host mirror push failed
-- mirror path not visible inside the container
-- expected commit id not present in the runtime repo
-- reinstall required but blocked or failed
-
-### Recoverable but reportable
-
-- no reinstall needed
-- GC skipped
-- optional manifest upload skipped even though parity succeeded
-
-## Optional transport fallback
-
-The preferred path is host-local bare mirrors.
-
-If mirror publication is impossible but SSH stdin/stdout still works, a later implementation can stream `git bundle` files over plain `ssh` without using `scp`. That fallback should remain explicit and secondary so the normal path stays incremental and cache-friendly.

--- a/.agents/skills/remote-code-parity/references/command-recipes.md
+++ b/.agents/skills/remote-code-parity/references/command-recipes.md
@@ -5,13 +5,22 @@ Prefer the helper scripts in `scripts/` when possible.
 ## Inspect the current consent state
 
 ```bash
-python3 .agents/skills/remote-code-parity/scripts/install_consent.py resolve   --repo-root .   --server-name blue-a   --container-identity c-20260405-01
+python3 .agents/skills/remote-code-parity/scripts/install_consent.py resolve \
+  --repo-root . \
+  --server-name blue-a \
+  --container-identity vaws-blue@/vllm-workspace
 ```
 
 ## Approve the first runtime replacement for one container
 
 ```bash
-python3 .agents/skills/remote-code-parity/scripts/install_consent.py set   --repo-root .   --server-name blue-a   --container-identity c-20260405-01   --decision allow   --note "approved for first editable install"
+python3 .agents/skills/remote-code-parity/scripts/install_consent.py set \
+  --repo-root . \
+  --server-name blue-a \
+  --container-identity vaws-blue@/vllm-workspace \
+  --decision allow \
+  --note "approved for first editable install" \
+  --approved-by-user
 ```
 
 ## Bulk-approve several containers at once
@@ -22,12 +31,12 @@ Input file example:
 [
   {
     "server_name": "blue-a",
-    "container_identity": "c-20260405-01",
+    "container_identity": "vaws-blue@/vllm-workspace",
     "decision": "allow"
   },
   {
     "server_name": "blue-b",
-    "container_identity": "c-20260405-09",
+    "container_identity": "vaws-blue-b@/vllm-workspace",
     "decision": "deny",
     "note": "leave image packages intact"
   }
@@ -37,44 +46,85 @@ Input file example:
 Apply:
 
 ```bash
-python3 .agents/skills/remote-code-parity/scripts/install_consent.py batch-set   --repo-root .   --input approvals.json
+python3 .agents/skills/remote-code-parity/scripts/install_consent.py batch-set \
+  --repo-root . \
+  --input approvals.json \
+  --approved-by-user
 ```
 
-## Dry-run the local parity plan
+## Inspect the derived sync arguments from inventory
 
 ```bash
-python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py plan   --workspace-root .   --workspace-id vaws-main   --server-name blue-a   --container-identity c-20260405-01   --runtime-root /vllm-workspace   --storage-root /mnt/nvme/vaws
+python3 .agents/skills/remote-code-parity/scripts/parity_sync.py \
+  --machine blue-a \
+  --print-derived-args
 ```
 
-## Full sync against an already-known storage root
+## Normal sync against a managed machine
 
 ```bash
-python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py sync   --workspace-root .   --workspace-id vaws-main   --server-name blue-a   --host lab.example.internal   --host-port 22   --host-user root   --container-host lab.example.internal   --container-port 41001   --container-user root   --container-identity c-20260405-01   --runtime-root /vllm-workspace   --storage-root /mnt/nvme/vaws
+python3 .agents/skills/remote-code-parity/scripts/parity_sync.py \
+  --machine blue-a
 ```
 
-## Probe storage-root candidates on the first run
+## Dry-run sync without remote mutation
 
 ```bash
-python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py sync   --workspace-root .   --workspace-id vaws-main   --server-name blue-a   --host lab.example.internal   --host-port 22   --host-user root   --container-host lab.example.internal   --container-port 41001   --container-user root   --container-identity c-20260405-01   --runtime-root /vllm-workspace   --storage-root-candidate /mnt/nvme/vaws   --storage-root-candidate /mnt/data/vaws   --storage-root-candidate /data/vaws
+python3 .agents/skills/remote-code-parity/scripts/parity_sync.py \
+  --machine blue-a \
+  --dry-run
 ```
 
-## Force a dry-run without touching the host or container
+## Override runtime root or preserve an extra runtime-private path
 
 ```bash
-python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py sync   --workspace-root .   --workspace-id vaws-main   --server-name blue-a   --host lab.example.internal   --host-port 22   --host-user root   --container-host lab.example.internal   --container-port 41001   --container-user root   --container-identity c-20260405-01   --runtime-root /vllm-workspace   --storage-root /mnt/nvme/vaws   --dry-run
+python3 .agents/skills/remote-code-parity/scripts/parity_sync.py \
+  --machine blue-a \
+  --runtime-root /vllm-workspace \
+  --preserve-path model-cache
 ```
 
-## Clean old parity artifacts
+## Low-level sync helper
 
 ```bash
-python3 .agents/skills/remote-code-parity/scripts/gc_runtime_cache.py   --storage-root /mnt/nvme/vaws   --workspace-id vaws-main   --keep-success 3   --keep-failure 1   --dry-run
+python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py sync \
+  --workspace-root . \
+  --workspace-id vaws-main \
+  --server-name blue-a \
+  --container-host 10.0.0.8 \
+  --container-port 46001 \
+  --container-user root \
+  --container-identity vaws-blue@/vllm-workspace \
+  --runtime-root /vllm-workspace
+```
+
+## Low-level local parity plan
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py plan \
+  --workspace-root . \
+  --workspace-id vaws-main \
+  --server-name blue-a \
+  --container-identity vaws-blue@/vllm-workspace \
+  --runtime-root /vllm-workspace
+```
+
+## Clean old container-local manifests
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/gc_runtime_cache.py \
+  --container-host 10.0.0.8 \
+  --container-port 46001 \
+  --container-user root \
+  --workspace-id vaws-main \
+  --dry-run
 ```
 
 ## Recommended upper-skill routing rule
 
 When a serving / benchmark / smoke workflow is about to execute remotely:
 
-1. ensure `machine-management` already proved host + container SSH
+1. ensure `machine-management` already proved container SSH and recorded the machine in inventory
 2. call `remote-code-parity`
 3. continue only if `status == ready`
 

--- a/.agents/skills/remote-code-parity/scripts/common.py
+++ b/.agents/skills/remote-code-parity/scripts/common.py
@@ -9,40 +9,29 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
-STATE_SUBDIR = Path(".vaws-local/remote-code-parity")
+STATE_SUBDIR = Path('.vaws-local/remote-code-parity')
+LEGACY_STATE_DIR = Path('.vaws-local')
 
 DEFAULT_DENYLIST = (
-    ".vaws-local/",
-    ".workspace.local/",
-    ".machine-inventory.json",
-    ".codex/",
-    ".claude/settings.local.json",
-    ".env",
-    ".env.*",
-    ".venv/",
-    "venv/",
-    "__pycache__/",
-    ".pytest_cache/",
-    ".mypy_cache/",
-    ".ruff_cache/",
-    "*.log",
-    "*.out",
-    ".DS_Store",
-    "._*",
-    "Thumbs.db",
+    '.vaws-local/',
+    '.workspace.local/',
+    '.machine-inventory.json',
+    '.codex/',
+    '.claude/settings.local.json',
+    '.env',
+    '.env.*',
+    '.venv/',
+    'venv/',
+    '__pycache__/',
+    '.pytest_cache/',
+    '.mypy_cache/',
+    '.ruff_cache/',
+    '*.log',
+    '*.out',
+    '.DS_Store',
+    '._*',
+    'Thumbs.db',
 )
-
-DEFAULT_REJECTED_FS_TYPES = {
-    "nfs",
-    "nfs4",
-    "cifs",
-    "smbfs",
-    "sshfs",
-    "fuse.sshfs",
-    "lustre",
-    "ceph",
-    "glusterfs",
-}
 
 HARD_MIN_FREE_BYTES = 512 * 1024 * 1024
 FIRST_INSTALL_MIN_FREE_BYTES = 4 * 1024 * 1024 * 1024
@@ -55,7 +44,7 @@ class SshEndpoint:
     user: str
 
     def destination(self) -> str:
-        return f"{self.user}@{self.host}"
+        return f'{self.user}@{self.host}'
 
 
 def run(
@@ -77,23 +66,23 @@ def run(
     if check and result.returncode != 0:
         raise RuntimeError(
             f"command failed ({result.returncode}): {' '.join(shlex.quote(part) for part in cmd)}\n"
-            f"stdout:\n{result.stdout}\n"
-            f"stderr:\n{result.stderr}"
+            f'stdout:\n{result.stdout}\n'
+            f'stderr:\n{result.stderr}'
         )
     return result
 
 
 def git(repo: Path, args: list[str], *, env: dict[str, str] | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
-    return run(["git", "-C", str(repo), *args], env=env, check=check)
+    return run(['git', '-C', str(repo), *args], env=env, check=check)
 
 
 def repo_root_from(path: Path) -> Path:
     current = path.resolve()
     while True:
-        if (current / ".git").exists():
+        if (current / '.git').exists():
             return current
         if current.parent == current:
-            raise RuntimeError(f"could not find git repo root above {path}")
+            raise RuntimeError(f'could not find git repo root above {path}')
         current = current.parent
 
 
@@ -103,27 +92,41 @@ def state_dir(repo_root: Path) -> Path:
     return target
 
 
+def canonical_state_path(repo_root: Path, filename: str) -> Path:
+    return state_dir(repo_root) / filename
+
+
+def legacy_state_path(repo_root: Path, filename: str) -> Path:
+    return repo_root / LEGACY_STATE_DIR / filename
+
+
 def load_state(repo_root: Path, filename: str, default: Any) -> Any:
-    path = state_dir(repo_root) / filename
-    if not path.exists():
-        return default
-    return json.loads(path.read_text(encoding="utf-8"))
+    canonical = canonical_state_path(repo_root, filename)
+    if canonical.exists():
+        return json.loads(canonical.read_text(encoding='utf-8'))
+    legacy = legacy_state_path(repo_root, filename)
+    if legacy.exists():
+        return json.loads(legacy.read_text(encoding='utf-8'))
+    return default
 
 
 def save_state(repo_root: Path, filename: str, data: Any) -> Path:
-    path = state_dir(repo_root) / filename
-    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path = canonical_state_path(repo_root, filename)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+    legacy = legacy_state_path(repo_root, filename)
+    if legacy != path:
+        legacy.unlink(missing_ok=True)
     return path
 
 
 def now_utc() -> str:
     import datetime as _dt
 
-    return _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
 
 
 def sanitize_repo_id(relpath: str) -> str:
-    return "workspace" if relpath in ("", ".") else relpath.replace("/", "__")
+    return 'workspace' if relpath in ('', '.') else relpath.replace('/', '__')
 
 
 def json_dump(data: Any) -> str:
@@ -131,17 +134,32 @@ def json_dump(data: Any) -> str:
 
 
 def human_bytes(value: int) -> str:
-    units = ["B", "KiB", "MiB", "GiB", "TiB"]
+    units = ['B', 'KiB', 'MiB', 'GiB', 'TiB']
     size = float(value)
     for unit in units:
         if size < 1024.0 or unit == units[-1]:
-            return f"{size:.1f} {unit}"
+            return f'{size:.1f} {unit}'
         size /= 1024.0
-    return f"{value} B"
+    return f'{value} B'
 
 
 def quoted(script: str) -> str:
     return shlex.quote(script)
+
+
+def _ssh_base_cmd(endpoint: SshEndpoint) -> list[str]:
+    return [
+        'ssh',
+        '-o',
+        'BatchMode=yes',
+        '-o',
+        'StrictHostKeyChecking=accept-new',
+        '-o',
+        'LogLevel=ERROR',
+        '-p',
+        str(endpoint.port),
+        endpoint.destination(),
+    ]
 
 
 def ssh_exec(
@@ -151,46 +169,25 @@ def ssh_exec(
     check: bool = True,
     capture_output: bool = True,
 ) -> subprocess.CompletedProcess[str]:
-    cmd = [
-        "ssh",
-        "-o",
-        "BatchMode=yes",
-        "-p",
-        str(endpoint.port),
-        endpoint.destination(),
-        "bash",
-        "-lc",
-        script,
-    ]
+    cmd = [*_ssh_base_cmd(endpoint), 'bash', '-c', shlex.quote(script)]
     return run(cmd, check=check, capture_output=capture_output)
 
 
 def ssh_stream_to_file(endpoint: SshEndpoint, remote_path: str, payload: str) -> None:
-    cmd = [
-        "ssh",
-        "-o",
-        "BatchMode=yes",
-        "-p",
-        str(endpoint.port),
-        endpoint.destination(),
-        "bash",
-        "-lc",
-        f"mkdir -p {quoted(str(Path(remote_path).parent))} && cat > {quoted(remote_path)}",
-    ]
+    script = f'mkdir -p {quoted(str(Path(remote_path).parent))} && cat > {quoted(remote_path)}'
+    cmd = [*_ssh_base_cmd(endpoint), 'bash', '-c', shlex.quote(script)]
     result = subprocess.run(cmd, input=payload, text=True, capture_output=True)
     if result.returncode != 0:
         raise RuntimeError(
-            f"failed to stream payload to {remote_path}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            f'failed to stream payload to {remote_path}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}'
         )
 
 
-
-
 def is_git_worktree(path: Path) -> bool:
-    result = git(path, ["rev-parse", "--is-inside-work-tree"], check=False)
-    if result.returncode != 0 or result.stdout.strip() != "true":
+    result = git(path, ['rev-parse', '--is-inside-work-tree'], check=False)
+    if result.returncode != 0 or result.stdout.strip() != 'true':
         return False
-    top = git(path, ["rev-parse", "--show-toplevel"], check=False)
+    top = git(path, ['rev-parse', '--show-toplevel'], check=False)
     if top.returncode != 0:
         return False
     try:
@@ -198,14 +195,15 @@ def is_git_worktree(path: Path) -> bool:
     except FileNotFoundError:
         return False
 
+
 def ensure_local_git_identity(repo: Path) -> tuple[str | None, str | None]:
-    name = git(repo, ["config", "--get", "user.name"], check=False).stdout.strip() or None
-    email = git(repo, ["config", "--get", "user.email"], check=False).stdout.strip() or None
+    name = git(repo, ['config', '--get', 'user.name'], check=False).stdout.strip() or None
+    email = git(repo, ['config', '--get', 'user.email'], check=False).stdout.strip() or None
     return name, email
 
 
 def glob_match_any(path: str, patterns: Iterable[str]) -> bool:
     import fnmatch
 
-    normalized = path.replace("\\", "/")
+    normalized = path.replace('\\', '/')
     return any(fnmatch.fnmatch(normalized, pattern) for pattern in patterns)

--- a/.agents/skills/remote-code-parity/scripts/gc_runtime_cache.py
+++ b/.agents/skills/remote-code-parity/scripts/gc_runtime_cache.py
@@ -2,78 +2,61 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
+import json
 from pathlib import Path
+from typing import Any
 
-from common import json_dump, now_utc
-
-
-@dataclass
-class Candidate:
-    path: Path
-    category: str
-    modified_ns: int
-
-
-def list_candidates(workspace_root: Path) -> list[Candidate]:
-    candidates: list[Candidate] = []
-    for category in ("manifests", "logs"):
-        category_path = workspace_root / category
-        if not category_path.exists():
-            continue
-        for item in category_path.iterdir():
-            if item.is_file():
-                candidates.append(Candidate(item, category, item.stat().st_mtime_ns))
-    return sorted(candidates, key=lambda item: item.modified_ns, reverse=True)
-
-
-def run_gc(args: argparse.Namespace) -> int:
-    workspace_root = Path(args.storage_root) / "remote-code-parity" / "workspaces" / args.workspace_id
-    candidates = list_candidates(workspace_root)
-
-    kept: list[str] = []
-    removed: list[str] = []
-    keep_limit = {
-        "manifests": args.keep_success,
-        "logs": args.keep_failure,
-    }
-    counts = {"manifests": 0, "logs": 0}
-    for candidate in candidates:
-        counts[candidate.category] += 1
-        if counts[candidate.category] <= keep_limit[candidate.category]:
-            kept.append(str(candidate.path))
-            continue
-        removed.append(str(candidate.path))
-        if not args.dry_run:
-            candidate.path.unlink(missing_ok=True)
-
-    print(
-        json_dump(
-            {
-                "generated_at": now_utc(),
-                "workspace_root": str(workspace_root),
-                "dry_run": args.dry_run,
-                "kept": kept,
-                "removed": removed,
-            }
-        )
-    )
-    return 0
+from common import SshEndpoint, json_dump, quoted, ssh_exec
+from remote_code_parity import DEFAULT_CONTAINER_CACHE_ROOT, cache_workspace_root
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Prune old remote-code-parity manifests and logs.")
-    parser.add_argument("--storage-root", required=True)
-    parser.add_argument("--workspace-id", required=True)
-    parser.add_argument("--keep-success", type=int, default=3)
-    parser.add_argument("--keep-failure", type=int, default=1)
-    parser.add_argument("--dry-run", action="store_true")
+    parser = argparse.ArgumentParser(description='Prune old remote-code-parity manifests inside the container-local cache root.')
+    parser.add_argument('--container-host', required=True)
+    parser.add_argument('--container-port', type=int, required=True)
+    parser.add_argument('--container-user', required=True)
+    parser.add_argument('--workspace-id', required=True)
+    parser.add_argument('--container-cache-root', default=DEFAULT_CONTAINER_CACHE_ROOT)
+    parser.add_argument('--keep-manifests', type=int, default=5)
+    parser.add_argument('--dry-run', action='store_true')
     return parser
+
+
+def run_gc(args: argparse.Namespace) -> int:
+    container = SshEndpoint(host=args.container_host, port=args.container_port, user=args.container_user)
+    workspace_root = cache_workspace_root(args.container_cache_root, args.workspace_id)
+    manifests_dir = str(Path(workspace_root) / 'manifests')
+    script = '\n'.join(
+        [
+            'set -eo pipefail',
+            f"python3 - {quoted(manifests_dir)} {args.keep_manifests} {1 if args.dry_run else 0} <<'PY'",
+            'import json',
+            'import os',
+            'import sys',
+            'from pathlib import Path',
+            'manifests_dir = Path(sys.argv[1])',
+            'keep = int(sys.argv[2])',
+            'dry_run = bool(int(sys.argv[3]))',
+            "files = sorted([item for item in manifests_dir.iterdir() if item.is_file()], key=lambda item: item.stat().st_mtime_ns, reverse=True) if manifests_dir.exists() else []",
+            'kept = [str(item) for item in files[:keep]]',
+            'removed = [str(item) for item in files[keep:]]',
+            'if not dry_run:',
+            '    for item in files[keep:]:',
+            '        item.unlink(missing_ok=True)',
+            "print(json.dumps({'workspace_root': str(manifests_dir.parent), 'kept': kept, 'removed': removed}, indent=2, sort_keys=True))",
+            'PY',
+        ]
+    )
+    result = ssh_exec(container, script)
+    payload: dict[str, Any] = json.loads(result.stdout)
+    payload['dry_run'] = args.dry_run
+    print(json_dump(payload))
+    return 0
 
 
 def main() -> int:
     return run_gc(build_parser().parse_args())
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     raise SystemExit(main())

--- a/.agents/skills/remote-code-parity/scripts/install_consent.py
+++ b/.agents/skills/remote-code-parity/scripts/install_consent.py
@@ -6,43 +6,49 @@ import json
 from pathlib import Path
 from typing import Any
 
-from common import json_dump, load_state, repo_root_from, save_state, now_utc
+from common import json_dump, load_state, now_utc, repo_root_from, save_state
 
 
-FILENAME = "install-consents.json"
+FILENAME = 'install-consents.json'
 
 
 def load_consent_state(repo_root: Path) -> dict[str, Any]:
-    return load_state(repo_root, FILENAME, {"schema_version": 1, "consents": {}})
+    return load_state(repo_root, FILENAME, {'schema_version': 1, 'consents': {}})
 
 
 def save_consent_state(repo_root: Path, state: dict[str, Any]) -> Path:
     return save_state(repo_root, FILENAME, state)
 
 
-def set_decision(state: dict[str, Any], server_name: str, container_identity: str, decision: str, note: str | None) -> None:
-    containers = state.setdefault("consents", {}).setdefault(server_name, {}).setdefault("containers", {})
+def set_decision(
+    state: dict[str, Any],
+    server_name: str,
+    container_identity: str,
+    decision: str,
+    note: str | None,
+    *,
+    approved_by_user: bool,
+) -> None:
+    if not approved_by_user:
+        raise RuntimeError('explicit --approved-by-user is required before writing first-install consent')
+    containers = state.setdefault('consents', {}).setdefault(server_name, {}).setdefault('containers', {})
     containers[container_identity] = {
-        "decision": decision,
-        "updated_at": now_utc(),
-        "note": note or "",
+        'decision': decision,
+        'updated_at': now_utc(),
+        'note': note or '',
+        'approved_by_user': True,
     }
 
 
 def run_resolve(args: argparse.Namespace) -> int:
     repo_root = repo_root_from(Path(args.repo_root))
     state = load_consent_state(repo_root)
-    record = (
-        state.get("consents", {})
-        .get(args.server_name, {})
-        .get("containers", {})
-        .get(args.container_identity)
-    )
+    record = state.get('consents', {}).get(args.server_name, {}).get('containers', {}).get(args.container_identity)
     payload = {
-        "server_name": args.server_name,
-        "container_identity": args.container_identity,
-        "decision": record.get("decision") if record else "unknown",
-        "record": record,
+        'server_name': args.server_name,
+        'container_identity': args.container_identity,
+        'decision': record.get('decision') if record else 'unknown',
+        'record': record,
     }
     print(json_dump(payload))
     return 0
@@ -51,53 +57,63 @@ def run_resolve(args: argparse.Namespace) -> int:
 def run_set(args: argparse.Namespace) -> int:
     repo_root = repo_root_from(Path(args.repo_root))
     state = load_consent_state(repo_root)
-    set_decision(state, args.server_name, args.container_identity, args.decision, args.note)
+    set_decision(
+        state,
+        args.server_name,
+        args.container_identity,
+        args.decision,
+        args.note,
+        approved_by_user=args.approved_by_user,
+    )
     path = save_consent_state(repo_root, state)
-    print(json_dump({"status": "updated", "path": str(path)}))
+    print(json_dump({'status': 'updated', 'path': str(path)}))
     return 0
 
 
 def run_batch_set(args: argparse.Namespace) -> int:
     repo_root = repo_root_from(Path(args.repo_root))
     state = load_consent_state(repo_root)
-    items = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    items = json.loads(Path(args.input).read_text(encoding='utf-8'))
     if not isinstance(items, list):
-        raise RuntimeError("batch-set input must be a JSON list")
+        raise RuntimeError('batch-set input must be a JSON list')
     for item in items:
         if not isinstance(item, dict):
-            raise RuntimeError("each batch-set entry must be an object")
+            raise RuntimeError('each batch-set entry must be an object')
         set_decision(
             state,
-            item["server_name"],
-            item["container_identity"],
-            item["decision"],
-            item.get("note"),
+            item['server_name'],
+            item['container_identity'],
+            item['decision'],
+            item.get('note'),
+            approved_by_user=args.approved_by_user,
         )
     path = save_consent_state(repo_root, state)
-    print(json_dump({"status": "updated", "count": len(items), "path": str(path)}))
+    print(json_dump({'status': 'updated', 'count': len(items), 'path': str(path)}))
     return 0
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Manage first-install consent for remote-code-parity.")
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    parser = argparse.ArgumentParser(description='Manage first-install consent for remote-code-parity.')
+    subparsers = parser.add_subparsers(dest='command', required=True)
 
     def add_common(target: argparse.ArgumentParser) -> None:
-        target.add_argument("--repo-root", default=".")
-        target.add_argument("--server-name", required=True)
-        target.add_argument("--container-identity", required=True)
+        target.add_argument('--repo-root', default='.')
+        target.add_argument('--server-name', required=True)
+        target.add_argument('--container-identity', required=True)
 
-    resolve = subparsers.add_parser("resolve")
+    resolve = subparsers.add_parser('resolve')
     add_common(resolve)
 
-    set_parser = subparsers.add_parser("set")
+    set_parser = subparsers.add_parser('set')
     add_common(set_parser)
-    set_parser.add_argument("--decision", required=True, choices=("allow", "deny"))
-    set_parser.add_argument("--note", default=None)
+    set_parser.add_argument('--decision', required=True, choices=('allow', 'deny'))
+    set_parser.add_argument('--note', default=None)
+    set_parser.add_argument('--approved-by-user', action='store_true')
 
-    batch = subparsers.add_parser("batch-set")
-    batch.add_argument("--repo-root", default=".")
-    batch.add_argument("--input", required=True)
+    batch = subparsers.add_parser('batch-set')
+    batch.add_argument('--repo-root', default='.')
+    batch.add_argument('--input', required=True)
+    batch.add_argument('--approved-by-user', action='store_true')
 
     return parser
 
@@ -105,15 +121,19 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
-    if args.command == "resolve":
-        return run_resolve(args)
-    if args.command == "set":
-        return run_set(args)
-    if args.command == "batch-set":
-        return run_batch_set(args)
-    parser.error(f"unsupported command: {args.command}")
-    return 2
+    try:
+        if args.command == 'resolve':
+            return run_resolve(args)
+        if args.command == 'set':
+            return run_set(args)
+        if args.command == 'batch-set':
+            return run_batch_set(args)
+        parser.error(f'unsupported command: {args.command}')
+        return 2
+    except Exception as exc:
+        print(json_dump({'status': 'failed', 'reason': str(exc)}))
+        return 1
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     raise SystemExit(main())

--- a/.agents/skills/remote-code-parity/scripts/parity_sync.py
+++ b/.agents/skills/remote-code-parity/scripts/parity_sync.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from common import json_dump, repo_root_from
+from remote_code_parity import DEFAULT_CONTAINER_CACHE_ROOT
+
+
+DEFAULT_CONTAINER_USER = 'root'
+WORKSPACE_ID_PATTERN = re.compile(r'[^A-Za-z0-9._-]+')
+
+
+def derive_workspace_id(repo_root: Path) -> str:
+    base = WORKSPACE_ID_PATTERN.sub('-', repo_root.name.lower()).strip('.-') or 'workspace'
+    digest = hashlib.sha1(str(repo_root.resolve()).encode('utf-8')).hexdigest()[:8]
+    return f'{base}-{digest}'
+
+
+def canonical_inventory_path(repo_root: Path) -> Path:
+    return repo_root / '.vaws-local' / 'machine-inventory.json'
+
+
+def legacy_inventory_path(repo_root: Path) -> Path:
+    return repo_root / '.machine-inventory.json'
+
+
+def load_machine_inventory(repo_root: Path) -> dict[str, Any]:
+    for path in (canonical_inventory_path(repo_root), legacy_inventory_path(repo_root)):
+        if path.exists():
+            return json.loads(path.read_text(encoding='utf-8'))
+    return {'schema_version': 1, 'machines': []}
+
+
+def resolve_machine_record(inventory: dict[str, Any], identifier: str) -> dict[str, Any]:
+    matches = []
+    for record in inventory.get('machines', []):
+        if record.get('alias') == identifier or record.get('host', {}).get('ip') == identifier:
+            matches.append(record)
+    if not matches:
+        raise RuntimeError(f'machine {identifier!r} was not found in local inventory')
+    if len(matches) > 1:
+        raise RuntimeError(f'machine {identifier!r} matched multiple inventory records')
+    return matches[0]
+
+
+def build_derived_args(repo_root: Path, args: argparse.Namespace) -> dict[str, Any]:
+    inventory = load_machine_inventory(repo_root)
+    record = resolve_machine_record(inventory, args.machine)
+    runtime_root = args.runtime_root or record.get('container', {}).get('workdir') or '/vllm-workspace'
+    workspace_id = args.workspace_id or derive_workspace_id(repo_root)
+    server_name = record.get('alias') or record.get('host', {}).get('ip')
+    container_name = record.get('container', {}).get('name')
+    if not container_name:
+        raise RuntimeError(f'machine {args.machine!r} is missing container.name in inventory')
+    container_port = record.get('container', {}).get('ssh_port')
+    if not isinstance(container_port, int):
+        raise RuntimeError(f'machine {args.machine!r} is missing container.ssh_port in inventory')
+    container_host = record.get('host', {}).get('ip')
+    if not container_host:
+        raise RuntimeError(f'machine {args.machine!r} is missing host.ip in inventory')
+    container_identity = f'{container_name}@{runtime_root}'
+    return {
+        'workspace_root': str(repo_root),
+        'workspace_id': workspace_id,
+        'server_name': server_name,
+        'runtime_root': runtime_root,
+        'container_identity': container_identity,
+        'container_cache_root': args.container_cache_root,
+        'container_host': container_host,
+        'container_port': container_port,
+        'container_user': args.container_user,
+        'preserve_path': list(args.preserve_path),
+        'machine_record': record,
+        'inventory_path': str(canonical_inventory_path(repo_root) if canonical_inventory_path(repo_root).exists() else legacy_inventory_path(repo_root)),
+    }
+
+
+def build_low_level_command(derived: dict[str, Any], args: argparse.Namespace) -> list[str]:
+    script_path = Path(__file__).with_name('remote_code_parity.py')
+    cmd = [
+        sys.executable,
+        str(script_path),
+        'sync',
+        '--workspace-root', derived['workspace_root'],
+        '--workspace-id', derived['workspace_id'],
+        '--server-name', derived['server_name'],
+        '--runtime-root', derived['runtime_root'],
+        '--container-identity', derived['container_identity'],
+        '--container-cache-root', derived['container_cache_root'],
+        '--container-host', derived['container_host'],
+        '--container-port', str(derived['container_port']),
+        '--container-user', derived['container_user'],
+    ]
+    for preserve_path in derived['preserve_path']:
+        cmd.extend(['--preserve-path', preserve_path])
+    if args.snapshot_id:
+        cmd.extend(['--snapshot-id', args.snapshot_id])
+    if args.print_manifest:
+        cmd.append('--print-manifest')
+    if args.dry_run:
+        cmd.append('--dry-run')
+    return cmd
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description='Resolve a managed machine from inventory and run container-only remote-code-parity sync.')
+    parser.add_argument('--machine', required=True, help='machine alias or host IP from inventory')
+    parser.add_argument('--repo-root', default='.')
+    parser.add_argument('--workspace-id', default=None)
+    parser.add_argument('--runtime-root', default=None)
+    parser.add_argument('--container-user', default=DEFAULT_CONTAINER_USER)
+    parser.add_argument('--container-cache-root', default=DEFAULT_CONTAINER_CACHE_ROOT)
+    parser.add_argument('--preserve-path', action='append', default=[])
+    parser.add_argument('--snapshot-id', default=None)
+    parser.add_argument('--print-manifest', action='store_true')
+    parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--print-derived-args', action='store_true')
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    repo_root = repo_root_from(Path(args.repo_root))
+    derived = build_derived_args(repo_root, args)
+    low_level_cmd = build_low_level_command(derived, args)
+    if args.print_derived_args:
+        payload = dict(derived)
+        payload['command'] = low_level_cmd
+        print(json_dump(payload))
+        return 0
+    result = subprocess.run(low_level_cmd)
+    return result.returncode
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
+++ b/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
@@ -2,25 +2,22 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import os
+import re
 import tempfile
 import uuid
-from dataclasses import dataclass, field, asdict
-from pathlib import Path
+from dataclasses import asdict, dataclass, field
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from common import (
     DEFAULT_DENYLIST,
-    DEFAULT_REJECTED_FS_TYPES,
-    FIRST_INSTALL_MIN_FREE_BYTES,
-    HARD_MIN_FREE_BYTES,
     SshEndpoint,
     ensure_local_git_identity,
     git,
     glob_match_any,
-    human_bytes,
+    is_git_worktree,
     json_dump,
     load_state,
     now_utc,
@@ -30,41 +27,47 @@ from common import (
     save_state,
     ssh_exec,
     ssh_stream_to_file,
-    is_git_worktree,
 )
 
 
 VLLM_REINSTALL_PATTERNS = (
-    "requirements*",
-    "pyproject.toml",
-    "setup.py",
-    "setup.cfg",
-    "CMakeLists.txt",
-    "cmake/**",
-    "csrc/**",
-    "**/*.cu",
-    "**/*.cuh",
-    "**/*.cpp",
-    "**/*.cc",
-    "**/*.h",
-    "**/*.hpp",
+    'requirements*',
+    'pyproject.toml',
+    'setup.py',
+    'setup.cfg',
+    'CMakeLists.txt',
+    'cmake/**',
+    'csrc/**',
+    '**/*.cu',
+    '**/*.cuh',
+    '**/*.cpp',
+    '**/*.cc',
+    '**/*.h',
+    '**/*.hpp',
 )
 
 VLLM_ASCEND_REINSTALL_PATTERNS = VLLM_REINSTALL_PATTERNS + (
-    "vllm_ascend/_cann_ops_custom/**",
+    'vllm_ascend/_cann_ops_custom/**',
 )
 
 DEFAULT_ENV_PREAMBLE = (
-    "if [ -f /usr/local/Ascend/ascend-toolkit/set_env.sh ]; then source /usr/local/Ascend/ascend-toolkit/set_env.sh; fi",
-    "if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then source /usr/local/Ascend/nnal/atb/set_env.sh; fi",
-    "if [ -f /vllm-workspace/vllm-ascend/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/bin/set_env.bash ]; then source /vllm-workspace/vllm-ascend/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/bin/set_env.bash; fi",
-    "export PATH=/usr/local/python3.11.14/bin:$PATH",
-    "export PYTHON=/usr/local/python3.11.14/bin/python3",
-    "export PIP=/usr/local/python3.11.14/bin/pip",
-    "export VLLM_WORKER_MULTIPROC_METHOD=spawn",
-    "export OMP_NUM_THREADS=1",
-    "export MKL_NUM_THREADS=1",
+    'if [ -f /usr/local/Ascend/ascend-toolkit/set_env.sh ]; then source /usr/local/Ascend/ascend-toolkit/set_env.sh; fi',
+    'if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then source /usr/local/Ascend/nnal/atb/set_env.sh; fi',
+    'if [ -f /vllm-workspace/vllm-ascend/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/bin/set_env.bash ]; then source /vllm-workspace/vllm-ascend/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/bin/set_env.bash; fi',
+    'export PATH=/usr/local/python3.11.14/bin:$PATH',
+    'export PYTHON=/usr/local/python3.11.14/bin/python3',
+    'export PIP=/usr/local/python3.11.14/bin/pip',
+    'export VLLM_WORKER_MULTIPROC_METHOD=spawn',
+    'export OMP_NUM_THREADS=1',
+    'export MKL_NUM_THREADS=1',
 )
+
+DEFAULT_CONTAINER_CACHE_ROOT = '/root/.cache/vaws/remote-code-parity'
+DEFAULT_MARKER_DIRNAME = '.remote-code-parity'
+DEFAULT_ROOT_PRESERVE_PATHS = ('Mooncake',)
+STATE_FILENAME = 'runtime-state.json'
+CONSENT_FILENAME = 'install-consents.json'
+WORKSPACE_ID_PATTERN = re.compile(r'[^A-Za-z0-9._-]+')
 
 
 @dataclass
@@ -78,7 +81,7 @@ class RepoNode:
     relpath: str
     repo_path: Path
     submodule_name: str | None
-    children: list["RepoNode"] = field(default_factory=list)
+    children: list['RepoNode'] = field(default_factory=list)
 
 
 @dataclass
@@ -93,38 +96,78 @@ class SnapshotRecord:
     submodules: list[dict[str, str]]
 
 
+def normalize_workspace_id(value: str) -> str:
+    cleaned = WORKSPACE_ID_PATTERN.sub('-', value).strip('.-')
+    return cleaned or 'workspace'
+
+
+def validate_relative_posix_path(value: str, *, label: str) -> str:
+    candidate = PurePosixPath(value)
+    if not value or value in ('.', '..'):
+        raise RuntimeError(f'{label} must not be empty')
+    if candidate.is_absolute():
+        raise RuntimeError(f'{label} must be relative, got: {value!r}')
+    if '..' in candidate.parts:
+        raise RuntimeError(f'{label} must not contain parent traversal, got: {value!r}')
+    normalized = candidate.as_posix()
+    if normalized in ('.', ''):
+        raise RuntimeError(f'{label} must not be empty')
+    return normalized
+
+
+def validate_absolute_posix_path(value: str, *, label: str) -> str:
+    if not value.startswith('/'):
+        raise RuntimeError(f'{label} must be an absolute POSIX path, got: {value!r}')
+    return PurePosixPath(value).as_posix()
+
+
+def resolved_root_preserve_paths(marker_dirname: str, extra_paths: list[str]) -> tuple[str, ...]:
+    ordered: list[str] = []
+    for path in [*DEFAULT_ROOT_PRESERVE_PATHS, marker_dirname, *extra_paths]:
+        normalized = validate_relative_posix_path(path, label='preserve path')
+        if normalized not in ordered:
+            ordered.append(normalized)
+    return tuple(ordered)
+
+
+@dataclass
+class RuntimeInstallMarker:
+    path: str
+    record: dict[str, Any] | None
+
+
 def ensure_populated_worktree(repo: Path, relpath: str) -> None:
     if not repo.exists():
         raise RuntimeError(
-            f"required repo path {relpath} is missing; initialize submodules before remote-code-parity"
+            f'required repo path {relpath} is missing; initialize submodules before remote-code-parity'
         )
     if not is_git_worktree(repo):
         raise RuntimeError(
-            f"required repo path {relpath} is not a populated Git worktree; run repo-init or git submodule update --init --recursive before remote-code-parity"
+            f'required repo path {relpath} is not a populated Git worktree; run repo-init or git submodule update --init --recursive before remote-code-parity'
         )
 
 
 def list_submodules(repo: Path) -> list[SubmoduleEntry]:
-    gitmodules = repo / ".gitmodules"
+    gitmodules = repo / '.gitmodules'
     if not gitmodules.exists():
         return []
-    result = git(repo, ["config", "--file", str(gitmodules), "--get-regexp", r"^submodule\..*\.path$"], check=False)
-    entries: list[SubmoduleEntry] = []
+    result = git(repo, ['config', '--file', '.gitmodules', '--get-regexp', r'^submodule\..*\.path$'], check=False)
     if result.returncode != 0 or not result.stdout.strip():
-        return entries
+        return []
+    entries: list[SubmoduleEntry] = []
     for line in result.stdout.splitlines():
         key, path = line.split(maxsplit=1)
-        name = key.removeprefix("submodule.").removesuffix(".path")
+        name = key.removeprefix('submodule.').removesuffix('.path')
         entries.append(SubmoduleEntry(name=name, path=path.strip()))
     return entries
 
 
-def discover_repo_tree(repo: Path, relpath: str = ".", submodule_name: str | None = None) -> RepoNode:
+def discover_repo_tree(repo: Path, relpath: str = '.', submodule_name: str | None = None) -> RepoNode:
     ensure_populated_worktree(repo, relpath)
     node = RepoNode(relpath=relpath, repo_path=repo, submodule_name=submodule_name)
     for entry in list_submodules(repo):
         child_repo = repo / entry.path
-        child_relpath = entry.path if relpath in ("", ".") else f"{relpath}/{entry.path}"
+        child_relpath = entry.path if relpath in ('', '.') else f'{relpath}/{entry.path}'
         ensure_populated_worktree(child_repo, child_relpath)
         node.children.append(discover_repo_tree(child_repo, child_relpath, entry.name))
     return node
@@ -137,39 +180,30 @@ def iter_postorder(node: RepoNode):
 
 
 def git_head(repo: Path) -> str | None:
-    result = git(repo, ["rev-parse", "--verify", "HEAD"], check=False)
+    result = git(repo, ['rev-parse', '--verify', 'HEAD'], check=False)
     if result.returncode != 0:
         return None
     return result.stdout.strip() or None
 
 
-def git_current_branch(repo: Path) -> str | None:
-    result = git(repo, ["symbolic-ref", "--short", "HEAD"], check=False)
-    if result.returncode != 0:
-        return None
-    return result.stdout.strip() or None
-
-
-def exclude_pathspecs(node: RepoNode, denylist: tuple[str, ...]) -> list[str]:
+def reset_pathspecs(node: RepoNode, denylist: tuple[str, ...]) -> list[str]:
     specs: list[str] = []
     for child in node.children:
-        specs.append(f":(exclude){child.repo_path.relative_to(node.repo_path).as_posix()}")
+        specs.append(child.repo_path.relative_to(node.repo_path).as_posix())
     for pattern in denylist:
-        if any(ch in pattern for ch in "*?[]"):
-            specs.append(f":(glob,exclude){pattern}")
+        if any(ch in pattern for ch in '*?[]'):
+            specs.append(f':(glob){pattern}')
         else:
-            specs.append(f":(exclude){pattern}")
+            specs.append(pattern)
     return specs
 
 
 def synthetic_ref(workspace_id: str, snapshot_id: str, relpath: str) -> str:
-    repo_id = sanitize_repo_id(relpath)
-    return f"refs/parity/{workspace_id}/{snapshot_id}/{repo_id}"
+    return f'refs/parity/{workspace_id}/{snapshot_id}/{sanitize_repo_id(relpath)}'
 
 
 def commit_message(workspace_id: str, snapshot_id: str, relpath: str) -> str:
-    repo_id = sanitize_repo_id(relpath)
-    return f"remote-code-parity snapshot {workspace_id} {snapshot_id} {repo_id}"
+    return f'remote-code-parity snapshot {workspace_id} {snapshot_id} {sanitize_repo_id(relpath)}'
 
 
 def build_synthetic_snapshot(
@@ -183,24 +217,27 @@ def build_synthetic_snapshot(
     repo = node.repo_path
     parent = git_head(repo)
     ref = synthetic_ref(workspace_id, snapshot_id, node.relpath)
-    temp_index = tempfile.NamedTemporaryFile(prefix="parity-index-", delete=False)
+    temp_index = tempfile.NamedTemporaryFile(prefix='parity-index-', delete=False)
     temp_index.close()
     temp_index_path = Path(temp_index.name)
     env = os.environ.copy()
-    env["GIT_INDEX_FILE"] = temp_index.name
-    env["GIT_OPTIONAL_LOCKS"] = "0"
+    env['GIT_INDEX_FILE'] = temp_index.name
+    env['GIT_OPTIONAL_LOCKS'] = '0'
     author_name, author_email = ensure_local_git_identity(repo)
-    env.setdefault("GIT_AUTHOR_NAME", author_name or "remote-code-parity")
-    env.setdefault("GIT_AUTHOR_EMAIL", author_email or "remote-code-parity@example.invalid")
-    env.setdefault("GIT_COMMITTER_NAME", author_name or "remote-code-parity")
-    env.setdefault("GIT_COMMITTER_EMAIL", author_email or "remote-code-parity@example.invalid")
+    env.setdefault('GIT_AUTHOR_NAME', author_name or 'remote-code-parity')
+    env.setdefault('GIT_AUTHOR_EMAIL', author_email or 'remote-code-parity@example.invalid')
+    env.setdefault('GIT_AUTHOR_DATE', '1970-01-01T00:00:00Z')
+    env.setdefault('GIT_COMMITTER_NAME', author_name or 'remote-code-parity')
+    env.setdefault('GIT_COMMITTER_EMAIL', author_email or 'remote-code-parity@example.invalid')
+    env.setdefault('GIT_COMMITTER_DATE', '1970-01-01T00:00:00Z')
 
     try:
         if parent:
-            git(repo, ["read-tree", parent], env=env)
-        add_args = ["add", "-A", "-f", "--", "."]
-        add_args.extend(exclude_pathspecs(node, denylist))
-        git(repo, add_args, env=env)
+            git(repo, ['read-tree', parent], env=env)
+        git(repo, ['add', '-A'], env=env)
+        reset_specs = reset_pathspecs(node, denylist)
+        if reset_specs:
+            git(repo, ['reset', '-q', '--', *reset_specs], env=env)
 
         submodule_records: list[dict[str, str]] = []
         for child in node.children:
@@ -208,30 +245,30 @@ def build_synthetic_snapshot(
             child_rel_to_repo = child.repo_path.relative_to(repo).as_posix()
             git(
                 repo,
-                ["update-index", "--add", "--cacheinfo", f"160000,{child_record.commit},{child_rel_to_repo}"],
+                ['update-index', '--add', '--cacheinfo', f'160000,{child_record.commit},{child_rel_to_repo}'],
                 env=env,
             )
             submodule_records.append(
                 {
-                    "name": child.submodule_name or child_rel_to_repo,
-                    "path": child_rel_to_repo,
-                    "commit": child_record.commit,
-                    "repo_id": child_record.repo_id,
+                    'name': child.submodule_name or child_rel_to_repo,
+                    'path': child_rel_to_repo,
+                    'commit': child_record.commit,
+                    'repo_id': child_record.repo_id,
                 }
             )
 
-        tree = git(repo, ["write-tree"], env=env).stdout.strip()
-        commit_args = ["commit-tree", tree]
+        tree = git(repo, ['write-tree'], env=env).stdout.strip()
+        commit_args = ['commit-tree', tree]
         if parent:
-            commit_args.extend(["-p", parent])
-        commit_args.extend(["-m", commit_message(workspace_id, snapshot_id, node.relpath)])
+            commit_args.extend(['-p', parent])
+        commit_args.extend(['-m', commit_message(workspace_id, snapshot_id, node.relpath)])
         commit = git(repo, commit_args, env=env).stdout.strip()
-        git(repo, ["update-ref", ref, commit])
+        git(repo, ['update-ref', ref, commit])
 
         if parent:
-            diff = git(repo, ["diff", "--name-only", f"{parent}..{commit}"]).stdout.splitlines()
+            diff = git(repo, ['diff', '--name-only', f'{parent}..{commit}']).stdout.splitlines()
         else:
-            diff = git(repo, ["show", "--pretty=", "--name-only", commit]).stdout.splitlines()
+            diff = git(repo, ['show', '--pretty=', '--name-only', commit]).stdout.splitlines()
 
         return SnapshotRecord(
             relpath=node.relpath,
@@ -247,224 +284,191 @@ def build_synthetic_snapshot(
         temp_index_path.unlink(missing_ok=True)
 
 
-
 def cleanup_synthetic_refs(workspace_root: Path, records: list[SnapshotRecord]) -> None:
     for record in records:
-        repo = workspace_root if record.relpath in ("", ".") else workspace_root / record.relpath
-        git(repo, ["update-ref", "-d", record.ref], check=False)
+        repo = workspace_root if record.relpath in ('', '.') else workspace_root / record.relpath
+        git(repo, ['update-ref', '-d', record.ref], check=False)
 
 
 def load_runtime_state(repo_root: Path) -> dict[str, Any]:
-    return load_state(repo_root, "runtime-state.json", {"schema_version": 1, "servers": {}})
+    return load_state(repo_root, STATE_FILENAME, {'schema_version': 2, 'servers': {}})
 
 
 def save_runtime_state(repo_root: Path, state: dict[str, Any]) -> Path:
-    return save_state(repo_root, "runtime-state.json", state)
-
-
-def choose_storage_root(
-    *,
-    repo_root: Path,
-    server_name: str,
-    host: SshEndpoint,
-    provided_root: str | None,
-    candidate_roots: list[str],
-    first_install: bool,
-    dry_run: bool,
-) -> tuple[str, dict[str, Any]]:
-    state = load_runtime_state(repo_root)
-    server_state = state.setdefault("servers", {}).setdefault(server_name, {})
-    threshold = FIRST_INSTALL_MIN_FREE_BYTES if first_install else HARD_MIN_FREE_BYTES
-
-    attempts: list[dict[str, Any]] = []
-    roots_to_try: list[str] = []
-    if provided_root:
-        roots_to_try.append(provided_root)
-    if server_state.get("storage_root") and server_state["storage_root"] not in roots_to_try:
-        roots_to_try.append(server_state["storage_root"])
-    roots_to_try.extend(root for root in candidate_roots if root not in roots_to_try)
-
-    if not roots_to_try:
-        raise RuntimeError("no storage root or storage-root candidates were supplied")
-
-    if dry_run:
-        chosen = roots_to_try[0]
-        attempts.append({"path": chosen, "status": "dry-run-assumed", "free_bytes": None, "fs_type": None})
-        return chosen, {"attempts": attempts, "threshold_bytes": threshold}
-
-    for root in roots_to_try:
-        script = (
-            f"mkdir -p {quoted(root)} && "
-            f"df -PT {quoted(root)} | tail -1 && "
-            f"python3 - <<'PY'\n"
-            f"import os\n"
-            f"st = os.statvfs({root!r})\n"
-            f"print(st.f_bavail * st.f_frsize)\n"
-            f"PY"
-        )
-        result = ssh_exec(host, script, check=False)
-        if result.returncode != 0:
-            attempts.append({"path": root, "status": "probe-failed", "stderr_tail": result.stderr[-400:]})
-            continue
-        lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
-        if len(lines) < 2:
-            attempts.append({"path": root, "status": "malformed-probe-output", "stdout": result.stdout})
-            continue
-        df_line = lines[-2]
-        free_line = lines[-1]
-        parts = df_line.split()
-        fs_type = parts[1].lower() if len(parts) >= 2 else "unknown"
-        try:
-            free_bytes = int(free_line)
-        except ValueError:
-            attempts.append({"path": root, "status": "invalid-free-byte-output", "stdout": result.stdout})
-            continue
-
-        if fs_type in DEFAULT_REJECTED_FS_TYPES:
-            attempts.append({"path": root, "status": "rejected-fs-type", "fs_type": fs_type, "free_bytes": free_bytes})
-            continue
-        if free_bytes < threshold:
-            attempts.append({"path": root, "status": "below-threshold", "fs_type": fs_type, "free_bytes": free_bytes})
-            continue
-
-        server_state["storage_root"] = root
-        save_runtime_state(repo_root, state)
-        attempts.append({"path": root, "status": "selected", "fs_type": fs_type, "free_bytes": free_bytes})
-        return root, {"attempts": attempts, "threshold_bytes": threshold}
-
-    raise RuntimeError("could not find a usable storage_root:\n" + json_dump({"attempts": attempts, "threshold_bytes": threshold}))
+    return save_state(repo_root, STATE_FILENAME, state)
 
 
 def load_consent(repo_root: Path) -> dict[str, Any]:
-    return load_state(repo_root, "install-consents.json", {"schema_version": 1, "consents": {}})
+    return load_state(repo_root, CONSENT_FILENAME, {'schema_version': 1, 'consents': {}})
 
 
 def resolve_install_consent(repo_root: Path, server_name: str, container_identity: str) -> str:
     state = load_consent(repo_root)
     decision = (
-        state.get("consents", {})
+        state.get('consents', {})
         .get(server_name, {})
-        .get("containers", {})
+        .get('containers', {})
         .get(container_identity, {})
-        .get("decision")
+        .get('decision')
     )
-    return decision or "unknown"
+    return decision or 'unknown'
 
 
-def ensure_remote_bare_repo(host: SshEndpoint, mirror_path: str, dry_run: bool) -> None:
+def cache_workspace_root(container_cache_root: str, workspace_id: str) -> str:
+    return f"{container_cache_root.rstrip('/')}/workspaces/{workspace_id}"
+
+
+def mirror_path_for(container_cache_root: str, workspace_id: str, record: SnapshotRecord) -> str:
+    root = Path(cache_workspace_root(container_cache_root, workspace_id)) / 'mirrors'
+    if record.repo_id == 'workspace':
+        return str(root / 'workspace.git')
+    return str(root / 'nested' / f'{record.repo_id}.git')
+
+
+def manifest_path_for(container_cache_root: str, workspace_id: str, snapshot_id: str) -> str:
+    return str(Path(cache_workspace_root(container_cache_root, workspace_id)) / 'manifests' / f'{snapshot_id}.json')
+
+
+def lock_path_for(container_cache_root: str, workspace_id: str, container_identity: str) -> str:
+    token = re.sub(r'[^A-Za-z0-9._-]+', '-', container_identity).strip('.-') or 'container'
+    return str(Path(cache_workspace_root(container_cache_root, workspace_id)) / 'locks' / token)
+
+
+def marker_path_for(runtime_root: str, marker_dirname: str) -> str:
+    return str(Path(runtime_root) / marker_dirname / 'runtime-install.json')
+
+
+def ensure_remote_bare_repo(container: SshEndpoint, mirror_path: str, dry_run: bool) -> None:
     if dry_run:
         return
-    script = (
-        f"mkdir -p {quoted(str(Path(mirror_path).parent))} && "
-        f"if [ ! -d {quoted(mirror_path)} ]; then git init --bare {quoted(mirror_path)} >/dev/null; fi"
+    script = '\n'.join(
+        [
+            'set -eo pipefail',
+            f'mkdir -p {quoted(str(Path(mirror_path).parent))}',
+            f'if [ -e {quoted(mirror_path)} ] && [ ! -d {quoted(str(Path(mirror_path) / "objects"))} ]; then rm -rf {quoted(mirror_path)}; fi',
+            f'if [ ! -d {quoted(mirror_path)} ]; then git init --bare {quoted(mirror_path)} >/dev/null; fi',
+        ]
     )
-    ssh_exec(host, script)
+    ssh_exec(container, script)
 
 
 def push_snapshot_to_mirror(
     repo: Path,
     *,
-    host: SshEndpoint,
+    container: SshEndpoint,
     mirror_path: str,
     record: SnapshotRecord,
     workspace_id: str,
     dry_run: bool,
 ) -> None:
-    ensure_remote_bare_repo(host, mirror_path, dry_run)
+    ensure_remote_bare_repo(container, mirror_path, dry_run)
     if dry_run:
         return
-    remote_url = f"ssh://{host.user}@{host.host}:{host.port}{mirror_path}"
-    target_ref = f"refs/parity/{workspace_id}/current"
-    git(repo, ["push", "--force", remote_url, f"{record.commit}:{target_ref}"])
+    remote_url = f'ssh://{container.user}@{container.host}:{container.port}{mirror_path}'
+    target_ref = f'refs/parity/{workspace_id}/current'
+    git(repo, ['push', '--force', remote_url, f'{record.commit}:{target_ref}'])
 
 
-def remote_workspace_root(storage_root: str, workspace_id: str) -> str:
-    return f"{storage_root.rstrip('/')}/remote-code-parity/workspaces/{workspace_id}"
-
-
-def mirror_path_for(storage_root: str, workspace_id: str, record: SnapshotRecord) -> str:
-    root = Path(remote_workspace_root(storage_root, workspace_id)) / "mirrors"
-    repo_id = record.repo_id
-    if repo_id == "workspace":
-        return str(root / "workspace.git")
-    return str(root / "nested" / f"{repo_id}.git")
-
-
-def host_manifest_path(storage_root: str, workspace_id: str, snapshot_id: str) -> str:
-    root = Path(remote_workspace_root(storage_root, workspace_id)) / "manifests"
-    return str(root / f"{snapshot_id}.json")
-
-
-def host_lock_path(storage_root: str, workspace_id: str, container_identity: str) -> str:
-    root = Path(remote_workspace_root(storage_root, workspace_id)) / "locks"
-    digest = hashlib.sha256(container_identity.encode("utf-8")).hexdigest()[:16]
-    return str(root / f"{digest}.lock")
-
-
-def acquire_host_lock(host: SshEndpoint, lock_path: str, dry_run: bool) -> None:
+def acquire_container_lock(container: SshEndpoint, lock_path: str, dry_run: bool) -> None:
     if dry_run:
         return
-    script = (
-        f"mkdir -p {quoted(str(Path(lock_path).parent))} && "
-        f"mkdir {quoted(lock_path)}"
+    script = '\n'.join(
+        [
+            'set -eo pipefail',
+            f'mkdir -p {quoted(str(Path(lock_path).parent))}',
+            f'mkdir {quoted(lock_path)}',
+        ]
     )
-    result = ssh_exec(host, script, check=False)
+    result = ssh_exec(container, script, check=False)
     if result.returncode != 0:
-        raise RuntimeError(f"could not acquire host lock {lock_path}: {result.stderr or result.stdout}")
+        raise RuntimeError(f'could not acquire container lock {lock_path}: {result.stderr or result.stdout}')
 
 
-def release_host_lock(host: SshEndpoint, lock_path: str, dry_run: bool) -> None:
+def release_container_lock(container: SshEndpoint, lock_path: str, dry_run: bool) -> None:
     if dry_run:
         return
-    ssh_exec(host, f"rmdir {quoted(lock_path)} >/dev/null 2>&1 || true", check=False)
+    ssh_exec(container, f'rmdir {quoted(lock_path)} >/dev/null 2>&1 || true', check=False)
 
 
-def upload_manifest(host: SshEndpoint, manifest_path: str, manifest: dict[str, Any], dry_run: bool) -> None:
+def upload_manifest(container: SshEndpoint, manifest_path: str, manifest: dict[str, Any], dry_run: bool) -> None:
     if dry_run:
         return
-    ssh_stream_to_file(host, manifest_path, json_dump(manifest) + "\n")
+    ssh_stream_to_file(container, manifest_path, json_dump(manifest) + '\n')
 
 
-def container_repo_paths(runtime_root: str, record: SnapshotRecord) -> str:
-    relpath = record.relpath
-    if relpath in ("", "."):
+def container_repo_path(runtime_root: str, record: SnapshotRecord) -> str:
+    if record.relpath in ('', '.'):
         return runtime_root
-    return str(Path(runtime_root) / relpath)
+    return str(Path(runtime_root) / record.relpath)
+
+
+def first_install_prepare_script(runtime_root: str) -> str:
+    lines = ['set -eo pipefail', f'mkdir -p {quoted(runtime_root)}', f'cd {quoted(runtime_root)}']
+    lines.extend(DEFAULT_ENV_PREAMBLE)
+    lines.extend(
+        [
+            '$PIP uninstall -y vllm vllm-ascend vllm_ascend >/dev/null 2>&1 || true',
+            f'rm -rf {quoted(str(Path(runtime_root) / "vllm"))} {quoted(str(Path(runtime_root) / "vllm-ascend"))}',
+            f'rm -rf {quoted(str(Path(runtime_root) / ".git/modules/vllm"))} {quoted(str(Path(runtime_root) / ".git/modules/vllm-ascend"))}',
+        ]
+    )
+    return '\n'.join(lines)
+
+
+def render_git_clean(repo_dir: str, preserve_paths: tuple[str, ...]) -> str:
+    parts = ['git', '-C', quoted(repo_dir), 'clean', '-ffd']
+    for path in preserve_paths:
+        parts.extend(['-e', quoted(path)])
+    parts.append('>/dev/null')
+    return ' '.join(parts)
 
 
 def materialize_runtime(
     *,
     container: SshEndpoint,
     runtime_root: str,
-    container_storage_root: str,
+    container_cache_root: str,
     workspace_id: str,
+    marker_dirname: str,
+    root_preserve_paths: tuple[str, ...],
     records: list[SnapshotRecord],
     dry_run: bool,
 ) -> None:
     record_by_relpath = {record.relpath: record for record in records}
-    root_record = record_by_relpath["."]
-    # Top-down materialization so each repo can rewrite its child submodule URLs before update.
+    root_record = record_by_relpath['.']
+
     def render_repo_step(record: SnapshotRecord) -> list[str]:
-        repo_dir = container_repo_paths(runtime_root, record)
-        mirror_path = mirror_path_for(container_storage_root, workspace_id, record)
-        lines = [
-            f"mkdir -p {quoted(str(Path(repo_dir).parent))}",
-            f"if [ ! -d {quoted(repo_dir + '/.git')} ]; then rm -rf {quoted(repo_dir)} && git clone --no-checkout {quoted(mirror_path)} {quoted(repo_dir)} >/dev/null; fi",
-            f"git -C {quoted(repo_dir)} remote get-url parity >/dev/null 2>&1 || git -C {quoted(repo_dir)} remote add parity {quoted(mirror_path)}",
-            f"git -C {quoted(repo_dir)} remote set-url parity {quoted(mirror_path)}",
-            f"git -C {quoted(repo_dir)} fetch --force parity refs/parity/{workspace_id}/current >/dev/null",
-            f"git -C {quoted(repo_dir)} checkout -B parity/current FETCH_HEAD >/dev/null",
-            f"git -C {quoted(repo_dir)} reset --hard FETCH_HEAD >/dev/null",
-            f"git -C {quoted(repo_dir)} clean -ffd >/dev/null",
-        ]
+        repo_dir = container_repo_path(runtime_root, record)
+        mirror_path = mirror_path_for(container_cache_root, workspace_id, record)
+        lines = [f'mkdir -p {quoted(str(Path(repo_dir).parent))}']
+        if record.relpath in ('', '.'):
+            lines.append(f'if [ ! -e {quoted(str(Path(repo_dir) / ".git"))} ]; then git init {quoted(repo_dir)} >/dev/null; fi')
+        else:
+            lines.append(
+                f'if [ ! -e {quoted(str(Path(repo_dir) / ".git"))} ]; then rm -rf {quoted(repo_dir)} && git clone --no-checkout {quoted(mirror_path)} {quoted(repo_dir)} >/dev/null; fi'
+            )
+        lines.extend(
+            [
+                f'git -C {quoted(repo_dir)} remote get-url parity >/dev/null 2>&1 || git -C {quoted(repo_dir)} remote add parity {quoted(mirror_path)}',
+                f'git -C {quoted(repo_dir)} remote set-url parity {quoted(mirror_path)}',
+                f'git -C {quoted(repo_dir)} fetch --force --no-recurse-submodules parity refs/parity/{workspace_id}/current >/dev/null',
+                f'git -C {quoted(repo_dir)} checkout -B parity/current FETCH_HEAD >/dev/null',
+                f'git -C {quoted(repo_dir)} reset --hard FETCH_HEAD >/dev/null',
+            ]
+        )
+        if record.relpath in ('', '.'):
+            lines.append(render_git_clean(repo_dir, root_preserve_paths))
+        else:
+            lines.append(f'git -C {quoted(repo_dir)} clean -ffd >/dev/null')
         for child in record.submodules:
-            child_record = record_by_relpath[child["path"] if record.relpath in ("", ".") else f'{record.relpath}/{child["path"]}']
-            child_mirror = mirror_path_for(container_storage_root, workspace_id, child_record)
+            child_relpath = child['path'] if record.relpath in ('', '.') else f"{record.relpath}/{child['path']}"
+            child_record = record_by_relpath[child_relpath]
+            child_mirror = mirror_path_for(container_cache_root, workspace_id, child_record)
             lines.extend(
                 [
-                    f"git -C {quoted(repo_dir)} config submodule.{quoted(child['name'])}.url {quoted(child_mirror)}",
-                    f"git -C {quoted(repo_dir)} submodule sync -- {quoted(child['path'])} >/dev/null || true",
-                    f"git -C {quoted(repo_dir)} submodule update --init --checkout --force -- {quoted(child['path'])} >/dev/null",
+                    f'git -C {quoted(repo_dir)} config {quoted(f"submodule.{child['name']}.url")} {quoted(child_mirror)}',
+                    f'git -C {quoted(repo_dir)} submodule sync -- {quoted(child["path"])} >/dev/null || true',
+                    f'git -C {quoted(repo_dir)} submodule update --init --checkout --force -- {quoted(child["path"])} >/dev/null',
                 ]
             )
         return lines
@@ -472,16 +476,15 @@ def materialize_runtime(
     def walk(record: SnapshotRecord) -> list[str]:
         lines = render_repo_step(record)
         for child in record.submodules:
-            child_relpath = child["path"] if record.relpath in ("", ".") else f"{record.relpath}/{child['path']}"
+            child_relpath = child['path'] if record.relpath in ('', '.') else f"{record.relpath}/{child['path']}"
             lines.extend(walk(record_by_relpath[child_relpath]))
         return lines
 
-    script_lines = ["set -eo pipefail", f"mkdir -p {quoted(runtime_root)}"]
+    script_lines = ['set -eo pipefail', f'mkdir -p {quoted(runtime_root)}', f'mkdir -p {quoted(str(Path(runtime_root) / marker_dirname))}']
     script_lines.extend(walk(root_record))
-    script = "\n".join(script_lines)
     if dry_run:
         return
-    ssh_exec(container, script)
+    ssh_exec(container, '\n'.join(script_lines))
 
 
 def reinstall_required_for_repo(record: SnapshotRecord, patterns: tuple[str, ...]) -> bool:
@@ -491,59 +494,91 @@ def reinstall_required_for_repo(record: SnapshotRecord, patterns: tuple[str, ...
 def runtime_install_script(
     *,
     runtime_root: str,
+    marker_dirname: str,
     reinstall_vllm: bool,
     reinstall_vllm_ascend: bool,
     container_identity: str,
 ) -> str:
-    lines = ["set -eo pipefail", f"cd {quoted(runtime_root)}"]
+    lines = ['set -eo pipefail', f'cd {quoted(runtime_root)}']
     lines.extend(DEFAULT_ENV_PREAMBLE)
     if reinstall_vllm or reinstall_vllm_ascend:
-        lines.append("$PIP uninstall -y vllm vllm-ascend vllm_ascend >/dev/null 2>&1 || true")
+        lines.append('$PIP uninstall -y vllm vllm-ascend vllm_ascend >/dev/null 2>&1 || true')
     if reinstall_vllm:
         lines.extend(
             [
-                f"cd {quoted(str(Path(runtime_root) / 'vllm'))}",
-                "export VLLM_TARGET_DEVICE=empty",
-                "$PIP install -e . --no-build-isolation",
+                f'cd {quoted(str(Path(runtime_root) / "vllm"))}',
+                'export VLLM_TARGET_DEVICE=empty',
+                '$PIP install -e . --no-build-isolation',
             ]
         )
     if reinstall_vllm_ascend:
         lines.extend(
             [
-                f"cd {quoted(str(Path(runtime_root) / 'vllm-ascend'))}",
-                "$PIP install -r requirements.txt",
-                "$PIP install -v -e . --no-build-isolation",
+                f'cd {quoted(str(Path(runtime_root) / "vllm-ascend"))}',
+                '$PIP install -r requirements.txt',
+                '$PIP install -v -e . --no-build-isolation',
             ]
         )
     lines.extend(
         [
-            "$PYTHON - <<'PY'",
-            "import importlib.util",
-            "import torch_npu  # noqa: F401",
+            '$PYTHON - <<\'PY\'',
+            'import importlib.util',
+            'import torch_npu  # noqa: F401',
             "assert importlib.util.find_spec('vllm') is not None",
             "assert importlib.util.find_spec('vllm_ascend') is not None",
             "print('editable-import-smoke=ok')",
-            "PY",
-            f"mkdir -p {quoted(str(Path(runtime_root) / '.remote-code-parity'))}",
+            'PY',
+            f'mkdir -p {quoted(str(Path(runtime_root) / marker_dirname))}',
             (
-                "cat > "
-                + quoted(str(Path(runtime_root) / ".remote-code-parity/runtime-install.json"))
+                'cat > '
+                + quoted(marker_path_for(runtime_root, marker_dirname))
                 + " <<'JSON'\n"
                 + json.dumps(
                     {
-                        "container_identity": container_identity,
-                        "updated_at": now_utc(),
-                        "reinstall_vllm": reinstall_vllm,
-                        "reinstall_vllm_ascend": reinstall_vllm_ascend,
+                        'container_identity': container_identity,
+                        'runtime_root': runtime_root,
+                        'updated_at': now_utc(),
+                        'reinstall_vllm': reinstall_vllm,
+                        'reinstall_vllm_ascend': reinstall_vllm_ascend,
                     },
                     indent=2,
                     sort_keys=True,
                 )
-                + "\nJSON"
+                + '\nJSON'
             ),
         ]
     )
-    return "\n".join(lines)
+    return '\n'.join(lines)
+
+
+def read_runtime_install_marker(
+    *,
+    container: SshEndpoint,
+    runtime_root: str,
+    marker_dirname: str,
+    dry_run: bool,
+) -> RuntimeInstallMarker:
+    path = marker_path_for(runtime_root, marker_dirname)
+    script = '\n'.join(
+        [
+            'set -eo pipefail',
+            f'if [ -f {quoted(path)} ]; then cat {quoted(path)}; fi',
+        ]
+    )
+    result = ssh_exec(container, script)
+    content = result.stdout.strip()
+    if not content:
+        return RuntimeInstallMarker(path=path, record=None)
+    try:
+        return RuntimeInstallMarker(path=path, record=json.loads(content))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f'container runtime-install marker at {path} is invalid JSON: {exc}') from exc
+
+
+def first_install_needed(marker: RuntimeInstallMarker, container_identity: str, runtime_root: str) -> bool:
+    if marker.record is None:
+        return True
+    return marker.record.get('container_identity') != container_identity or marker.record.get('runtime_root') != runtime_root
 
 
 def verify_runtime_commits(
@@ -556,11 +591,11 @@ def verify_runtime_commits(
     expected = {record.relpath: record.commit for record in records}
     if dry_run:
         return expected
-    lines = ["set -eo pipefail"]
-    for relpath, _commit in expected.items():
-        repo_dir = runtime_root if relpath in ("", ".") else str(Path(runtime_root) / relpath)
+    lines = ['set -eo pipefail']
+    for relpath in expected:
+        repo_dir = runtime_root if relpath in ('', '.') else str(Path(runtime_root) / relpath)
         lines.append(f"printf '%s %s\\n' {quoted(relpath)} \"$(git -C {quoted(repo_dir)} rev-parse HEAD)\"")
-    result = ssh_exec(container, "\n".join(lines))
+    result = ssh_exec(container, '\n'.join(lines))
     observed: dict[str, str] = {}
     for line in result.stdout.splitlines():
         relpath, commit = line.split(maxsplit=1)
@@ -574,19 +609,21 @@ def update_runtime_state(
     server_name: str,
     container_identity: str,
     runtime_root: str,
-    storage_root: str,
+    container_cache_root: str,
+    marker_dirname: str,
     records: list[SnapshotRecord],
     first_reinstall_completed: bool,
 ) -> None:
     state = load_runtime_state(repo_root)
-    server_state = state.setdefault("servers", {}).setdefault(server_name, {})
-    server_state["storage_root"] = storage_root
-    containers = server_state.setdefault("containers", {})
+    server_state = state.setdefault('servers', {}).setdefault(server_name, {})
+    containers = server_state.setdefault('containers', {})
     containers[container_identity] = {
-        "runtime_root": runtime_root,
-        "last_sync_at": now_utc(),
-        "first_reinstall_completed": first_reinstall_completed,
-        "last_snapshot_commits": {record.relpath: record.commit for record in records},
+        'runtime_root': runtime_root,
+        'container_cache_root': container_cache_root,
+        'marker_dirname': marker_dirname,
+        'last_sync_at': now_utc(),
+        'first_reinstall_completed': first_reinstall_completed,
+        'last_snapshot_commits': {record.relpath: record.commit for record in records},
     }
     save_runtime_state(repo_root, state)
 
@@ -599,24 +636,27 @@ def make_manifest(
     server_name: str,
     container_identity: str,
     runtime_root: str,
-    storage_root: str,
+    container_cache_root: str,
+    marker_dirname: str,
+    root_preserve_paths: tuple[str, ...],
     records: list[SnapshotRecord],
-    storage_probe: dict[str, Any],
 ) -> dict[str, Any]:
     git_name, git_email = ensure_local_git_identity(workspace_root)
     return {
-        "schema_version": 1,
-        "generated_at": now_utc(),
-        "workspace_root": str(workspace_root),
-        "workspace_id": workspace_id,
-        "snapshot_id": snapshot_id,
-        "server_name": server_name,
-        "container_identity": container_identity,
-        "runtime_root": runtime_root,
-        "storage_root": storage_root,
-        "git_identity": {"name": git_name, "email": git_email},
-        "storage_probe": storage_probe,
-        "repos": [asdict(record) for record in records],
+        'schema_version': 2,
+        'generated_at': now_utc(),
+        'workspace_root': str(workspace_root),
+        'workspace_id': workspace_id,
+        'snapshot_id': snapshot_id,
+        'server_name': server_name,
+        'container_identity': container_identity,
+        'runtime_root': runtime_root,
+        'container_cache_root': container_cache_root,
+        'marker_dirname': marker_dirname,
+        'root_preserve_paths': list(root_preserve_paths),
+        'git_identity': {'name': git_name, 'email': git_email},
+        'repos': [asdict(record) for record in records],
+        'local_source_of_truth': 'tracked + staged + unstaged + untracked-nonignored',
     }
 
 
@@ -626,27 +666,29 @@ def summary_payload(
     server_name: str,
     container_identity: str,
     workspace_id: str,
-    storage_root: str | None,
+    container_cache_root: str | None,
     records: list[SnapshotRecord],
     reinstall_status: str,
     reason: str | None,
+    first_install: bool,
     observed_runtime_commits: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     return {
-        "status": status,
-        "server_name": server_name,
-        "container_identity": container_identity,
-        "workspace_id": workspace_id,
-        "storage_root": storage_root,
-        "snapshot_commits": {record.relpath: record.commit for record in records},
-        "runtime_commits": observed_runtime_commits,
-        "reinstall": reinstall_status,
-        "reason": reason,
+        'status': status,
+        'server_name': server_name,
+        'container_identity': container_identity,
+        'workspace_id': workspace_id,
+        'container_cache_root': container_cache_root,
+        'first_install': first_install,
+        'snapshot_commits': {record.relpath: record.commit for record in records},
+        'runtime_commits': observed_runtime_commits,
+        'reinstall': reinstall_status,
+        'reason': reason,
     }
 
 
 def build_snapshot_records(workspace_root: Path, workspace_id: str, snapshot_id: str, denylist: tuple[str, ...]) -> list[SnapshotRecord]:
-    tree = discover_repo_tree(workspace_root, ".", None)
+    tree = discover_repo_tree(workspace_root, '.', None)
     child_records: dict[str, SnapshotRecord] = {}
     ordered_records: list[SnapshotRecord] = []
     for node in iter_postorder(tree):
@@ -662,21 +704,36 @@ def build_snapshot_records(workspace_root: Path, workspace_id: str, snapshot_id:
     return ordered_records
 
 
+def final_manifest(manifest: dict[str, Any], *, status: str, reinstall_status: str, runtime_commits: dict[str, str] | None) -> dict[str, Any]:
+    enriched = dict(manifest)
+    enriched['completed_at'] = now_utc()
+    enriched['status'] = status
+    enriched['reinstall'] = reinstall_status
+    enriched['runtime_commits'] = runtime_commits
+    return enriched
+
+
 def run_plan(args: argparse.Namespace) -> int:
     workspace_root = repo_root_from(Path(args.workspace_root))
-    snapshot_id = args.snapshot_id or now_utc().replace(":", "").replace("-", "")
-    records = build_snapshot_records(workspace_root, args.workspace_id, snapshot_id, tuple(DEFAULT_DENYLIST))
+    workspace_id = normalize_workspace_id(args.workspace_id)
+    runtime_root = validate_absolute_posix_path(args.runtime_root, label='runtime root')
+    container_cache_root = validate_absolute_posix_path(args.container_cache_root, label='container cache root')
+    marker_dirname = validate_relative_posix_path(args.marker_dirname, label='marker dirname')
+    root_preserve_paths = resolved_root_preserve_paths(marker_dirname, args.preserve_path)
+    snapshot_id = args.snapshot_id or now_utc().replace(':', '').replace('-', '')
+    records = build_snapshot_records(workspace_root, workspace_id, snapshot_id, tuple(DEFAULT_DENYLIST))
     try:
         manifest = make_manifest(
             workspace_root=workspace_root,
-            workspace_id=args.workspace_id,
+            workspace_id=workspace_id,
             snapshot_id=snapshot_id,
             server_name=args.server_name,
             container_identity=args.container_identity,
-            runtime_root=args.runtime_root,
-            storage_root=args.storage_root or (args.storage_root_candidate[0] if args.storage_root_candidate else ""),
+            runtime_root=runtime_root,
+            container_cache_root=container_cache_root,
+            marker_dirname=marker_dirname,
+            root_preserve_paths=root_preserve_paths,
             records=records,
-            storage_probe={"attempts": [], "threshold_bytes": HARD_MIN_FREE_BYTES},
         )
         print(json_dump(manifest))
         return 0
@@ -686,133 +743,151 @@ def run_plan(args: argparse.Namespace) -> int:
 
 def run_sync(args: argparse.Namespace) -> int:
     workspace_root = repo_root_from(Path(args.workspace_root))
-    snapshot_id = args.snapshot_id or now_utc().replace(":", "").replace("-", "") + "-" + uuid.uuid4().hex[:8]
-    host = SshEndpoint(host=args.host, port=args.host_port, user=args.host_user)
+    workspace_id = normalize_workspace_id(args.workspace_id)
+    runtime_root = validate_absolute_posix_path(args.runtime_root, label='runtime root')
+    container_cache_root = validate_absolute_posix_path(args.container_cache_root, label='container cache root')
+    marker_dirname = validate_relative_posix_path(args.marker_dirname, label='marker dirname')
+    root_preserve_paths = resolved_root_preserve_paths(marker_dirname, args.preserve_path)
+    snapshot_id = args.snapshot_id or now_utc().replace(':', '').replace('-', '') + '-' + uuid.uuid4().hex[:8]
     container = SshEndpoint(host=args.container_host, port=args.container_port, user=args.container_user)
 
-    records = build_snapshot_records(workspace_root, args.workspace_id, snapshot_id, tuple(DEFAULT_DENYLIST))
+    records = build_snapshot_records(workspace_root, workspace_id, snapshot_id, tuple(DEFAULT_DENYLIST))
+    manifest_path = manifest_path_for(container_cache_root, workspace_id, snapshot_id)
     try:
         record_map = {record.relpath: record for record in records}
-        reinstall_vllm = reinstall_required_for_repo(record_map["vllm"], VLLM_REINSTALL_PATTERNS) if "vllm" in record_map else False
-        reinstall_vllm_ascend = reinstall_required_for_repo(record_map["vllm-ascend"], VLLM_ASCEND_REINSTALL_PATTERNS) if "vllm-ascend" in record_map else False
+        reinstall_vllm = reinstall_required_for_repo(record_map['vllm'], VLLM_REINSTALL_PATTERNS) if 'vllm' in record_map else False
+        reinstall_vllm_ascend = reinstall_required_for_repo(record_map['vllm-ascend'], VLLM_ASCEND_REINSTALL_PATTERNS) if 'vllm-ascend' in record_map else False
 
-        runtime_state = load_runtime_state(workspace_root)
-        previous_container_state = (
-            runtime_state.get("servers", {})
-            .get(args.server_name, {})
-            .get("containers", {})
-            .get(args.container_identity, {})
-        )
-        first_install = not bool(previous_container_state.get("first_reinstall_completed"))
-        storage_root, storage_probe = choose_storage_root(
-            repo_root=workspace_root,
-            server_name=args.server_name,
-            host=host,
-            provided_root=args.storage_root,
-            candidate_roots=args.storage_root_candidate,
-            first_install=first_install,
+        marker = read_runtime_install_marker(
+            container=container,
+            runtime_root=runtime_root,
+            marker_dirname=marker_dirname,
             dry_run=args.dry_run,
         )
-
-        reinstall_status = "not-needed"
-        consent = resolve_install_consent(workspace_root, args.server_name, args.container_identity)
+        first_install = first_install_needed(marker, args.container_identity, runtime_root)
         if first_install:
-            if consent != "allow":
-                manifest = make_manifest(
-                    workspace_root=workspace_root,
-                    workspace_id=args.workspace_id,
-                    snapshot_id=snapshot_id,
-                    server_name=args.server_name,
-                    container_identity=args.container_identity,
-                    runtime_root=args.runtime_root,
-                    storage_root=storage_root,
-                    records=records,
-                    storage_probe=storage_probe,
-                )
-                if args.print_manifest:
-                    print(json_dump(manifest))
+            consent = resolve_install_consent(workspace_root, args.server_name, args.container_identity)
+            if consent != 'allow':
                 summary = summary_payload(
-                    status="blocked",
+                    status='blocked',
                     server_name=args.server_name,
                     container_identity=args.container_identity,
-                    workspace_id=args.workspace_id,
-                    storage_root=storage_root,
+                    workspace_id=workspace_id,
+                    container_cache_root=container_cache_root,
                     records=records,
-                    reinstall_status="blocked-by-consent",
-                    reason="first-time runtime replacement requires explicit consent",
+                    reinstall_status='blocked-by-consent',
+                    reason='first-time runtime replacement requires explicit consent',
+                    first_install=True,
+                    observed_runtime_commits=None,
                 )
                 print(json_dump(summary))
                 return 2
-            reinstall_vllm = True if "vllm" in record_map else reinstall_vllm
-            reinstall_vllm_ascend = True if "vllm-ascend" in record_map else reinstall_vllm_ascend
+            reinstall_vllm = True if 'vllm' in record_map else reinstall_vllm
+            reinstall_vllm_ascend = True if 'vllm-ascend' in record_map else reinstall_vllm_ascend
 
         manifest = make_manifest(
             workspace_root=workspace_root,
-            workspace_id=args.workspace_id,
+            workspace_id=workspace_id,
             snapshot_id=snapshot_id,
             server_name=args.server_name,
             container_identity=args.container_identity,
-            runtime_root=args.runtime_root,
-            storage_root=storage_root,
+            runtime_root=runtime_root,
+            container_cache_root=container_cache_root,
+            marker_dirname=marker_dirname,
+            root_preserve_paths=root_preserve_paths,
             records=records,
-            storage_probe=storage_probe,
         )
-
         if args.print_manifest:
             print(json_dump(manifest))
 
-        lock_path = host_lock_path(storage_root, args.workspace_id, args.container_identity)
+        if args.dry_run:
+            reinstall_status = 'would-perform' if (reinstall_vllm or reinstall_vllm_ascend) else 'not-needed'
+            summary = summary_payload(
+                status='dry-run',
+                server_name=args.server_name,
+                container_identity=args.container_identity,
+                workspace_id=workspace_id,
+                container_cache_root=container_cache_root,
+                records=records,
+                reinstall_status=reinstall_status,
+                reason=None,
+                first_install=first_install,
+                observed_runtime_commits=None,
+            )
+            print(json_dump(summary))
+            return 0
+
+        lock_path = lock_path_for(container_cache_root, workspace_id, args.container_identity)
+        acquire_container_lock(container, lock_path, args.dry_run)
         try:
-            acquire_host_lock(host, lock_path, args.dry_run)
             for record in records:
-                mirror_path = mirror_path_for(storage_root, args.workspace_id, record)
                 push_snapshot_to_mirror(
+                    repo=workspace_root if record.relpath in ('', '.') else workspace_root / record.relpath,
+                    container=container,
+                    mirror_path=mirror_path_for(container_cache_root, workspace_id, record),
                     record=record,
-                    repo=workspace_root if record.relpath in ("", ".") else workspace_root / record.relpath,
-                    host=host,
-                    mirror_path=mirror_path,
-                    workspace_id=args.workspace_id,
+                    workspace_id=workspace_id,
                     dry_run=args.dry_run,
                 )
-            upload_manifest(host, host_manifest_path(storage_root, args.workspace_id, snapshot_id), manifest, args.dry_run)
+            upload_manifest(container, manifest_path, manifest, args.dry_run)
+
+            if first_install:
+                ssh_exec(container, first_install_prepare_script(runtime_root))
+
             materialize_runtime(
                 container=container,
-                runtime_root=args.runtime_root,
-                container_storage_root=args.container_storage_root or storage_root,
-                workspace_id=args.workspace_id,
+                runtime_root=runtime_root,
+                container_cache_root=container_cache_root,
+                workspace_id=workspace_id,
+                marker_dirname=marker_dirname,
+                root_preserve_paths=root_preserve_paths,
                 records=records,
                 dry_run=args.dry_run,
             )
 
+            reinstall_status = 'not-needed'
             if reinstall_vllm or reinstall_vllm_ascend:
-                reinstall_status = "performed"
-                if not args.dry_run:
-                    ssh_exec(
-                        container,
-                        runtime_install_script(
-                            runtime_root=args.runtime_root,
-                            reinstall_vllm=reinstall_vllm,
-                            reinstall_vllm_ascend=reinstall_vllm_ascend,
-                            container_identity=args.container_identity,
-                        ),
-                    )
+                reinstall_status = 'performed'
+                ssh_exec(
+                    container,
+                    runtime_install_script(
+                        runtime_root=runtime_root,
+                        marker_dirname=marker_dirname,
+                        reinstall_vllm=reinstall_vllm,
+                        reinstall_vllm_ascend=reinstall_vllm_ascend,
+                        container_identity=args.container_identity,
+                    ),
+                )
+
             observed_runtime_commits = verify_runtime_commits(
                 container=container,
-                runtime_root=args.runtime_root,
+                runtime_root=runtime_root,
                 records=records,
                 dry_run=args.dry_run,
             )
             expected_runtime_commits = {record.relpath: record.commit for record in records}
             if observed_runtime_commits != expected_runtime_commits:
+                upload_manifest(
+                    container,
+                    manifest_path,
+                    final_manifest(
+                        manifest,
+                        status='failed',
+                        reinstall_status=reinstall_status,
+                        runtime_commits=observed_runtime_commits,
+                    ),
+                    False,
+                )
                 summary = summary_payload(
-                    status="failed",
+                    status='failed',
                     server_name=args.server_name,
                     container_identity=args.container_identity,
-                    workspace_id=args.workspace_id,
-                    storage_root=storage_root,
+                    workspace_id=workspace_id,
+                    container_cache_root=container_cache_root,
                     records=records,
                     reinstall_status=reinstall_status,
-                    reason="runtime commit verification mismatch",
+                    reason='runtime commit verification mismatch',
+                    first_install=first_install,
                     observed_runtime_commits=observed_runtime_commits,
                 )
                 print(json_dump(summary))
@@ -822,60 +897,69 @@ def run_sync(args: argparse.Namespace) -> int:
                 repo_root=workspace_root,
                 server_name=args.server_name,
                 container_identity=args.container_identity,
-                runtime_root=args.runtime_root,
-                storage_root=storage_root,
+                runtime_root=runtime_root,
+                container_cache_root=container_cache_root,
+                marker_dirname=marker_dirname,
                 records=records,
-                first_reinstall_completed=first_install or previous_container_state.get("first_reinstall_completed", False) or reinstall_status == "performed",
+                first_reinstall_completed=first_install or load_runtime_state(workspace_root).get('servers', {}).get(args.server_name, {}).get('containers', {}).get(args.container_identity, {}).get('first_reinstall_completed', False) or reinstall_status == 'performed',
+            )
+            upload_manifest(
+                container,
+                manifest_path,
+                final_manifest(
+                    manifest,
+                    status='ready',
+                    reinstall_status=reinstall_status,
+                    runtime_commits=observed_runtime_commits,
+                ),
+                False,
             )
             summary = summary_payload(
-                status="ready",
+                status='ready',
                 server_name=args.server_name,
                 container_identity=args.container_identity,
-                workspace_id=args.workspace_id,
-                storage_root=storage_root,
+                workspace_id=workspace_id,
+                container_cache_root=container_cache_root,
                 records=records,
                 reinstall_status=reinstall_status,
                 reason=None,
+                first_install=first_install,
                 observed_runtime_commits=observed_runtime_commits,
             )
             print(json_dump(summary))
             return 0
         finally:
-            release_host_lock(host, lock_path, args.dry_run)
+            release_container_lock(container, lock_path, args.dry_run)
     finally:
         cleanup_synthetic_refs(workspace_root, records)
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Prepare or enforce remote code parity for a ready runtime.")
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    parser = argparse.ArgumentParser(description='Prepare or enforce remote code parity for a ready runtime.')
+    subparsers = parser.add_subparsers(dest='command', required=True)
 
     def add_shared_arguments(target: argparse.ArgumentParser) -> None:
-        target.add_argument("--workspace-root", required=True, help="Local workspace root.")
-        target.add_argument("--workspace-id", required=True, help="Stable workspace id used for remote cache namespacing.")
-        target.add_argument("--server-name", required=True)
-        target.add_argument("--runtime-root", required=True)
-        target.add_argument("--container-identity", required=True)
-        target.add_argument("--storage-root", default=None)
-        target.add_argument("--storage-root-candidate", action="append", default=[])
+        target.add_argument('--workspace-root', required=True, help='Local workspace root.')
+        target.add_argument('--workspace-id', required=True, help='Stable workspace id used for container cache namespacing.')
+        target.add_argument('--server-name', required=True)
+        target.add_argument('--runtime-root', required=True)
+        target.add_argument('--container-identity', required=True)
+        target.add_argument('--container-cache-root', default=DEFAULT_CONTAINER_CACHE_ROOT)
+        target.add_argument('--marker-dirname', default=DEFAULT_MARKER_DIRNAME)
+        target.add_argument('--preserve-path', action='append', default=[])
 
-    plan = subparsers.add_parser("plan", help="Build a synthetic snapshot manifest without remote mutations.")
+    plan = subparsers.add_parser('plan', help='Build a synthetic snapshot manifest without remote mutations.')
     add_shared_arguments(plan)
-    plan.add_argument("--snapshot-id", default=None)
-    plan.add_argument("--print-manifest", action="store_true")
+    plan.add_argument('--snapshot-id', default=None)
 
-    sync = subparsers.add_parser("sync", help="Publish mirrors, materialize runtime state, and reinstall when required.")
+    sync = subparsers.add_parser('sync', help='Publish container-local mirrors, materialize runtime state, and reinstall when required.')
     add_shared_arguments(sync)
-    sync.add_argument("--snapshot-id", default=None)
-    sync.add_argument("--host", required=True)
-    sync.add_argument("--host-port", type=int, default=22)
-    sync.add_argument("--host-user", required=True)
-    sync.add_argument("--container-host", required=True)
-    sync.add_argument("--container-port", type=int, required=True)
-    sync.add_argument("--container-user", required=True)
-    sync.add_argument("--container-storage-root", default=None, help="Container-visible path for the host storage root. Defaults to --storage-root.")
-    sync.add_argument("--dry-run", action="store_true")
-    sync.add_argument("--print-manifest", action="store_true")
+    sync.add_argument('--snapshot-id', default=None)
+    sync.add_argument('--container-host', required=True)
+    sync.add_argument('--container-port', type=int, required=True)
+    sync.add_argument('--container-user', required=True)
+    sync.add_argument('--dry-run', action='store_true')
+    sync.add_argument('--print-manifest', action='store_true')
 
     return parser
 
@@ -884,23 +968,23 @@ def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
     try:
-        if args.command == "plan":
+        if args.command == 'plan':
             return run_plan(args)
-        if args.command == "sync":
+        if args.command == 'sync':
             return run_sync(args)
-        parser.error(f"unsupported command: {args.command}")
+        parser.error(f'unsupported command: {args.command}')
         return 2
     except Exception as exc:
         payload: dict[str, Any] = {
-            "status": "failed",
-            "reason": str(exc),
+            'status': 'failed',
+            'reason': str(exc),
         }
-        for field in ("server_name", "container_identity", "workspace_id"):
+        for field in ('server_name', 'container_identity', 'workspace_id'):
             if hasattr(args, field):
                 payload[field] = getattr(args, field)
         print(json_dump(payload))
         return 1
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     raise SystemExit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Repo-local skills live under `.agents/skills/`.
   - `.agents/skills/machine-management/scripts/machine_remove.py`
 - Treat `.agents/skills/machine-management/scripts/inventory.py` and `.agents/skills/machine-management/scripts/manage_machine.py` as low-level maintenance helpers, not the default agent-facing surface.
 - Keep helper CLIs ergonomic: accept common aliases, disable brittle prefix-abbreviation behavior, and default metadata that can be inferred safely.
+- For normal remote-code-parity work, prefer `.agents/skills/remote-code-parity/scripts/parity_sync.py` over the low-level `remote_code_parity.py` helper.
 - Prefer concise machine-readable summaries over long raw command logs.
 - When a command is noisy, capture the log and report only a compact summary plus a short failure tail.
 - Preserve user choices and extra remotes unless the user explicitly asks to replace them.
@@ -48,7 +49,7 @@ Repo-local skills live under `.agents/skills/`.
 
 ## Mandatory execution gate
 
-- When a ready managed machine is about to run a remote smoke, service launch, or benchmark, run `remote-code-parity` first.
+- When a ready managed machine is about to run a remote smoke, service launch, or benchmark, run `remote-code-parity` first. Prefer the inventory-driven `parity_sync.py` entrypoint.
 - Do not continue remote execution unless `remote-code-parity` returned `status == ready`.
 - If the first runtime replacement is blocked by missing consent, stop and get consent instead of silently using the image-provided packages.
 
@@ -76,7 +77,7 @@ Do not use `machine-management` for code sync, source rebuilds, serving, benchma
 Use `remote-code-parity` automatically when:
 
 - a ready managed machine is about to run a remote smoke, service launch, or benchmark
-- the request depends on local uncommitted changes, untracked files, or ignored-but-allowed files being reflected remotely
+- the request depends on local uncommitted changes, untracked files, or other non-ignored local files being reflected remotely
 - the container already accepts direct local -> container key-based SSH
 
 Do not use `remote-code-parity` for initial machine attach, SSH repair, generic Git topology work, or unrelated local-only tasks.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Untracked workspace-local state lives under `.vaws-local/`:
 - `.vaws-local/machine-profile.json`: the stable machine username / namespace used to derive collision-safe container names such as `vaws-alice123`
 - `.vaws-local/machine-inventory.json`: managed remote-machine records for this local clone
 - `.vaws-local/remote-code-parity/install-consents.json`: per-container approval state for the first replacement of image-provided `vllm` / `vllm-ascend`
-- `.vaws-local/remote-code-parity/runtime-state.json`: advisory parity state such as the last validated `storage_root` per server and the last synced synthetic commits
+- `.vaws-local/remote-code-parity/runtime-state.json`: advisory parity state such as the last synced synthetic commits, runtime root, and container-local cache root per managed target
 
 The legacy repo-root `.machine-inventory.json` is compatibility input only.
 
@@ -89,13 +89,14 @@ New managed containers should derive their name from the local machine profile r
 
 When invoked automatically before remote execution, `remote-code-parity` can:
 
-1. treat the local working tree as the source of truth, including committed, staged, unstaged, and untracked files
+1. treat the local working tree as the source of truth, including committed, staged, unstaged, and untracked **non-ignored** files
 2. build synthetic Git snapshot commits for the workspace root, `vllm/`, `vllm-ascend/`, and any nested populated submodules without forcing a real commit
-3. publish those snapshots into host-local bare mirror repositories under a validated `storage_root`
-4. materialize the mirrored commits inside the ready runtime container so the checked-out code matches the local workspace exactly
-5. on the first sync for a fresh container, require explicit user consent before uninstalling image-provided `vllm` / `vllm-ascend` and reinstalling them from the mirrored source trees
-6. on later syncs, reinstall only when build-critical paths changed
-7. verify the final runtime commit ids instead of assuming success from command exit status alone
+3. push those snapshots directly into **container-local** bare mirror repositories over direct local -> container SSH
+4. materialize the mirrored commits in place inside `/vllm-workspace` so the checked-out code matches the local workspace exactly
+5. preserve runtime-private paths such as `Mooncake` instead of replacing the entire runtime root
+6. on the first sync for a fresh container, require explicit user consent before uninstalling image-provided `vllm` / `vllm-ascend`, deleting only `/vllm-workspace/vllm` and `/vllm-workspace/vllm-ascend`, and reinstalling them from the synced source trees
+7. on later syncs, reinstall only when build-critical paths changed
+8. verify the final runtime commit ids instead of assuming success from command exit status alone
 
 `remote-code-parity` is not a machine-attach or SSH-repair workflow. It assumes `machine-management` already proved the target container is reachable by key-based SSH.
 


### PR DESCRIPTION
## Summary

Apply the rebased `vaws_container_only_parity_rebased_main.patch` on top of `main`.

This updates the `remote-code-parity` skill package and related repo docs for the container-only transport model:
- resolve the target from machine inventory after machine attach
- sync synthetic refs directly into the container-local cache root
- add the `parity_sync.py` wrapper and refresh the supporting scripts and references

## Validation

- Patch applies cleanly on top of `origin/main`
- PR is mergeable into `main`
