### PR TITLE
[codex] add rc image track and atomic parity state

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -17,7 +17,7 @@ When a workflow has deterministic shell, SSH, Git, or local-state mechanics, pre
 
 Wrapper-style helpers should stream bounded phase progress on `stderr` and keep one final machine-readable JSON payload on `stdout`.
 
-For machine-management specifically, image selection is an explicit user decision gate: choose `main`, `stable`, or a concrete custom image reference. Do not silently fall back to `auto`, `latest`, or another moving tag.
+For machine-management specifically, image selection is an explicit user decision gate: choose `rc`, `main`, `stable`, or a concrete custom image reference. `rc` is the recommended developer track. Do not silently fall back to `auto`, `latest`, or another moving tag.
 
 When you add or revise a helper script, keep the CLI alias-tolerant and give safe defaults for metadata that can be inferred. The goal is to reduce agent parameter brittleness, not to force one exact flag spelling.
 
@@ -52,7 +52,7 @@ Untracked workspace-local state lives under `.vaws-local/`:
 - `.vaws-local/remote-code-parity/install-consents.json`
 - `.vaws-local/remote-code-parity/runtime-state.json`
 
-Remote-code-parity transport is container-only after machine attach: use machine inventory to resolve the target, then push synthetic refs directly into the container-local cache root. Synthetic mirrors should also publish an advertised branch ref for the current snapshot so nested repos can be materialized without brittle submodule fetch behavior.
+Remote-code-parity transport is container-only after machine attach: use machine inventory to resolve the target, then push synthetic refs directly into the container-local cache root. Synthetic mirrors should also publish an advertised branch ref for the current snapshot so nested repos can be materialized without brittle submodule fetch behavior. Runtime installs should keep pip mirror fallback on Tsinghua -> Aliyun -> PyPI, stream progress for long package steps, and keep consent/runtime-state writes atomic.
 
 The legacy repo-root `.machine-inventory.json` is compatibility input only and should not be reintroduced as the primary path.
 

--- a/.agents/skills/machine-management/SKILL.md
+++ b/.agents/skills/machine-management/SKILL.md
@@ -39,6 +39,7 @@ Ready does **not** imply code sync, rebuild, serving, or benchmark readiness.
 - Never write passwords or tokens into tracked files or `.vaws-local/`.
 - Never use `scp`, `sftp`, `sshpass`, or `expect` in this workflow.
 - Never default the container image silently. Ask the user to choose one of:
+  - `rc`: resolve the newest official prerelease `vllm-ascend` tag, then try `quay.nju.edu.cn/ascend/vllm-ascend:<tag>` first and `quay.io/ascend/vllm-ascend:<tag>` second; this is the recommended developer track
   - `main`: `quay.nju.edu.cn/ascend/vllm-ascend:main`, then `quay.io/ascend/vllm-ascend:main`
   - `stable`: resolve the latest official non-prerelease `vllm-ascend` release tag, then try NJU first and `quay.io` second
   - `custom`: a full image reference with a concrete non-`latest` tag or digest
@@ -61,9 +62,9 @@ The primary bootstrap path must not depend on `ssh-copy-id`, `expect`, or any ot
 
 Use these task-oriented wrappers for normal agent work. They keep the parameter surface narrow and return structured JSON statuses such as `ready`, `needs_input`, `needs_repair`, `blocked`, `removed`, or `unmanaged`. They also stream phase progress on `stderr` as `__VAWS_PROGRESS__=<json>` while reserving `stdout` for one final machine-readable JSON payload.
 
-- `python3 .agents/skills/machine-management/scripts/machine_add.py --host <ip> --image <main|stable|custom-ref> [--machine-username <letters-or-digits> | --generate-machine-username] [--password-env NAME | --password-stdin | --password ...]`
+- `python3 .agents/skills/machine-management/scripts/machine_add.py --host <ip> --image <rc|main|stable|custom-ref> [--machine-username <letters-or-digits> | --generate-machine-username] [--password-env NAME | --password-stdin | --password ...]`
 - `python3 .agents/skills/machine-management/scripts/machine_verify.py --machine <alias-or-ip>`
-- `python3 .agents/skills/machine-management/scripts/machine_repair.py --machine <alias-or-ip> [--image <main|stable|custom-ref>] [--password-env NAME | --password-stdin | --password ...]`
+- `python3 .agents/skills/machine-management/scripts/machine_repair.py --machine <alias-or-ip> [--image <rc|main|stable|custom-ref>] [--password-env NAME | --password-stdin | --password ...]`
 - `python3 .agents/skills/machine-management/scripts/machine_remove.py --machine <alias-or-ip>`
 
 Design intent:
@@ -207,8 +208,8 @@ Do not remove host firewall rules or host-level `authorized_keys` entries.
 - Use the dedicated container SSH config `/etc/ssh/sshd_vaws_config` instead of editing `/etc/ssh/sshd_config` inline.
 - Quote remote-script arguments that may contain spaces, especially SSH public keys and mesh peer keys, before sending them through `ssh`.
 - Ensure `/run/sshd` exists before starting the dedicated `sshd`.
-- Image pulls should follow the selected mirror order and emit heartbeat-style progress so long `docker pull`, `apt-get update`, and `apt-get install` phases remain attributable.
-- Keep `stable` resolution dynamic: resolve the latest official non-prerelease release tag at execution time instead of using the moving `latest` tag.
+- Image pulls should follow the selected mirror order and emit heartbeat-style progress so long `docker pull`, `apt-get update`, and `apt-get install` phases remain attributable. Persist the actually selected image in inventory, not only the selector.
+- Keep `rc` and `stable` resolution dynamic: resolve the newest official prerelease tag or latest official non-prerelease release tag at execution time instead of using the moving `latest` tag.
 - Keep progress on `stderr` and the final status JSON on `stdout`; do not mix partial human narration into the terminal contract.
 - For smoke tests, do not pin a Python patch version. Discover the highest available `/usr/local/python*/bin/python3`, then fall back to `python3`.
 - Source only environment scripts that actually exist.

--- a/.agents/skills/machine-management/references/acceptance.md
+++ b/.agents/skills/machine-management/references/acceptance.md
@@ -56,7 +56,7 @@ These should not trigger `machine-management` unless machine readiness is the ob
 
 ### Add / attach
 
-- `machine_add.py` can succeed with `--host --image main` when the profile and host key SSH are already in place
+- `machine_add.py` can succeed with `--host --image rc` when the profile and host key SSH are already in place
 - when the profile is missing, `machine_add.py` returns `needs_input` instead of silently generating a username
 - when the image choice is missing for a new machine, `machine_add.py` returns `needs_input` instead of silently defaulting to `auto`, `latest`, or another moving tag
 - when an existing inventory record still points at a legacy or moving image tag, `machine_add.py` returns `await-image-selection` before any `already-ready` shortcut
@@ -70,8 +70,9 @@ These should not trigger `machine-management` unless machine readiness is the ob
 - space-containing remote arguments such as SSH public keys and mesh peer keys survive the SSH hop intact
 - `machine_add.py` persists final alias, namespace, host identity, container name, image, and SSH port into inventory without the agent having to call `inventory.py put`
 - the recorded inventory image is the actual selected image after mirror resolution and pull / cache fallback
-- `main` and `stable` remain first-class selectors, while `auto`, `*:latest`, and bare repositories without a tag are rejected as defaults
+- `rc`, `main`, and `stable` remain first-class selectors, while `auto`, `*:latest`, and bare repositories without a tag are rejected as defaults
 - long-running bootstrap phases keep emitting attributable progress for image pull and package-install steps instead of going silent behind one global timeout
+- inventory `put` / `remove` writes are atomic and serialized so concurrent wrappers do not clobber the recorded machine set
 
 ### Verify
 

--- a/.agents/skills/machine-management/references/behavior.md
+++ b/.agents/skills/machine-management/references/behavior.md
@@ -226,12 +226,13 @@ Do **not**:
 
 Image selection is an explicit decision gate, not an implicit default:
 
-1. ask the user to choose `main`, `stable`, or a custom image reference before new-machine bootstrap
-2. `main` resolves to `quay.nju.edu.cn/ascend/vllm-ascend:main`, then `quay.io/ascend/vllm-ascend:main`
-3. `stable` resolves the latest official non-prerelease `vllm-ascend` release tag at execution time, then tries NJU first and `quay.io` second
-4. custom references must include a concrete non-`latest` tag or digest; `auto`, `*:latest`, and bare repositories without a tag are forbidden defaults
-5. if fresh pulls fail but one of the explicit candidate refs is already cached locally, reuse that cached image as a bounded fallback
-6. for non-destructive attach / repair, a recorded explicit non-`latest` image may be reused; ambiguous legacy images require another user choice
+1. ask the user to choose `rc`, `main`, `stable`, or a custom image reference before new-machine bootstrap
+2. `rc` resolves the newest official prerelease `vllm-ascend` tag at execution time, then tries `quay.nju.edu.cn/ascend/vllm-ascend:<tag>` first and `quay.io/ascend/vllm-ascend:<tag>` second; this is the recommended developer track
+3. `main` resolves to `quay.nju.edu.cn/ascend/vllm-ascend:main`, then `quay.io/ascend/vllm-ascend:main`
+4. `stable` resolves the latest official non-prerelease `vllm-ascend` release tag at execution time, then tries NJU first and `quay.io` second
+5. custom references must include a concrete non-`latest` tag or digest; `auto`, `*:latest`, and bare repositories without a tag are forbidden defaults
+6. if fresh pulls fail but one of the explicit candidate refs is already cached locally, reuse that cached image as a bounded fallback
+7. for non-destructive attach / repair, a recorded explicit non-`latest` image may be reused; ambiguous legacy images require another user choice
 
 Inventory should record the actual selected image, not only the requested selector string.
 

--- a/.agents/skills/machine-management/references/command-recipes.md
+++ b/.agents/skills/machine-management/references/command-recipes.md
@@ -9,7 +9,7 @@ Prefer the task-oriented wrappers. Treat the low-level helpers as fallback maint
 macOS / Linux / WSL:
 
 ```bash
-python3 .agents/skills/machine-management/scripts/machine_add.py --host 173.125.1.2 --image main
+python3 .agents/skills/machine-management/scripts/machine_add.py --host 173.125.1.2 --image rc
 python3 .agents/skills/machine-management/scripts/machine_verify.py --machine 173.125.1.2
 python3 .agents/skills/machine-management/scripts/machine_repair.py --machine 173.125.1.2
 python3 .agents/skills/machine-management/scripts/machine_remove.py --machine 173.125.1.2
@@ -18,7 +18,7 @@ python3 .agents/skills/machine-management/scripts/machine_remove.py --machine 17
 Windows:
 
 ```powershell
