### PR TITLE
[codex] require explicit managed image selection

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -17,6 +17,8 @@ When a workflow has deterministic shell, SSH, Git, or local-state mechanics, pre
 
 Wrapper-style helpers should stream bounded phase progress on `stderr` and keep one final machine-readable JSON payload on `stdout`.
 
+For machine-management specifically, image selection is an explicit user decision gate: choose `main`, `stable`, or a concrete custom image reference. Do not silently fall back to `auto`, `latest`, or another moving tag.
+
 When you add or revise a helper script, keep the CLI alias-tolerant and give safe defaults for metadata that can be inferred. The goal is to reduce agent parameter brittleness, not to force one exact flag spelling.
 
 Current primary helpers:

--- a/.agents/skills/machine-management/SKILL.md
+++ b/.agents/skills/machine-management/SKILL.md
@@ -38,7 +38,11 @@ Ready does **not** imply code sync, rebuild, serving, or benchmark readiness.
 - Keep local runtime state only under `.vaws-local/`.
 - Never write passwords or tokens into tracked files or `.vaws-local/`.
 - Never use `scp`, `sftp`, `sshpass`, or `expect` in this workflow.
-- Default container image policy is `auto`: try `quay.nju.edu.cn/ascend/vllm-ascend:latest` first, then `quay.io/ascend/vllm-ascend:latest`, always attempting a fresh pull before falling back to a cached local copy.
+- Never default the container image silently. Ask the user to choose one of:
+  - `main`: `quay.nju.edu.cn/ascend/vllm-ascend:main`, then `quay.io/ascend/vllm-ascend:main`
+  - `stable`: resolve the latest official non-prerelease `vllm-ascend` release tag, then try NJU first and `quay.io` second
+  - `custom`: a full image reference with a concrete non-`latest` tag or digest
+- Treat `auto`, `*:latest`, and bare repositories without a tag as forbidden defaults for managed-machine bootstrap.
 - Report and persist the **actual selected image** for the managed container, not only the requested image policy.
 - Long probe / bootstrap / smoke operations must expose bounded phase progress and have an overall timeout budget, not only a connect timeout.
 - On a missing local machine profile, never call `workspace_profile.py ensure` bare. Use either:
@@ -57,9 +61,9 @@ The primary bootstrap path must not depend on `ssh-copy-id`, `expect`, or any ot
 
 Use these task-oriented wrappers for normal agent work. They keep the parameter surface narrow and return structured JSON statuses such as `ready`, `needs_input`, `needs_repair`, `blocked`, `removed`, or `unmanaged`. They also stream phase progress on `stderr` as `__VAWS_PROGRESS__=<json>` while reserving `stdout` for one final machine-readable JSON payload.
 
-- `python3 .agents/skills/machine-management/scripts/machine_add.py --host <ip> [--machine-username <letters-or-digits> | --generate-machine-username] [--password-env NAME | --password-stdin | --password ...]`
+- `python3 .agents/skills/machine-management/scripts/machine_add.py --host <ip> --image <main|stable|custom-ref> [--machine-username <letters-or-digits> | --generate-machine-username] [--password-env NAME | --password-stdin | --password ...]`
 - `python3 .agents/skills/machine-management/scripts/machine_verify.py --machine <alias-or-ip>`
-- `python3 .agents/skills/machine-management/scripts/machine_repair.py --machine <alias-or-ip> [--password-env NAME | --password-stdin | --password ...]`
+- `python3 .agents/skills/machine-management/scripts/machine_repair.py --machine <alias-or-ip> [--image <main|stable|custom-ref>] [--password-env NAME | --password-stdin | --password ...]`
 - `python3 .agents/skills/machine-management/scripts/machine_remove.py --machine <alias-or-ip>`
 
 Design intent:
@@ -156,14 +160,16 @@ When password bootstrap is required:
 `machine_add.py` should own this order:
 
 1. ensure or reuse the local machine profile
-2. ensure a local public key exists
-3. if needed, establish host key auth
-4. probe the host
-5. choose or reuse the container name and container SSH port
-6. bootstrap or repair the managed container
-7. run final readiness verification
-8. persist the record into inventory
-9. best-effort mesh the new container with existing managed containers
+2. ask for or reuse an explicit image choice; never fall back to `auto` or `latest`
+3. if an existing record still points at a legacy or moving image tag, stop for re-selection before any `already-ready` shortcut
+4. ensure a local public key exists
+5. if needed, establish host key auth
+6. probe the host
+7. choose or reuse the container name and container SSH port
+8. bootstrap or repair the managed container
+9. persist the record into inventory
+10. best-effort mesh the new container with existing managed containers
+11. run final readiness verification
 
 If inventory already contains the same alias or host IP, treat add as an idempotent attach-or-repair path instead of creating a duplicate record.
 
@@ -201,7 +207,8 @@ Do not remove host firewall rules or host-level `authorized_keys` entries.
 - Use the dedicated container SSH config `/etc/ssh/sshd_vaws_config` instead of editing `/etc/ssh/sshd_config` inline.
 - Quote remote-script arguments that may contain spaces, especially SSH public keys and mesh peer keys, before sending them through `ssh`.
 - Ensure `/run/sshd` exists before starting the dedicated `sshd`.
-- Prefer low-level `--image auto` unless the user explicitly pins another image. It should pull first, then reuse a cached image only as a bounded fallback.
+- Image pulls should follow the selected mirror order and emit heartbeat-style progress so long `docker pull`, `apt-get update`, and `apt-get install` phases remain attributable.
+- Keep `stable` resolution dynamic: resolve the latest official non-prerelease release tag at execution time instead of using the moving `latest` tag.
 - Keep progress on `stderr` and the final status JSON on `stdout`; do not mix partial human narration into the terminal contract.
 - For smoke tests, do not pin a Python patch version. Discover the highest available `/usr/local/python*/bin/python3`, then fall back to `python3`.
 - Source only environment scripts that actually exist.

--- a/.agents/skills/machine-management/references/acceptance.md
+++ b/.agents/skills/machine-management/references/acceptance.md
@@ -56,8 +56,10 @@ These should not trigger `machine-management` unless machine readiness is the ob
 
 ### Add / attach
 
-- `machine_add.py` can succeed with only `--host` when the profile and host key SSH are already in place
+- `machine_add.py` can succeed with `--host --image main` when the profile and host key SSH are already in place
 - when the profile is missing, `machine_add.py` returns `needs_input` instead of silently generating a username
+- when the image choice is missing for a new machine, `machine_add.py` returns `needs_input` instead of silently defaulting to `auto`, `latest`, or another moving tag
+- when an existing inventory record still points at a legacy or moving image tag, `machine_add.py` returns `await-image-selection` before any `already-ready` shortcut
 - the skill prefers host key SSH first and uses a password only for the first bootstrap of a new machine
 - if the user already supplied the host password in the request, the skill prefers scripted bootstrap before asking the user to run a manual command
 - the primary bootstrap path does not depend on `ssh-copy-id`
@@ -67,7 +69,9 @@ These should not trigger `machine-management` unless machine readiness is the ob
 - the container bootstrap ensures `/run/sshd` exists
 - space-containing remote arguments such as SSH public keys and mesh peer keys survive the SSH hop intact
 - `machine_add.py` persists final alias, namespace, host identity, container name, image, and SSH port into inventory without the agent having to call `inventory.py put`
-- when image policy is `auto`, the recorded inventory image is the actual selected image after pull / fallback resolution
+- the recorded inventory image is the actual selected image after mirror resolution and pull / cache fallback
+- `main` and `stable` remain first-class selectors, while `auto`, `*:latest`, and bare repositories without a tag are rejected as defaults
+- long-running bootstrap phases keep emitting attributable progress for image pull and package-install steps instead of going silent behind one global timeout
 
 ### Verify
 
@@ -79,6 +83,8 @@ These should not trigger `machine-management` unless machine readiness is the ob
 ### Repair
 
 - `machine_repair.py` accepts a single machine identifier for the normal case
+- `machine_repair.py` can request an explicit replacement image when the recorded image is legacy, ambiguous, or the user wants to rotate tracks
+- `machine_repair.py` does not short-circuit to `already-ready` when the recorded image is legacy, ambiguous, or still points at a moving tag
 - the skill prefers non-destructive repairs first
 - the skill uses the bare-metal host only when container SSH is broken
 - the skill does not recreate or delete a container unless the user explicitly asked for destructive repair

--- a/.agents/skills/machine-management/references/behavior.md
+++ b/.agents/skills/machine-management/references/behavior.md
@@ -224,18 +224,21 @@ Do **not**:
 
 ## Image selection policy
 
-Default low-level image policy is `auto`:
+Image selection is an explicit decision gate, not an implicit default:
 
-1. attempt `docker pull quay.nju.edu.cn/ascend/vllm-ascend:latest`
-2. if that fails, attempt `docker pull quay.io/ascend/vllm-ascend:latest`
-3. if fresh pulls fail but one of those tags is already cached locally, reuse the cached image as a bounded fallback
-4. if a managed container already exists, prefer its current image identity for non-destructive attach / repair
+1. ask the user to choose `main`, `stable`, or a custom image reference before new-machine bootstrap
+2. `main` resolves to `quay.nju.edu.cn/ascend/vllm-ascend:main`, then `quay.io/ascend/vllm-ascend:main`
+3. `stable` resolves the latest official non-prerelease `vllm-ascend` release tag at execution time, then tries NJU first and `quay.io` second
+4. custom references must include a concrete non-`latest` tag or digest; `auto`, `*:latest`, and bare repositories without a tag are forbidden defaults
+5. if fresh pulls fail but one of the explicit candidate refs is already cached locally, reuse that cached image as a bounded fallback
+6. for non-destructive attach / repair, a recorded explicit non-`latest` image may be reused; ambiguous legacy images require another user choice
 
