### PR TITLE
[codex] optimize skill helper workflows

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -15,6 +15,8 @@ This directory contains the repository-local skill layer for Codex, Claude Code,
 
 When a workflow has deterministic shell, SSH, Git, or local-state mechanics, prefer the helper script instead of rebuilding the command inline in the conversation.
 
+Wrapper-style helpers should stream bounded phase progress on `stderr` and keep one final machine-readable JSON payload on `stdout`.
+
 When you add or revise a helper script, keep the CLI alias-tolerant and give safe defaults for metadata that can be inferred. The goal is to reduce agent parameter brittleness, not to force one exact flag spelling.
 
 Current primary helpers:
@@ -48,7 +50,7 @@ Untracked workspace-local state lives under `.vaws-local/`:
 - `.vaws-local/remote-code-parity/install-consents.json`
 - `.vaws-local/remote-code-parity/runtime-state.json`
 
-Remote-code-parity transport is container-only after machine attach: use machine inventory to resolve the target, then push synthetic refs directly into the container-local cache root.
+Remote-code-parity transport is container-only after machine attach: use machine inventory to resolve the target, then push synthetic refs directly into the container-local cache root. Synthetic mirrors should also publish an advertised branch ref for the current snapshot so nested repos can be materialized without brittle submodule fetch behavior.
 
 The legacy repo-root `.machine-inventory.json` is compatibility input only and should not be reintroduced as the primary path.
 

--- a/.agents/skills/machine-management/SKILL.md
+++ b/.agents/skills/machine-management/SKILL.md
@@ -38,6 +38,9 @@ Ready does **not** imply code sync, rebuild, serving, or benchmark readiness.
 - Keep local runtime state only under `.vaws-local/`.
 - Never write passwords or tokens into tracked files or `.vaws-local/`.
 - Never use `scp`, `sftp`, `sshpass`, or `expect` in this workflow.
+- Default container image policy is `auto`: try `quay.nju.edu.cn/ascend/vllm-ascend:latest` first, then `quay.io/ascend/vllm-ascend:latest`, always attempting a fresh pull before falling back to a cached local copy.
+- Report and persist the **actual selected image** for the managed container, not only the requested image policy.
+- Long probe / bootstrap / smoke operations must expose bounded phase progress and have an overall timeout budget, not only a connect timeout.
 - On a missing local machine profile, never call `workspace_profile.py ensure` bare. Use either:
   - `--username <letters-or-digits>` after the user chose a name
   - `--generate` only after the user explicitly accepted the default/random option
@@ -52,7 +55,7 @@ The primary bootstrap path must not depend on `ssh-copy-id`, `expect`, or any ot
 
 ## Public workflow entry points
 
-Use these task-oriented wrappers for normal agent work. They keep the parameter surface narrow and return structured JSON statuses such as `ready`, `needs_input`, `needs_repair`, `blocked`, `removed`, or `unmanaged`.
+Use these task-oriented wrappers for normal agent work. They keep the parameter surface narrow and return structured JSON statuses such as `ready`, `needs_input`, `needs_repair`, `blocked`, `removed`, or `unmanaged`. They also stream phase progress on `stderr` as `__VAWS_PROGRESS__=<json>` while reserving `stdout` for one final machine-readable JSON payload.
 
 - `python3 .agents/skills/machine-management/scripts/machine_add.py --host <ip> [--machine-username <letters-or-digits> | --generate-machine-username] [--password-env NAME | --password-stdin | --password ...]`
 - `python3 .agents/skills/machine-management/scripts/machine_verify.py --machine <alias-or-ip>`
@@ -198,6 +201,8 @@ Do not remove host firewall rules or host-level `authorized_keys` entries.
 - Use the dedicated container SSH config `/etc/ssh/sshd_vaws_config` instead of editing `/etc/ssh/sshd_config` inline.
 - Quote remote-script arguments that may contain spaces, especially SSH public keys and mesh peer keys, before sending them through `ssh`.
 - Ensure `/run/sshd` exists before starting the dedicated `sshd`.
+- Prefer low-level `--image auto` unless the user explicitly pins another image. It should pull first, then reuse a cached image only as a bounded fallback.
+- Keep progress on `stderr` and the final status JSON on `stdout`; do not mix partial human narration into the terminal contract.
 - For smoke tests, do not pin a Python patch version. Discover the highest available `/usr/local/python*/bin/python3`, then fall back to `python3`.
 - Source only environment scripts that actually exist.
 - Preseed `PATH` and `LD_LIBRARY_PATH` before sourcing env scripts under `set -u`.

--- a/.agents/skills/machine-management/references/acceptance.md
+++ b/.agents/skills/machine-management/references/acceptance.md
@@ -32,6 +32,7 @@ These should not trigger `machine-management` unless machine readiness is the ob
 - the skill does not use `scp`, `sftp`, `sshpass`, or `expect`
 - the final report is compact and evidence-based
 - structured wrapper outputs are sufficient for the agent to distinguish `ready`, `needs_input`, `needs_repair`, `blocked`, `removed`, and `unmanaged`
+- wrappers stream phase progress on `stderr` as `__VAWS_PROGRESS__=<json>` while keeping the final JSON result on `stdout`
 
 ### Public wrapper surface
 
@@ -66,11 +67,13 @@ These should not trigger `machine-management` unless machine readiness is the ob
 - the container bootstrap ensures `/run/sshd` exists
 - space-containing remote arguments such as SSH public keys and mesh peer keys survive the SSH hop intact
 - `machine_add.py` persists final alias, namespace, host identity, container name, image, and SSH port into inventory without the agent having to call `inventory.py put`
+- when image policy is `auto`, the recorded inventory image is the actual selected image after pull / fallback resolution
 
 ### Verify
 
 - verify-only runs are read-only
 - a `ready` report requires host SSH, container SSH, and a passing smoke test
+- verify and smoke paths have an overall timeout budget, not only SSH connect timeouts
 - the skill does not silently repair drift during verify-only requests
 
 ### Repair

--- a/.agents/skills/machine-management/references/behavior.md
+++ b/.agents/skills/machine-management/references/behavior.md
@@ -32,6 +32,7 @@ Rules:
 - alias and host IP must not resolve to different records
 - machine username must be letters and digits only, normalized to lowercase
 - v1 supports one managed workspace container per host
+- wrapper scripts stream phase progress on `stderr` as `__VAWS_PROGRESS__=<json>` and keep one final JSON result on `stdout`
 - on a missing profile, `workspace_profile.py ensure` must use either `--username` or `--generate`
 
 Relevant files:
@@ -220,3 +221,21 @@ Do **not**:
 - remove host firewall rules
 - remove host-level `authorized_keys`
 - guess at unmanaged containers
+
+## Image selection policy
+
+Default low-level image policy is `auto`:
+
+1. attempt `docker pull quay.nju.edu.cn/ascend/vllm-ascend:latest`
+2. if that fails, attempt `docker pull quay.io/ascend/vllm-ascend:latest`
+3. if fresh pulls fail but one of those tags is already cached locally, reuse the cached image as a bounded fallback
+4. if a managed container already exists, prefer its current image identity for non-destructive attach / repair
+
+Inventory should record the actual selected image, not only the requested policy string.
+
+## Observability and timeout contract
+
+- wrappers and low-level helpers should report phase progress early enough for an agent to distinguish `probe`, `bootstrap`, `smoke`, `inventory`, and `verify` work
+- `stderr` carries progress events; `stdout` stays reserved for the final machine-readable JSON payload
+- host probe, container bootstrap, and smoke should each have an overall timeout budget in addition to SSH connect timeouts
+- timeout failures should preserve the last known phase and any successfully returned remote payload

--- a/.agents/skills/machine-management/references/command-recipes.md
+++ b/.agents/skills/machine-management/references/command-recipes.md
@@ -1,3 +1,5 @@
+Prefer the task wrappers for normal add / verify / repair / remove work. Wrappers emit live phase events on `stderr` as `__VAWS_PROGRESS__=<json>` and keep the final structured result on `stdout`.
+
 # Machine-management command recipes
 
 Prefer the task-oriented wrappers. Treat the low-level helpers as fallback maintenance tools.
@@ -123,7 +125,8 @@ Probe one host:
 
 ```bash
 python3 .agents/skills/machine-management/scripts/manage_machine.py probe-host \
-  --host 173.125.1.2
+  --host 173.125.1.2 \
+  --image auto
 ```
 
 Bootstrap host key auth directly:
@@ -141,7 +144,8 @@ python3 .agents/skills/machine-management/scripts/manage_machine.py bootstrap-co
   --host 173.125.1.2 \
   --name vaws-alice123 \
   --port 46671 \
