### PR TITLE
feat: add TRAE IDE adaptation layer

### DIFF
--- a/.cursor/rules/vllm-ascend-coding.mdc
+++ b/.cursor/rules/vllm-ascend-coding.mdc
@@ -8,11 +8,3 @@ alwaysApply: false
 
 For version-specific conventions (naming, file layout, patching patterns, review checklists), always read the current `vllm-ascend/AGENTS.md` first — it updates automatically with each submodule version.
 
-## Version-independent NPU principles
-
-These hold across all vllm-ascend versions:
-
-- **`tensor.item()` sync overhead**: Calling `.item()` on a device tensor triggers a synchronous NPU-to-CPU transfer. Avoid it in hot paths; prefer device-side ops (`torch.max`, `torch.sum`) or batched transfers.
-- **Minimize CPU-NPU transfers**: Keep data on device whenever possible. In-place ops (`x.add_()`, `x.mul_()`) are preferred when safe.
-- **Plugin architecture**: vllm-ascend is a hardware plugin — it does not add model files directly. Use patching or inheritance to extend upstream vLLM (see `vllm-ascend/AGENTS.md` for current patterns).
-- **Environment variables**: Must be centralized in the designated env module (see `vllm-ascend/AGENTS.md`), never scattered across the codebase.

--- a/.trae/rules/project_rules.md
+++ b/.trae/rules/project_rules.md
@@ -1,0 +1,23 @@
+# Project Rules
+
+The authoritative agent instructions and skill packages for this workspace are defined in the following locations — always consult them:
+
+1. **`AGENTS.md`** (repo root) — repo-wide routing rules, mandatory decision gates, and maintenance constraints.
+2. **`.agents/skills/`** — skill packages (repo-init, machine-management, remote-code-parity), each with SKILL.md, scripts/, and references/.
+3. **`.agents/README.md`** — skill layout and script-first conventions.
+4. Each submodule's own `AGENTS.md` (e.g. `vllm-ascend/AGENTS.md`) — version-specific coding conventions; always defer to the submodule's own file.
+
+## Submodule awareness
+
+- `vllm/` and `vllm-ascend/` are Git submodules checked out at arbitrary versions. Never assume a specific commit or directory layout inside them.
+- Submodules may be uninitialized (empty directories); do not attempt to read their internal files when this is the case.
+- Identically-named symbols across submodules may have different semantics.
+
+## Commit conventions
+
+- Scaffold repo: `<type>: <summary>` (feat / fix / refactor / docs / chore / test).
+- Commits inside `vllm-ascend/` follow its own `AGENTS.md` format.
+
+## Skill package maintenance
+
+When modifying any skill under `.agents/skills/`, keep SKILL.md, scripts/, and references/ in sync. See the Maintenance rule section in `AGENTS.md`.

--- a/.trae/skills/machine-management/SKILL.md
+++ b/.trae/skills/machine-management/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: machine-management
+description: Add, verify, repair, or remove a managed remote NPU host for this workspace. Use for requests like "configure server", "add a machine", "check ready", "fix container SSH", or "remove machine". Do not use for code sync, rebuilds, serving, or benchmarking.
+---
+
+# machine-management
+
+Thin routing stub — the full skill definition lives at `.agents/skills/machine-management/SKILL.md`. Read that file for complete rules, decision gates, and workflow steps.
+
+Quick entry point:
+
+```bash
+python3 .agents/skills/machine-management/scripts/machine_verify.py --name <machine>
+```

--- a/.trae/skills/remote-code-parity/SKILL.md
+++ b/.trae/skills/remote-code-parity/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: remote-code-parity
+description: Ensure the remote runtime runs the exact current local workspace state before any remote smoke test, service launch, or benchmark. Triggered automatically before remote execution when direct local-to-container SSH works. Do not use for initial machine attach, generic Git topology work, or unrelated local tasks.
+---
+
+# remote-code-parity
+
+Thin routing stub — the full skill definition lives at `.agents/skills/remote-code-parity/SKILL.md`. Read that file for complete rules, decision gates, and workflow steps.
+
+Quick entry point:
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/parity_sync.py
+```

--- a/.trae/skills/repo-init/SKILL.md
+++ b/.trae/skills/repo-init/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: repo-init
+description: Initialize the workspace after clone. Use for requests like "init repo", "configure gh / GitHub login", "init submodules", or "set up forks / remotes".
+---
+
+# repo-init
+
+Thin routing stub — the full skill definition lives at `.agents/skills/repo-init/SKILL.md`. Read that file for complete rules, decision gates, and workflow steps.
+
+Quick entry point:
+
+```bash
+python3 .agents/skills/repo-init/scripts/repo_init_probe.py --compact
+```


### PR DESCRIPTION
## Summary

- Add thin `.trae/` routing stubs so TRAE IDE can discover existing skills and project rules without duplicating content
- `.trae/rules/project_rules.md` consolidates pointers to `AGENTS.md`, submodule conventions, commit rules, and skill maintenance
- `.trae/skills/{repo-init,machine-management,remote-code-parity}/SKILL.md` each redirect to the canonical `.agents/skills/` definitions
- Remove redundant NPU coding principles from both `.cursor/rules/vllm-ascend-coding.mdc` and TRAE rules (already covered by `vllm-ascend/AGENTS.md`)

## Test plan

- [ ] Open workspace in TRAE IDE, verify `project_rules.md` is loaded as active rules
- [ ] Trigger skill routing (e.g. ask "init repo") and confirm TRAE loads the stub then follows through to `.agents/skills/repo-init/SKILL.md`


Made with [Cursor](https://cursor.com)