-Inventory should record the actual selected image, not only the requested policy string.
+Inventory should record the actual selected image, not only the requested selector string.
 
 ## Observability and timeout contract
 
 - wrappers and low-level helpers should report phase progress early enough for an agent to distinguish `probe`, `bootstrap`, `smoke`, `inventory`, and `verify` work
 - `stderr` carries progress events; `stdout` stays reserved for the final machine-readable JSON payload
 - host probe, container bootstrap, and smoke should each have an overall timeout budget in addition to SSH connect timeouts
+- long-running bootstrap steps should keep emitting attributable heartbeats for image pull, `apt-get update`, and `apt-get install` instead of going silent behind one generic timeout
 - timeout failures should preserve the last known phase and any successfully returned remote payload

--- a/.agents/skills/machine-management/references/command-recipes.md
+++ b/.agents/skills/machine-management/references/command-recipes.md
@@ -9,7 +9,7 @@ Prefer the task-oriented wrappers. Treat the low-level helpers as fallback maint
 macOS / Linux / WSL:
 
 ```bash
-python3 .agents/skills/machine-management/scripts/machine_add.py --host 173.125.1.2
+python3 .agents/skills/machine-management/scripts/machine_add.py --host 173.125.1.2 --image main
 python3 .agents/skills/machine-management/scripts/machine_verify.py --machine 173.125.1.2
 python3 .agents/skills/machine-management/scripts/machine_repair.py --machine 173.125.1.2
 python3 .agents/skills/machine-management/scripts/machine_remove.py --machine 173.125.1.2
@@ -18,7 +18,7 @@ python3 .agents/skills/machine-management/scripts/machine_remove.py --machine 17
 Windows:
 
 ```powershell
-py -3 .agents/skills/machine-management/scripts/machine_add.py --host 173.125.1.2
+py -3 .agents/skills/machine-management/scripts/machine_add.py --host 173.125.1.2 --image main
 py -3 .agents/skills/machine-management/scripts/machine_verify.py --machine 173.125.1.2
 py -3 .agents/skills/machine-management/scripts/machine_repair.py --machine 173.125.1.2
 py -3 .agents/skills/machine-management/scripts/machine_remove.py --machine 173.125.1.2
@@ -30,7 +30,8 @@ If the local machine profile already exists and host key SSH is already healthy,
 
 ```bash
 python3 .agents/skills/machine-management/scripts/machine_add.py \
-  --host 173.125.1.2
+  --host 173.125.1.2 \
+  --image main
 ```
 
 If the profile is missing and the user chose a specific username:
@@ -38,6 +39,7 @@ If the profile is missing and the user chose a specific username:
 ```bash
 python3 .agents/skills/machine-management/scripts/machine_add.py \
   --host 173.125.1.2 \
+  --image main \
   --machine-username alice123
 ```
 
@@ -46,6 +48,7 @@ If the user explicitly accepted the default/random option:
 ```bash
 python3 .agents/skills/machine-management/scripts/machine_add.py \
   --host 173.125.1.2 \
+  --image main \
   --generate-machine-username
 ```
 
@@ -55,6 +58,7 @@ If host key SSH is missing and the password can be hidden in an env var:
 export VAWS_SSH_PASSWORD='YOUR_PASSWORD'
 python3 .agents/skills/machine-management/scripts/machine_add.py \
   --host 173.125.1.2 \
+  --image main \
   --password-env VAWS_SSH_PASSWORD
 unset VAWS_SSH_PASSWORD
 ```
@@ -65,6 +69,7 @@ PowerShell example:
 $env:VAWS_SSH_PASSWORD = 'YOUR_PASSWORD'
 py -3 .agents/skills/machine-management/scripts/machine_add.py `
   --host 173.125.1.2 `
+  --image main `
   --password-env VAWS_SSH_PASSWORD
 Remove-Item Env:VAWS_SSH_PASSWORD
 ```
@@ -74,7 +79,16 @@ If the user already exposed the password in chat and the tool cannot hide stdin 
 ```bash
 python3 .agents/skills/machine-management/scripts/machine_add.py \
   --host 173.125.1.2 \
+  --image main \
   --password 'YOUR_PASSWORD_ALREADY_IN_CHAT'
+```
+
+If the user explicitly wants the latest official release track instead of `main`:
+
+```bash
+python3 .agents/skills/machine-management/scripts/machine_add.py \
+  --host 173.125.1.2 \
+  --image stable
 ```
 
 ## Verify one managed machine
@@ -91,6 +105,14 @@ Use the machine identifier already recorded in inventory.
 ```bash
 python3 .agents/skills/machine-management/scripts/machine_repair.py \
   --machine 173.125.1.2
+```
+
+If the recorded image is legacy or the user wants to rotate to a different track:
+
+```bash
+python3 .agents/skills/machine-management/scripts/machine_repair.py \
+  --machine 173.125.1.2 \
+  --image main
 ```
 
 If host key SSH drifted and a password bootstrap is needed again for recovery:
@@ -126,7 +148,7 @@ Probe one host:
 ```bash
 python3 .agents/skills/machine-management/scripts/manage_machine.py probe-host \
   --host 173.125.1.2 \
-  --image auto
+  --image main
 ```
 
 Bootstrap host key auth directly:
@@ -145,7 +167,7 @@ python3 .agents/skills/machine-management/scripts/manage_machine.py bootstrap-co
   --name vaws-alice123 \
   --port 46671 \
   --namespace alice123 \
-  --image auto
+  --image main
 ```
 
 Run the smoke test directly:
@@ -164,7 +186,8 @@ python3 .agents/skills/machine-management/scripts/inventory.py upsert \
   --machine-username alice123 \
   --host 173.125.1.2 \
   --name vaws-alice123 \