-  --namespace alice123
+  --namespace alice123 \
+  --image auto
 ```
 
 Run the smoke test directly:

--- a/.agents/skills/machine-management/scripts/_workflow_common.py
+++ b/.agents/skills/machine-management/scripts/_workflow_common.py
@@ -15,7 +15,7 @@ import os
 import pathlib
 import sys
 from dataclasses import dataclass
-from typing import Any, Literal, Sequence
+from typing import Any, Callable, Literal, Sequence
 
 ROOT = pathlib.Path(__file__).resolve().parents[4]
 LIB_DIR = ROOT / ".agents" / "lib"
@@ -62,6 +62,19 @@ class InventoryState:
 
 def print_json(data: dict[str, Any]) -> None:
     print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def emit_progress(*, action: str, phase: str, message: str, machine: str | None = None, **extra: Any) -> None:
+    payload: dict[str, Any] = {
+        "action": action,
+        "phase": phase,
+        "message": message,
+    }
+    if machine is not None:
+        payload["machine"] = machine
+    payload.update({key: value for key, value in extra.items() if value is not None})
+    sys.stderr.write(machine_ops.PROGRESS_SENTINEL + json.dumps(payload, ensure_ascii=False) + "\n")
+    sys.stderr.flush()
 
 
 def status_payload(
@@ -326,6 +339,7 @@ def probe_host(
         machine_ops.render_host_probe_script(),
         args=[image, port_range, managed_prefix],
         batch_mode=True,
+        timeout_seconds=machine_ops.DEFAULT_PROBE_TIMEOUT_SECONDS,
     )
     try:
         payload = machine_ops.assert_remote_success(result)
@@ -339,6 +353,8 @@ def probe_host(
             stderr_tail=machine_ops.compact_failure_tail(result.stderr),
         )
     payload["target"] = {"host": target.host, "user": target.user, "host_port": target.port}
+    if result.progress_events:
+        payload["progress_events"] = result.progress_events
     return payload
 
 
@@ -363,6 +379,7 @@ def bootstrap_container(
         machine_ops.render_bootstrap_host_script(),
         args=[container_name, str(container_ssh_port), image, workdir, public_key, namespace or ""],
         batch_mode=True,
+        timeout_seconds=machine_ops.DEFAULT_BOOTSTRAP_TIMEOUT_SECONDS,
     )
     try:
         payload = machine_ops.assert_remote_success(result)
@@ -399,6 +416,8 @@ def bootstrap_container(
             },
         }
     )
+    if result.progress_events:
+        payload["progress_events"] = result.progress_events
     if not ssh_check["ok"]:
         return status_payload(
             "needs_repair",
@@ -429,11 +448,19 @@ def smoke_machine(record: dict[str, Any], *, python: str | None = None) -> dict[
         )
 
 
-def verify_machine(record: dict[str, Any], *, python: str | None = None) -> dict[str, Any]:
+def verify_machine(
+    record: dict[str, Any],
+    *,
+    python: str | None = None,
+    progress_cb: Callable[[str, str], None] | None = None,
+) -> dict[str, Any]:
     try:
         identity_file = machine_ops.private_key_for_public_key(machine_ops.find_public_key(None))
     except machine_ops.MachineManagementError:
         identity_file = None
+
+    if progress_cb is not None:
+        progress_cb("host-ssh", "checking host SSH")
 
     host = host_target(
         host=record["host"]["ip"],
@@ -442,6 +469,8 @@ def verify_machine(record: dict[str, Any], *, python: str | None = None) -> dict
     )
     container = container_target(record)
     host_check = machine_ops.check_direct_ssh(host, identity_file=identity_file)
+    if progress_cb is not None:
+        progress_cb("container-ssh", "checking direct container SSH")
     container_check = machine_ops.check_direct_ssh(container, identity_file=identity_file)
     payload: dict[str, Any] = {
         "machine": machine_summary(record),
@@ -468,11 +497,15 @@ def verify_machine(record: dict[str, Any], *, python: str | None = None) -> dict
         )
         return payload
     if container_check["ok"]:
+        if progress_cb is not None:
+            progress_cb("smoke", "running torch/torch_npu smoke")
         smoke = smoke_machine(record, python=python)
     else:
         smoke = {"success": False, "skipped": "container SSH failed"}
     payload["smoke"] = smoke
     payload["ready"] = bool(host_check["ok"] and container_check["ok"] and smoke.get("success") is True)
+    if progress_cb is not None:
+        progress_cb("complete", "machine verification finished")
     if payload["ready"]:
         payload.update({"success": True, "status": "ready", "action": "verified"})
         return payload

--- a/.agents/skills/machine-management/scripts/machine_add.py
+++ b/.agents/skills/machine-management/scripts/machine_add.py
@@ -18,6 +18,7 @@ from _workflow_common import (  # noqa: E402
     bootstrap_host_key,
     check_host_key,
     choose_alias,
+    emit_progress,
     find_record,
     host_target,
     list_records,
@@ -63,6 +64,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
+        emit_progress(action="add", phase="profile", message="ensuring local machine profile", machine=args.host)
         profile, needs_profile, profile_action = load_or_create_profile(
             machine_username=args.machine_username,
             generate_machine_username=args.generate_machine_username,
@@ -139,6 +141,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
 
         password = resolve_password_args(args)
+        emit_progress(action="add", phase="host-auth", message="checking host key SSH", machine=alias)
         host_ssh_precheck = check_host_key(target, private_key)
         host_auth = None
         if not host_ssh_precheck["ok"]:
@@ -153,6 +156,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             host_auth = {"success": True, "result": "already-configured", "precheck": host_ssh_precheck}
 
         image_for_probe = existing["container"]["image"] if existing is not None else args.image
+        emit_progress(action="add", phase="probe", message="probing host prerequisites", machine=alias)
         probe = probe_host(target, image=image_for_probe)
         if probe.get("status") == "blocked":
             print_json(probe)
@@ -176,6 +180,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         image = existing["container"]["image"] if existing is not None else args.image
         workdir = existing["container"]["workdir"] if existing is not None else args.workdir
 
+        emit_progress(action="add", phase="bootstrap", message="bootstrapping or repairing the managed container", machine=alias)
         container = bootstrap_container(
             target,
             host=target_host,
@@ -190,7 +195,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             print_json(container)
             return 0
 
+        actual_image = container.get("selected_image") or container.get("image") or image
         bootstrap_method = "password-once" if host_ssh_precheck.get("ok") is False and password.value is not None else None
+        emit_progress(action="add", phase="inventory", message="persisting machine record and refreshing mesh", machine=alias)
         inventory_payload, record = upsert_machine_record(
             alias=alias,
             namespace=namespace,
@@ -199,13 +206,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             host_user=target_user,
             container_name=container_name,
             container_ssh_port=container_port,
-            image=image,
+            image=actual_image,
             workdir=workdir,
             bootstrap_method=bootstrap_method,
         )
         peers = [peer for peer in list_records() if peer["alias"] != record["alias"]]
         mesh = sync_mesh(record, peers=peers)
-        verified = verify_machine(record)
+        emit_progress(action="add", phase="verify", message="running final readiness verification", machine=record["alias"])
+        verified = verify_machine(
+            record,
+            progress_cb=lambda phase, message: emit_progress(action="add", phase=phase, message=message, machine=record["alias"]),
+        )
         if verified.get("status") == "blocked":
             print_json(verified)
             return 0

--- a/.agents/skills/machine-management/scripts/machine_remove.py
+++ b/.agents/skills/machine-management/scripts/machine_remove.py
@@ -14,6 +14,7 @@ from typing import Sequence
 from _workflow_common import (  # noqa: E402
     WorkflowError,
     cleanup_mesh,
+    emit_progress,
     find_record,
     list_records,
     machine_summary,
@@ -46,13 +47,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 0
 
+        emit_progress(action="remove", phase="mesh", message="cleaning up peer mesh trust", machine=record["alias"])
         peers = [peer for peer in list_records() if peer["alias"] != record["alias"]]
         mesh_cleanup = cleanup_mesh(record, peers=peers)
+        emit_progress(action="remove", phase="container", message="removing the managed container", machine=record["alias"])
         removed_container = remove_container(record)
         if removed_container.get("status") == "blocked":
             print_json(removed_container)
             return 0
 
+        emit_progress(action="remove", phase="inventory", message="removing the machine from local inventory", machine=record["alias"])
         inventory_payload, _ = remove_machine_record(record["alias"])
         print_json(
             status_payload(

--- a/.agents/skills/machine-management/scripts/machine_repair.py
+++ b/.agents/skills/machine-management/scripts/machine_repair.py
@@ -17,6 +17,7 @@ from _workflow_common import (  # noqa: E402
     bootstrap_container,
     bootstrap_host_key,
     check_host_key,
+    emit_progress,
     ensure_local_public_key,
     find_record,
     host_target,
@@ -59,7 +60,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 0
 
-        verified_before = verify_machine(record, python=args.python)
+        emit_progress(action="repair", phase="verify-before", message="checking current machine readiness", machine=record["alias"])
+        verified_before = verify_machine(
+            record,
+            python=args.python,
+            progress_cb=lambda phase, message: emit_progress(action="repair", phase=f"before-{phase}", message=message, machine=record["alias"]),
+        )
         if verified_before.get("status") == "ready":
             print_json(
                 status_payload(
@@ -82,6 +88,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
 
         password = resolve_password_args(args)
+        emit_progress(action="repair", phase="host-auth", message="checking host key SSH", machine=record["alias"])
         target = host_target(
             host=record["host"]["ip"],
             user=record["host"]["user"],
@@ -99,6 +106,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 print_json(host_auth)
                 return 0
 
+        emit_progress(action="repair", phase="bootstrap", message="repairing the managed container", machine=record["alias"])
         container = bootstrap_container(
             target,
             host=record["host"]["ip"],
@@ -113,7 +121,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             print_json(container)
             return 0
 
+        actual_image = container.get("selected_image") or container.get("image") or record["container"]["image"]
         bootstrap_method = "password-once" if host_ssh_precheck.get("ok") is False and password.value is not None else None
+        emit_progress(action="repair", phase="inventory", message="refreshing inventory and mesh state", machine=record["alias"])
         inventory_payload, updated_record = upsert_machine_record(
             alias=record["alias"],
             namespace=record.get("namespace"),
@@ -122,13 +132,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             host_user=record["host"]["user"],
             container_name=record["container"]["name"],
             container_ssh_port=record["container"]["ssh_port"],
-            image=record["container"]["image"],
+            image=actual_image,
             workdir=record["container"]["workdir"],
             bootstrap_method=bootstrap_method,
         )
         peers = [peer for peer in list_records() if peer["alias"] != updated_record["alias"]]
         mesh = sync_mesh(updated_record, peers=peers)
-        verified_after = verify_machine(updated_record, python=args.python)
+        emit_progress(action="repair", phase="verify-after", message="running post-repair readiness verification", machine=updated_record["alias"])
+        verified_after = verify_machine(
+            updated_record,
+            python=args.python,
+            progress_cb=lambda phase, message: emit_progress(action="repair", phase=f"after-{phase}", message=message, machine=updated_record["alias"]),
+        )
         if verified_after.get("status") == "blocked":
             print_json(verified_after)
             return 0

--- a/.agents/skills/machine-management/scripts/machine_verify.py
+++ b/.agents/skills/machine-management/scripts/machine_verify.py
@@ -13,6 +13,7 @@ from typing import Sequence
 
 from _workflow_common import (  # noqa: E402
     WorkflowError,
+    emit_progress,
     find_record,
     machine_summary,
     print_json,
@@ -43,7 +44,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
             )
             return 0
-        verified = verify_machine(record, python=args.python)
+        emit_progress(action="verify", phase="verify", message="running managed-machine verification", machine=record["alias"])
+        verified = verify_machine(
+            record,
+            python=args.python,
+            progress_cb=lambda phase, message: emit_progress(action="verify", phase=phase, message=message, machine=record["alias"]),
+        )
         if verified.get("status") == "ready":
             print_json(verified)
             return 0

--- a/.agents/skills/machine-management/scripts/manage_machine.py
+++ b/.agents/skills/machine-management/scripts/manage_machine.py
@@ -14,24 +14,36 @@ import argparse
 import json
 import os
 import pathlib
+import queue
 import re
 import shlex
 import shutil
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 from dataclasses import dataclass
 from typing import Any, Sequence
 
 
-DEFAULT_IMAGE = "quay.nju.edu.cn/ascend/vllm-ascend:latest"
+DEFAULT_IMAGE = "auto"
+DEFAULT_IMAGE_CANDIDATES = (
+    "quay.nju.edu.cn/ascend/vllm-ascend:latest",
+    "quay.io/ascend/vllm-ascend:latest",
+)
 DEFAULT_WORKDIR = "/vllm-workspace"
 DEFAULT_HOST_USER = "root"
 DEFAULT_HOST_PORT = 22
 DEFAULT_PORT_RANGE = "46000:46999"
 DEFAULT_KNOWN_HOSTS = pathlib.Path.home() / ".ssh" / "known_hosts"
 SENTINEL = "__VAWS_JSON__="
+PROGRESS_SENTINEL = "__VAWS_PROGRESS__="
 DEFAULT_PASSWORD_ENV = "VAWS_SSH_PASSWORD"
+DEFAULT_PROBE_TIMEOUT_SECONDS = 60
+DEFAULT_BOOTSTRAP_TIMEOUT_SECONDS = 1800
+DEFAULT_SMOKE_TIMEOUT_SECONDS = 240
+DEFAULT_REMOTE_TIMEOUT_GRACE_SECONDS = 8
 ENV_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
@@ -224,6 +236,9 @@ class RemoteResult:
     stdout: str
     stderr: str
     payload: dict[str, Any] | None
+    timed_out: bool = False
+    timeout_seconds: int | None = None
+    progress_events: list[dict[str, Any]] | None = None
 
 
 def parse_sentinel(stdout: str) -> dict[str, Any] | None:
@@ -237,22 +252,146 @@ def parse_sentinel(stdout: str) -> dict[str, Any] | None:
     return payload
 
 
+def parse_progress_event(line: str) -> dict[str, Any] | None:
+    if not line.startswith(PROGRESS_SENTINEL):
+        return None
+    try:
+        event = json.loads(line[len(PROGRESS_SENTINEL) :])
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(event, dict):
+        return None
+    return event
+
+
+def format_progress_event(event: dict[str, Any], *, target: SshTarget | None = None) -> str:
+    phase = str(event.get("phase") or "remote")
+    message = str(event.get("message") or event.get("status") or "running")
+    expected = event.get("expected_seconds")
+    if isinstance(expected, int) and expected > 0:
+        message = f"{message} (~{expected}s)"
+    host = f" {target.host}" if target is not None else ""
+    return f"[vaws{host}][{phase}] {message}"
+
+
+def emit_progress_event(event: dict[str, Any], *, target: SshTarget | None = None) -> None:
+    sys.stderr.write(format_progress_event(event, target=target) + "\n")
+    sys.stderr.flush()
+
+
 def run_remote_script(
     target: SshTarget,
     script: str,
     *,
     args: Sequence[str] = (),
     batch_mode: bool = True,
+    timeout_seconds: int | None = None,
+    stream_progress: bool = True,
 ) -> RemoteResult:
     remote_cmd = remote_shell_command(["bash", "-s", "--", *args])
     cmd = ssh_command(target, batch_mode=batch_mode) + [remote_cmd]
-    proc = run_local(cmd, input_text=script)
+    try:
+        proc = subprocess.Popen(
+            list(cmd),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except FileNotFoundError as exc:
+        raise MachineManagementError(f"required local command not found: {cmd[0]}") from exc
+
+    assert proc.stdin is not None
+    proc.stdin.write(script)
+    proc.stdin.close()
+
+    q: queue.Queue[tuple[str, str | None]] = queue.Queue()
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+    progress_events: list[dict[str, Any]] = []
+
+    def reader(stream_name: str, pipe: Any) -> None:
+        try:
+            for line in pipe:
+                q.put((stream_name, line))
+        finally:
+            q.put((stream_name, None))
+
+    threads = [
+        threading.Thread(target=reader, args=("stdout", proc.stdout), daemon=True),
+        threading.Thread(target=reader, args=("stderr", proc.stderr), daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+
+    done_streams: set[str] = set()
+    deadline = time.monotonic() + timeout_seconds if timeout_seconds is not None else None
+    timed_out = False
+
+    while len(done_streams) < 2 or proc.poll() is None:
+        if deadline is not None and time.monotonic() >= deadline and proc.poll() is None:
+            timed_out = True
+            proc.kill()
+            break
+        wait_timeout = 0.2
+        if deadline is not None:
+            wait_timeout = max(0.01, min(wait_timeout, deadline - time.monotonic()))
+        try:
+            stream_name, line = q.get(timeout=wait_timeout)
+        except queue.Empty:
+            continue
+        if line is None:
+            done_streams.add(stream_name)
+            continue
+        if stream_name == "stdout":
+            stdout_parts.append(line)
+        else:
+            stderr_parts.append(line)
+        event = parse_progress_event(line)
+        if event is not None:
+            progress_events.append(event)
+            if stream_progress:
+                emit_progress_event(event, target=target)
+
+    try:
+        proc.wait(timeout=DEFAULT_REMOTE_TIMEOUT_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=DEFAULT_REMOTE_TIMEOUT_GRACE_SECONDS)
+
+    for thread in threads:
+        thread.join(timeout=1)
+
+    while True:
+        try:
+            stream_name, line = q.get_nowait()
+        except queue.Empty:
+            break
+        if line is None:
+            continue
+        if stream_name == "stdout":
+            stdout_parts.append(line)
+        else:
+            stderr_parts.append(line)
+        event = parse_progress_event(line)
+        if event is not None and event not in progress_events:
+            progress_events.append(event)
+            if stream_progress:
+                emit_progress_event(event, target=target)
+
+    stdout = "".join(stdout_parts)
+    stderr = "".join(stderr_parts)
     return RemoteResult(
         target=target,
-        returncode=proc.returncode,
-        stdout=proc.stdout,
-        stderr=proc.stderr,
-        payload=parse_sentinel(proc.stdout),
+        returncode=proc.returncode or 0,
+        stdout=stdout,
+        stderr=stderr,
+        payload=parse_sentinel(stdout),
+        timed_out=timed_out,
+        timeout_seconds=timeout_seconds,
+        progress_events=progress_events,
     )
 
 
@@ -268,6 +407,32 @@ def compact_failure_tail(text: str, *, max_lines: int = 20, max_chars: int = 160
 
 
 def assert_remote_success(result: RemoteResult, *, require_payload: bool = True) -> dict[str, Any]:
+    payload = dict(result.payload or {})
+    if result.progress_events:
+        payload.setdefault("progress_events", result.progress_events)
+    if result.timeout_seconds is not None:
+        transport = payload.setdefault("transport", {})
+        transport.setdefault("timeout_seconds", result.timeout_seconds)
+        transport.setdefault("timed_out", result.timed_out)
+
+    if result.timed_out:
+        if result.payload is not None and result.payload.get("success") is True:
+            transport = payload.setdefault("transport", {})
+            transport.update({
+                "timeout_seconds": result.timeout_seconds,
+                "timed_out": True,
+                "timeout_recovered_after_payload": True,
+                "returncode": result.returncode,
+            })
+            return payload
+        detail = f"remote command timed out after {result.timeout_seconds}s"
+        if result.progress_events:
+            detail += f"; last progress: {format_progress_event(result.progress_events[-1], target=result.target)}"
+        stderr_tail = compact_failure_tail(result.stderr)
+        if stderr_tail:
+            detail += f"\n--- stderr tail ---\n{stderr_tail}"
+        raise MachineManagementError(detail)
+
     if require_payload and result.payload is None:
         detail = result.stderr.strip() or result.stdout.strip() or "remote command produced no JSON payload"
         raise MachineManagementError(detail)
@@ -280,7 +445,7 @@ def assert_remote_success(result: RemoteResult, *, require_payload: bool = True)
             raise MachineManagementError(base)
         detail = result.stderr.strip() or result.stdout.strip() or "remote command failed"
         raise MachineManagementError(detail)
-    return result.payload or {}
+    return payload
 
 
 def find_public_key(explicit: str | None = None) -> pathlib.Path:
@@ -313,7 +478,7 @@ def load_public_key(path: pathlib.Path) -> str:
 def render_host_probe_script() -> str:
     template = r'''#!/usr/bin/env bash
 set -euo pipefail
-image="$1"
+image_spec="$1"
 port_range="$2"
 prefix="$3"
 py=""
@@ -327,7 +492,7 @@ if [ -z "$py" ]; then
   echo "__SENTINEL__{\"success\": false, \"error\": \"python not found on remote host\"}"
   exit 3
 fi
-"$py" - "$image" "$port_range" "$prefix" <<'PY'
+"$py" - "$image_spec" "$port_range" "$prefix" <<'PY'
 import json
 import os
 import pathlib
@@ -336,7 +501,8 @@ import socket
 import subprocess
 import sys
 
-image, port_range, prefix = sys.argv[1:4]
+AUTO_CANDIDATES = ["quay.nju.edu.cn/ascend/vllm-ascend:latest", "quay.io/ascend/vllm-ascend:latest"]
+image_spec, port_range, prefix = sys.argv[1:4]
 start_s, end_s = port_range.split(":", 1)
 start, end = int(start_s), int(end_s)
 
@@ -353,6 +519,14 @@ def run(cmd: list[str]) -> tuple[int, str, str]:
     return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
 
 
+def resolve_image_candidates(spec: str) -> list[str]:
+    if spec == "auto":
+        return list(AUTO_CANDIDATES)
+    candidates = [item.strip() for item in spec.split(",") if item.strip()]
+    return candidates or [spec]
+
+
+candidates = resolve_image_candidates(image_spec)
 result: dict[str, object] = {
     "success": True,
     "hostname": socket.gethostname(),
@@ -366,8 +540,12 @@ result: dict[str, object] = {
     "optional_mounts": [],
     "npu_smi_present": os.path.exists("/usr/local/bin/npu-smi"),
     "image": {
-        "name": image,
+        "name": image_spec,
+        "requested": image_spec,
+        "policy": "auto-refresh-pull" if image_spec == "auto" else "explicit",
+        "candidates": candidates,
         "present_local": False,
+        "present_local_candidates": [],
     },
     "managed_containers": [],
     "free_port": None,
@@ -401,8 +579,13 @@ if result["docker"]["present"]:
         result["docker"]["version"] = out
     rc, _, _ = run(["docker", "info"])
     result["docker"]["info_ok"] = rc == 0
-    rc, _, _ = run(["docker", "image", "inspect", image])
-    result["image"]["present_local"] = rc == 0
+    present_local_candidates: list[str] = []
+    for candidate in candidates:
+        rc, _, _ = run(["docker", "image", "inspect", candidate])
+        if rc == 0:
+            present_local_candidates.append(candidate)
+    result["image"]["present_local_candidates"] = present_local_candidates
+    result["image"]["present_local"] = bool(present_local_candidates)
     rc, out, _ = run(["docker", "ps", "-a", "--format", "{{.Names}}\t{{.Status}}\t{{.Image}}"])
     if rc == 0:
         rows = []
@@ -447,10 +630,11 @@ def render_bootstrap_host_script() -> str:
 set -euo pipefail
 container="$1"
 port="$2"
-image="$3"
+image_spec="$3"
 workdir="$4"
 pubkey="$5"
 namespace="${6:-}"
+auto_candidates_json='["quay.nju.edu.cn/ascend/vllm-ascend:latest", "quay.io/ascend/vllm-ascend:latest"]'
 
 emit_json() {
   python3 - "$1" <<'PY'
@@ -460,6 +644,40 @@ print("__SENTINEL__" + json.dumps(json.loads(sys.argv[1]), ensure_ascii=False))
 PY
 }
 
+emit_progress() {
+  python3 - "$1" "$2" "$3" "${4:-}" <<'PY' >&2
+import json
+import sys
+payload = {
+    "phase": sys.argv[1],
+    "status": sys.argv[2],
+    "message": sys.argv[3],
+}
+if len(sys.argv) > 4 and sys.argv[4]:
+    try:
+        payload["expected_seconds"] = int(sys.argv[4])
+    except ValueError:
+        pass
+print("__PROGRESS__" + json.dumps(payload, ensure_ascii=False))
+PY
+}
+
+resolve_image_candidates() {
+  python3 - "$image_spec" "$auto_candidates_json" <<'PY'
+import json
+import sys
+image_spec = sys.argv[1]
+auto_candidates = json.loads(sys.argv[2])
+if image_spec == "auto":
+    candidates = auto_candidates
+else:
+    candidates = [item.strip() for item in image_spec.split(",") if item.strip()] or [image_spec]
+for item in candidates:
+    print(item)
+PY
+}
+
+emit_progress "preflight" "running" "validating host docker and Ascend prerequisites" 15
 if ! command -v docker >/dev/null 2>&1; then
   emit_json '{"success": false, "error": "docker not found on host", "phase": "probe"}'
   exit 10
@@ -499,26 +717,47 @@ started=false
 pulled=false
 installed_ssh=false
 firewall="none"
+selected_image=""
+image_resolution="unknown"
 
 if docker inspect "$container" >/dev/null 2>&1; then
+  emit_progress "container" "running" "reusing an existing managed container" 15
   state=$(docker inspect -f '{{.State.Status}}' "$container")
+  selected_image=$(docker inspect -f '{{.Config.Image}}' "$container")
+  image_resolution="existing-container"
   if [ "$state" != "running" ]; then
     docker start "$container" >/dev/null
     started=true
     actions+=("started-existing-container")
   fi
 else
-  if ! docker image inspect "$image" >/dev/null 2>&1; then
+  mapfile -t image_candidates < <(resolve_image_candidates)
+  if [ "${#image_candidates[@]}" -eq 0 ]; then
+    image_candidates=("$image_spec")
+  fi
+  emit_progress "image" "running" "resolving container image" 180
+  for candidate in "${image_candidates[@]}"; do
+    emit_progress "image" "running" "trying image candidate $candidate" 180
     pull_log=$(mktemp)
-    if ! docker pull "$image" >"$pull_log" 2>&1; then
-      tail -n 120 "$pull_log" >&2 || true
+    if docker pull "$candidate" >"$pull_log" 2>&1; then
       rm -f "$pull_log"
-      emit_json '{"success": false, "error": "docker pull failed", "phase": "image"}'
-      exit 20
+      selected_image="$candidate"
+      image_resolution="pulled"
+      pulled=true
+      actions+=("pulled-image")
+      break
     fi
     rm -f "$pull_log"
-    pulled=true
-    actions+=("pulled-image")
+    if docker image inspect "$candidate" >/dev/null 2>&1; then
+      selected_image="$candidate"
+      image_resolution="local-cache"
+      actions+=("reused-local-image-cache")
+      break
+    fi
+  done
+  if [ -z "$selected_image" ]; then
+    emit_json '{"success": false, "error": "no usable image candidate was found", "phase": "image"}'
+    exit 20
   fi
 
   mount_args=()
@@ -528,6 +767,7 @@ else
     fi
   done
 
+  emit_progress "container" "running" "creating managed container" 45
   docker run --name "$container" -it -d --network host --shm-size=500g \
     --privileged=true \
     --label com.vaws.managed=true \
@@ -545,13 +785,14 @@ else
     -v /usr/local/sbin:/usr/local/sbin \
     -v /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime:ro \
     "${mount_args[@]}" \
-    "$image" >/dev/null
+    "$selected_image" >/dev/null
 
   created=true
   actions+=("created-container")
 fi
 
 if ! docker exec "$container" bash -lc 'command -v sshd >/dev/null 2>&1 && command -v ssh >/dev/null 2>&1'; then
+  emit_progress "container-ssh" "running" "installing openssh inside the container" 600
   if ! docker exec "$container" bash -lc '
 set -euo pipefail
 log=$(mktemp)
@@ -569,6 +810,7 @@ fi
   actions+=("installed-openssh")
 fi
 
+emit_progress "container-ssh" "running" "configuring dedicated container sshd" 60
 if ! docker exec -i "$container" bash -s -- "$port" "$pubkey" <<'INNER'
 set -euo pipefail
 port="$1"
@@ -581,7 +823,7 @@ fi
 chmod 600 /root/.ssh/authorized_keys
 install -d -m 0755 /run/sshd
 ssh-keygen -A >/dev/null 2>&1 || true
-cat > /etc/ssh/sshd_vaws_config <<EOF
+cat > /etc/ssh/sshd_vaws_config <<EOF2
 Port ${port}
 ListenAddress 0.0.0.0
 Protocol 2
@@ -597,7 +839,7 @@ UsePAM no
 PrintMotd no
 AuthorizedKeysFile .ssh/authorized_keys
 PidFile /run/sshd_vaws.pid
-EOF
+EOF2
 /usr/sbin/sshd -t -f /etc/ssh/sshd_vaws_config
 if [ -f /run/sshd_vaws.pid ]; then
   kill "$(cat /run/sshd_vaws.pid)" 2>/dev/null || true
@@ -615,6 +857,7 @@ then
 fi
 actions+=("configured-dedicated-sshd")
 
+emit_progress "firewall" "running" "updating host firewall for the container ssh port" 30
 if command -v ufw >/dev/null 2>&1; then
   ufw allow "${port}/tcp" >/dev/null 2>&1 || true
   firewall="ufw"
@@ -624,15 +867,26 @@ elif command -v firewall-cmd >/dev/null 2>&1 && firewall-cmd --state >/dev/null 
   firewall="firewalld"
 fi
 
-payload=$(python3 - <<'PY' "$container" "$port" "$image" "$workdir" "$namespace" "$created" "$started" "$pulled" "$installed_ssh" "$firewall" "${actions[*]}"
+payload=$(python3 - <<'PY' "$container" "$port" "$image_spec" "$selected_image" "$image_resolution" "$workdir" "$namespace" "$created" "$started" "$pulled" "$installed_ssh" "$firewall" "${actions[*]}" "$auto_candidates_json"
 import json
 import sys
-container, port, image, workdir, namespace, created, started, pulled, installed_ssh, firewall, actions = sys.argv[1:]
+
+def resolve_candidates(spec: str, auto_candidates_text: str) -> list[str]:
+    auto_candidates = json.loads(auto_candidates_text)
+    if spec == "auto":
+        return auto_candidates
+    return [item.strip() for item in spec.split(",") if item.strip()] or [spec]
+
+container, port, requested_image, selected_image, image_resolution, workdir, namespace, created, started, pulled, installed_ssh, firewall, actions, auto_candidates_json = sys.argv[1:]
 print(json.dumps({
     "success": True,
     "container": container,
     "container_ssh_port": int(port),
-    "image": image,
+    "image": selected_image,
+    "requested_image": requested_image,
+    "selected_image": selected_image,
+    "image_resolution": image_resolution,
+    "image_candidates": resolve_candidates(requested_image, auto_candidates_json),
     "workdir": workdir,
     "namespace": namespace or None,
     "created": created == "true",
@@ -644,15 +898,28 @@ print(json.dumps({
 }, ensure_ascii=False))
 PY
 )
+emit_progress "complete" "done" "managed container bootstrap completed" 0
 emit_json "$payload"
 '''
-    return template.replace("__SENTINEL__", SENTINEL)
+    return template.replace("__SENTINEL__", SENTINEL).replace("__PROGRESS__", PROGRESS_SENTINEL)
 
 
 def render_smoke_script() -> str:
     template = r'''#!/usr/bin/env bash
 set -euo pipefail
 requested_python="${1:-}"
+
+emit_progress() {
+  python3 - "$1" "$2" "$3" <<'PY' >&2
+import json
+import sys
+print("__PROGRESS__" + json.dumps({
+    "phase": sys.argv[1],
+    "status": sys.argv[2],
+    "message": sys.argv[3],
+}, ensure_ascii=False))
+PY
+}
 
 detect_python() {
   if [ -n "$requested_python" ] && [ -x "$requested_python" ]; then
@@ -676,12 +943,14 @@ detect_python() {
   return 1
 }
 
+emit_progress "python-discovery" "running" "discovering a usable python inside the container"
 PYTHON_BIN="$(detect_python || true)"
 if [ -z "$PYTHON_BIN" ]; then
   echo "__SENTINEL__{\"success\": false, \"error\": \"python not found in container\", \"phase\": \"python-discovery\"}"
   exit 40
 fi
 
+emit_progress "env" "running" "preparing Ascend and python environment"
 export PATH="${PATH:-}"
 export LD_LIBRARY_PATH="/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/driver/lib64:${LD_LIBRARY_PATH:-}"
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
@@ -710,8 +979,14 @@ import os
 import sys
 import traceback
 
+PROGRESS = "__PROGRESS__"
 python_path = sys.argv[1]
 sourced_text = sys.argv[2]
+
+def progress(phase: str, message: str) -> None:
+    sys.stderr.write(PROGRESS + json.dumps({"phase": phase, "status": "running", "message": message}, ensure_ascii=False) + "\n")
+    sys.stderr.flush()
+
 result = {
     "success": False,
     "python_path": python_path,
@@ -724,10 +999,13 @@ result = {
     "sourced_scripts": [line for line in sourced_text.splitlines() if line],
 }
 try:
+    progress("smoke", "importing torch and torch_npu")
     import torch
     import torch_npu  # noqa: F401
 
+    progress("smoke", "allocating a small tensor on NPU")
     x = torch.zeros(1, 2).npu()
+    progress("smoke", "container smoke test passed")
     result.update(
         {
             "success": True,
@@ -751,7 +1029,7 @@ print("__SENTINEL__" + json.dumps(result, ensure_ascii=False))
 raise SystemExit(0 if result["success"] else 3)
 PY
 '''
-    return template.replace("__SENTINEL__", SENTINEL)
+    return template.replace("__SENTINEL__", SENTINEL).replace("__PROGRESS__", PROGRESS_SENTINEL)
 
 
 def render_mesh_export_key_script() -> str:
@@ -1025,6 +1303,7 @@ def cmd_probe_host(args: argparse.Namespace) -> int:
         render_host_probe_script(),
         args=[args.image, args.port_range, args.managed_prefix],
         batch_mode=True,
+        timeout_seconds=DEFAULT_PROBE_TIMEOUT_SECONDS,
     )
     payload = assert_remote_success(result)
     payload["target"] = {
@@ -1053,6 +1332,7 @@ def cmd_bootstrap_container(args: argparse.Namespace) -> int:
             args.namespace or "",
         ],
         batch_mode=True,
+        timeout_seconds=DEFAULT_BOOTSTRAP_TIMEOUT_SECONDS,
     )
     payload = assert_remote_success(result)
 
@@ -1092,6 +1372,7 @@ def smoke_payload(args: argparse.Namespace) -> dict[str, Any]:
         render_smoke_script(),
         args=[python_arg],
         batch_mode=True,
+        timeout_seconds=DEFAULT_SMOKE_TIMEOUT_SECONDS,
     )
     payload = assert_remote_success(result, require_payload=True)
     payload["target"] = {
@@ -1290,7 +1571,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     probe = subparsers.add_parser("probe-host", help="probe host prerequisites and choose a free high SSH port")
     add_host_args(probe)
-    probe.add_argument("--image", default=DEFAULT_IMAGE, help=f"image name (default: {DEFAULT_IMAGE})")
+    probe.add_argument("--image", default=DEFAULT_IMAGE, help=f"image name or image policy (default: {DEFAULT_IMAGE}; auto tries {DEFAULT_IMAGE_CANDIDATES[0]} then {DEFAULT_IMAGE_CANDIDATES[1]})")
     probe.add_argument("--port-range", default=DEFAULT_PORT_RANGE, help=f"inclusive range START:END (default: {DEFAULT_PORT_RANGE})")
     probe.add_argument("--managed-prefix", default="vaws-", help="managed container name prefix (default: vaws-)")
     probe.set_defaults(func=cmd_probe_host)
@@ -1338,7 +1619,7 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="high non-default SSH port for the managed container",
     )
-    bootstrap.add_argument("--image", default=DEFAULT_IMAGE, help=f"image name (default: {DEFAULT_IMAGE})")
+    bootstrap.add_argument("--image", default=DEFAULT_IMAGE, help=f"image name or image policy (default: {DEFAULT_IMAGE}; auto tries {DEFAULT_IMAGE_CANDIDATES[0]} then {DEFAULT_IMAGE_CANDIDATES[1]})")
     bootstrap.add_argument("--workdir", default=DEFAULT_WORKDIR, help=f"container workdir (default: {DEFAULT_WORKDIR})")
     bootstrap.add_argument("--namespace", help="stable workspace machine username used for collision-safe container naming")
     bootstrap.add_argument("--public-key-file", help="local SSH public key to add to the container; defaults to ~/.ssh/id_ed25519.pub if present")

--- a/.agents/skills/remote-code-parity/SKILL.md
+++ b/.agents/skills/remote-code-parity/SKILL.md
@@ -32,6 +32,11 @@ Keep a **ready** remote runtime in exact code parity with the local `vllm-ascend
 - Use synthetic snapshot refs so dirty working trees can move through Git transport.
 - Keep container cache / lock / manifest paths isolated by `workspace_id` under a container-local cache root.
 - Preserve runtime-private paths under `/vllm-workspace`, especially `Mooncake`.