-py -3 .agents/skills/machine-management/scripts/machine_add.py --host 173.125.1.2 --image main
+py -3 .agents/skills/machine-management/scripts/machine_add.py --host 173.125.1.2 --image rc
 py -3 .agents/skills/machine-management/scripts/machine_verify.py --machine 173.125.1.2
 py -3 .agents/skills/machine-management/scripts/machine_repair.py --machine 173.125.1.2
 py -3 .agents/skills/machine-management/scripts/machine_remove.py --machine 173.125.1.2
@@ -31,7 +31,7 @@ If the local machine profile already exists and host key SSH is already healthy,
 ```bash
 python3 .agents/skills/machine-management/scripts/machine_add.py \
   --host 173.125.1.2 \
-  --image main
+  --image rc
 ```
 
 If the profile is missing and the user chose a specific username:
@@ -83,12 +83,20 @@ python3 .agents/skills/machine-management/scripts/machine_add.py \
   --password 'YOUR_PASSWORD_ALREADY_IN_CHAT'
 ```
 
-If the user explicitly wants the latest official release track instead of `main`:
+If the user explicitly wants the latest final release track instead of the recommended `rc` track:
 
 ```bash
 python3 .agents/skills/machine-management/scripts/machine_add.py \
   --host 173.125.1.2 \
   --image stable
