### PR TITLE
feat: add Cursor IDE adaptation layer

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -86,3 +86,7 @@ If you change `remote-code-parity`, update these together:
 - `AGENTS.md`, `README.md`, and this file when routing, transport model, or local-state behavior changes
 
 Keep the files under `.agents/skills/` as the canonical supporting files for repo-local skills.
+
+## Cursor IDE integration
+
+Cursor IDE users: see `.cursor/rules/` for IDE-specific glob-activated rules that complement `AGENTS.md`. These rules are a thin pointer layer — they do not duplicate skill or routing content, and are designed to remain stable across submodule version switches.

--- a/.cursor/rules/commit-conventions.mdc
+++ b/.cursor/rules/commit-conventions.mdc
@@ -1,0 +1,20 @@
+---
+description: Commit message and PR conventions for scaffold and vllm-ascend submodule
+alwaysApply: false
+---
+
+# Commit Conventions
+
+## Scaffold repository (this repo)
+
+Standard conventional commits:
+
+```
+<type>: <summary>
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `chore`, `test`
+
+## vllm-ascend submodule
+
+Commits inside `vllm-ascend/` must follow the submodule's own conventions — always read `vllm-ascend/AGENTS.md` for the current commit format, sign-off requirements, and PR title rules.

--- a/.cursor/rules/skill-maintenance.mdc
+++ b/.cursor/rules/skill-maintenance.mdc
@@ -1,0 +1,15 @@
+---
+description: Synchronization constraints when editing agent skill packages under .agents/skills/
+globs: .agents/skills/**
+alwaysApply: false
+---
+
+# Skill Package Maintenance
+
+When modifying any skill package, follow the maintenance rule in `AGENTS.md` — keep the per-skill bundle (SKILL.md + scripts/ + references/), shared modules, and remote-code-parity files in sync.
+
+## Script conventions (supplemental to AGENTS.md)
+
+- CLI parsers must accept common aliases and disable brittle prefix-abbreviation.
+- Progress on `stderr` (`__VAWS_PROGRESS__=<json>`), final payload on `stdout` (single JSON object).
+- Default metadata that can be safely inferred; never silently default security-sensitive values.

--- a/.cursor/rules/submodule-context.mdc
+++ b/.cursor/rules/submodule-context.mdc
@@ -1,0 +1,22 @@
+---
+description: Submodule awareness and version-switch guidance for vllm-ascend-workspace
+alwaysApply: true
+---
+
+# Submodule Context
+
+This repository is a composable scaffold. `vllm/` and `vllm-ascend/` are Git submodules that may be checked out at **any** version — treat their content as volatile.
+
+## Key facts
+
+- Submodule versions switch frequently; never assume a specific commit or directory layout inside them.
+- Each submodule has its own `AGENTS.md` that ships with the checked-out version — always defer to **the submodule's own `AGENTS.md`** for version-specific coding conventions.
+- Do not modify `.gitmodules` URLs (keep community upstream URLs).
+- Submodule commits are independent of the parent scaffold repo.
+- Submodules may be uninitialized (empty directories); do not attempt to read their internal files when this is the case.
+
+## Cross-submodule search
+
+- `vllm/` is the upstream vLLM implementation (GPU-centric).
+- `vllm-ascend/` is the Ascend NPU hardware plugin built on top of vLLM.
+- When searching across both, be aware that identically-named symbols may have different semantics.

--- a/.cursor/rules/vllm-ascend-coding.mdc
+++ b/.cursor/rules/vllm-ascend-coding.mdc
@@ -1,0 +1,18 @@
+---
+description: Version-independent NPU coding principles for vllm-ascend development
+globs: vllm-ascend/**/*.py
+alwaysApply: false
+---
+
+# vllm-ascend NPU Coding Guide
+
+For version-specific conventions (naming, file layout, patching patterns, review checklists), always read the current `vllm-ascend/AGENTS.md` first — it updates automatically with each submodule version.
+
+## Version-independent NPU principles
+
+These hold across all vllm-ascend versions:
+
+- **`tensor.item()` sync overhead**: Calling `.item()` on a device tensor triggers a synchronous NPU-to-CPU transfer. Avoid it in hot paths; prefer device-side ops (`torch.max`, `torch.sum`) or batched transfers.
+- **Minimize CPU-NPU transfers**: Keep data on device whenever possible. In-place ops (`x.add_()`, `x.mul_()`) are preferred when safe.
+- **Plugin architecture**: vllm-ascend is a hardware plugin — it does not add model files directly. Use patching or inheritance to extend upstream vLLM (see `vllm-ascend/AGENTS.md` for current patterns).
+- **Environment variables**: Must be centralized in the designated env module (see `vllm-ascend/AGENTS.md`), never scattered across the codebase.

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,74 @@
+# =============================================================================
+# .cursorignore — Cursor IDE indexing exclusions for vllm-ascend-workspace
+#
+# Two tiers of patterns:
+#   1. Universally stable (extensions + generic dir names) — never break.
+#   2. Submodule convention dirs (tests/, docs/, .github/) — highly stable
+#      by open-source convention but technically version-dependent.
+# =============================================================================
+
+# === Tier 1: build artifacts (generic extensions, universally stable) ===
+**/*.so
+**/*.o
+**/*.a
+**/*.dylib
+**/*.pyc
+**/*.pyo
+**/*.egg-info/
+**/*.egg
+**/*.whl
+
+# === Tier 1: model weights (defensive — prevent accidental indexing) ===
+**/*.pth
+**/*.bin
+**/*.safetensors
+**/*.gguf
+
+# === Tier 1: common build / cache directories ===
+**/build/
+**/dist/
+**/__pycache__/
+**/.mypy_cache/
+**/.ruff_cache/
+**/.pytest_cache/
+**/.tox/
+**/.triton/
+**/kernel_meta/
+**/.eggs/
+**/develop-eggs/
+**/cmake-build-*/
+**/_build/
+**/site/
+
+# === Tier 2: submodule convention dirs (highly stable by OSS convention) ===
+# vllm
+vllm/tests/
+vllm/benchmarks/
+vllm/examples/
+vllm/csrc/
+vllm/docker/
+vllm/.buildkite/
+vllm/.github/
+vllm/docs/
+
+# vllm-ascend
+vllm-ascend/tests/
+vllm-ascend/benchmarks/
+vllm-ascend/examples/
+vllm-ascend/csrc/
+vllm-ascend/.github/
+vllm-ascend/docs/
+
+# === Workspace runtime state ===
+.vaws-local/
+
+# === Worktrees ===
+.worktrees/
+
+# =============================================================================
+# Explicitly NOT excluded (ensure reachable):
+#   vllm-ascend/vllm_ascend/**  — daily NPU plugin development
+#   vllm/vllm/**                — upstream Python source reference
+#   **/AGENTS.md                — agent routing rules
+#   .agents/**                  — skill packages
+# =============================================================================

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ docs/superpowers/
 .codex/
 .vaws-local/
 .machine-inventory.json
+.worktrees/
+
+# Cursor IDE — ignore all except rules and skills (those are tracked / shared)
+.cursor/*
+!.cursor/rules/
+!.cursor/skills/


### PR DESCRIPTION
## Summary

- Add `.cursorignore` with cross-version-stable patterns (file extensions + generic directory names) to exclude build artifacts, large submodule directories, and runtime state from Cursor indexing
- Add `.cursor/rules/` with 4 modular rule files that supplement the existing `AGENTS.md` without duplicating submodule content
- Update `.gitignore` to track `.cursor/rules/` and `.cursor/skills/` while ignoring other Cursor local state

## Design decisions

**Submodule version stability**: `vllm/` and `vllm-ascend/` are submodules that switch versions frequently. All Cursor config uses only version-independent patterns — `.cursorignore` matches by extension/generic dir names, and `.cursor/rules/` acts as a pointer layer that defers to each submodule's own `AGENTS.md` for version-specific conventions.

**No duplication**: The existing `AGENTS.md` is already loaded by Cursor as an always-applied workspace rule, and `.agents/skills/` are auto-discovered. The new `.cursor/rules/` only adds what `AGENTS.md` cannot: glob-activated file-pattern rules and Cursor-specific context guidance.

## Files changed

| File | Purpose |
|------|---------|
| `.cursorignore` | Index exclusions — build artifacts, large test/benchmark/csrc dirs, runtime state |
| `.cursor/rules/submodule-context.mdc` | Always-on: submodule awareness + version-switch guidance |
| `.cursor/rules/vllm-ascend-coding.mdc` | Glob `vllm-ascend/**/*.py`: pointer to AGENTS.md + version-independent NPU principles |
| `.cursor/rules/skill-maintenance.mdc` | Glob `.agents/skills/**`: skill package sync constraints |
| `.cursor/rules/commit-conventions.mdc` | Manual-activate: commit/PR format reference |
| `.gitignore` | Add `.worktrees/`, whitelist `.cursor/rules/` and `.cursor/skills/` |

## Test plan

- [ ] Open workspace in Cursor IDE and verify `.cursor/rules/` appear in the rules picker
- [ ] Edit a `vllm-ascend/**/*.py` file and verify `vllm-ascend-coding.mdc` activates
- [ ] Edit a `.agents/skills/**` file and verify `skill-maintenance.mdc` activates
- [ ] Verify `submodule-context.mdc` is always active
- [ ] Switch submodule version and verify no Cursor config breaks
- [ ] Verify `.cursorignore` excludes `vllm/tests/`, `**/build/` etc. from search results


Made with [Cursor](https://cursor.com)