+- Keep `stdout` reserved for one final JSON summary and stream phase progress on `stderr` as `__VAWS_PARITY_PROGRESS__=<json>`.
+- Publish each synthetic snapshot to both the parity ref and an advertised branch ref inside the container-local mirror.
+- Materialize child repos explicitly; do not rely on `git submodule update` to fetch synthetic child commits.
+- Use dynamic Python / pip discovery and the Ascend driver `LD_LIBRARY_PATH` preamble instead of pinning one Python patch path.
+- If editable install fails because the image packaging stack is too old, attempt one bounded packaging-stack refresh before failing closed.
 - Fail closed if parity cannot be proven.
 - First replacement of image-provided `vllm` / `vllm-ascend` requires explicit user consent for that logical container identity.
 - `install_consent.py set` and `batch-set` must include `--approved-by-user`.
@@ -134,7 +139,7 @@ Ignored files stay ignored. The snapshot source of truth is tracked + untracked 
 For each repo in scope:
 
 - ensure the container-local bare mirror repo exists under the cache root
-- push the synthetic commit to `refs/parity/<workspace_id>/current`
+- push the synthetic commit to `refs/parity/<workspace_id>/current` and to an advertised branch ref inside that same mirror
 - write a compact manifest for this sync attempt under `manifests/`
 - use a **container-local** lock while mutating cache or runtime state
 