+```
+
+If the user explicitly wants the upstream `main` image track:
+
+```bash
+python3 .agents/skills/machine-management/scripts/machine_add.py \
+  --host 173.125.1.2 \
+  --image main
 ```
 
 ## Verify one managed machine

--- a/.agents/skills/machine-management/scripts/_workflow_common.py
+++ b/.agents/skills/machine-management/scripts/_workflow_common.py
@@ -132,8 +132,15 @@ def image_selection_needs_input_payload(
     machine: str | None = None,
     current_image: str | None = None,
 ) -> dict[str, Any]:
+    latest_prerelease_tag = None
     latest_release_tag = None
+    prerelease_resolution_note = "resolved at execution time"
     release_resolution_note = "resolved at execution time"
+    try:
+        latest_prerelease_tag = machine_ops.fetch_latest_prerelease_tag()
+        prerelease_resolution_note = f"currently resolves to {latest_prerelease_tag}"
+    except machine_ops.MachineManagementError:
+        latest_prerelease_tag = None
     try:
         latest_release_tag = machine_ops.fetch_latest_release_tag()
         release_resolution_note = f"currently resolves to {latest_release_tag}"
@@ -152,9 +159,17 @@ def image_selection_needs_input_payload(
             "required": True,
             "choices": [
                 {
+                    "value": machine_ops.IMAGE_SELECTOR_RC,
+                    "label": "latest official rc image",
+                    "recommended": True,
+                    "resolution": prerelease_resolution_note,
+                    "use_when": "recommended default for active development when you want the newest release-candidate image with matched container dependencies",
+                    **({"resolved_tag": latest_prerelease_tag} if latest_prerelease_tag else {}),
+                },
+                {
                     "value": machine_ops.IMAGE_SELECTOR_MAIN,
                     "label": "main branch image",
-                    "recommended": True,
+                    "recommended": False,
                     "resolution": f"{machine_ops.IMAGE_REGISTRY_NJU}:main, then {machine_ops.IMAGE_REGISTRY_OFFICIAL}:main",
                     "use_when": "active development against the upstream main branch",
                 },
@@ -209,7 +224,7 @@ def resolve_workflow_image(
     if existing_record is None:
         return None, image_selection_needs_input_payload(
             reason=(
-                f"{action} requires an explicit image choice; ask the user to choose `main`, `stable`, or a custom non-latest image reference before continuing"
+                f"{action} requires an explicit image choice; ask the user to choose `rc`, `main`, `stable`, or a custom non-latest image reference before continuing"
             )
         )
 
@@ -217,7 +232,7 @@ def resolve_workflow_image(
     if image_requires_explicit_reselection(current_image):
         return None, image_selection_needs_input_payload(
             reason=(
-                f"{action} cannot reuse the recorded image automatically because it is missing, ambiguous, or points at a forbidden moving tag; ask the user to choose `main`, `stable`, or a custom non-latest image reference"
+                f"{action} cannot reuse the recorded image automatically because it is missing, ambiguous, or points at a forbidden moving tag; ask the user to choose `rc`, `main`, `stable`, or a custom non-latest image reference"
             ),
             machine=existing_record["alias"],
             current_image=current_image,
@@ -446,10 +461,11 @@ def probe_host(
     port_range: str = machine_ops.DEFAULT_PORT_RANGE,
     managed_prefix: str = "vaws-",
 ) -> dict[str, Any]:
+    image_request = machine_ops.image_request_payload(image)
     result = machine_ops.run_remote_script(
         target,
         machine_ops.render_host_probe_script(),
-        args=[image, port_range, managed_prefix],
+        args=[json.dumps(image_request, ensure_ascii=False), port_range, managed_prefix],
         batch_mode=True,
         timeout_seconds=machine_ops.DEFAULT_PROBE_TIMEOUT_SECONDS,
     )
@@ -486,6 +502,7 @@ def bootstrap_container(
     if needs_input is not None:
         return needs_input
     assert key_path is not None and public_key is not None
+    image_request = machine_ops.image_request_payload(image)
 
     result = machine_ops.run_remote_script(
         target,
@@ -493,7 +510,7 @@ def bootstrap_container(
         args=[
             container_name,
             str(container_ssh_port),
-            image,
+            json.dumps(image_request, ensure_ascii=False),
             workdir,
             public_key,
             namespace or "",

--- a/.agents/skills/machine-management/scripts/inventory.py
+++ b/.agents/skills/machine-management/scripts/inventory.py
@@ -10,8 +10,12 @@ task-oriented wrappers for normal add / verify / repair / remove workflows.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
+import os
 import sys
+import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +33,9 @@ from vaws_local_state import (  # noqa: E402
 )
 
 SCHEMA_VERSION = 1
+STATE_LOCK_SUFFIX = ".lock"
+DEFAULT_LOCK_TIMEOUT_SECONDS = 15.0
+DEFAULT_LOCK_POLL_SECONDS = 0.05
 
 
 class InventoryError(RuntimeError):
@@ -91,9 +98,51 @@ def load_inventory(path: Path) -> dict[str, Any]:
     return data
 
 
-def save_inventory(path: Path, inventory: dict[str, Any]) -> None:
+def _atomic_write_json(path: Path, data: Any) -> None:
     ensure_state_dir(path.parent)
-    path.write_text(json.dumps(inventory, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    handle, temp_name = tempfile.mkstemp(prefix=f'.{path.name}.', suffix='.tmp', dir=str(path.parent))
+    try:
+        with os.fdopen(handle, 'w', encoding='utf-8') as fh:
+            fh.write(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(temp_name, path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temp_name)
+
+
+def save_inventory(path: Path, inventory: dict[str, Any]) -> None:
+    _atomic_write_json(path, inventory)
+
+
+@contextlib.contextmanager
+def inventory_lock(
+    path: Path,
+    *,
+    timeout_seconds: float = DEFAULT_LOCK_TIMEOUT_SECONDS,
+    poll_seconds: float = DEFAULT_LOCK_POLL_SECONDS,
+):
+    ensure_state_dir(path.parent)
+    lock_path = path.with_name(path.name + STATE_LOCK_SUFFIX)
+    deadline = time.monotonic() + timeout_seconds
+    fd: int | None = None
+    while True:
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            os.write(fd, f'{os.getpid()}\n'.encode('utf-8'))
+            break
+        except FileExistsError:
+            if time.monotonic() >= deadline:
+                raise InventoryError(f'timed out waiting for inventory lock {lock_path}')
+            time.sleep(poll_seconds)
+    try:
+        yield lock_path
+    finally:
+        if fd is not None:
+            os.close(fd)
+        with contextlib.suppress(FileNotFoundError):
+            lock_path.unlink()
 
 
 def _validate_record(record: Any, where: str = "record") -> None:
@@ -226,55 +275,56 @@ def cmd_get(args: argparse.Namespace) -> int:
 def cmd_put(args: argparse.Namespace) -> int:
     if not args.image:
         raise InventoryError(
-            "--image is required; record an explicit `main`, `stable`-resolved, or concrete non-latest image reference"
+            "--image is required; record an explicit `rc`-resolved, `main`, `stable`-resolved, or concrete non-latest image reference"
         )
     requested_path = preferred_inventory_path(args.inventory)
-    active_path = read_inventory_path(requested_path)
-    inventory = load_inventory(active_path)
-    alias_matches = _find_matches(inventory, alias=args.alias)
-    ip_matches = _find_matches(inventory, host_ip=args.host_ip)
+    with inventory_lock(requested_path):
+        active_path = read_inventory_path(requested_path)
+        inventory = load_inventory(active_path)
+        alias_matches = _find_matches(inventory, alias=args.alias)
+        ip_matches = _find_matches(inventory, host_ip=args.host_ip)
 
-    alias_record = alias_matches[0] if alias_matches else None
-    ip_record = ip_matches[0] if ip_matches else None
-    if alias_record is not None and ip_record is not None and alias_record is not ip_record:
-        raise InventoryError(
-            "alias and host IP match different existing records; resolve the conflict manually"
-        )
+        alias_record = alias_matches[0] if alias_matches else None
+        ip_record = ip_matches[0] if ip_matches else None
+        if alias_record is not None and ip_record is not None and alias_record is not ip_record:
+            raise InventoryError(
+                "alias and host IP match different existing records; resolve the conflict manually"
+            )
 
-    target = alias_record or ip_record
-    namespace = validate_machine_username(args.namespace) if args.namespace else None
-    record = {
-        "alias": args.alias,
-        "namespace": namespace,
-        "host": {
-            "ip": args.host_ip,
-            "port": args.host_port,
-            "user": args.host_user,
-        },
-        "container": {
-            "name": args.container_name,
-            "ssh_port": args.container_ssh_port,
-            "image": args.image,
-            "workdir": args.workdir,
-        },
-        "bootstrap_method": resolve_bootstrap_method(args.bootstrap_method, existing_record=target),
-        "managed_by_skill": True,
-        "created_by_skill": args.created_by_skill,
-        "last_verified_at": args.last_verified_at,
-    }
-    if namespace is None:
-        record.pop("namespace")
-    _validate_record(record)
+        target = alias_record or ip_record
+        namespace = validate_machine_username(args.namespace) if args.namespace else None
+        record = {
+            "alias": args.alias,
+            "namespace": namespace,
+            "host": {
+                "ip": args.host_ip,
+                "port": args.host_port,
+                "user": args.host_user,
+            },
+            "container": {
+                "name": args.container_name,
+                "ssh_port": args.container_ssh_port,
+                "image": args.image,
+                "workdir": args.workdir,
+            },
+            "bootstrap_method": resolve_bootstrap_method(args.bootstrap_method, existing_record=target),
+            "managed_by_skill": True,
+            "created_by_skill": args.created_by_skill,
+            "last_verified_at": args.last_verified_at,
+        }
+        if namespace is None:
+            record.pop("namespace")
+        _validate_record(record)
 
-    if target is None:
-        inventory["machines"].append(record)
-        action = "inserted"
-    else:
-        target.clear()
-        target.update(record)
-        action = "updated"
+        if target is None:
+            inventory["machines"].append(record)
+            action = "inserted"
+        else:
+            target.clear()
+            target.update(record)
+            action = "updated"
 
-    save_inventory(requested_path, inventory)
+        save_inventory(requested_path, inventory)
     payload = {
         "result": action,
         "alias": record["alias"],
@@ -291,18 +341,19 @@ def cmd_put(args: argparse.Namespace) -> int:
 
 def cmd_remove(args: argparse.Namespace) -> int:
     requested_path = preferred_inventory_path(args.inventory)
-    active_path = read_inventory_path(requested_path)
-    inventory = load_inventory(active_path)
-    matches = _find_matches(inventory, identifier=args.identifier)
-    if not matches:
-        raise InventoryError(f"no machine found for identifier: {args.identifier}")
-    if len(matches) > 1:
-        raise InventoryError(
-            f"multiple machines matched {args.identifier!r}; use a unique alias or host IP"
-        )
-    target = matches[0]
-    inventory["machines"] = [record for record in inventory["machines"] if record is not target]
-    save_inventory(requested_path, inventory)
+    with inventory_lock(requested_path):
+        active_path = read_inventory_path(requested_path)
+        inventory = load_inventory(active_path)
+        matches = _find_matches(inventory, identifier=args.identifier)
+        if not matches:
+            raise InventoryError(f"no machine found for identifier: {args.identifier}")
+        if len(matches) > 1:
+            raise InventoryError(
+                f"multiple machines matched {args.identifier!r}; use a unique alias or host IP"
+            )
+        target = matches[0]
+        inventory["machines"] = [record for record in inventory["machines"] if record is not target]
+        save_inventory(requested_path, inventory)
     payload = {
         "result": "removed",
         "alias": target["alias"],

--- a/.agents/skills/machine-management/scripts/machine_add.py
+++ b/.agents/skills/machine-management/scripts/machine_add.py
@@ -55,7 +55,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--image",
         help=(
-            "explicit image selector: `main`, `stable`, or a full non-latest image reference; "
+            "explicit image selector: `rc`, `main`, `stable`, or a full non-latest image reference; "
             "this workflow does not default implicitly"
         ),
     )

--- a/.agents/skills/machine-management/scripts/machine_repair.py
+++ b/.agents/skills/machine-management/scripts/machine_repair.py
@@ -40,7 +40,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--image",
         help=(
-            "explicit replacement image selector: `main`, `stable`, or a full non-latest image reference; "
+            "explicit replacement image selector: `rc`, `main`, `stable`, or a full non-latest image reference; "
             "omit only when the recorded image is already explicit and acceptable"
         ),
     )

--- a/.agents/skills/machine-management/scripts/manage_machine.py
+++ b/.agents/skills/machine-management/scripts/manage_machine.py
@@ -33,9 +33,18 @@ from typing import Any, Sequence
 IMAGE_REGISTRY_NJU = "quay.nju.edu.cn/ascend/vllm-ascend"
 IMAGE_REGISTRY_OFFICIAL = "quay.io/ascend/vllm-ascend"
 IMAGE_REGISTRY_MIRRORS = (IMAGE_REGISTRY_NJU, IMAGE_REGISTRY_OFFICIAL)
+IMAGE_SELECTOR_RC = "rc"
 IMAGE_SELECTOR_MAIN = "main"
 IMAGE_SELECTOR_STABLE = "stable"
 IMAGE_SELECTOR_ALIASES = {
+    IMAGE_SELECTOR_RC: IMAGE_SELECTOR_RC,
+    "release-candidate": IMAGE_SELECTOR_RC,
+    "release-candidates": IMAGE_SELECTOR_RC,
+    "latest-rc": IMAGE_SELECTOR_RC,
+    "latest-prerelease": IMAGE_SELECTOR_RC,
+    "latest-pre-release": IMAGE_SELECTOR_RC,
+    "prerelease": IMAGE_SELECTOR_RC,
+    "pre-release": IMAGE_SELECTOR_RC,
     IMAGE_SELECTOR_MAIN: IMAGE_SELECTOR_MAIN,
     "main-branch": IMAGE_SELECTOR_MAIN,
     IMAGE_SELECTOR_STABLE: IMAGE_SELECTOR_STABLE,
@@ -45,9 +54,11 @@ IMAGE_SELECTOR_ALIASES = {
 }
 LEGACY_IMAGE_SELECTORS = {"auto"}
 FORBIDDEN_IMAGE_TAGS = {"latest"}
-DEFAULT_IMAGE = IMAGE_SELECTOR_MAIN
+DEFAULT_IMAGE = IMAGE_SELECTOR_RC
 DEFAULT_IMAGE_CANDIDATES = tuple(f"{repo}:main" for repo in IMAGE_REGISTRY_MIRRORS)
+RELEASES_API = "https://api.github.com/repos/vllm-project/vllm-ascend/releases?per_page=100"
 LATEST_RELEASE_API = "https://api.github.com/repos/vllm-project/vllm-ascend/releases/latest"
+RELEASES_PAGE = "https://github.com/vllm-project/vllm-ascend/releases"
 LATEST_RELEASE_PAGE = "https://github.com/vllm-project/vllm-ascend/releases/latest"
 LATEST_RELEASE_TIMEOUT_SECONDS = 10
 IMAGE_RESOLVER_USER_AGENT = "vaws-machine-management/1.0"
@@ -64,6 +75,10 @@ DEFAULT_BOOTSTRAP_TIMEOUT_SECONDS = 1800
 DEFAULT_SMOKE_TIMEOUT_SECONDS = 240
 DEFAULT_REMOTE_TIMEOUT_GRACE_SECONDS = 8
 ENV_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+SEMVER_TAG_PATTERN = re.compile(
+    r"^v?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:(?P<kind>rc)(?P<kind_number>\d+))?$",
+    re.IGNORECASE,
+)
 
 
 class MachineManagementError(RuntimeError):
@@ -109,12 +124,12 @@ def require_explicit_image_ref(ref: str) -> str:
     candidate = ref.strip()
     if not candidate:
         raise MachineManagementError(
-            "image reference is empty; choose `main`, `stable`, or an explicit non-latest image reference"
+            "image reference is empty; choose `rc`, `main`, `stable`, or an explicit non-latest image reference"
         )
     normalized = candidate.lower()
     if normalized in LEGACY_IMAGE_SELECTORS:
         raise MachineManagementError(
-            "legacy image selector `auto` is no longer allowed; ask the user to choose `main`, `stable`, or a concrete image reference"
+            "legacy image selector `auto` is no longer allowed; ask the user to choose `rc`, `main`, `stable`, or a concrete image reference"
         )
     if normalized in IMAGE_SELECTOR_ALIASES:
         raise MachineManagementError(
@@ -129,26 +144,95 @@ def require_explicit_image_ref(ref: str) -> str:
         )
     if tag.lower() in FORBIDDEN_IMAGE_TAGS:
         raise MachineManagementError(
-            "the moving `latest` tag is not allowed for managed machine bootstrap; choose `main`, `stable`, or a concrete version tag"
+            "the moving `latest` tag is not allowed for managed machine bootstrap; choose `rc`, `main`, `stable`, or a concrete version tag"
         )
     return candidate
 
 
-def fetch_latest_release_tag(timeout_seconds: int = LATEST_RELEASE_TIMEOUT_SECONDS) -> str:
-    errors: list[str] = []
+def parse_release_tag(tag: str) -> tuple[int, int, int, int | None] | None:
+    match = SEMVER_TAG_PATTERN.fullmatch(tag.strip())
+    if match is None:
+        return None
+    major = int(match.group("major"))
+    minor = int(match.group("minor"))
+    patch = int(match.group("patch"))
+    kind = (match.group("kind") or "").lower()
+    kind_number = match.group("kind_number")
+    if kind == "rc":
+        return major, minor, patch, int(kind_number or "0")
+    return major, minor, patch, None
+
+
+def choose_latest_tag(tags: Sequence[str], *, prerelease: bool) -> str | None:
+    parsed_tags: list[tuple[tuple[int, int, int, int], str]] = []
+    for tag in tags:
+        parsed = parse_release_tag(tag)
+        if parsed is None:
+            continue
+        major, minor, patch, rc_number = parsed
+        is_prerelease = rc_number is not None
+        if prerelease != is_prerelease:
+            continue
+        sort_key = (major, minor, patch, rc_number or 0)
+        parsed_tags.append((sort_key, tag.strip()))
+    if not parsed_tags:
+        return None
+    parsed_tags.sort(key=lambda item: item[0], reverse=True)
+    return parsed_tags[0][1]
+
+
+def fetch_release_catalog(timeout_seconds: int = LATEST_RELEASE_TIMEOUT_SECONDS) -> list[dict[str, Any]]:
     headers = {
         "Accept": "application/vnd.github+json",
         "User-Agent": IMAGE_RESOLVER_USER_AGENT,
     }
-    api_request = urllib.request.Request(LATEST_RELEASE_API, headers=headers)
+    request = urllib.request.Request(RELEASES_API, headers=headers)
+    with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+        payload = json.load(response)
+    if not isinstance(payload, list):
+        raise MachineManagementError("GitHub releases API returned an unexpected payload")
+    releases = [item for item in payload if isinstance(item, dict)]
+    if not releases:
+        raise MachineManagementError("GitHub releases API returned no releases")
+    return releases
+
+
+def choose_release_tag_from_catalog(catalog: Sequence[dict[str, Any]], *, prerelease: bool) -> str | None:
+    tags: list[str] = []
+    for release in catalog:
+        if release.get("draft"):
+            continue
+        tag = str(release.get("tag_name") or "").strip()
+        if not tag:
+            continue
+        parsed = parse_release_tag(tag)
+        if parsed is None:
+            continue
+        is_prerelease = parsed[3] is not None
+        if prerelease:
+            if release.get("prerelease") or is_prerelease:
+                tags.append(tag)
+        else:
+            if not release.get("prerelease") and not is_prerelease:
+                tags.append(tag)
+    return choose_latest_tag(tags, prerelease=prerelease)
+
+
+def choose_release_tag_from_page(html: str, *, prerelease: bool) -> str | None:
+    matches = re.findall(r'/vllm-project/vllm-ascend/releases/tag/([^"?#]+)', html)
+    tags = [urllib.parse.unquote(item).strip() for item in matches]
+    return choose_latest_tag(tags, prerelease=prerelease)
+
+
+def fetch_latest_release_tag(timeout_seconds: int = LATEST_RELEASE_TIMEOUT_SECONDS) -> str:
+    errors: list[str] = []
     try:
-        with urllib.request.urlopen(api_request, timeout=timeout_seconds) as response:
-            payload = json.load(response)
-        tag = str(payload.get("tag_name") or "").strip()
-        if tag and not payload.get("draft") and not payload.get("prerelease"):
+        catalog = fetch_release_catalog(timeout_seconds=timeout_seconds)
+        tag = choose_release_tag_from_catalog(catalog, prerelease=False)
+        if tag:
             return tag
-        errors.append("GitHub API did not return a final release tag")
-    except (OSError, urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError) as exc:
+        errors.append("GitHub releases catalog did not contain a final release tag")
+    except (MachineManagementError, OSError, urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError) as exc:
         errors.append(f"GitHub API: {exc}")
 
     page_request = urllib.request.Request(LATEST_RELEASE_PAGE, headers={"User-Agent": IMAGE_RESOLVER_USER_AGENT})
@@ -157,14 +241,56 @@ def fetch_latest_release_tag(timeout_seconds: int = LATEST_RELEASE_TIMEOUT_SECON
             final_url = response.geturl()
         match = re.search(r"/tag/([^/?#]+)$", final_url)
         if match:
-            return urllib.parse.unquote(match.group(1))
+            tag = urllib.parse.unquote(match.group(1))
+            if choose_latest_tag([tag], prerelease=False):
+                return tag
         errors.append("release redirect did not expose a tag name")
     except (OSError, urllib.error.URLError, urllib.error.HTTPError) as exc:
         errors.append(f"GitHub releases page: {exc}")
 
+    page_request = urllib.request.Request(RELEASES_PAGE, headers={"User-Agent": IMAGE_RESOLVER_USER_AGENT})
+    try:
+        with urllib.request.urlopen(page_request, timeout=timeout_seconds) as response:
+            html = response.read().decode("utf-8", errors="replace")
+        tag = choose_release_tag_from_page(html, prerelease=False)
+        if tag:
+            return tag
+        errors.append("releases page did not expose a final release tag")
+    except (OSError, urllib.error.URLError, urllib.error.HTTPError) as exc:
+        errors.append(f"GitHub releases listing: {exc}")
+
     detail = "; ".join(errors)
     raise MachineManagementError(
-        "could not resolve the latest official vllm-ascend release tag; retry later, choose `main`, or pass an explicit image reference"
+        "could not resolve the latest official vllm-ascend release tag; retry later, choose `rc`, `main`, or pass an explicit image reference"
+        + (f" ({detail})" if detail else "")
+    )
+
+
+def fetch_latest_prerelease_tag(timeout_seconds: int = LATEST_RELEASE_TIMEOUT_SECONDS) -> str:
+    errors: list[str] = []
+    try:
+        catalog = fetch_release_catalog(timeout_seconds=timeout_seconds)
+        tag = choose_release_tag_from_catalog(catalog, prerelease=True)
+        if tag:
+            return tag
+        errors.append("GitHub releases catalog did not contain a prerelease tag")
+    except (MachineManagementError, OSError, urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError) as exc:
+        errors.append(f"GitHub API: {exc}")
+
+    page_request = urllib.request.Request(RELEASES_PAGE, headers={"User-Agent": IMAGE_RESOLVER_USER_AGENT})
+    try:
+        with urllib.request.urlopen(page_request, timeout=timeout_seconds) as response:
+            html = response.read().decode("utf-8", errors="replace")
+        tag = choose_release_tag_from_page(html, prerelease=True)
+        if tag:
+            return tag
+        errors.append("releases page did not expose a prerelease tag")
+    except (OSError, urllib.error.URLError, urllib.error.HTTPError) as exc:
+        errors.append(f"GitHub releases listing: {exc}")
+
+    detail = "; ".join(errors)
+    raise MachineManagementError(
+        "could not resolve the latest official vllm-ascend prerelease tag; retry later, choose `main`, `stable`, or pass an explicit image reference"
         + (f" ({detail})" if detail else "")
     )
 
@@ -173,10 +299,19 @@ def resolve_image_request(spec: str) -> ImageResolution:
     requested = spec.strip()
     if not requested:
         raise MachineManagementError(
-            "image selector is missing; choose `main`, `stable`, or an explicit non-latest image reference"
+            "image selector is missing; choose `rc`, `main`, `stable`, or an explicit non-latest image reference"
         )
     normalized = requested.lower()
     selector = IMAGE_SELECTOR_ALIASES.get(normalized)
+    if selector == IMAGE_SELECTOR_RC:
+        release_tag = fetch_latest_prerelease_tag()
+        return ImageResolution(
+            selector=IMAGE_SELECTOR_RC,
+            requested=requested,
+            policy="latest-official-prerelease",
+            candidates=image_candidates_for_tag(release_tag),
+            resolved_tag=release_tag,
+        )
     if selector == IMAGE_SELECTOR_MAIN:
         return ImageResolution(
             selector=IMAGE_SELECTOR_MAIN,
@@ -198,7 +333,7 @@ def resolve_image_request(spec: str) -> ImageResolution:
     candidates = tuple(require_explicit_image_ref(item) for item in requested.split(",") if item.strip())
     if not candidates:
         raise MachineManagementError(
-            "image selector is empty; choose `main`, `stable`, or an explicit non-latest image reference"
+            "image selector is empty; choose `rc`, `main`, `stable`, or an explicit non-latest image reference"
         )
     return ImageResolution(
         selector="explicit",
@@ -1825,8 +1960,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--image",
         required=True,
         help=(
-            "explicit image selector: `main`, `stable`, or a full non-latest image reference; "
-            f"`main` tries {DEFAULT_IMAGE_CANDIDATES[0]} then {DEFAULT_IMAGE_CANDIDATES[1]}"
+            "explicit image selector: `rc`, `main`, `stable`, or a full non-latest image reference; "
+            f"`rc` resolves the newest official prerelease tag, and `main` tries {DEFAULT_IMAGE_CANDIDATES[0]} then {DEFAULT_IMAGE_CANDIDATES[1]}"
         ),
     )
     probe.add_argument("--port-range", default=DEFAULT_PORT_RANGE, help=f"inclusive range START:END (default: {DEFAULT_PORT_RANGE})")
@@ -1880,8 +2015,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--image",
         required=True,
         help=(
-            "explicit image selector: `main`, `stable`, or a full non-latest image reference; "
-            f"`main` tries {DEFAULT_IMAGE_CANDIDATES[0]} then {DEFAULT_IMAGE_CANDIDATES[1]}"
+            "explicit image selector: `rc`, `main`, `stable`, or a full non-latest image reference; "
+            f"`rc` resolves the newest official prerelease tag, and `main` tries {DEFAULT_IMAGE_CANDIDATES[0]} then {DEFAULT_IMAGE_CANDIDATES[1]}"
         ),
     )
     bootstrap.add_argument(

--- a/.agents/skills/remote-code-parity/SKILL.md
+++ b/.agents/skills/remote-code-parity/SKILL.md
@@ -60,6 +60,7 @@ Keep local untracked state here:
 
 - `.vaws-local/remote-code-parity/install-consents.json`
 - `.vaws-local/remote-code-parity/runtime-state.json`
+- `install-consents.json` and `runtime-state.json` writes must be atomic and lock-protected.
 
 Container-local cache layout under the cache root:
 
@@ -191,7 +192,7 @@ Conservative defaults:
 - `vllm-ascend`: same as `vllm`, plus `vllm_ascend/_cann_ops_custom/**`
 - pure Python, docs, configs, tests, and ordinary scripts: parity only, no rebuild
 
-Use these commands inside the container when required. The normal path first tries the in-place environment, then does one bounded packaging refresh / retry when legacy packaging metadata blocks editable install:
+Use these commands inside the container when required. The normal path first unifies the runtime Python across `python`, `python3`, CMake, and CANN helper tools, then tries the in-place environment, and finally does one bounded packaging refresh / retry when legacy packaging metadata blocks editable install. Pip resolution should prefer Tsinghua, then Aliyun, then the public PyPI index:
 
 ### `vllm`
 
@@ -203,11 +204,14 @@ pip install -e . --no-build-isolation
 ### `vllm-ascend`
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.txt  # mirror-aware fallback: Tsinghua -> Aliyun -> PyPI
 pip install -v -e . --no-build-isolation
 ```
 
 ### 7. Finish with proof, not assumptions
+
+- Finish with real import smoke (`import vllm`, `import vllm_ascend`, `import torch_npu`) instead of `find_spec()` only.
+
 
 Return a compact JSON summary that includes:
 

--- a/.agents/skills/remote-code-parity/references/acceptance.md
+++ b/.agents/skills/remote-code-parity/references/acceptance.md
@@ -31,6 +31,7 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 - normal outcomes are reported as compact JSON with `status` equal to `ready`, `blocked`, `failed`, or `dry-run`
 - phase progress is emitted on `stderr` as `__VAWS_PARITY_PROGRESS__=<json>` while the final summary stays on `stdout`
 - long runtime-install waits remain attributable because uninstall, requirements install, editable install, import verification, and marker write each emit their own progress phase
+- runtime install keeps pip mirror fallback in the order Tsinghua -> Aliyun -> PyPI instead of hard-coding only the public index
 
 ### Repo graph and snapshotting
 
@@ -53,11 +54,14 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 
 - first sync on a fresh container without recorded approval ends with `status == blocked`
 - consent writes require explicit `--approved-by-user`
+- consent and runtime-state writes are atomic / lock-protected so concurrent sync wrappers do not overwrite each other
 - first sync on a fresh container with `allow` recorded proceeds to uninstall image-provided packages best-effort, remove only `vllm` and `vllm-ascend`, and perform editable installs
 - later syncs on the same logical container identity do not ask again unless the marker or identity changed
 - batch approval supports mixed decisions across different servers or containers
 
 ### Runtime materialization and proof
+
+- final verification performs real imports for `vllm`, `vllm_ascend`, and `torch_npu` in the prepared runtime environment
 
 - `/vllm-workspace` is updated in place instead of being replaced wholesale
 - nested repos are materialized explicitly instead of relying on `git submodule update` for synthetic child commits

--- a/.agents/skills/remote-code-parity/references/behavior.md
+++ b/.agents/skills/remote-code-parity/references/behavior.md
@@ -156,7 +156,11 @@ A trustworthy parity result records:
 ## Runtime install compatibility
 
 - discover the runtime Python dynamically from `/usr/local/python*/bin/python3`, then fall back to `python3` or `python`
+- unify that interpreter across `python`, `python3`, `HI_PYTHON`, `Python_EXECUTABLE`, `Python3_EXECUTABLE`, and CMake-driven helper processes before editable install
 - export the Ascend driver `LD_LIBRARY_PATH` prefix before sourcing optional env scripts
 - keep the fast path on `pip install -e . --no-build-isolation`
+- route pip installs through mirror-aware fallback in the order Tsinghua -> Aliyun -> PyPI
 - if editable install fails because the image packaging stack is too old for the current `pyproject.toml`, attempt one bounded packaging-stack refresh and one retry before failing closed
+- finish runtime verification with real imports, not `find_spec()` alone
 - surface a progress transition before each long runtime-install package step so an agent can tell whether the wait is in uninstall, requirements, editable install, or verification
+- keep consent and runtime-state writes atomic so parallel wrapper calls do not clobber local state

--- a/.agents/skills/remote-code-parity/scripts/common.py
+++ b/.agents/skills/remote-code-parity/scripts/common.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import contextlib
 import json
 import os
+import queue
 import shlex
 import subprocess
+import sys
+import tempfile
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
@@ -35,6 +41,10 @@ DEFAULT_DENYLIST = (
 
 HARD_MIN_FREE_BYTES = 512 * 1024 * 1024
 FIRST_INSTALL_MIN_FREE_BYTES = 4 * 1024 * 1024 * 1024
+PROGRESS_SENTINEL = '__VAWS_PARITY_PROGRESS__='
+STATE_LOCK_SUFFIX = '.lock'
+DEFAULT_STATE_LOCK_TIMEOUT_SECONDS = 15.0
+DEFAULT_STATE_LOCK_POLL_SECONDS = 0.05
 
 
 @dataclass(frozen=True)
@@ -45,6 +55,14 @@ class SshEndpoint:
 
     def destination(self) -> str:
         return f'{self.user}@{self.host}'
+
+
+@dataclass(frozen=True)
+class SshStreamingResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    progress_events: list[dict[str, Any]]
 
 
 def run(
@@ -110,13 +128,64 @@ def load_state(repo_root: Path, filename: str, default: Any) -> Any:
     return default
 
 
+def _atomic_write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle, temp_name = tempfile.mkstemp(prefix=f'.{path.name}.', suffix='.tmp', dir=str(path.parent))
+    try:
+        with os.fdopen(handle, 'w', encoding='utf-8') as fh:
+            fh.write(json.dumps(data, indent=2, sort_keys=True) + '\n')
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(temp_name, path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temp_name)
+
+
 def save_state(repo_root: Path, filename: str, data: Any) -> Path:
     path = canonical_state_path(repo_root, filename)
-    path.write_text(json.dumps(data, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+    _atomic_write_json(path, data)
     legacy = legacy_state_path(repo_root, filename)
     if legacy != path:
         legacy.unlink(missing_ok=True)
     return path
+
+
+@contextlib.contextmanager
+def state_lock(
+    repo_root: Path,
+    filename: str,
+    *,
+    timeout_seconds: float = DEFAULT_STATE_LOCK_TIMEOUT_SECONDS,
+    poll_seconds: float = DEFAULT_STATE_LOCK_POLL_SECONDS,
+):
+    lock_path = canonical_state_path(repo_root, filename + STATE_LOCK_SUFFIX)
+    deadline = time.monotonic() + timeout_seconds
+    fd: int | None = None
+    while True:
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            os.write(fd, f'{os.getpid()}\n'.encode('utf-8'))
+            break
+        except FileExistsError:
+            if time.monotonic() >= deadline:
+                raise RuntimeError(f'timed out waiting for state lock {lock_path}')
+            time.sleep(poll_seconds)
+    try:
+        yield lock_path
+    finally:
+        if fd is not None:
+            os.close(fd)
+        with contextlib.suppress(FileNotFoundError):
+            lock_path.unlink()
+
+
+def update_state(repo_root: Path, filename: str, default: Any, updater: Any) -> tuple[Any, Path, Any]:
+    with state_lock(repo_root, filename):
+        state = load_state(repo_root, filename, default)
+        result = updater(state)
+        path = save_state(repo_root, filename, state)
+    return state, path, result
 
 
 def now_utc() -> str:
@@ -162,6 +231,18 @@ def _ssh_base_cmd(endpoint: SshEndpoint) -> list[str]:
     ]
 
 
+def parse_progress_event(line: str) -> dict[str, Any] | None:
+    if not line.startswith(PROGRESS_SENTINEL):
+        return None
+    try:
+        payload = json.loads(line[len(PROGRESS_SENTINEL) :])
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
 def ssh_exec(
     endpoint: SshEndpoint,
     script: str,
@@ -171,6 +252,107 @@ def ssh_exec(
 ) -> subprocess.CompletedProcess[str]:
     cmd = [*_ssh_base_cmd(endpoint), 'bash', '-c', shlex.quote(script)]
     return run(cmd, check=check, capture_output=capture_output)
+
+
+def ssh_exec_stream(
+    endpoint: SshEndpoint,
+    script: str,
+    *,
+    check: bool = True,
+    stream_progress: bool = True,
+) -> SshStreamingResult:
+    cmd = [*_ssh_base_cmd(endpoint), 'bash', '-c', shlex.quote(script)]
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding='utf-8',
+        errors='replace',
+    )
+
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+
+    q: queue.Queue[tuple[str, str | None]] = queue.Queue()
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+    progress_events: list[dict[str, Any]] = []
+
+    def reader(stream_name: str, pipe: Any) -> None:
+        try:
+            for line in pipe:
+                q.put((stream_name, line))
+        finally:
+            q.put((stream_name, None))
+
+    threads = [
+        threading.Thread(target=reader, args=('stdout', proc.stdout), daemon=True),
+        threading.Thread(target=reader, args=('stderr', proc.stderr), daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+
+    done_streams: set[str] = set()
+    while len(done_streams) < 2 or proc.poll() is None:
+        try:
+            stream_name, line = q.get(timeout=0.2)
+        except queue.Empty:
+            continue
+        if line is None:
+            done_streams.add(stream_name)
+            continue
+        if stream_name == 'stdout':
+            stdout_parts.append(line)
+            continue
+        event = parse_progress_event(line)
+        if event is not None:
+            progress_events.append(event)
+            if stream_progress:
+                sys.stderr.write(line if line.endswith('\n') else line + '\n')
+                sys.stderr.flush()
+            continue
+        stderr_parts.append(line)
+
+    returncode = proc.wait()
+    for thread in threads:
+        thread.join(timeout=1)
+
+    while True:
+        try:
+            stream_name, line = q.get_nowait()
+        except queue.Empty:
+            break
+        if line is None:
+            continue
+        if stream_name == 'stdout':
+            stdout_parts.append(line)
+            continue
+        event = parse_progress_event(line)
+        if event is not None:
+            if event not in progress_events:
+                progress_events.append(event)
+            if stream_progress:
+                sys.stderr.write(line if line.endswith('\n') else line + '\n')
+                sys.stderr.flush()
+            continue
+        stderr_parts.append(line)
+
+    stdout = ''.join(stdout_parts)
+    stderr = ''.join(stderr_parts)
+    if check and returncode != 0:
+        rendered_cmd = ' '.join(shlex.quote(part) for part in cmd)
+        raise RuntimeError(
+            f'command failed ({returncode}): {rendered_cmd}\n'
+            f'stdout:\n{stdout}\n'
+            f'stderr:\n{stderr}'
+        )
+    return SshStreamingResult(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+        progress_events=progress_events,
+    )
 
 
 def ssh_stream_to_file(endpoint: SshEndpoint, remote_path: str, payload: str) -> None:

--- a/.agents/skills/remote-code-parity/scripts/install_consent.py
+++ b/.agents/skills/remote-code-parity/scripts/install_consent.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from common import json_dump, load_state, now_utc, repo_root_from, save_state
+from common import json_dump, load_state, now_utc, repo_root_from, save_state, update_state
 
 
 FILENAME = 'install-consents.json'
@@ -56,39 +56,43 @@ def run_resolve(args: argparse.Namespace) -> int:
 
 def run_set(args: argparse.Namespace) -> int:
     repo_root = repo_root_from(Path(args.repo_root))
-    state = load_consent_state(repo_root)
-    set_decision(
-        state,
-        args.server_name,
-        args.container_identity,
-        args.decision,
-        args.note,
-        approved_by_user=args.approved_by_user,
-    )
-    path = save_consent_state(repo_root, state)
+    def apply_update(state: dict[str, Any]) -> None:
+        set_decision(
+            state,
+            args.server_name,
+            args.container_identity,
+            args.decision,
+            args.note,
+            approved_by_user=args.approved_by_user,
+        )
+
+    _, path, _ = update_state(repo_root, FILENAME, {'schema_version': 1, 'consents': {}}, apply_update)
     print(json_dump({'status': 'updated', 'path': str(path)}))
     return 0
 
 
 def run_batch_set(args: argparse.Namespace) -> int:
     repo_root = repo_root_from(Path(args.repo_root))
-    state = load_consent_state(repo_root)
     items = json.loads(Path(args.input).read_text(encoding='utf-8'))
     if not isinstance(items, list):
         raise RuntimeError('batch-set input must be a JSON list')
-    for item in items:
-        if not isinstance(item, dict):
-            raise RuntimeError('each batch-set entry must be an object')
-        set_decision(
-            state,
-            item['server_name'],
-            item['container_identity'],
-            item['decision'],
-            item.get('note'),
-            approved_by_user=args.approved_by_user,
-        )
-    path = save_consent_state(repo_root, state)
-    print(json_dump({'status': 'updated', 'count': len(items), 'path': str(path)}))
+
+    def apply_update(state: dict[str, Any]) -> int:
+        for item in items:
+            if not isinstance(item, dict):
+                raise RuntimeError('each batch-set entry must be an object')
+            set_decision(
+                state,
+                item['server_name'],
+                item['container_identity'],
+                item['decision'],
+                item.get('note'),
+                approved_by_user=args.approved_by_user,
+            )
+        return len(items)
+
+    _, path, count = update_state(repo_root, FILENAME, {'schema_version': 1, 'consents': {}}, apply_update)
+    print(json_dump({'status': 'updated', 'count': count, 'path': str(path)}))
     return 0
 
 

--- a/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
+++ b/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
@@ -27,7 +27,9 @@ from common import (
     sanitize_repo_id,
     save_state,
     ssh_exec,
+    ssh_exec_stream,
     ssh_stream_to_file,
+    update_state,
 )
 
 
@@ -52,17 +54,50 @@ VLLM_ASCEND_REINSTALL_PATTERNS = VLLM_REINSTALL_PATTERNS + (
 )
 
 DEFAULT_ENV_PREAMBLE = (
-    'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH:-}"',
     'export LD_LIBRARY_PATH="/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/driver/lib64:${LD_LIBRARY_PATH:-}"',
     'if [ -f /usr/local/Ascend/ascend-toolkit/set_env.sh ]; then source /usr/local/Ascend/ascend-toolkit/set_env.sh; fi',
     'if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then source /usr/local/Ascend/nnal/atb/set_env.sh; fi',
     'if [ -f /vllm-workspace/vllm-ascend/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/bin/set_env.bash ]; then source /vllm-workspace/vllm-ascend/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/bin/set_env.bash; fi',
     'PYTHON_CANDIDATE="$(ls -1d /usr/local/python*/bin/python3 2>/dev/null | sort -V | tail -n 1 || true)"',
     'if [ -n "$PYTHON_CANDIDATE" ]; then export PYTHON="$PYTHON_CANDIDATE"; elif command -v python3 >/dev/null 2>&1; then export PYTHON="$(command -v python3)"; elif command -v python >/dev/null 2>&1; then export PYTHON="$(command -v python)"; else echo "python not found" >&2; exit 127; fi',
+    'PYTHON_BIN_DIR="$(dirname "$PYTHON")"',
+    'VAWS_PYTHON_SHIM_DIR="$(mktemp -d /tmp/vaws-python-shim.XXXXXX)"',
+    'trap "rm -rf \"$VAWS_PYTHON_SHIM_DIR\"" EXIT',
+    'ln -sf "$PYTHON" "$VAWS_PYTHON_SHIM_DIR/python"',
+    'ln -sf "$PYTHON" "$VAWS_PYTHON_SHIM_DIR/python3"',
+    'export PATH="$VAWS_PYTHON_SHIM_DIR:$PYTHON_BIN_DIR:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH:-}"',
+    'hash -r',
+    'export HI_PYTHON="$PYTHON"',
+    'export Python3_EXECUTABLE="$PYTHON"',
+    'export Python_EXECUTABLE="$PYTHON"',
+    'export CMAKE_ARGS="-DPython3_EXECUTABLE=$PYTHON -DPython_EXECUTABLE=$PYTHON ${CMAKE_ARGS:-}"',
     'export PIP="$PYTHON -m pip"',
+    'export PIP_DISABLE_PIP_VERSION_CHECK=1',
+    'export PIP_NO_INPUT=1',
+    'export PIP_DEFAULT_TIMEOUT=60',
+    'export PIP_RETRIES=2',
+    'export PIP_PROGRESS_BAR=off',
     'export VLLM_WORKER_MULTIPROC_METHOD=spawn',
     'export OMP_NUM_THREADS=1',
     'export MKL_NUM_THREADS=1',
+)
+
+PIP_MIRROR_CANDIDATES = (
+    {
+        'name': 'tsinghua',
+        'index_url': 'https://pypi.tuna.tsinghua.edu.cn/simple',
+        'trusted_host': 'pypi.tuna.tsinghua.edu.cn',
+    },
+    {
+        'name': 'aliyun',
+        'index_url': 'https://mirrors.aliyun.com/pypi/simple',
+        'trusted_host': 'mirrors.aliyun.com',
+    },
+    {
+        'name': 'pypi',
+        'index_url': 'https://pypi.org/simple',
+        'trusted_host': 'pypi.org files.pythonhosted.org',
+    },
 )
 
 DEFAULT_CONTAINER_CACHE_ROOT = '/root/.cache/vaws/remote-code-parity'
@@ -525,78 +560,201 @@ def runtime_install_step_script(
     container_identity: str,
     step: str,
 ) -> str:
-    lines = ['set -eo pipefail', f'cd {quoted(runtime_root)}']
+    lines = ['set -euo pipefail', f'cd {quoted(runtime_root)}']
     lines.extend(DEFAULT_ENV_PREAMBLE)
-    if step in {'install-vllm', 'install-vllm-ascend'}:
+    if step in {'install-vllm', 'install-vllm-ascend', 'install-vllm-ascend-requirements'}:
         lines.extend(
             [
-                'upgrade_packaging_stack() {',
-                '  $PIP install --upgrade "pip>=24.0" "setuptools>=77" "wheel>=0.43" "packaging>=24.0" >/dev/null 2>&1 || true',
+                'emit_progress() {',
+                "  python3 - \"$1\" \"$2\" \"$3\" \"${4:-}\" <<'PY' >&2",
+                'import json',
+                'import sys',
+                'payload = {"phase": sys.argv[1], "message": sys.argv[2]}',
+                'if len(sys.argv) > 3 and sys.argv[3]:',
+                '    try:',
+                '        payload["expected_seconds"] = int(sys.argv[3])',
+                '    except ValueError:',
+                '        pass',
+                f'print("{PROGRESS_SENTINEL}" + json.dumps(payload, ensure_ascii=False))',
+                'PY',
                 '}',
-                'install_with_fallback() {',
-                '  target_dir="$1"',
-                '  install_cmd="$2"',
-                '  log_file="$(mktemp -t parity-install.XXXXXX.log)"',
-                '  cd "$target_dir"',
-                '  if bash -lc "$install_cmd" >"$log_file" 2>&1; then',
-                '    rm -f "$log_file"',
-                '    return 0',
-                '  fi',
+                'run_with_log_progress() {',
+                '  phase="$1"',
+                '  message="$2"',
+                '  expected_seconds="$3"',
+                '  log_file="$4"',
+                '  shift 4',
+                '  "$@" >"$log_file" 2>&1 &',
+                '  pid=$!',
+                '  start_ts=$(date +%s)',
+                '  while kill -0 "$pid" 2>/dev/null; do',
+                '    sleep 8',
+                '    if ! kill -0 "$pid" 2>/dev/null; then',
+                '      break',
+                '    fi',
+                '    elapsed=$(( $(date +%s) - start_ts ))',
+                '    if [ -s "$log_file" ]; then',
+                '      last_line="$(tail -n 1 "$log_file" 2>/dev/null | tr -d \"\\r\" | sed \"s/[^[:print:]\\t]//g\" | cut -c1-180)"',
+                '      if [ -n "$last_line" ]; then',
+                '        emit_progress "$phase" "$message - $last_line" "$expected_seconds"',
+                '      else',
+                '        emit_progress "$phase" "$message - still working (elapsed ${elapsed}s)" "$expected_seconds"',
+                '      fi',
+                '    else',
+                '      emit_progress "$phase" "$message - still working (elapsed ${elapsed}s)" "$expected_seconds"',
+                '    fi',
+                '  done',
+                '  set +e',
+                '  wait "$pid"',
                 '  status=$?',
-                '  if grep -Eiq "project\\.license|license[^[:alnum:]]|spdx|pyproject" "$log_file"; then',
-                '    upgrade_packaging_stack',
-                '    if bash -lc "$install_cmd" >>"$log_file" 2>&1; then',
-                '      rm -f "$log_file"',
-                '      return 0',
-                '    fi',
-                '    status=$?',
-                '    alt_cmd="$(printf "%s" "$install_cmd" | sed "s/--no-build-isolation//g")"',
-                '    if bash -lc "$alt_cmd" >>"$log_file" 2>&1; then',
-                '      rm -f "$log_file"',
-                '      return 0',
-                '    fi',
-                '    status=$?',
+                '  set -e',
+                '  if [ "$status" -ne 0 ]; then',
+                '    tail -n 160 "$log_file" >&2 || true',
                 '  fi',
-                '  tail -n 120 "$log_file" >&2 || true',
+                '  return "$status"',
+                '}',
+                'run_with_progress() {',
+                '  phase="$1"',
+                '  message="$2"',
+                '  expected_seconds="$3"',
+                '  shift 3',
+                '  log_file="$(mktemp -t parity-step.XXXXXX.log)"',
+                '  set +e',
+                '  run_with_log_progress "$phase" "$message" "$expected_seconds" "$log_file" "$@"',
+                '  status=$?',
+                '  set -e',
                 '  rm -f "$log_file"',
                 '  return "$status"',
+                '}',
+                'pip_apply_mirror() {',
+                '  mirror="$1"',
+                '  unset PIP_INDEX_URL PIP_TRUSTED_HOST',
+                '  case "$mirror" in',
+            ]
+        )
+        for mirror in PIP_MIRROR_CANDIDATES:
+            lines.extend(
+                [
+                    f'    {mirror["name"]}) export PIP_INDEX_URL={quoted(mirror["index_url"])}; export PIP_TRUSTED_HOST={quoted(mirror["trusted_host"])} ;;',
+                ]
+            )
+        lines.extend(
+            [
+                '    *) return 1 ;;',
+                '  esac',
+                '  emit_progress "runtime-pip-mirror" "using pip mirror $mirror" 30',
+                '}',
+                'pip_install_with_mirrors() {',
+                '  phase="$1"',
+                '  message="$2"',
+                '  expected_seconds="$3"',
+                '  shift 3',
+                '  last_status=1',
+                '  for mirror in tsinghua aliyun pypi; do',
+                '    pip_apply_mirror "$mirror"',
+                '    set +e',
+                '    run_with_progress "$phase" "$message via $mirror" "$expected_seconds" "$PYTHON" -m pip "$@"',
+                '    status=$?',
+                '    set -e',
+                '    if [ "$status" -eq 0 ]; then',
+                '      return 0',
+                '    fi',
+                '    last_status="$status"',
+                '  done',
+                '  return "$last_status"',
+                '}',
+                'upgrade_packaging_stack() {',
+                '  set +e',
+                '  pip_install_with_mirrors "runtime-install-packaging" "upgrading packaging toolchain" 300 install --upgrade "pip>=24.0" "setuptools>=77" "wheel>=0.43" "packaging>=24.0"',
+                '  status=$?',
+                '  set -e',
+                '  return "$status"',
+                '}',
+                'install_with_fallback() {',
+                '  phase="$1"',
+                '  message="$2"',
+                '  target_dir="$3"',
+                '  expected_seconds="$4"',
+                '  install_cmd="$5"',
+                '  log_file="$(mktemp -t parity-install.XXXXXX.log)"',
+                '  cd "$target_dir"',
+                '  last_status=1',
+                '  for mirror in tsinghua aliyun pypi; do',
+                '    pip_apply_mirror "$mirror"',
+                '    set +e',
+                '    run_with_log_progress "$phase" "$message via $mirror" "$expected_seconds" "$log_file" bash -lc "$install_cmd"',
+                '    status=$?',
+                '    set -e',
+                '    if [ "$status" -eq 0 ]; then',
+                '      rm -f "$log_file"',
+                '      return 0',
+                '    fi',
+                '    last_status="$status"',
+                '    if grep -Eiq "project\\.license|license[^[:alnum:]]|spdx|pyproject" "$log_file"; then',
+                '      upgrade_packaging_stack || true',
+                '      set +e',
+                '      run_with_log_progress "$phase" "$message via $mirror (packaging retry)" "$expected_seconds" "$log_file" bash -lc "$install_cmd"',
+                '      status=$?',
+                '      set -e',
+                '      if [ "$status" -eq 0 ]; then',
+                '        rm -f "$log_file"',
+                '        return 0',
+                '      fi',
+                '      last_status="$status"',
+                '      alt_cmd="$(printf "%s" "$install_cmd" | sed "s/--no-build-isolation//g" | xargs)"',
+                '      if [ -n "$alt_cmd" ] && [ "$alt_cmd" != "$install_cmd" ]; then',
+                '        set +e',
+                '        run_with_log_progress "$phase" "$message via $mirror (isolation fallback)" "$expected_seconds" "$log_file" bash -lc "$alt_cmd"',
+                '        status=$?',
+                '        set -e',
+                '        if [ "$status" -eq 0 ]; then',
+                '          rm -f "$log_file"',
+                '          return 0',
+                '        fi',
+                '        last_status="$status"',
+                '      fi',
+                '    fi',
+                '  done',
+                '  rm -f "$log_file"',
+                '  return "$last_status"',
                 '}',
             ]
         )
 
     if step == 'uninstall':
-        lines.append('$PIP uninstall -y vllm vllm-ascend vllm_ascend >/dev/null 2>&1 || true')
+        lines.append('$PYTHON -m pip uninstall -y vllm vllm-ascend vllm_ascend >/dev/null 2>&1 || true')
     elif step == 'install-vllm':
         lines.extend(
             [
                 f'cd {quoted(str(Path(runtime_root) / "vllm"))}',
                 'export VLLM_TARGET_DEVICE=empty',
-                'install_with_fallback . "$PIP install -e . --no-build-isolation"',
+                'install_with_fallback "runtime-install-vllm" "building editable vllm" . 1800 "$PYTHON -m pip install -e . --no-build-isolation"',
             ]
         )
     elif step == 'install-vllm-ascend-requirements':
         lines.extend(
             [
                 f'cd {quoted(str(Path(runtime_root) / "vllm-ascend"))}',
-                '$PIP install -r requirements.txt >/dev/null',
+                'pip_install_with_mirrors "runtime-install-vllm-ascend-requirements" "installing vllm-ascend requirements" 900 install -r requirements.txt',
             ]
         )
     elif step == 'install-vllm-ascend':
         lines.extend(
             [
                 f'cd {quoted(str(Path(runtime_root) / "vllm-ascend"))}',
-                'install_with_fallback . "$PIP install -v -e . --no-build-isolation"',
+                'install_with_fallback "runtime-install-vllm-ascend" "building editable vllm-ascend" . 2400 "$PYTHON -m pip install -v -e . --no-build-isolation"',
             ]
         )
     elif step == 'verify-imports':
         lines.extend(
             [
-                '$PYTHON - <<\'PY\'',
-                'import importlib.util',
+                "$PYTHON - <<'PY'",
+                'import sys',
+                'import torch',
                 'import torch_npu  # noqa: F401',
-                "assert importlib.util.find_spec('vllm') is not None",
-                "assert importlib.util.find_spec('vllm_ascend') is not None",
-                "print('editable-import-smoke=ok')",
+                'import vllm',
+                'import vllm_ascend',
+                'print(f"editable-import-smoke=ok python={sys.executable} torch={torch.__version__} vllm={getattr(vllm, "__version__", "unknown")}")',
                 'PY',
             ]
         )
@@ -624,6 +782,28 @@ def runtime_install_step_script(
     else:
         raise ValueError(f'unknown runtime install step: {step}')
     return '\n'.join(lines)
+
+
+def run_runtime_install_step(
+    *,
+    container: SshEndpoint,
+    runtime_root: str,
+    marker_dirname: str,
+    container_identity: str,
+    step: str,
+    stream_progress: bool = False,
+) -> None:
+    script = runtime_install_step_script(
+        runtime_root=runtime_root,
+        marker_dirname=marker_dirname,
+        container_identity=container_identity,
+        step=step,
+    )
+    if stream_progress:
+        ssh_exec_stream(container, script, stream_progress=True)
+    else:
+        ssh_exec(container, script)
+
 
 def read_runtime_install_marker(
     *,
@@ -688,18 +868,19 @@ def update_runtime_state(
     records: list[SnapshotRecord],
     first_reinstall_completed: bool,
 ) -> None:
-    state = load_runtime_state(repo_root)
-    server_state = state.setdefault('servers', {}).setdefault(server_name, {})
-    containers = server_state.setdefault('containers', {})
-    containers[container_identity] = {
-        'runtime_root': runtime_root,
-        'container_cache_root': container_cache_root,
-        'marker_dirname': marker_dirname,
-        'last_sync_at': now_utc(),
-        'first_reinstall_completed': first_reinstall_completed,
-        'last_snapshot_commits': {record.relpath: record.commit for record in records},
-    }
-    save_runtime_state(repo_root, state)
+    def apply_update(state: dict[str, Any]) -> None:
+        server_state = state.setdefault('servers', {}).setdefault(server_name, {})
+        containers = server_state.setdefault('containers', {})
+        containers[container_identity] = {
+            'runtime_root': runtime_root,
+            'container_cache_root': container_cache_root,
+            'marker_dirname': marker_dirname,
+            'last_sync_at': now_utc(),
+            'first_reinstall_completed': first_reinstall_completed,
+            'last_snapshot_commits': {record.relpath: record.commit for record in records},
+        }
+
+    update_state(repo_root, STATE_FILENAME, {'schema_version': 1, 'servers': {}}, apply_update)
 
 
 def make_manifest(
@@ -948,66 +1129,60 @@ def run_sync(args: argparse.Namespace) -> int:
                         reinstall_vllm_ascend=reinstall_vllm_ascend,
                     )
                     emit_progress('runtime-install-uninstall', packages=['vllm', 'vllm-ascend'])
-                    ssh_exec(
-                        container,
-                        runtime_install_step_script(
-                            runtime_root=runtime_root,
-                            marker_dirname=marker_dirname,
-                            container_identity=args.container_identity,
-                            step='uninstall',
-                        ),
+                    run_runtime_install_step(
+                        container=container,
+                        runtime_root=runtime_root,
+                        marker_dirname=marker_dirname,
+                        container_identity=args.container_identity,
+                        step='uninstall',
+                        stream_progress=False,
                     )
                     if reinstall_vllm:
                         emit_progress('runtime-install-vllm', package='vllm')
-                        ssh_exec(
-                            container,
-                            runtime_install_step_script(
-                                runtime_root=runtime_root,
-                                marker_dirname=marker_dirname,
-                                container_identity=args.container_identity,
-                                step='install-vllm',
-                            ),
+                        run_runtime_install_step(
+                            container=container,
+                            runtime_root=runtime_root,
+                            marker_dirname=marker_dirname,
+                            container_identity=args.container_identity,
+                            step='install-vllm',
+                            stream_progress=True,
                         )
                     if reinstall_vllm_ascend:
                         emit_progress('runtime-install-vllm-ascend-requirements', requirements='requirements.txt')
-                        ssh_exec(
-                            container,
-                            runtime_install_step_script(
-                                runtime_root=runtime_root,
-                                marker_dirname=marker_dirname,
-                                container_identity=args.container_identity,
-                                step='install-vllm-ascend-requirements',
-                            ),
+                        run_runtime_install_step(
+                            container=container,
+                            runtime_root=runtime_root,
+                            marker_dirname=marker_dirname,
+                            container_identity=args.container_identity,
+                            step='install-vllm-ascend-requirements',
+                            stream_progress=True,
                         )
                         emit_progress('runtime-install-vllm-ascend', package='vllm-ascend')
-                        ssh_exec(
-                            container,
-                            runtime_install_step_script(
-                                runtime_root=runtime_root,
-                                marker_dirname=marker_dirname,
-                                container_identity=args.container_identity,
-                                step='install-vllm-ascend',
-                            ),
+                        run_runtime_install_step(
+                            container=container,
+                            runtime_root=runtime_root,
+                            marker_dirname=marker_dirname,
+                            container_identity=args.container_identity,
+                            step='install-vllm-ascend',
+                            stream_progress=True,
                         )
                     emit_progress('runtime-install-verify-imports')
-                    ssh_exec(
-                        container,
-                        runtime_install_step_script(
-                            runtime_root=runtime_root,
-                            marker_dirname=marker_dirname,
-                            container_identity=args.container_identity,
-                            step='verify-imports',
-                        ),
+                    run_runtime_install_step(
+                        container=container,
+                        runtime_root=runtime_root,
+                        marker_dirname=marker_dirname,
+                        container_identity=args.container_identity,
+                        step='verify-imports',
+                        stream_progress=True,
                     )
                     emit_progress('runtime-install-marker')
-                    ssh_exec(
-                        container,
-                        runtime_install_step_script(
-                            runtime_root=runtime_root,
-                            marker_dirname=marker_dirname,
-                            container_identity=args.container_identity,
-                            step='write-marker',
-                        ),
+                    run_runtime_install_step(
+                        container=container,
+                        runtime_root=runtime_root,
+                        marker_dirname=marker_dirname,
+                        container_identity=args.container_identity,
+                        step='write-marker',
+                        stream_progress=False,
                     )
 
                 current_phase = 'verify-runtime-commits'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,13 +28,14 @@ Repo-local skills live under `.agents/skills/`.
   - `.agents/skills/machine-management/scripts/machine_repair.py`
   - `.agents/skills/machine-management/scripts/machine_remove.py`
 - Treat `.agents/skills/machine-management/scripts/inventory.py` and `.agents/skills/machine-management/scripts/manage_machine.py` as low-level maintenance helpers, not the default agent-facing surface.
-- For machine bootstrap, never default the image silently. Ask the user to choose `main`, `stable`, or a concrete custom image reference.
+- For machine bootstrap, never default the image silently. Ask the user to choose `rc`, `main`, `stable`, or a concrete custom image reference.
+- `rc` is the recommended developer track: resolve the newest official prerelease `vllm-ascend` tag at execution time, then try `quay.nju.edu.cn/ascend/vllm-ascend:<tag>` first and `quay.io/ascend/vllm-ascend:<tag>` second.
 - `main` should try `quay.nju.edu.cn/ascend/vllm-ascend:main` first and `quay.io/ascend/vllm-ascend:main` second.
 - `stable` should resolve the latest official non-prerelease `vllm-ascend` release tag at execution time, then try NJU first and `quay.io` second.
 - Reject `auto`, `*:latest`, and bare repositories without a tag as machine-bootstrap defaults.
 - Keep helper CLIs ergonomic: accept common aliases, disable brittle prefix-abbreviation behavior, and default metadata that can be inferred safely.
 - For normal remote-code-parity work, prefer `.agents/skills/remote-code-parity/scripts/parity_sync.py` over the low-level `remote_code_parity.py` helper.
-- Remote-code-parity should expose phase progress, materialize nested repos explicitly, and avoid hard-coding one container Python patch path.
+- Remote-code-parity should expose phase progress, materialize nested repos explicitly, keep consent/runtime-state writes atomic, unify the runtime Python across `python`, `python3`, CMake, and CANN helper tools, and use mirror-aware pip fallback in the order Tsinghua -> Aliyun -> PyPI.
 - Prefer concise machine-readable summaries over long raw command logs.
 - When a command is noisy, capture the log and report only a compact summary plus a short failure tail.
 - Wrapper-style skills should keep progress on `stderr` and reserve `stdout` for a final machine-readable JSON payload.
@@ -50,7 +51,7 @@ Repo-local skills live under `.agents/skills/`.
 - For a missing broad-init machine profile, prefer `.agents/skills/repo-init/scripts/repo_init_profile.py` over calling `workspace_profile.py` directly.
 - The broad-init machine-username question should use exactly three options: detected Git username, random `agent#####`, or custom. If the user picks custom, ask one more text question and wait for the literal username before mutating.
 - Never treat a custom selection as permission to reuse the detected Git username.