-  --container-port 46671
+  --container-port 46671 \
+  --image quay.nju.edu.cn/ascend/vllm-ascend:main
 ```
 
 Notes:

--- a/.agents/skills/machine-management/scripts/_workflow_common.py
+++ b/.agents/skills/machine-management/scripts/_workflow_common.py
@@ -126,6 +126,118 @@ def public_key_needs_input_payload(error: str) -> dict[str, Any]:
     )
 
 
+def image_selection_needs_input_payload(
+    *,
+    reason: str,
+    machine: str | None = None,
+    current_image: str | None = None,
+) -> dict[str, Any]:
+    latest_release_tag = None
+    release_resolution_note = "resolved at execution time"
+    try:
+        latest_release_tag = machine_ops.fetch_latest_release_tag()
+        release_resolution_note = f"currently resolves to {latest_release_tag}"
+    except machine_ops.MachineManagementError:
+        latest_release_tag = None
+
+    return status_payload(
+        "needs_input",
+        success=False,
+        action="await-image-selection",
+        message=reason,
+        machine=machine,
+        current_image=current_image,
+        missing={
+            "name": "image",
+            "required": True,
+            "choices": [
+                {
+                    "value": machine_ops.IMAGE_SELECTOR_MAIN,
+                    "label": "main branch image",
+                    "recommended": True,
+                    "resolution": f"{machine_ops.IMAGE_REGISTRY_NJU}:main, then {machine_ops.IMAGE_REGISTRY_OFFICIAL}:main",
+                    "use_when": "active development against the upstream main branch",
+                },
+                {
+                    "value": machine_ops.IMAGE_SELECTOR_STABLE,
+                    "label": "latest official release image",
+                    "recommended": False,
+                    "resolution": release_resolution_note,
+                    "use_when": "reproducing the newest official non-prerelease container release",
+                    **({"resolved_tag": latest_release_tag} if latest_release_tag else {}),
+                },
+                {
+                    "value": "custom",
+                    "label": "custom image reference",
+                    "recommended": False,
+                    "expected": "a full image reference with a concrete non-latest tag or digest; comma-separated fallbacks are allowed",
+                },
+            ],
+            "forbidden_defaults": [
+                "auto",
+                "*:latest",
+                "bare repositories without a tag",
+            ],
+            "mirror_order": [machine_ops.IMAGE_REGISTRY_NJU, machine_ops.IMAGE_REGISTRY_OFFICIAL],
+        },
+    )
+
+
+def image_requires_explicit_reselection(image: str | None) -> bool:
+    if image is None or not image.strip():
+        return True
+    normalized = image.strip().lower()
+    if normalized in machine_ops.LEGACY_IMAGE_SELECTORS:
+        return True
+    if "@" in image:
+        return False
+    tag = machine_ops.docker_ref_tag(image.strip())
+    if tag is None:
+        return True
+    return tag.lower() in machine_ops.FORBIDDEN_IMAGE_TAGS
+
+
+def resolve_workflow_image(
+    *,
+    explicit_image: str | None,
+    existing_record: dict[str, Any] | None,
+    action: str,
+) -> tuple[str | None, dict[str, Any] | None]:
+    if explicit_image is not None and explicit_image.strip():
+        return explicit_image.strip(), None
+
+    if existing_record is None:
+        return None, image_selection_needs_input_payload(
+            reason=(
+                f"{action} requires an explicit image choice; ask the user to choose `main`, `stable`, or a custom non-latest image reference before continuing"
+            )
+        )
+
+    current_image = existing_record["container"].get("image")
+    if image_requires_explicit_reselection(current_image):
+        return None, image_selection_needs_input_payload(
+            reason=(
+                f"{action} cannot reuse the recorded image automatically because it is missing, ambiguous, or points at a forbidden moving tag; ask the user to choose `main`, `stable`, or a custom non-latest image reference"
+            ),
+            machine=existing_record["alias"],
+            current_image=current_image,
+        )
+    return current_image, None
+
+
+def image_request_matches_record(explicit_image: str | None, record: dict[str, Any] | None) -> bool:
+    if explicit_image is None or record is None:
+        return False
+    current_image = record.get("container", {}).get("image")
+    if not current_image:
+        return False
+    try:
+        resolution = machine_ops.resolve_image_request(explicit_image.strip())
+    except machine_ops.MachineManagementError:
+        return False
+    return current_image in resolution.candidates
+
+
 def host_password_needs_input_payload(target: machine_ops.SshTarget) -> dict[str, Any]:
     return status_payload(
         "needs_input",
@@ -330,7 +442,7 @@ def bootstrap_host_key(
 def probe_host(
     target: machine_ops.SshTarget,
     *,
-    image: str = machine_ops.DEFAULT_IMAGE,
+    image: str,
     port_range: str = machine_ops.DEFAULT_PORT_RANGE,
     managed_prefix: str = "vaws-",
 ) -> dict[str, Any]:
@@ -368,6 +480,7 @@ def bootstrap_container(
     workdir: str,
     namespace: str | None,
     public_key_file: str | None = None,
+    replace_container_on_image_change: bool = False,
 ) -> dict[str, Any]:
     key_path, private_key, public_key, needs_input = ensure_local_public_key(public_key_file)
     if needs_input is not None:
@@ -377,7 +490,15 @@ def bootstrap_container(
     result = machine_ops.run_remote_script(
         target,
         machine_ops.render_bootstrap_host_script(),
-        args=[container_name, str(container_ssh_port), image, workdir, public_key, namespace or ""],
+        args=[
+            container_name,
+            str(container_ssh_port),
+            image,
+            workdir,
+            public_key,
+            namespace or "",
+            "true" if replace_container_on_image_change else "false",
+        ],
         batch_mode=True,
         timeout_seconds=machine_ops.DEFAULT_BOOTSTRAP_TIMEOUT_SECONDS,
     )

--- a/.agents/skills/machine-management/scripts/inventory.py
+++ b/.agents/skills/machine-management/scripts/inventory.py
@@ -224,6 +224,10 @@ def cmd_get(args: argparse.Namespace) -> int:
 
 
 def cmd_put(args: argparse.Namespace) -> int:
+    if not args.image:
+        raise InventoryError(
+            "--image is required; record an explicit `main`, `stable`-resolved, or concrete non-latest image reference"
+        )
     requested_path = preferred_inventory_path(args.inventory)
     active_path = read_inventory_path(requested_path)
     inventory = load_inventory(active_path)
@@ -358,7 +362,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     put_cmd.add_argument(
         "--image",
-        default="quay.nju.edu.cn/ascend/vllm-ascend:latest",
+        required=True,
     )
     put_cmd.add_argument("--workdir", default="/vllm-workspace")
     put_cmd.add_argument(
@@ -402,7 +406,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     upsert_cmd.add_argument(
         "--image",
-        default="quay.nju.edu.cn/ascend/vllm-ascend:latest",
+        required=True,
     )
     upsert_cmd.add_argument("--workdir", default="/vllm-workspace")
     upsert_cmd.add_argument(

--- a/.agents/skills/machine-management/scripts/machine_add.py
+++ b/.agents/skills/machine-management/scripts/machine_add.py
@@ -21,6 +21,7 @@ from _workflow_common import (  # noqa: E402
     emit_progress,
     find_record,
     host_target,
+    image_request_matches_record,
     list_records,
     load_or_create_profile,
     machine_summary,
@@ -28,6 +29,7 @@ from _workflow_common import (  # noqa: E402
     probe_host,
     public_key_needs_input_payload,
     resolve_password_args,
+    resolve_workflow_image,
     status_payload,
     sync_mesh,
     upsert_machine_record,
@@ -50,7 +52,13 @@ def build_parser() -> argparse.ArgumentParser:
         default=False,
         help="generate a default workspace machine username; only use after explicit user consent",
     )
-    parser.add_argument("--image", default=machine_ops.DEFAULT_IMAGE, help=f"container image (default: {machine_ops.DEFAULT_IMAGE})")
+    parser.add_argument(
+        "--image",
+        help=(
+            "explicit image selector: `main`, `stable`, or a full non-latest image reference; "
+            "this workflow does not default implicitly"
+        ),
+    )
     parser.add_argument("--workdir", default=machine_ops.DEFAULT_WORKDIR, help=f"container workdir (default: {machine_ops.DEFAULT_WORKDIR})")
     parser.add_argument("--public-key-file", help="local public key to install; defaults to ~/.ssh/id_ed25519.pub if present")
     password_group = parser.add_mutually_exclusive_group()
@@ -76,16 +84,36 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         existing = find_record(args.host)
         alias = choose_alias(explicit_alias=args.alias, host=args.host)
+        existing_from_host = existing is not None
         if existing is not None:
             alias = existing["alias"]
+        else:
+            existing = find_record(alias)
+
+        image, image_needs_input = resolve_workflow_image(
+            explicit_image=args.image,
+            existing_record=existing,
+            action="machine add / attach",
+        )
+        if image_needs_input is not None:
+            print_json(image_needs_input)
+            return 0
+        assert image is not None
+
+        if existing is not None:
             verified = verify_machine(existing)
-            if verified.get("status") == "ready":
+            if verified.get("status") == "ready" and image_request_matches_record(image, existing):
+                message = (
+                    "machine is already managed and ready; no mutation was needed"
+                    if existing_from_host
+                    else "machine alias already exists in inventory and is ready"
+                )
                 print_json(
                     status_payload(
                         "ready",
                         success=True,
                         action="already-ready",
-                        message="machine is already managed and ready; no mutation was needed",
+                        message=message,
                         machine=machine_summary(existing),
                         profile={
                             "action": profile_action,
@@ -99,30 +127,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             if verified.get("status") == "blocked":
                 print_json(verified)
                 return 0
-        else:
-            existing = find_record(alias)
-            if existing is not None:
-                verified = verify_machine(existing)
-                if verified.get("status") == "ready":
-                    print_json(
-                        status_payload(
-                            "ready",
-                            success=True,
-                            action="already-ready",
-                            message="machine alias already exists in inventory and is ready",
-                            machine=machine_summary(existing),
-                            profile={
-                                "action": profile_action,
-                                "machine_username": profile["machine_username"],
-                                "container_name": profile["container_name"],
-                            },
-                            verify=verified,
-                        )
-                    )
-                    return 0
-                if verified.get("status") == "blocked":
-                    print_json(verified)
-                    return 0
 
         target_host = existing["host"]["ip"] if existing is not None else args.host
         target_user = existing["host"]["user"] if existing is not None else args.host_user
@@ -155,9 +159,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         else:
             host_auth = {"success": True, "result": "already-configured", "precheck": host_ssh_precheck}
 
-        image_for_probe = existing["container"]["image"] if existing is not None else args.image
         emit_progress(action="add", phase="probe", message="probing host prerequisites", machine=alias)
-        probe = probe_host(target, image=image_for_probe)
+        probe = probe_host(target, image=image)
         if probe.get("status") == "blocked":
             print_json(probe)
             return 0
@@ -177,7 +180,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         namespace = existing.get("namespace") if existing is not None else profile["machine_username"]
         container_name = existing["container"]["name"] if existing is not None else profile["container_name"]
         container_port = existing["container"]["ssh_port"] if existing is not None else free_port
-        image = existing["container"]["image"] if existing is not None else args.image
         workdir = existing["container"]["workdir"] if existing is not None else args.workdir
 
         emit_progress(action="add", phase="bootstrap", message="bootstrapping or repairing the managed container", machine=alias)
@@ -190,6 +192,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             workdir=workdir,
             namespace=namespace,
             public_key_file=args.public_key_file,
+            replace_container_on_image_change=bool(args.image),
         )
         if container.get("status") in {"needs_input", "needs_repair", "blocked"}:
             print_json(container)

--- a/.agents/skills/machine-management/scripts/machine_repair.py
+++ b/.agents/skills/machine-management/scripts/machine_repair.py
@@ -21,10 +21,12 @@ from _workflow_common import (  # noqa: E402
     ensure_local_public_key,
     find_record,
     host_target,
+    image_request_matches_record,
     list_records,
     machine_summary,
     print_json,
     resolve_password_args,
+    resolve_workflow_image,
     status_payload,
     sync_mesh,
     upsert_machine_record,
@@ -35,6 +37,13 @@ from _workflow_common import (  # noqa: E402
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
     parser.add_argument("--machine", required=True, help="machine alias or host IP from inventory")
+    parser.add_argument(
+        "--image",
+        help=(
+            "explicit replacement image selector: `main`, `stable`, or a full non-latest image reference; "
+            "omit only when the recorded image is already explicit and acceptable"
+        ),
+    )
     parser.add_argument("--public-key-file", help="local public key to install; defaults to ~/.ssh/id_ed25519.pub if present")
     parser.add_argument("--python", help="optional explicit python path inside the container")
     password_group = parser.add_mutually_exclusive_group()
@@ -60,13 +69,23 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 0
 
+        image, image_needs_input = resolve_workflow_image(
+            explicit_image=args.image,
+            existing_record=record,
+            action="machine repair",
+        )
+        if image_needs_input is not None:
+            print_json(image_needs_input)
+            return 0
+        assert image is not None
+
         emit_progress(action="repair", phase="verify-before", message="checking current machine readiness", machine=record["alias"])
         verified_before = verify_machine(
             record,
             python=args.python,
             progress_cb=lambda phase, message: emit_progress(action="repair", phase=f"before-{phase}", message=message, machine=record["alias"]),
         )
-        if verified_before.get("status") == "ready":
+        if verified_before.get("status") == "ready" and image_request_matches_record(image, record):
             print_json(
                 status_payload(
                     "ready",
@@ -112,16 +131,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             host=record["host"]["ip"],
             container_name=record["container"]["name"],
             container_ssh_port=record["container"]["ssh_port"],
-            image=record["container"]["image"],
+            image=image,
             workdir=record["container"]["workdir"],
             namespace=record.get("namespace"),
             public_key_file=args.public_key_file,
+            replace_container_on_image_change=bool(args.image),
         )
         if container.get("status") in {"needs_input", "needs_repair", "blocked"}:
             print_json(container)
             return 0
 
-        actual_image = container.get("selected_image") or container.get("image") or record["container"]["image"]
+        actual_image = container.get("selected_image") or container.get("image") or image
         bootstrap_method = "password-once" if host_ssh_precheck.get("ok") is False and password.value is not None else None
         emit_progress(action="repair", phase="inventory", message="refreshing inventory and mesh state", machine=record["alias"])
         inventory_payload, updated_record = upsert_machine_record(

--- a/.agents/skills/machine-management/scripts/manage_machine.py
+++ b/.agents/skills/machine-management/scripts/manage_machine.py
@@ -23,15 +23,34 @@ import sys
 import tempfile
 import threading
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
 from dataclasses import dataclass
 from typing import Any, Sequence
 
 
-DEFAULT_IMAGE = "auto"
-DEFAULT_IMAGE_CANDIDATES = (
-    "quay.nju.edu.cn/ascend/vllm-ascend:latest",
-    "quay.io/ascend/vllm-ascend:latest",
-)
+IMAGE_REGISTRY_NJU = "quay.nju.edu.cn/ascend/vllm-ascend"
+IMAGE_REGISTRY_OFFICIAL = "quay.io/ascend/vllm-ascend"
+IMAGE_REGISTRY_MIRRORS = (IMAGE_REGISTRY_NJU, IMAGE_REGISTRY_OFFICIAL)
+IMAGE_SELECTOR_MAIN = "main"
+IMAGE_SELECTOR_STABLE = "stable"
+IMAGE_SELECTOR_ALIASES = {
+    IMAGE_SELECTOR_MAIN: IMAGE_SELECTOR_MAIN,
+    "main-branch": IMAGE_SELECTOR_MAIN,
+    IMAGE_SELECTOR_STABLE: IMAGE_SELECTOR_STABLE,
+    "release": IMAGE_SELECTOR_STABLE,
+    "latest-release": IMAGE_SELECTOR_STABLE,
+    "latest-official": IMAGE_SELECTOR_STABLE,
+}
+LEGACY_IMAGE_SELECTORS = {"auto"}
+FORBIDDEN_IMAGE_TAGS = {"latest"}
+DEFAULT_IMAGE = IMAGE_SELECTOR_MAIN
+DEFAULT_IMAGE_CANDIDATES = tuple(f"{repo}:main" for repo in IMAGE_REGISTRY_MIRRORS)
+LATEST_RELEASE_API = "https://api.github.com/repos/vllm-project/vllm-ascend/releases/latest"
+LATEST_RELEASE_PAGE = "https://github.com/vllm-project/vllm-ascend/releases/latest"
+LATEST_RELEASE_TIMEOUT_SECONDS = 10
+IMAGE_RESOLVER_USER_AGENT = "vaws-machine-management/1.0"
 DEFAULT_WORKDIR = "/vllm-workspace"
 DEFAULT_HOST_USER = "root"
 DEFAULT_HOST_PORT = 22
@@ -58,8 +77,147 @@ class SshTarget:
     port: int = DEFAULT_HOST_PORT
 
 
+@dataclass(frozen=True)
+class ImageResolution:
+    selector: str
+    requested: str
+    policy: str
+    candidates: tuple[str, ...]
+    resolved_tag: str | None = None
+    mirror_order: tuple[str, ...] = IMAGE_REGISTRY_MIRRORS
+
+
 def print_json(data: dict[str, Any]) -> None:
     print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def image_candidates_for_tag(tag: str) -> tuple[str, ...]:
+    return tuple(f"{repo}:{tag}" for repo in IMAGE_REGISTRY_MIRRORS)
+
+
+def docker_ref_tag(ref: str) -> str | None:
+    if "@" in ref:
+        return None
+    last_slash = ref.rfind("/")
+    last_colon = ref.rfind(":")
+    if last_colon > last_slash:
+        return ref[last_colon + 1 :]
+    return None
+
+
+def require_explicit_image_ref(ref: str) -> str:
+    candidate = ref.strip()
+    if not candidate:
+        raise MachineManagementError(
+            "image reference is empty; choose `main`, `stable`, or an explicit non-latest image reference"
+        )
+    normalized = candidate.lower()
+    if normalized in LEGACY_IMAGE_SELECTORS:
+        raise MachineManagementError(
+            "legacy image selector `auto` is no longer allowed; ask the user to choose `main`, `stable`, or a concrete image reference"
+        )
+    if normalized in IMAGE_SELECTOR_ALIASES:
+        raise MachineManagementError(
+            "semantic image selectors must be handled directly, not mixed into a custom candidate list"
+        )
+    if "@" in candidate:
+        return candidate
+    tag = docker_ref_tag(candidate)
+    if tag is None:
+        raise MachineManagementError(
+            "explicit image references must include a concrete tag or digest; bare repositories implicitly resolve to `latest` and are not allowed"
+        )
+    if tag.lower() in FORBIDDEN_IMAGE_TAGS:
+        raise MachineManagementError(
+            "the moving `latest` tag is not allowed for managed machine bootstrap; choose `main`, `stable`, or a concrete version tag"
+        )
+    return candidate
+
+
+def fetch_latest_release_tag(timeout_seconds: int = LATEST_RELEASE_TIMEOUT_SECONDS) -> str:
+    errors: list[str] = []
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": IMAGE_RESOLVER_USER_AGENT,
+    }
+    api_request = urllib.request.Request(LATEST_RELEASE_API, headers=headers)
+    try:
+        with urllib.request.urlopen(api_request, timeout=timeout_seconds) as response:
+            payload = json.load(response)
+        tag = str(payload.get("tag_name") or "").strip()
+        if tag and not payload.get("draft") and not payload.get("prerelease"):
+            return tag
+        errors.append("GitHub API did not return a final release tag")
+    except (OSError, urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError) as exc:
+        errors.append(f"GitHub API: {exc}")
+
+    page_request = urllib.request.Request(LATEST_RELEASE_PAGE, headers={"User-Agent": IMAGE_RESOLVER_USER_AGENT})
+    try:
+        with urllib.request.urlopen(page_request, timeout=timeout_seconds) as response:
+            final_url = response.geturl()
+        match = re.search(r"/tag/([^/?#]+)$", final_url)
+        if match:
+            return urllib.parse.unquote(match.group(1))
+        errors.append("release redirect did not expose a tag name")
+    except (OSError, urllib.error.URLError, urllib.error.HTTPError) as exc:
+        errors.append(f"GitHub releases page: {exc}")
+
+    detail = "; ".join(errors)
+    raise MachineManagementError(
+        "could not resolve the latest official vllm-ascend release tag; retry later, choose `main`, or pass an explicit image reference"
+        + (f" ({detail})" if detail else "")
+    )
+
+
+def resolve_image_request(spec: str) -> ImageResolution:
+    requested = spec.strip()
+    if not requested:
+        raise MachineManagementError(
+            "image selector is missing; choose `main`, `stable`, or an explicit non-latest image reference"
+        )
+    normalized = requested.lower()
+    selector = IMAGE_SELECTOR_ALIASES.get(normalized)
+    if selector == IMAGE_SELECTOR_MAIN:
+        return ImageResolution(
+            selector=IMAGE_SELECTOR_MAIN,
+            requested=requested,
+            policy="main-branch",
+            candidates=image_candidates_for_tag(IMAGE_SELECTOR_MAIN),
+            resolved_tag=IMAGE_SELECTOR_MAIN,
+        )
+    if selector == IMAGE_SELECTOR_STABLE:
+        release_tag = fetch_latest_release_tag()
+        return ImageResolution(
+            selector=IMAGE_SELECTOR_STABLE,
+            requested=requested,
+            policy="latest-official-release",
+            candidates=image_candidates_for_tag(release_tag),
+            resolved_tag=release_tag,
+        )
+
+    candidates = tuple(require_explicit_image_ref(item) for item in requested.split(",") if item.strip())
+    if not candidates:
+        raise MachineManagementError(
+            "image selector is empty; choose `main`, `stable`, or an explicit non-latest image reference"
+        )
+    return ImageResolution(
+        selector="explicit",
+        requested=requested,
+        policy="explicit",
+        candidates=candidates,
+    )
+
+
+def image_request_payload(spec: str) -> dict[str, Any]:
+    resolution = resolve_image_request(spec)
+    return {
+        "requested": resolution.requested,
+        "selector": resolution.selector,
+        "policy": resolution.policy,
+        "candidates": list(resolution.candidates),
+        "resolved_tag": resolution.resolved_tag,
+        "mirror_order": list(resolution.mirror_order),
+    }
 
 
 def run_local(
@@ -478,7 +636,7 @@ def load_public_key(path: pathlib.Path) -> str:
 def render_host_probe_script() -> str:
     template = r'''#!/usr/bin/env bash
 set -euo pipefail
-image_spec="$1"
+image_request_json="$1"
 port_range="$2"
 prefix="$3"
 py=""
@@ -492,7 +650,7 @@ if [ -z "$py" ]; then
   echo "__SENTINEL__{\"success\": false, \"error\": \"python not found on remote host\"}"
   exit 3
 fi
-"$py" - "$image_spec" "$port_range" "$prefix" <<'PY'
+"$py" - "$image_request_json" "$port_range" "$prefix" <<'PY'
 import json
 import os
 import pathlib
@@ -501,8 +659,8 @@ import socket
 import subprocess
 import sys
 
-AUTO_CANDIDATES = ["quay.nju.edu.cn/ascend/vllm-ascend:latest", "quay.io/ascend/vllm-ascend:latest"]
-image_spec, port_range, prefix = sys.argv[1:4]
+image_request, port_range, prefix = sys.argv[1:4]
+image = json.loads(image_request)
 start_s, end_s = port_range.split(":", 1)
 start, end = int(start_s), int(end_s)
 
@@ -519,14 +677,7 @@ def run(cmd: list[str]) -> tuple[int, str, str]:
     return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
 
 
-def resolve_image_candidates(spec: str) -> list[str]:
-    if spec == "auto":
-        return list(AUTO_CANDIDATES)
-    candidates = [item.strip() for item in spec.split(",") if item.strip()]
-    return candidates or [spec]
-
-
-candidates = resolve_image_candidates(image_spec)
+candidates = list(image.get("candidates") or [])
 result: dict[str, object] = {
     "success": True,
     "hostname": socket.gethostname(),
@@ -540,10 +691,13 @@ result: dict[str, object] = {
     "optional_mounts": [],
     "npu_smi_present": os.path.exists("/usr/local/bin/npu-smi"),
     "image": {
-        "name": image_spec,
-        "requested": image_spec,
-        "policy": "auto-refresh-pull" if image_spec == "auto" else "explicit",
+        "name": image.get("requested"),
+        "requested": image.get("requested"),
+        "selector": image.get("selector"),
+        "policy": image.get("policy"),
+        "resolved_tag": image.get("resolved_tag"),
         "candidates": candidates,
+        "mirror_order": list(image.get("mirror_order") or []),
         "present_local": False,
         "present_local_candidates": [],
     },
@@ -630,11 +784,11 @@ def render_bootstrap_host_script() -> str:
 set -euo pipefail
 container="$1"
 port="$2"
-image_spec="$3"
+image_request_json="$3"
 workdir="$4"
 pubkey="$5"
 namespace="${6:-}"
-auto_candidates_json='["quay.nju.edu.cn/ascend/vllm-ascend:latest", "quay.io/ascend/vllm-ascend:latest"]'
+replace_on_image_change="${7:-false}"
 
 emit_json() {
   python3 - "$1" <<'PY'
@@ -662,19 +816,65 @@ print("__PROGRESS__" + json.dumps(payload, ensure_ascii=False))
 PY
 }
 
-resolve_image_candidates() {
-  python3 - "$image_spec" "$auto_candidates_json" <<'PY'
+image_field() {
+  python3 - "$image_request_json" "$1" <<'PY'
 import json
 import sys
-image_spec = sys.argv[1]
-auto_candidates = json.loads(sys.argv[2])
-if image_spec == "auto":
-    candidates = auto_candidates
+payload = json.loads(sys.argv[1])
+field = sys.argv[2]
+value = payload.get(field)
+if value is None:
+    raise SystemExit(1)
+if isinstance(value, str):
+    print(value)
 else:
-    candidates = [item.strip() for item in image_spec.split(",") if item.strip()] or [image_spec]
-for item in candidates:
+    print(json.dumps(value, ensure_ascii=False))
+PY
+}
+
+resolve_image_candidates() {
+  python3 - "$image_request_json" <<'PY'
+import json
+import sys
+payload = json.loads(sys.argv[1])
+for item in payload.get("candidates") or []:
     print(item)
 PY
+}
+
+run_with_progress() {
+  phase="$1"
+  message="$2"
+  expected_seconds="$3"
+  shift 3
+  log_file="$(mktemp)"
+  "$@" >"$log_file" 2>&1 &
+  pid=$!
+  start_ts=$(date +%s)
+  while kill -0 "$pid" 2>/dev/null; do
+    sleep 8
+    if ! kill -0 "$pid" 2>/dev/null; then
+      break
+    fi
+    elapsed=$(( $(date +%s) - start_ts ))
+    if [ -s "$log_file" ]; then
+      last_line="$(tail -n 1 "$log_file" 2>/dev/null | tr -d '\r' | sed 's/[^[:print:]\t]//g' | cut -c1-180)"
+      if [ -n "$last_line" ]; then
+        emit_progress "$phase" "running" "$message - $last_line" "$expected_seconds"
+      else
+        emit_progress "$phase" "running" "$message - still working (elapsed ${elapsed}s)" "$expected_seconds"
+      fi
+    else
+      emit_progress "$phase" "running" "$message - still working (elapsed ${elapsed}s)" "$expected_seconds"
+    fi
+  done
+  wait "$pid"
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    tail -n 120 "$log_file" >&2 || true
+  fi
+  rm -f "$log_file"
+  return "$status"
 }
 
 emit_progress "preflight" "running" "validating host docker and Ascend prerequisites" 15
@@ -719,8 +919,62 @@ installed_ssh=false
 firewall="none"
 selected_image=""
 image_resolution="unknown"
+requested_image="$(image_field requested || true)"
+requested_selector="$(image_field selector || true)"
+image_policy="$(image_field policy || true)"
+resolved_tag="$(image_field resolved_tag || true)"
+previous_image=""
+mapfile -t image_candidates < <(resolve_image_candidates)
+if [ "${#image_candidates[@]}" -eq 0 ]; then
+  emit_json '{"success": false, "error": "image selector resolved to zero candidates", "phase": "image"}'
+  exit 19
+fi
 
+container_exists=false
 if docker inspect "$container" >/dev/null 2>&1; then
+  container_exists=true
+  current_image=$(docker inspect -f '{{.Config.Image}}' "$container")
+  previous_image="$current_image"
+  image_matches=false
+  for candidate in "${image_candidates[@]}"; do
+    if [ "$candidate" = "$current_image" ]; then
+      image_matches=true
+      break
+    fi
+  done
+  if [ "$image_matches" != "true" ]; then
+    if [ "$replace_on_image_change" = "true" ]; then
+      emit_progress "image" "running" "existing container image $current_image does not match requested selector; recreating container" 60
+      docker rm -f "$container" >/dev/null
+      actions+=("removed-container-for-image-change")
+      container_exists=false
+    else
+      mismatch_payload=$(python3 - <<'PY' "$current_image" "$image_request_json"
+import json
+import sys
+current_image, image_request_json = sys.argv[1:]
+image_request = json.loads(image_request_json)
+print(json.dumps({
+    "success": False,
+    "error": "existing container image does not match the requested selector",
+    "phase": "image",
+    "existing_container_image": current_image,
+    "requested_image": image_request.get("requested"),
+    "requested_selector": image_request.get("selector"),
+    "image_policy": image_request.get("policy"),
+    "resolved_tag": image_request.get("resolved_tag"),
+    "image_candidates": list(image_request.get("candidates") or []),
+    "suggestion": "rerun with explicit container replacement consent or remove the managed container first",
+}, ensure_ascii=False))
+PY
+)
+      emit_json "$mismatch_payload"
+      exit 21
+    fi
+  fi
+fi
+
+if [ "$container_exists" = "true" ]; then
   emit_progress "container" "running" "reusing an existing managed container" 15
   state=$(docker inspect -f '{{.State.Status}}' "$container")
   selected_image=$(docker inspect -f '{{.Config.Image}}' "$container")
@@ -731,23 +985,17 @@ if docker inspect "$container" >/dev/null 2>&1; then
     actions+=("started-existing-container")
   fi
 else
-  mapfile -t image_candidates < <(resolve_image_candidates)
-  if [ "${#image_candidates[@]}" -eq 0 ]; then
-    image_candidates=("$image_spec")
-  fi
-  emit_progress "image" "running" "resolving container image" 180
+  emit_progress "image" "running" "resolved image selector ${requested_image:-unknown} (${image_policy:-unknown})" 30
   for candidate in "${image_candidates[@]}"; do
-    emit_progress "image" "running" "trying image candidate $candidate" 180
-    pull_log=$(mktemp)
-    if docker pull "$candidate" >"$pull_log" 2>&1; then
-      rm -f "$pull_log"
+    emit_progress "image" "running" "trying image candidate $candidate" 600
+    if run_with_progress "image-pull" "docker pull $candidate" 600 docker pull "$candidate"; then
       selected_image="$candidate"
       image_resolution="pulled"
       pulled=true
       actions+=("pulled-image")
       break
     fi
-    rm -f "$pull_log"
+    emit_progress "image" "running" "pull failed for $candidate; checking local cache" 30
     if docker image inspect "$candidate" >/dev/null 2>&1; then
       selected_image="$candidate"
       image_resolution="local-cache"
@@ -792,19 +1040,17 @@ else
 fi
 
 if ! docker exec "$container" bash -lc 'command -v sshd >/dev/null 2>&1 && command -v ssh >/dev/null 2>&1'; then
-  emit_progress "container-ssh" "running" "installing openssh inside the container" 600
-  if ! docker exec "$container" bash -lc '
-set -euo pipefail
-log=$(mktemp)
-trap "rm -f \"$log\"" EXIT
-export DEBIAN_FRONTEND=noninteractive
-if ! (apt-get -o Acquire::Check-Date=false -o Acquire::Check-Valid-Until=false update >"$log" 2>&1 && apt-get install -y openssh-server openssh-client --fix-missing >>"$log" 2>&1); then
-  tail -n 120 "$log" >&2 || true
-  exit 97
-fi
-'; then
-    emit_json '{"success": false, "error": "installing openssh inside container failed", "phase": "container-ssh"}'
+  emit_progress "container-ssh" "running" "updating apt metadata inside the container" 300
+  if ! run_with_progress "container-ssh-apt-update" "apt-get update inside the container" 300 \
+    docker exec "$container" bash -lc 'set -euo pipefail; export DEBIAN_FRONTEND=noninteractive; apt-get -o Acquire::Check-Date=false -o Acquire::Check-Valid-Until=false update'; then
+    emit_json '{"success": false, "error": "apt-get update inside container failed", "phase": "container-ssh-apt-update"}'
     exit 30
+  fi
+  emit_progress "container-ssh" "running" "installing openssh inside the container" 600
+  if ! run_with_progress "container-ssh-apt-install" "apt-get install openssh-server openssh-client" 600 \
+    docker exec "$container" bash -lc 'set -euo pipefail; export DEBIAN_FRONTEND=noninteractive; apt-get install -y openssh-server openssh-client --fix-missing'; then
+    emit_json '{"success": false, "error": "installing openssh inside container failed", "phase": "container-ssh-apt-install"}'
+    exit 31
   fi
   installed_ssh=true
   actions+=("installed-openssh")
@@ -853,7 +1099,7 @@ fi
 INNER
 then
   emit_json '{"success": false, "error": "configuring dedicated container sshd failed", "phase": "container-ssh"}'
-  exit 31
+  exit 32
 fi
 actions+=("configured-dedicated-sshd")
 
@@ -867,32 +1113,33 @@ elif command -v firewall-cmd >/dev/null 2>&1 && firewall-cmd --state >/dev/null 
   firewall="firewalld"
 fi
 
-payload=$(python3 - <<'PY' "$container" "$port" "$image_spec" "$selected_image" "$image_resolution" "$workdir" "$namespace" "$created" "$started" "$pulled" "$installed_ssh" "$firewall" "${actions[*]}" "$auto_candidates_json"
+payload=$(python3 - <<'PY' "$container" "$port" "$image_request_json" "$selected_image" "$image_resolution" "$workdir" "$namespace" "$created" "$started" "$pulled" "$installed_ssh" "$firewall" "${actions[*]}" "$previous_image" "$replace_on_image_change"
 import json
 import sys
 
-def resolve_candidates(spec: str, auto_candidates_text: str) -> list[str]:
-    auto_candidates = json.loads(auto_candidates_text)
-    if spec == "auto":
-        return auto_candidates
-    return [item.strip() for item in spec.split(",") if item.strip()] or [spec]
-
-container, port, requested_image, selected_image, image_resolution, workdir, namespace, created, started, pulled, installed_ssh, firewall, actions, auto_candidates_json = sys.argv[1:]
+container, port, image_request_json, selected_image, image_resolution, workdir, namespace, created, started, pulled, installed_ssh, firewall, actions, previous_image, replace_on_image_change = sys.argv[1:]
+image_request = json.loads(image_request_json)
 print(json.dumps({
     "success": True,
     "container": container,
     "container_ssh_port": int(port),
     "image": selected_image,
-    "requested_image": requested_image,
+    "requested_image": image_request.get("requested"),
+    "requested_selector": image_request.get("selector"),
+    "image_policy": image_request.get("policy"),
+    "resolved_tag": image_request.get("resolved_tag"),
     "selected_image": selected_image,
     "image_resolution": image_resolution,
-    "image_candidates": resolve_candidates(requested_image, auto_candidates_json),
+    "image_candidates": list(image_request.get("candidates") or []),
+    "image_mirror_order": list(image_request.get("mirror_order") or []),
     "workdir": workdir,
     "namespace": namespace or None,
+    "previous_image": previous_image or None,
     "created": created == "true",
     "started_existing": started == "true",
     "pulled_image": pulled == "true",
     "installed_openssh": installed_ssh == "true",
+    "replace_container_on_image_change": replace_on_image_change == "true",
     "firewall": firewall,
     "actions": [item for item in actions.split() if item],
 }, ensure_ascii=False))
@@ -1298,10 +1545,11 @@ def cmd_bootstrap_host_key(args: argparse.Namespace) -> int:
 
 def cmd_probe_host(args: argparse.Namespace) -> int:
     target = host_target(args)
+    image_request = image_request_payload(args.image)
     result = run_remote_script(
         target,
         render_host_probe_script(),
-        args=[args.image, args.port_range, args.managed_prefix],
+        args=[json.dumps(image_request, ensure_ascii=False), args.port_range, args.managed_prefix],
         batch_mode=True,
         timeout_seconds=DEFAULT_PROBE_TIMEOUT_SECONDS,
     )
@@ -1320,16 +1568,18 @@ def cmd_bootstrap_container(args: argparse.Namespace) -> int:
     key_path = find_public_key(args.public_key_file)
     private_key = private_key_for_public_key(key_path)
     public_key = load_public_key(key_path)
+    image_request = image_request_payload(args.image)
     result = run_remote_script(
         target,
         render_bootstrap_host_script(),
         args=[
             args.container_name,
             str(args.container_ssh_port),
-            args.image,
+            json.dumps(image_request, ensure_ascii=False),
             args.workdir,
             public_key,
             args.namespace or "",
+            "true" if args.replace_container_on_image_change else "false",
         ],
         batch_mode=True,
         timeout_seconds=DEFAULT_BOOTSTRAP_TIMEOUT_SECONDS,
@@ -1571,7 +1821,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     probe = subparsers.add_parser("probe-host", help="probe host prerequisites and choose a free high SSH port")
     add_host_args(probe)
-    probe.add_argument("--image", default=DEFAULT_IMAGE, help=f"image name or image policy (default: {DEFAULT_IMAGE}; auto tries {DEFAULT_IMAGE_CANDIDATES[0]} then {DEFAULT_IMAGE_CANDIDATES[1]})")
+    probe.add_argument(
+        "--image",
+        required=True,
+        help=(
+            "explicit image selector: `main`, `stable`, or a full non-latest image reference; "
+            f"`main` tries {DEFAULT_IMAGE_CANDIDATES[0]} then {DEFAULT_IMAGE_CANDIDATES[1]}"
+        ),
+    )
     probe.add_argument("--port-range", default=DEFAULT_PORT_RANGE, help=f"inclusive range START:END (default: {DEFAULT_PORT_RANGE})")
     probe.add_argument("--managed-prefix", default="vaws-", help="managed container name prefix (default: vaws-)")
     probe.set_defaults(func=cmd_probe_host)
@@ -1619,7 +1876,20 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="high non-default SSH port for the managed container",
     )
-    bootstrap.add_argument("--image", default=DEFAULT_IMAGE, help=f"image name or image policy (default: {DEFAULT_IMAGE}; auto tries {DEFAULT_IMAGE_CANDIDATES[0]} then {DEFAULT_IMAGE_CANDIDATES[1]})")
+    bootstrap.add_argument(
+        "--image",
+        required=True,
+        help=(
+            "explicit image selector: `main`, `stable`, or a full non-latest image reference; "
+            f"`main` tries {DEFAULT_IMAGE_CANDIDATES[0]} then {DEFAULT_IMAGE_CANDIDATES[1]}"
+        ),
+    )
+    bootstrap.add_argument(
+        "--replace-container-on-image-change",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="recreate the existing managed container when its current image does not match the requested selector",
+    )
     bootstrap.add_argument("--workdir", default=DEFAULT_WORKDIR, help=f"container workdir (default: {DEFAULT_WORKDIR})")
     bootstrap.add_argument("--namespace", help="stable workspace machine username used for collision-safe container naming")
     bootstrap.add_argument("--public-key-file", help="local SSH public key to add to the container; defaults to ~/.ssh/id_ed25519.pub if present")

--- a/.agents/skills/remote-code-parity/SKILL.md
+++ b/.agents/skills/remote-code-parity/SKILL.md
@@ -33,6 +33,7 @@ Keep a **ready** remote runtime in exact code parity with the local `vllm-ascend
 - Keep container cache / lock / manifest paths isolated by `workspace_id` under a container-local cache root.
 - Preserve runtime-private paths under `/vllm-workspace`, especially `Mooncake`.
 - Keep `stdout` reserved for one final JSON summary and stream phase progress on `stderr` as `__VAWS_PARITY_PROGRESS__=<json>`.