@@ -169,7 +174,7 @@ Inside the container:
 - fetch each repo from the container-local mirror path
 - force the runtime repo to the synthetic parity ref
 - rewrite submodule URLs to container-local mirror paths
-- initialize / update submodules against those mirror paths
+- rewrite submodule URLs to those mirror paths and recursively materialize child repos explicitly
 - preserve runtime-private paths such as `Mooncake` and `.remote-code-parity`
 - ensure the checked-out commits match the manifest
 
@@ -185,7 +190,7 @@ Conservative defaults:
 - `vllm-ascend`: same as `vllm`, plus `vllm_ascend/_cann_ops_custom/**`
 - pure Python, docs, configs, tests, and ordinary scripts: parity only, no rebuild
 
-Use these commands inside the container when required:
+Use these commands inside the container when required. The normal path first tries the in-place environment, then does one bounded packaging refresh / retry when legacy packaging metadata blocks editable install:
 
 ### `vllm`
 

--- a/.agents/skills/remote-code-parity/references/acceptance.md
+++ b/.agents/skills/remote-code-parity/references/acceptance.md
@@ -29,6 +29,7 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 - the skill does not require GitHub credentials on the host or in the container
 - the skill keeps local runtime state only under `.vaws-local/remote-code-parity/`
 - normal outcomes are reported as compact JSON with `status` equal to `ready`, `blocked`, `failed`, or `dry-run`