-- During new-machine bootstrap, stop for an explicit image choice unless an existing inventory record already points at a concrete non-`latest` image. The allowed default tracks are `main` and `stable`; any other choice must be a concrete custom ref.
+- During new-machine bootstrap, stop for an explicit image choice unless an existing inventory record already points at a concrete non-`latest` image. The named selector tracks are `rc`, `main`, and `stable`; any other choice must be a concrete custom ref.
 - During `machine-management`, if host key SSH is missing and the user already supplied the host password in the request, prefer a one-shot scripted bootstrap first. Do not immediately bounce the user to a manual terminal command.
 - During `machine-management`, long `docker pull`, `apt-get update`, and package-install phases should keep emitting attributable progress instead of going silent behind one global timeout.
 

--- a/README.md
+++ b/README.md
@@ -76,12 +76,13 @@ When invoked, `machine-management` can:
 1. create or reuse the local workspace machine profile when repo-init was skipped
 2. bootstrap host key-based SSH with a single interactive password-authenticated step
 3. probe host prerequisites
-4. stop for an explicit image decision gate: `main`, `stable`, or a concrete custom image reference
+4. stop for an explicit image decision gate: `rc`, `main`, `stable`, or a concrete custom image reference (`rc` is the recommended developer track)
 5. create or repair one managed host-network container per requested machine
 6. verify direct local -> container SSH and run a `torch` + `torch_npu` smoke test
 6. stream bounded machine-phase progress and record the actual selected image used for that container
 7. keep long `docker pull`, `apt-get update`, and package-install steps attributable with heartbeat-style progress