+- Runtime install progress should be attributable at the package-step level: uninstall, `vllm`, `vllm-ascend` requirements, `vllm-ascend`, import smoke, and marker write.
 - Publish each synthetic snapshot to both the parity ref and an advertised branch ref inside the container-local mirror.
 - Materialize child repos explicitly; do not rely on `git submodule update` to fetch synthetic child commits.
 - Use dynamic Python / pip discovery and the Ascend driver `LD_LIBRARY_PATH` preamble instead of pinning one Python patch path.

--- a/.agents/skills/remote-code-parity/references/acceptance.md
+++ b/.agents/skills/remote-code-parity/references/acceptance.md
@@ -30,6 +30,7 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 - the skill keeps local runtime state only under `.vaws-local/remote-code-parity/`
 - normal outcomes are reported as compact JSON with `status` equal to `ready`, `blocked`, `failed`, or `dry-run`
 - phase progress is emitted on `stderr` as `__VAWS_PARITY_PROGRESS__=<json>` while the final summary stays on `stdout`
+- long runtime-install waits remain attributable because uninstall, requirements install, editable install, import verification, and marker write each emit their own progress phase
 
 ### Repo graph and snapshotting
 

--- a/.agents/skills/remote-code-parity/references/behavior.md
+++ b/.agents/skills/remote-code-parity/references/behavior.md
@@ -11,6 +11,7 @@ This file defines the durable behavior of `remote-code-parity`.
 - Fail closed when parity cannot be proven.
 - Prove the final container-side commit ids instead of trusting command exit status alone.
 - Stream phase progress on `stderr` as `__VAWS_PARITY_PROGRESS__=<json>` and keep one final JSON payload on `stdout`.