+- phase progress is emitted on `stderr` as `__VAWS_PARITY_PROGRESS__=<json>` while the final summary stays on `stdout`
 
 ### Repo graph and snapshotting
 
@@ -43,6 +44,7 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 
 - the normal sync path does not require host storage, host lock directories, or `docker inspect`
 - container-local bare mirrors are populated directly through container SSH
+- advertised branch refs are published inside the mirror so synthetic child commits are fetchable through ordinary Git paths
 - the normal agent-facing entrypoint can resolve the target from machine inventory through `parity_sync.py`
 - the skill does not create or reuse a flat shared host path such as `/home/vaws`
 
@@ -57,10 +59,13 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 ### Runtime materialization and proof
 
 - `/vllm-workspace` is updated in place instead of being replaced wholesale
+- nested repos are materialized explicitly instead of relying on `git submodule update` for synthetic child commits
 - runtime-private paths such as `Mooncake` survive root cleanups
 - final `git rev-parse HEAD` values inside the container match the synthetic snapshot commits exactly
 - reinstall runs only when the trigger matrix says it should, except for the mandatory first approved replacement on a fresh container
 - a successful run ends with `status == ready`
+- runtime install uses dynamic Python discovery plus the Ascend driver `LD_LIBRARY_PATH` preamble instead of one hard-coded Python patch path
+- packaging-metadata failures from stale image toolchains trigger one bounded packaging-stack refresh / retry before the skill reports `failed`
 
 ## Regression checklist from this patch
 

--- a/.agents/skills/remote-code-parity/references/behavior.md
+++ b/.agents/skills/remote-code-parity/references/behavior.md
@@ -10,6 +10,7 @@ This file defines the durable behavior of `remote-code-parity`.
 - Keep all local parity state under `.vaws-local/remote-code-parity/`.
 - Fail closed when parity cannot be proven.
 - Prove the final container-side commit ids instead of trusting command exit status alone.
+- Stream phase progress on `stderr` as `__VAWS_PARITY_PROGRESS__=<json>` and keep one final JSON payload on `stdout`.
 
 ## Scope and routing
 
@@ -77,6 +78,7 @@ Required behavior:
 
 - create bare mirror repos inside the container cache root
 - push synthetic refs directly from local -> container SSH
+- also publish an advertised branch ref inside each mirror so ordinary fetch paths can see the latest synthetic snapshot
 - use a container-local lock while mutating cache or runtime state
 - do not create or reuse a shared flat host path such as `/home/vaws`
 
@@ -89,6 +91,7 @@ Materialization requirements:
 - initialize the root repo in place when `.git` is missing
 - force the root repo and submodules to the synthetic snapshot commits
 - rewrite submodule URLs to container-local mirror paths
+- materialize child repos explicitly instead of relying on `git submodule update` to fetch synthetic child commits
 - preserve runtime-private sibling paths such as `Mooncake`
 - preserve `.remote-code-parity` so the container-side marker survives root cleanups
 - do not delete the entire runtime root as part of normal sync
@@ -148,3 +151,10 @@ A trustworthy parity result records:
 - whether `vllm` and `vllm-ascend` were reinstalled
 - whether first-time consent was consulted or blocked
 - any mismatch between the manifest and runtime state
+
+## Runtime install compatibility
+
+- discover the runtime Python dynamically from `/usr/local/python*/bin/python3`, then fall back to `python3` or `python`
+- export the Ascend driver `LD_LIBRARY_PATH` prefix before sourcing optional env scripts
+- keep the fast path on `pip install -e . --no-build-isolation`
+- if editable install fails because the image packaging stack is too old for the current `pyproject.toml`, attempt one bounded packaging-stack refresh and one retry before failing closed