-8. persist managed-machine state in local inventory
+8. keep local inventory writes atomic so concurrent wrapper calls do not clobber each other
+8. persist managed-machine state in local inventory with atomic writes / lock protection
 9. mesh managed containers together on a best-effort basis
 10. remove a managed container and clean local trust state
 
@@ -98,6 +99,7 @@ When invoked automatically before remote execution, `remote-code-parity` can:
 3. push those snapshots directly into **container-local** bare mirror repositories over direct local -> container SSH
 4. publish an advertised current branch inside each mirror so nested repos can fetch the synthetic snapshot cleanly
 5. materialize the mirrored commits in place inside `/vllm-workspace` so the checked-out code matches the local workspace exactly
+6. keep runtime install progress attributable, use pip mirror fallback in the order Tsinghua -> Aliyun -> PyPI, and unify the runtime Python path for editable builds
 6. preserve runtime-private paths such as `Mooncake` instead of replacing the entire runtime root
 7. on the first sync for a fresh container, require explicit user consent before uninstalling image-provided `vllm` / `vllm-ascend`, deleting only `/vllm-workspace/vllm` and `/vllm-workspace/vllm-ascend`, and reinstalling them from the synced source trees
 8. on later syncs, reinstall only when build-critical paths changed


### PR DESCRIPTION
## What changed
- added an `rc` image selector as the recommended developer track for machine-management, resolving the newest official prerelease `vllm-ascend` tag dynamically and publishing the mirrored NJU -> quay.io candidate list
- tightened machine-management inventory behavior with atomic writes and a simple file lock so concurrent wrapper operations do not clobber local machine state
- hardened remote-code-parity local state handling with atomic consent/runtime-state updates, streaming SSH progress support, runtime Python unification, pip mirror fallback in the order Tsinghua -> Aliyun -> PyPI, and real import-based runtime verification
- aligned repo docs, skill docs, references, and command recipes with the new `rc` track and parity/runtime state contract