+- Keep runtime-install phases attributable instead of collapsing them into one opaque step: uninstall, `vllm`, `vllm-ascend` requirements, `vllm-ascend`, import verification, and marker write should each surface their own progress event.
 
 ## Scope and routing
 
@@ -158,3 +159,4 @@ A trustworthy parity result records:
 - export the Ascend driver `LD_LIBRARY_PATH` prefix before sourcing optional env scripts
 - keep the fast path on `pip install -e . --no-build-isolation`
 - if editable install fails because the image packaging stack is too old for the current `pyproject.toml`, attempt one bounded packaging-stack refresh and one retry before failing closed
+- surface a progress transition before each long runtime-install package step so an agent can tell whether the wait is in uninstall, requirements, editable install, or verification

--- a/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
+++ b/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
@@ -518,54 +518,55 @@ def reinstall_required_for_repo(record: SnapshotRecord, patterns: tuple[str, ...
     return any(glob_match_any(path, patterns) for path in record.changed_paths)
 
 
-def runtime_install_script(
+def runtime_install_step_script(
     *,
     runtime_root: str,
     marker_dirname: str,
-    reinstall_vllm: bool,
-    reinstall_vllm_ascend: bool,
     container_identity: str,
+    step: str,
 ) -> str:
     lines = ['set -eo pipefail', f'cd {quoted(runtime_root)}']
     lines.extend(DEFAULT_ENV_PREAMBLE)
-    lines.extend(
-        [
-            'upgrade_packaging_stack() {',
-            '  $PIP install --upgrade "pip>=24.0" "setuptools>=77" "wheel>=0.43" "packaging>=24.0" >/dev/null 2>&1 || true',
-            '}',
-            'install_with_fallback() {',
-            '  target_dir="$1"',
-            '  install_cmd="$2"',
-            '  log_file="$(mktemp -t parity-install.XXXXXX.log)"',
-            '  cd "$target_dir"',
-            '  if bash -lc "$install_cmd" >"$log_file" 2>&1; then',
-            '    rm -f "$log_file"',
-            '    return 0',
-            '  fi',
-            '  status=$?',
-            '  if grep -Eiq "project\\.license|license[^[:alnum:]]|spdx|pyproject" "$log_file"; then',
-            '    upgrade_packaging_stack',
-            '    if bash -lc "$install_cmd" >>"$log_file" 2>&1; then',
-            '      rm -f "$log_file"',
-            '      return 0',
-            '    fi',
-            '    status=$?',
-            '    alt_cmd="$(printf "%s" "$install_cmd" | sed "s/--no-build-isolation//g")"',
-            '    if bash -lc "$alt_cmd" >>"$log_file" 2>&1; then',
-            '      rm -f "$log_file"',
-            '      return 0',
-            '    fi',
-            '    status=$?',
-            '  fi',
-            '  tail -n 120 "$log_file" >&2 || true',
-            '  rm -f "$log_file"',
-            '  return "$status"',
-            '}',
-        ]
-    )
-    if reinstall_vllm or reinstall_vllm_ascend:
+    if step in {'install-vllm', 'install-vllm-ascend'}:
+        lines.extend(
+            [
+                'upgrade_packaging_stack() {',
+                '  $PIP install --upgrade "pip>=24.0" "setuptools>=77" "wheel>=0.43" "packaging>=24.0" >/dev/null 2>&1 || true',
+                '}',
+                'install_with_fallback() {',
+                '  target_dir="$1"',
+                '  install_cmd="$2"',
+                '  log_file="$(mktemp -t parity-install.XXXXXX.log)"',
+                '  cd "$target_dir"',
+                '  if bash -lc "$install_cmd" >"$log_file" 2>&1; then',
+                '    rm -f "$log_file"',
+                '    return 0',
+                '  fi',
+                '  status=$?',
+                '  if grep -Eiq "project\\.license|license[^[:alnum:]]|spdx|pyproject" "$log_file"; then',
+                '    upgrade_packaging_stack',
+                '    if bash -lc "$install_cmd" >>"$log_file" 2>&1; then',
+                '      rm -f "$log_file"',
+                '      return 0',
+                '    fi',
+                '    status=$?',
+                '    alt_cmd="$(printf "%s" "$install_cmd" | sed "s/--no-build-isolation//g")"',
+                '    if bash -lc "$alt_cmd" >>"$log_file" 2>&1; then',
+                '      rm -f "$log_file"',
+                '      return 0',
+                '    fi',
+                '    status=$?',
+                '  fi',
+                '  tail -n 120 "$log_file" >&2 || true',
+                '  rm -f "$log_file"',
+                '  return "$status"',
+                '}',
+            ]
+        )
+
+    if step == 'uninstall':
         lines.append('$PIP uninstall -y vllm vllm-ascend vllm_ascend >/dev/null 2>&1 || true')
-    if reinstall_vllm:
+    elif step == 'install-vllm':
         lines.extend(
             [
                 f'cd {quoted(str(Path(runtime_root) / "vllm"))}',
@@ -573,43 +574,55 @@ def runtime_install_script(
                 'install_with_fallback . "$PIP install -e . --no-build-isolation"',
             ]
         )
-    if reinstall_vllm_ascend:
+    elif step == 'install-vllm-ascend-requirements':
         lines.extend(
             [
                 f'cd {quoted(str(Path(runtime_root) / "vllm-ascend"))}',
                 '$PIP install -r requirements.txt >/dev/null',
+            ]
+        )
+    elif step == 'install-vllm-ascend':
+        lines.extend(
+            [
+                f'cd {quoted(str(Path(runtime_root) / "vllm-ascend"))}',
                 'install_with_fallback . "$PIP install -v -e . --no-build-isolation"',
             ]
         )
-    lines.extend(
-        [
-            '$PYTHON - <<\'PY\'',
-            'import importlib.util',
-            'import torch_npu  # noqa: F401',
-            "assert importlib.util.find_spec('vllm') is not None",
-            "assert importlib.util.find_spec('vllm_ascend') is not None",
-            "print('editable-import-smoke=ok')",
-            'PY',
-            f'mkdir -p {quoted(str(Path(runtime_root) / marker_dirname))}',
-            (
-                'cat > '
-                + quoted(marker_path_for(runtime_root, marker_dirname))
-                + " <<'JSON'\n"
-                + json.dumps(
-                    {
-                        'container_identity': container_identity,
-                        'runtime_root': runtime_root,
-                        'updated_at': now_utc(),
-                        'reinstall_vllm': reinstall_vllm,
-                        'reinstall_vllm_ascend': reinstall_vllm_ascend,
-                    },
-                    indent=2,
-                    sort_keys=True,
-                )
-                + '\nJSON'
-            ),
-        ]
-    )
+    elif step == 'verify-imports':
+        lines.extend(
+            [
+                '$PYTHON - <<\'PY\'',
+                'import importlib.util',
+                'import torch_npu  # noqa: F401',
+                "assert importlib.util.find_spec('vllm') is not None",
+                "assert importlib.util.find_spec('vllm_ascend') is not None",
+                "print('editable-import-smoke=ok')",
+                'PY',
+            ]
+        )
+    elif step == 'write-marker':
+        lines.extend(
+            [
+                f'mkdir -p {quoted(str(Path(runtime_root) / marker_dirname))}',
+                (
+                    'cat > '
+                    + quoted(marker_path_for(runtime_root, marker_dirname))
+                    + " <<'JSON'\n"
+                    + json.dumps(
+                        {
+                            'container_identity': container_identity,
+                            'runtime_root': runtime_root,
+                            'updated_at': now_utc(),
+                        },
+                        indent=2,
+                        sort_keys=True,
+                    )
+                    + '\nJSON'
+                ),
+            ]
+        )
+    else:
+        raise ValueError(f'unknown runtime install step: {step}')
     return '\n'.join(lines)
 
 def read_runtime_install_marker(
@@ -934,14 +947,66 @@ def run_sync(args: argparse.Namespace) -> int:
                         reinstall_vllm=reinstall_vllm,
                         reinstall_vllm_ascend=reinstall_vllm_ascend,
                     )
+                    emit_progress('runtime-install-uninstall', packages=['vllm', 'vllm-ascend'])
                     ssh_exec(
                         container,
-                        runtime_install_script(
+                        runtime_install_step_script(
                             runtime_root=runtime_root,
                             marker_dirname=marker_dirname,
-                            reinstall_vllm=reinstall_vllm,
-                            reinstall_vllm_ascend=reinstall_vllm_ascend,
                             container_identity=args.container_identity,
+                            step='uninstall',
+                        ),
+                    )
+                    if reinstall_vllm:
+                        emit_progress('runtime-install-vllm', package='vllm')
+                        ssh_exec(
+                            container,
+                            runtime_install_step_script(
+                                runtime_root=runtime_root,
+                                marker_dirname=marker_dirname,
+                                container_identity=args.container_identity,
+                                step='install-vllm',
+                            ),
+                        )
+                    if reinstall_vllm_ascend:
+                        emit_progress('runtime-install-vllm-ascend-requirements', requirements='requirements.txt')
+                        ssh_exec(
+                            container,
+                            runtime_install_step_script(
+                                runtime_root=runtime_root,
+                                marker_dirname=marker_dirname,
+                                container_identity=args.container_identity,
+                                step='install-vllm-ascend-requirements',
+                            ),
+                        )
+                        emit_progress('runtime-install-vllm-ascend', package='vllm-ascend')
+                        ssh_exec(
+                            container,
+                            runtime_install_step_script(
+                                runtime_root=runtime_root,
+                                marker_dirname=marker_dirname,
+                                container_identity=args.container_identity,
+                                step='install-vllm-ascend',
+                            ),
+                        )
+                    emit_progress('runtime-install-verify-imports')
+                    ssh_exec(
+                        container,
+                        runtime_install_step_script(
+                            runtime_root=runtime_root,
+                            marker_dirname=marker_dirname,
+                            container_identity=args.container_identity,
+                            step='verify-imports',
+                        ),
+                    )
+                    emit_progress('runtime-install-marker')
+                    ssh_exec(
+                        container,
+                        runtime_install_step_script(
+                            runtime_root=runtime_root,
+                            marker_dirname=marker_dirname,
+                            container_identity=args.container_identity,
+                            step='write-marker',
                         ),
                     )
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,10 @@ Repo-local skills live under `.agents/skills/`.
   - `.agents/skills/machine-management/scripts/machine_repair.py`
   - `.agents/skills/machine-management/scripts/machine_remove.py`
 - Treat `.agents/skills/machine-management/scripts/inventory.py` and `.agents/skills/machine-management/scripts/manage_machine.py` as low-level maintenance helpers, not the default agent-facing surface.
-- For machine bootstrap, prefer the low-level `--image auto` policy unless the user explicitly pins a different image. It resolves to a pull-first latest-tag strategy with NJU first and `quay.io` fallback.
+- For machine bootstrap, never default the image silently. Ask the user to choose `main`, `stable`, or a concrete custom image reference.
+- `main` should try `quay.nju.edu.cn/ascend/vllm-ascend:main` first and `quay.io/ascend/vllm-ascend:main` second.
+- `stable` should resolve the latest official non-prerelease `vllm-ascend` release tag at execution time, then try NJU first and `quay.io` second.
+- Reject `auto`, `*:latest`, and bare repositories without a tag as machine-bootstrap defaults.
 - Keep helper CLIs ergonomic: accept common aliases, disable brittle prefix-abbreviation behavior, and default metadata that can be inferred safely.
 - For normal remote-code-parity work, prefer `.agents/skills/remote-code-parity/scripts/parity_sync.py` over the low-level `remote_code_parity.py` helper.
 - Remote-code-parity should expose phase progress, materialize nested repos explicitly, and avoid hard-coding one container Python patch path.
@@ -47,7 +50,9 @@ Repo-local skills live under `.agents/skills/`.
 - For a missing broad-init machine profile, prefer `.agents/skills/repo-init/scripts/repo_init_profile.py` over calling `workspace_profile.py` directly.
 - The broad-init machine-username question should use exactly three options: detected Git username, random `agent#####`, or custom. If the user picks custom, ask one more text question and wait for the literal username before mutating.
 - Never treat a custom selection as permission to reuse the detected Git username.
+- During new-machine bootstrap, stop for an explicit image choice unless an existing inventory record already points at a concrete non-`latest` image. The allowed default tracks are `main` and `stable`; any other choice must be a concrete custom ref.
 - During `machine-management`, if host key SSH is missing and the user already supplied the host password in the request, prefer a one-shot scripted bootstrap first. Do not immediately bounce the user to a manual terminal command.
+- During `machine-management`, long `docker pull`, `apt-get update`, and package-install phases should keep emitting attributable progress instead of going silent behind one global timeout.
 
 
 ## Mandatory execution gate

--- a/README.md
+++ b/README.md
@@ -76,14 +76,17 @@ When invoked, `machine-management` can:
 1. create or reuse the local workspace machine profile when repo-init was skipped
 2. bootstrap host key-based SSH with a single interactive password-authenticated step
 3. probe host prerequisites
-4. create or repair one managed host-network container per requested machine
-5. verify direct local -> container SSH and run a `torch` + `torch_npu` smoke test
+4. stop for an explicit image decision gate: `main`, `stable`, or a concrete custom image reference
+5. create or repair one managed host-network container per requested machine
+6. verify direct local -> container SSH and run a `torch` + `torch_npu` smoke test
 6. stream bounded machine-phase progress and record the actual selected image used for that container
-7. persist managed-machine state in local inventory
-8. mesh managed containers together on a best-effort basis
-9. remove a managed container and clean local trust state
+7. keep long `docker pull`, `apt-get update`, and package-install steps attributable with heartbeat-style progress
+8. persist managed-machine state in local inventory
+9. mesh managed containers together on a best-effort basis
+10. remove a managed container and clean local trust state
 
 New managed containers should derive their name from the local machine profile rather than using one global shared name.
+The workflow should never default to `auto`, the moving `latest` tag, or another implicit image reference.
 
 
 ## What `remote-code-parity` does


### PR DESCRIPTION
## What changed
- made managed-machine image selection an explicit user decision instead of silently defaulting to `auto` or `latest`
- added image selector resolution for `main`, `stable`, and concrete custom references, including legacy-image re-selection gates and inventory enforcement for explicit recorded images
- updated machine bootstrap and repair flows to honor explicit image changes, emit attributable long-running progress, and handle image replacement deterministically
- refined remote-code-parity reinstall execution into smaller explicit steps and aligned docs, references, and repo routing text with the new contract

## Why
- moving tags and implicit image defaults make managed-machine bootstrap non-deterministic and hide an important user choice
- existing inventory records that still point at legacy or ambiguous images need a safe stop-and-reselect path before attach or repair can claim readiness
- parity reinstall work benefits from finer-grained progress and execution steps so failures are attributable instead of collapsing into one opaque install phase

## Impact
- `machine_add.py` now requires an explicit image choice for new machines and can block for re-selection when an existing record uses a legacy or ambiguous image
- `machine_repair.py` can rotate image tracks explicitly and will not short-circuit to `already-ready` if the requested or recorded image requires mutation
- low-level machine-management helpers now resolve `stable` dynamically from the latest official non-prerelease release tag, reject `latest`-style defaults, and persist the actual selected image
- remote-code-parity install progress is broken into smaller steps that are easier to observe and debug

## Validation
- `git diff --check`
- `python3 -m py_compile .agents/skills/machine-management/scripts/_workflow_common.py .agents/skills/machine-management/scripts/inventory.py .agents/skills/machine-management/scripts/machine_add.py .agents/skills/machine-management/scripts/machine_repair.py .agents/skills/machine-management/scripts/manage_machine.py .agents/skills/remote-code-parity/scripts/remote_code_parity.py`
- `python3 .agents/skills/machine-management/scripts/machine_add.py --help`
- `python3 .agents/skills/machine-management/scripts/machine_repair.py --help`
- `python3 .agents/skills/machine-management/scripts/manage_machine.py --help`
- `python3 .agents/skills/machine-management/scripts/inventory.py --help`
- `python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py --help`
- Python smoke that imports `manage_machine.py` and verifies `resolve_image_request()` for `main`, `stable`, and an explicit tagged image reference