--- a/.agents/skills/remote-code-parity/references/command-recipes.md
+++ b/.agents/skills/remote-code-parity/references/command-recipes.md
@@ -1,3 +1,5 @@
+All parity helpers stream phase progress on `stderr` as `__VAWS_PARITY_PROGRESS__=<json>` and keep the final summary JSON on `stdout`.
+
 # Remote-code-parity command recipes
 
 Prefer the helper scripts in `scripts/` when possible.

--- a/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
+++ b/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
@@ -5,6 +5,7 @@ import argparse
 import json
 import os
 import re
+import sys
 import tempfile
 import uuid
 from dataclasses import asdict, dataclass, field
@@ -51,12 +52,14 @@ VLLM_ASCEND_REINSTALL_PATTERNS = VLLM_REINSTALL_PATTERNS + (
 )
 
 DEFAULT_ENV_PREAMBLE = (
+    'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH:-}"',
+    'export LD_LIBRARY_PATH="/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/driver/lib64:${LD_LIBRARY_PATH:-}"',
     'if [ -f /usr/local/Ascend/ascend-toolkit/set_env.sh ]; then source /usr/local/Ascend/ascend-toolkit/set_env.sh; fi',
     'if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then source /usr/local/Ascend/nnal/atb/set_env.sh; fi',
     'if [ -f /vllm-workspace/vllm-ascend/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/bin/set_env.bash ]; then source /vllm-workspace/vllm-ascend/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/bin/set_env.bash; fi',
-    'export PATH=/usr/local/python3.11.14/bin:$PATH',
-    'export PYTHON=/usr/local/python3.11.14/bin/python3',
-    'export PIP=/usr/local/python3.11.14/bin/pip',
+    'PYTHON_CANDIDATE="$(ls -1d /usr/local/python*/bin/python3 2>/dev/null | sort -V | tail -n 1 || true)"',
+    'if [ -n "$PYTHON_CANDIDATE" ]; then export PYTHON="$PYTHON_CANDIDATE"; elif command -v python3 >/dev/null 2>&1; then export PYTHON="$(command -v python3)"; elif command -v python >/dev/null 2>&1; then export PYTHON="$(command -v python)"; else echo "python not found" >&2; exit 127; fi',
+    'export PIP="$PYTHON -m pip"',
     'export VLLM_WORKER_MULTIPROC_METHOD=spawn',
     'export OMP_NUM_THREADS=1',
     'export MKL_NUM_THREADS=1',
@@ -68,6 +71,8 @@ DEFAULT_ROOT_PRESERVE_PATHS = ('Mooncake',)
 STATE_FILENAME = 'runtime-state.json'
 CONSENT_FILENAME = 'install-consents.json'
 WORKSPACE_ID_PATTERN = re.compile(r'[^A-Za-z0-9._-]+')
+PROGRESS_SENTINEL = '__VAWS_PARITY_PROGRESS__='
+PARITY_BRANCH_NAME = 'parity-current'
 
 
 @dataclass
@@ -134,6 +139,11 @@ def resolved_root_preserve_paths(marker_dirname: str, extra_paths: list[str]) ->
 class RuntimeInstallMarker:
     path: str
     record: dict[str, Any] | None
+
+
+def emit_progress(phase: str, **fields: Any) -> None:
+    payload = {'phase': phase, **fields}
+    print(f'{PROGRESS_SENTINEL}{json.dumps(payload, ensure_ascii=False)}', file=sys.stderr, flush=True)
 
 
 def ensure_populated_worktree(repo: Path, relpath: str) -> None:
@@ -366,8 +376,16 @@ def push_snapshot_to_mirror(
         return
     remote_url = f'ssh://{container.user}@{container.host}:{container.port}{mirror_path}'
     target_ref = f'refs/parity/{workspace_id}/current'
-    git(repo, ['push', '--force', remote_url, f'{record.commit}:{target_ref}'])
-
+    git(
+        repo,
+        [
+            'push',
+            '--force',
+            remote_url,
+            f'{record.commit}:{target_ref}',
+            f'{record.commit}:refs/heads/{PARITY_BRANCH_NAME}',
+        ],
+    )
 
 def acquire_container_lock(container: SshEndpoint, lock_path: str, dry_run: bool) -> None:
     if dry_run:
@@ -436,11 +454,12 @@ def materialize_runtime(
 ) -> None:
     record_by_relpath = {record.relpath: record for record in records}
     root_record = record_by_relpath['.']
+    parity_tracking_ref = f'refs/remotes/parity/{PARITY_BRANCH_NAME}'
 
-    def render_repo_step(record: SnapshotRecord) -> list[str]:
+    def render_repo_step(record: SnapshotRecord) -> str:
         repo_dir = container_repo_path(runtime_root, record)
         mirror_path = mirror_path_for(container_cache_root, workspace_id, record)
-        lines = [f'mkdir -p {quoted(str(Path(repo_dir).parent))}']
+        lines = ['set -eo pipefail', f'mkdir -p {quoted(str(Path(repo_dir).parent))}']
         if record.relpath in ('', '.'):
             lines.append(f'if [ ! -e {quoted(str(Path(repo_dir) / ".git"))} ]; then git init {quoted(repo_dir)} >/dev/null; fi')
         else:
@@ -451,9 +470,9 @@ def materialize_runtime(
             [
                 f'git -C {quoted(repo_dir)} remote get-url parity >/dev/null 2>&1 || git -C {quoted(repo_dir)} remote add parity {quoted(mirror_path)}',
                 f'git -C {quoted(repo_dir)} remote set-url parity {quoted(mirror_path)}',
-                f'git -C {quoted(repo_dir)} fetch --force --no-recurse-submodules parity refs/parity/{workspace_id}/current >/dev/null',
-                f'git -C {quoted(repo_dir)} checkout -B parity/current FETCH_HEAD >/dev/null',
-                f'git -C {quoted(repo_dir)} reset --hard FETCH_HEAD >/dev/null',
+                f'git -C {quoted(repo_dir)} fetch --force --no-recurse-submodules parity {quoted(PARITY_BRANCH_NAME + ":" + parity_tracking_ref)} >/dev/null',
+                f'git -C {quoted(repo_dir)} checkout -B parity/current {quoted(parity_tracking_ref)} >/dev/null',
+                f'git -C {quoted(repo_dir)} reset --hard {quoted(parity_tracking_ref)} >/dev/null',
             ]
         )
         if record.relpath in ('', '.'):
@@ -464,28 +483,36 @@ def materialize_runtime(
             child_relpath = child['path'] if record.relpath in ('', '.') else f"{record.relpath}/{child['path']}"
             child_record = record_by_relpath[child_relpath]
             child_mirror = mirror_path_for(container_cache_root, workspace_id, child_record)
+            submodule_url_key = f"submodule.{child['name']}.url"
             lines.extend(
                 [
-                    f'git -C {quoted(repo_dir)} config {quoted(f"submodule.{child['name']}.url")} {quoted(child_mirror)}',
+                    f'git -C {quoted(repo_dir)} config {quoted(submodule_url_key)} {quoted(child_mirror)}',
                     f'git -C {quoted(repo_dir)} submodule sync -- {quoted(child["path"])} >/dev/null || true',
-                    f'git -C {quoted(repo_dir)} submodule update --init --checkout --force -- {quoted(child["path"])} >/dev/null',
                 ]
             )
-        return lines
+        return '\n'.join(lines)
 
-    def walk(record: SnapshotRecord) -> list[str]:
-        lines = render_repo_step(record)
+    def walk(record: SnapshotRecord) -> None:
+        emit_progress('materialize-repo', relpath=record.relpath)
+        if not dry_run:
+            ssh_exec(container, render_repo_step(record))
         for child in record.submodules:
             child_relpath = child['path'] if record.relpath in ('', '.') else f"{record.relpath}/{child['path']}"
-            lines.extend(walk(record_by_relpath[child_relpath]))
-        return lines
+            walk(record_by_relpath[child_relpath])
 
-    script_lines = ['set -eo pipefail', f'mkdir -p {quoted(runtime_root)}', f'mkdir -p {quoted(str(Path(runtime_root) / marker_dirname))}']
-    script_lines.extend(walk(root_record))
     if dry_run:
         return
-    ssh_exec(container, '\n'.join(script_lines))
-
+    ssh_exec(
+        container,
+        '\n'.join(
+            [
+                'set -eo pipefail',
+                f'mkdir -p {quoted(runtime_root)}',
+                f'mkdir -p {quoted(str(Path(runtime_root) / marker_dirname))}',
+            ]
+        ),
+    )
+    walk(root_record)
 
 def reinstall_required_for_repo(record: SnapshotRecord, patterns: tuple[str, ...]) -> bool:
     return any(glob_match_any(path, patterns) for path in record.changed_paths)
@@ -501,6 +528,41 @@ def runtime_install_script(
 ) -> str:
     lines = ['set -eo pipefail', f'cd {quoted(runtime_root)}']
     lines.extend(DEFAULT_ENV_PREAMBLE)
+    lines.extend(
+        [
+            'upgrade_packaging_stack() {',
+            '  $PIP install --upgrade "pip>=24.0" "setuptools>=77" "wheel>=0.43" "packaging>=24.0" >/dev/null 2>&1 || true',
+            '}',
+            'install_with_fallback() {',
+            '  target_dir="$1"',
+            '  install_cmd="$2"',
+            '  log_file="$(mktemp -t parity-install.XXXXXX.log)"',
+            '  cd "$target_dir"',
+            '  if bash -lc "$install_cmd" >"$log_file" 2>&1; then',
+            '    rm -f "$log_file"',
+            '    return 0',
+            '  fi',
+            '  status=$?',
+            '  if grep -Eiq "project\\.license|license[^[:alnum:]]|spdx|pyproject" "$log_file"; then',
+            '    upgrade_packaging_stack',
+            '    if bash -lc "$install_cmd" >>"$log_file" 2>&1; then',
+            '      rm -f "$log_file"',
+            '      return 0',
+            '    fi',
+            '    status=$?',
+            '    alt_cmd="$(printf "%s" "$install_cmd" | sed "s/--no-build-isolation//g")"',
+            '    if bash -lc "$alt_cmd" >>"$log_file" 2>&1; then',
+            '      rm -f "$log_file"',
+            '      return 0',
+            '    fi',
+            '    status=$?',
+            '  fi',
+            '  tail -n 120 "$log_file" >&2 || true',
+            '  rm -f "$log_file"',
+            '  return "$status"',
+            '}',
+        ]
+    )
     if reinstall_vllm or reinstall_vllm_ascend:
         lines.append('$PIP uninstall -y vllm vllm-ascend vllm_ascend >/dev/null 2>&1 || true')
     if reinstall_vllm:
@@ -508,15 +570,15 @@ def runtime_install_script(
             [
                 f'cd {quoted(str(Path(runtime_root) / "vllm"))}',
                 'export VLLM_TARGET_DEVICE=empty',
-                '$PIP install -e . --no-build-isolation',
+                'install_with_fallback . "$PIP install -e . --no-build-isolation"',
             ]
         )
     if reinstall_vllm_ascend:
         lines.extend(
             [
                 f'cd {quoted(str(Path(runtime_root) / "vllm-ascend"))}',
-                '$PIP install -r requirements.txt',
-                '$PIP install -v -e . --no-build-isolation',
+                '$PIP install -r requirements.txt >/dev/null',
+                'install_with_fallback . "$PIP install -v -e . --no-build-isolation"',
             ]
         )
     lines.extend(
@@ -549,7 +611,6 @@ def runtime_install_script(
         ]
     )
     return '\n'.join(lines)
-
 
 def read_runtime_install_marker(
     *,
@@ -751,188 +812,224 @@ def run_sync(args: argparse.Namespace) -> int:
     snapshot_id = args.snapshot_id or now_utc().replace(':', '').replace('-', '') + '-' + uuid.uuid4().hex[:8]
     container = SshEndpoint(host=args.container_host, port=args.container_port, user=args.container_user)
 
+    emit_progress('snapshot-build', workspace_id=workspace_id, snapshot_id=snapshot_id)
     records = build_snapshot_records(workspace_root, workspace_id, snapshot_id, tuple(DEFAULT_DENYLIST))
     manifest_path = manifest_path_for(container_cache_root, workspace_id, snapshot_id)
+    current_phase = 'snapshot-built'
     try:
-        record_map = {record.relpath: record for record in records}
-        reinstall_vllm = reinstall_required_for_repo(record_map['vllm'], VLLM_REINSTALL_PATTERNS) if 'vllm' in record_map else False
-        reinstall_vllm_ascend = reinstall_required_for_repo(record_map['vllm-ascend'], VLLM_ASCEND_REINSTALL_PATTERNS) if 'vllm-ascend' in record_map else False
+        try:
+            record_map = {record.relpath: record for record in records}
+            reinstall_vllm = reinstall_required_for_repo(record_map['vllm'], VLLM_REINSTALL_PATTERNS) if 'vllm' in record_map else False
+            reinstall_vllm_ascend = reinstall_required_for_repo(record_map['vllm-ascend'], VLLM_ASCEND_REINSTALL_PATTERNS) if 'vllm-ascend' in record_map else False
 
-        marker = read_runtime_install_marker(
-            container=container,
-            runtime_root=runtime_root,
-            marker_dirname=marker_dirname,
-            dry_run=args.dry_run,
-        )
-        first_install = first_install_needed(marker, args.container_identity, runtime_root)
-        if first_install:
-            consent = resolve_install_consent(workspace_root, args.server_name, args.container_identity)
-            if consent != 'allow':
+            current_phase = 'read-runtime-marker'
+            emit_progress(current_phase, runtime_root=runtime_root)
+            marker = read_runtime_install_marker(
+                container=container,
+                runtime_root=runtime_root,
+                marker_dirname=marker_dirname,
+                dry_run=args.dry_run,
+            )
+            first_install = first_install_needed(marker, args.container_identity, runtime_root)
+            if first_install:
+                current_phase = 'check-consent'
+                emit_progress(current_phase, container_identity=args.container_identity)
+                consent = resolve_install_consent(workspace_root, args.server_name, args.container_identity)
+                if consent != 'allow':
+                    summary = summary_payload(
+                        status='blocked',
+                        server_name=args.server_name,
+                        container_identity=args.container_identity,
+                        workspace_id=workspace_id,
+                        container_cache_root=container_cache_root,
+                        records=records,
+                        reinstall_status='blocked-by-consent',
+                        reason='first-time runtime replacement requires explicit consent',
+                        first_install=True,
+                        observed_runtime_commits=None,
+                    )
+                    print(json_dump(summary))
+                    return 2
+                reinstall_vllm = True if 'vllm' in record_map else reinstall_vllm
+                reinstall_vllm_ascend = True if 'vllm-ascend' in record_map else reinstall_vllm_ascend
+
+            manifest = make_manifest(
+                workspace_root=workspace_root,
+                workspace_id=workspace_id,
+                snapshot_id=snapshot_id,
+                server_name=args.server_name,
+                container_identity=args.container_identity,
+                runtime_root=runtime_root,
+                container_cache_root=container_cache_root,
+                marker_dirname=marker_dirname,
+                root_preserve_paths=root_preserve_paths,
+                records=records,
+            )
+            if args.print_manifest:
+                print(json_dump(manifest))
+
+            if args.dry_run:
+                reinstall_status = 'would-perform' if (reinstall_vllm or reinstall_vllm_ascend) else 'not-needed'
                 summary = summary_payload(
-                    status='blocked',
+                    status='dry-run',
                     server_name=args.server_name,
                     container_identity=args.container_identity,
                     workspace_id=workspace_id,
                     container_cache_root=container_cache_root,
                     records=records,
-                    reinstall_status='blocked-by-consent',
-                    reason='first-time runtime replacement requires explicit consent',
-                    first_install=True,
+                    reinstall_status=reinstall_status,
+                    reason=None,
+                    first_install=first_install,
                     observed_runtime_commits=None,
                 )
                 print(json_dump(summary))
-                return 2
-            reinstall_vllm = True if 'vllm' in record_map else reinstall_vllm
-            reinstall_vllm_ascend = True if 'vllm-ascend' in record_map else reinstall_vllm_ascend
+                return 0
 
-        manifest = make_manifest(
-            workspace_root=workspace_root,
-            workspace_id=workspace_id,
-            snapshot_id=snapshot_id,
-            server_name=args.server_name,
-            container_identity=args.container_identity,
-            runtime_root=runtime_root,
-            container_cache_root=container_cache_root,
-            marker_dirname=marker_dirname,
-            root_preserve_paths=root_preserve_paths,
-            records=records,
-        )
-        if args.print_manifest:
-            print(json_dump(manifest))
+            lock_path = lock_path_for(container_cache_root, workspace_id, args.container_identity)
+            current_phase = 'acquire-lock'
+            emit_progress(current_phase, lock_path=lock_path)
+            acquire_container_lock(container, lock_path, args.dry_run)
+            try:
+                current_phase = 'push-mirrors'
+                emit_progress(current_phase, repo_count=len(records))
+                for record in records:
+                    emit_progress('push-mirror', relpath=record.relpath)
+                    push_snapshot_to_mirror(
+                        repo=workspace_root if record.relpath in ('', '.') else workspace_root / record.relpath,
+                        container=container,
+                        mirror_path=mirror_path_for(container_cache_root, workspace_id, record),
+                        record=record,
+                        workspace_id=workspace_id,
+                        dry_run=args.dry_run,
+                    )
 
-        if args.dry_run:
-            reinstall_status = 'would-perform' if (reinstall_vllm or reinstall_vllm_ascend) else 'not-needed'
-            summary = summary_payload(
-                status='dry-run',
-                server_name=args.server_name,
-                container_identity=args.container_identity,
-                workspace_id=workspace_id,
-                container_cache_root=container_cache_root,
-                records=records,
-                reinstall_status=reinstall_status,
-                reason=None,
-                first_install=first_install,
-                observed_runtime_commits=None,
-            )
-            print(json_dump(summary))
-            return 0
+                current_phase = 'upload-manifest'
+                emit_progress(current_phase, manifest_path=manifest_path)
+                upload_manifest(container, manifest_path, manifest, args.dry_run)
 
-        lock_path = lock_path_for(container_cache_root, workspace_id, args.container_identity)
-        acquire_container_lock(container, lock_path, args.dry_run)
-        try:
-            for record in records:
-                push_snapshot_to_mirror(
-                    repo=workspace_root if record.relpath in ('', '.') else workspace_root / record.relpath,
+                if first_install:
+                    current_phase = 'first-install-prepare'
+                    emit_progress(current_phase, runtime_root=runtime_root)
+                    ssh_exec(container, first_install_prepare_script(runtime_root))
+
+                current_phase = 'materialize-runtime'
+                emit_progress(current_phase, runtime_root=runtime_root)
+                materialize_runtime(
                     container=container,
-                    mirror_path=mirror_path_for(container_cache_root, workspace_id, record),
-                    record=record,
+                    runtime_root=runtime_root,
+                    container_cache_root=container_cache_root,
                     workspace_id=workspace_id,
+                    marker_dirname=marker_dirname,
+                    root_preserve_paths=root_preserve_paths,
+                    records=records,
                     dry_run=args.dry_run,
                 )
-            upload_manifest(container, manifest_path, manifest, args.dry_run)
 
-            if first_install:
-                ssh_exec(container, first_install_prepare_script(runtime_root))
-
-            materialize_runtime(
-                container=container,
-                runtime_root=runtime_root,
-                container_cache_root=container_cache_root,
-                workspace_id=workspace_id,
-                marker_dirname=marker_dirname,
-                root_preserve_paths=root_preserve_paths,
-                records=records,
-                dry_run=args.dry_run,
-            )
-
-            reinstall_status = 'not-needed'
-            if reinstall_vllm or reinstall_vllm_ascend:
-                reinstall_status = 'performed'
-                ssh_exec(
-                    container,
-                    runtime_install_script(
-                        runtime_root=runtime_root,
-                        marker_dirname=marker_dirname,
+                reinstall_status = 'not-needed'
+                if reinstall_vllm or reinstall_vllm_ascend:
+                    reinstall_status = 'performed'
+                    current_phase = 'runtime-install'
+                    emit_progress(
+                        current_phase,
                         reinstall_vllm=reinstall_vllm,
                         reinstall_vllm_ascend=reinstall_vllm_ascend,
-                        container_identity=args.container_identity,
-                    ),
-                )
+                    )
+                    ssh_exec(
+                        container,
+                        runtime_install_script(
+                            runtime_root=runtime_root,
+                            marker_dirname=marker_dirname,
+                            reinstall_vllm=reinstall_vllm,
+                            reinstall_vllm_ascend=reinstall_vllm_ascend,
+                            container_identity=args.container_identity,
+                        ),
+                    )
 
-            observed_runtime_commits = verify_runtime_commits(
-                container=container,
-                runtime_root=runtime_root,
-                records=records,
-                dry_run=args.dry_run,
-            )
-            expected_runtime_commits = {record.relpath: record.commit for record in records}
-            if observed_runtime_commits != expected_runtime_commits:
+                current_phase = 'verify-runtime-commits'
+                emit_progress(current_phase, repo_count=len(records))
+                observed_runtime_commits = verify_runtime_commits(
+                    container=container,
+                    runtime_root=runtime_root,
+                    records=records,
+                    dry_run=args.dry_run,
+                )
+                expected_runtime_commits = {record.relpath: record.commit for record in records}
+                if observed_runtime_commits != expected_runtime_commits:
+                    upload_manifest(
+                        container,
+                        manifest_path,
+                        final_manifest(
+                            manifest,
+                            status='failed',
+                            reinstall_status=reinstall_status,
+                            runtime_commits=observed_runtime_commits,
+                        ),
+                        False,
+                    )
+                    summary = summary_payload(
+                        status='failed',
+                        server_name=args.server_name,
+                        container_identity=args.container_identity,
+                        workspace_id=workspace_id,
+                        container_cache_root=container_cache_root,
+                        records=records,
+                        reinstall_status=reinstall_status,
+                        reason='runtime commit verification mismatch',
+                        first_install=first_install,
+                        observed_runtime_commits=observed_runtime_commits,
+                    )
+                    print(json_dump(summary))
+                    return 1
+
+                current_phase = 'update-local-state'
+                emit_progress(current_phase, server_name=args.server_name)
+                update_runtime_state(
+                    repo_root=workspace_root,
+                    server_name=args.server_name,
+                    container_identity=args.container_identity,
+                    runtime_root=runtime_root,
+                    container_cache_root=container_cache_root,
+                    marker_dirname=marker_dirname,
+                    records=records,
+                    first_reinstall_completed=first_install
+                    or load_runtime_state(workspace_root).get('servers', {}).get(args.server_name, {}).get('containers', {}).get(args.container_identity, {}).get('first_reinstall_completed', False)
+                    or reinstall_status == 'performed',
+                )
+                current_phase = 'finalize-manifest'
+                emit_progress(current_phase, manifest_path=manifest_path)
                 upload_manifest(
                     container,
                     manifest_path,
                     final_manifest(
                         manifest,
-                        status='failed',
+                        status='ready',
                         reinstall_status=reinstall_status,
                         runtime_commits=observed_runtime_commits,
                     ),
                     False,
                 )
+                emit_progress('complete', status='ready')
                 summary = summary_payload(
-                    status='failed',
+                    status='ready',
                     server_name=args.server_name,
                     container_identity=args.container_identity,
                     workspace_id=workspace_id,
                     container_cache_root=container_cache_root,
                     records=records,
                     reinstall_status=reinstall_status,
-                    reason='runtime commit verification mismatch',
+                    reason=None,
                     first_install=first_install,
                     observed_runtime_commits=observed_runtime_commits,
                 )
                 print(json_dump(summary))
-                return 1
-
-            update_runtime_state(
-                repo_root=workspace_root,
-                server_name=args.server_name,
-                container_identity=args.container_identity,
-                runtime_root=runtime_root,
-                container_cache_root=container_cache_root,
-                marker_dirname=marker_dirname,
-                records=records,
-                first_reinstall_completed=first_install or load_runtime_state(workspace_root).get('servers', {}).get(args.server_name, {}).get('containers', {}).get(args.container_identity, {}).get('first_reinstall_completed', False) or reinstall_status == 'performed',
-            )
-            upload_manifest(
-                container,
-                manifest_path,
-                final_manifest(
-                    manifest,
-                    status='ready',
-                    reinstall_status=reinstall_status,
-                    runtime_commits=observed_runtime_commits,
-                ),
-                False,
-            )
-            summary = summary_payload(
-                status='ready',
-                server_name=args.server_name,
-                container_identity=args.container_identity,
-                workspace_id=workspace_id,
-                container_cache_root=container_cache_root,
-                records=records,
-                reinstall_status=reinstall_status,
-                reason=None,
-                first_install=first_install,
-                observed_runtime_commits=observed_runtime_commits,
-            )
-            print(json_dump(summary))
-            return 0
-        finally:
-            release_container_lock(container, lock_path, args.dry_run)
+                return 0
+            finally:
+                emit_progress('release-lock', lock_path=lock_path)
+                release_container_lock(container, lock_path, args.dry_run)
+        except Exception as exc:
+            raise RuntimeError(f'{current_phase}: {exc}') from exc
     finally:
         cleanup_synthetic_refs(workspace_root, records)
-
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description='Prepare or enforce remote code parity for a ready runtime.')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,13 @@ Repo-local skills live under `.agents/skills/`.
   - `.agents/skills/machine-management/scripts/machine_repair.py`
   - `.agents/skills/machine-management/scripts/machine_remove.py`
 - Treat `.agents/skills/machine-management/scripts/inventory.py` and `.agents/skills/machine-management/scripts/manage_machine.py` as low-level maintenance helpers, not the default agent-facing surface.
+- For machine bootstrap, prefer the low-level `--image auto` policy unless the user explicitly pins a different image. It resolves to a pull-first latest-tag strategy with NJU first and `quay.io` fallback.
 - Keep helper CLIs ergonomic: accept common aliases, disable brittle prefix-abbreviation behavior, and default metadata that can be inferred safely.
 - For normal remote-code-parity work, prefer `.agents/skills/remote-code-parity/scripts/parity_sync.py` over the low-level `remote_code_parity.py` helper.
+- Remote-code-parity should expose phase progress, materialize nested repos explicitly, and avoid hard-coding one container Python patch path.
 - Prefer concise machine-readable summaries over long raw command logs.
 - When a command is noisy, capture the log and report only a compact summary plus a short failure tail.
+- Wrapper-style skills should keep progress on `stderr` and reserve `stdout` for a final machine-readable JSON payload.
 - Preserve user choices and extra remotes unless the user explicitly asks to replace them.
 
 ## Mandatory decision gates

--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ When invoked, `machine-management` can:
 3. probe host prerequisites
 4. create or repair one managed host-network container per requested machine
 5. verify direct local -> container SSH and run a `torch` + `torch_npu` smoke test
-6. persist managed-machine state in local inventory
-7. mesh managed containers together on a best-effort basis
-8. remove a managed container and clean local trust state
+6. stream bounded machine-phase progress and record the actual selected image used for that container
+7. persist managed-machine state in local inventory
+8. mesh managed containers together on a best-effort basis
+9. remove a managed container and clean local trust state
 
 New managed containers should derive their name from the local machine profile rather than using one global shared name.
 
@@ -92,11 +93,12 @@ When invoked automatically before remote execution, `remote-code-parity` can:
 1. treat the local working tree as the source of truth, including committed, staged, unstaged, and untracked **non-ignored** files
 2. build synthetic Git snapshot commits for the workspace root, `vllm/`, `vllm-ascend/`, and any nested populated submodules without forcing a real commit
 3. push those snapshots directly into **container-local** bare mirror repositories over direct local -> container SSH
-4. materialize the mirrored commits in place inside `/vllm-workspace` so the checked-out code matches the local workspace exactly
-5. preserve runtime-private paths such as `Mooncake` instead of replacing the entire runtime root
-6. on the first sync for a fresh container, require explicit user consent before uninstalling image-provided `vllm` / `vllm-ascend`, deleting only `/vllm-workspace/vllm` and `/vllm-workspace/vllm-ascend`, and reinstalling them from the synced source trees
-7. on later syncs, reinstall only when build-critical paths changed
-8. verify the final runtime commit ids instead of assuming success from command exit status alone
+4. publish an advertised current branch inside each mirror so nested repos can fetch the synthetic snapshot cleanly
+5. materialize the mirrored commits in place inside `/vllm-workspace` so the checked-out code matches the local workspace exactly
+6. preserve runtime-private paths such as `Mooncake` instead of replacing the entire runtime root
+7. on the first sync for a fresh container, require explicit user consent before uninstalling image-provided `vllm` / `vllm-ascend`, deleting only `/vllm-workspace/vllm` and `/vllm-workspace/vllm-ascend`, and reinstalling them from the synced source trees
+8. on later syncs, reinstall only when build-critical paths changed
+9. verify the final runtime commit ids instead of assuming success from command exit status alone
 
 `remote-code-parity` is not a machine-attach or SSH-repair workflow. It assumes `machine-management` already proved the target container is reachable by key-based SSH.
 


### PR DESCRIPTION
## What changed
- tightened the machine-management helper contract so wrapper scripts stream bounded progress on `stderr`, keep the final JSON payload on `stdout`, and propagate progress metadata from low-level helpers
- added timeout budgets and richer remote execution handling for host probe, container bootstrap, verify, and smoke paths, including actual selected-image persistence for `--image auto`
- updated remote-code-parity snapshot materialization to publish an advertised parity branch, materialize repos recursively without brittle submodule fetch behavior, and harden runtime install setup with dynamic Python discovery and install fallbacks
- aligned `AGENTS.md`, repo docs, skill docs, references, and command recipes with the new helper behavior

## Why
- agents need deterministic wrapper output while still seeing phase progress during long-running machine bootstrap and verification work
- image selection, timeout handling, and parity materialization were too brittle for real remote environments, especially when installs or nested repos required fallback behavior
- the documentation needed to match the runtime contract so future changes do not regress the workflow

## Impact
- machine-management wrappers now expose progress events and preserve a clean final JSON contract for agent consumption
- managed container image tracking reflects the actual selected image instead of only the requested policy string
- remote-code-parity should be more reliable when syncing nested repos and reinstalling dependencies on varied remote runtimes

## Validation
- `git diff --check`
- `python3 -m py_compile .agents/skills/machine-management/scripts/_workflow_common.py .agents/skills/machine-management/scripts/machine_add.py .agents/skills/machine-management/scripts/machine_remove.py .agents/skills/machine-management/scripts/machine_repair.py .agents/skills/machine-management/scripts/machine_verify.py .agents/skills/machine-management/scripts/manage_machine.py .agents/skills/remote-code-parity/scripts/remote_code_parity.py`
- `python3 .agents/skills/machine-management/scripts/machine_add.py --help`
- `python3 .agents/skills/machine-management/scripts/machine_verify.py --help`
- `python3 .agents/skills/machine-management/scripts/machine_repair.py --help`
- `python3 .agents/skills/machine-management/scripts/machine_remove.py --help`
- `python3 .agents/skills/machine-management/scripts/manage_machine.py --help`
- `python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py --help`