## Why
- the previous `main`/`stable` split still left an awkward gap for active development when the newest supported container environment is actually a prerelease image
- both inventory and parity local-state files were vulnerable to concurrent wrapper writes racing with each other
- parity reinstall work needed clearer progress attribution, mirror-aware pip fallback, and stronger runtime proof than `find_spec()` alone

## Notes
- the supplied patch applied cleanly as a unified diff with `patch -p3`
- validation exposed two small follow-up fixes that are included in this branch: a malformed f-string in `remote-code-parity/scripts/common.py` and an accidentally duplicated `cmd_remove` block in `machine-management/scripts/inventory.py`

## Impact
- `machine_add.py` and `machine_repair.py` now advertise `rc`, `main`, `stable`, or an explicit non-`latest` image reference
- `manage_machine.py` can resolve both prerelease and final release tags dynamically and records the actual selected image
- local state files used by machine-management and remote-code-parity are written atomically and guarded by a lock file
- parity reinstall steps now keep long package operations attributable while using the configured Python consistently across pip, CMake, and helper processes

## Validation
- `git diff --check`
- `python3 -m py_compile .agents/skills/machine-management/scripts/_workflow_common.py .agents/skills/machine-management/scripts/inventory.py .agents/skills/machine-management/scripts/machine_add.py .agents/skills/machine-management/scripts/machine_repair.py .agents/skills/machine-management/scripts/manage_machine.py .agents/skills/remote-code-parity/scripts/common.py .agents/skills/remote-code-parity/scripts/install_consent.py .agents/skills/remote-code-parity/scripts/remote_code_parity.py`
- `python3 .agents/skills/machine-management/scripts/machine_add.py --help`
- `python3 .agents/skills/machine-management/scripts/machine_repair.py --help`
- `python3 .agents/skills/machine-management/scripts/manage_machine.py --help`
- `python3 .agents/skills/machine-management/scripts/inventory.py --help`
- `python3 .agents/skills/remote-code-parity/scripts/install_consent.py --help`
- `python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py --help`
- Python smoke for `resolve_image_request()` covering `rc`, `main`, `stable`, and an explicit tagged image reference
- Python smoke covering inventory `put` + `remove` on a temporary inventory file
- Python smoke covering `common.update_state()` plus generated parity install scripts containing pip mirror fallback and real import verification
