### PR TITLE
fix: improve remote-code-parity reinstall logic and add commit drift detection

### DIFF
--- a/.agents/skills/remote-code-parity/SKILL.md
+++ b/.agents/skills/remote-code-parity/SKILL.md
@@ -186,13 +186,29 @@ Do not claim success before the container-side commit ids match the snapshot man
 
 ### 6. Reinstall only when required after first install
 
-After the first approved replacement, reinstall only when matching paths changed.
+After the first approved replacement, reinstall only when one of the following triggers fires:
 
-Conservative defaults:
+**Trigger 1 — changed-path pattern match:**
 
 - `vllm`: `requirements*`, `pyproject.toml`, `setup.*`, `CMake*`, `cmake/**`, `csrc/**`, and common native-source suffixes
 - `vllm-ascend`: same as `vllm`, plus `vllm_ascend/_cann_ops_custom/**`
 - pure Python, docs, configs, tests, and ordinary scripts: parity only, no rebuild
+
+**Trigger 2 — commit drift from last sync:**
+
+Compare each repo's real HEAD commit with `last_head_commits` recorded in `runtime-state.json`. Synthetic snapshot commits change whenever the working tree is dirty, so drift detection must use the underlying HEAD to avoid false positives from pure-Python edits. If a repo's HEAD changed (e.g. the user did `git checkout v0.8.0` inside `vllm/`), trigger reinstall for that repo even when `changed_paths` is empty.
+
+**Trigger 3 — dependency cascade:**
+
+When `vllm` triggers reinstall (by either trigger), `vllm-ascend` is also reinstalled because it depends on `vllm` internals.
+
+**Uninstall scope:**
+
+Only uninstall the packages that will actually be reinstalled. If only `vllm-ascend` needs reinstall, `vllm` is not uninstalled. On first install, the uninstall step is skipped because `first_install_prepare_script` already handled it.
+
+**No-change fast path:**
+
+If all snapshot commits match `last_snapshot_commits` and no reinstall is needed, the sync verifies container-side commits with a single SSH call and returns `status == ready` immediately, skipping push, materialize, and manifest upload.
 
 Use these commands inside the container when required. The normal path first unifies the runtime Python across `python`, `python3`, CMake, and CANN helper tools, sources optional Ascend env scripts under a `set +u` / `set -u` guard, then tries the in-place environment, and finally does one bounded packaging refresh / retry when legacy packaging metadata blocks editable install. Pip resolution should prefer Tsinghua, then Aliyun, then the public PyPI index:
 

--- a/.agents/skills/remote-code-parity/references/acceptance.md
+++ b/.agents/skills/remote-code-parity/references/acceptance.md
@@ -69,6 +69,12 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 - runtime-private paths such as `Mooncake` survive root cleanups
 - final `git rev-parse HEAD` values inside the container match the synthetic snapshot commits exactly
 - reinstall runs only when the trigger matrix says it should, except for the mandatory first approved replacement on a fresh container
+- switching a submodule to a different commit (e.g. `git checkout v0.8.0` in `vllm/`) triggers reinstall via HEAD-based commit drift detection (comparing real HEAD, not synthetic snapshot commit), even when the new checkout is clean
+- pure Python file edits inside a submodule do not trigger reinstall even though the synthetic snapshot commit changes
+- vllm reinstall cascades to vllm-ascend reinstall because of the runtime dependency
+- uninstall only removes packages that will be reinstalled; changing only vllm-ascend does not uninstall vllm
+- first install does not run the reinstall-branch uninstall step because `first_install_prepare_script` already handled it
+- when nothing changed since last sync (snapshot commits == last_snapshot_commits, no reinstall needed), the sync verifies the container with a single SSH call and returns `status == ready` immediately
 - a successful run ends with `status == ready`
 - runtime install uses dynamic Python discovery plus a shell-safe env preamble and guarded env-script sourcing instead of one hard-coded Python patch path
 - packaging-metadata failures from stale image toolchains trigger one bounded packaging-stack refresh / retry before the skill reports `failed`
@@ -87,6 +93,9 @@ These specific mistakes should no longer be part of the normal path:
 - runtime-install should not fail closed just because Ascend env scripts reference shell-specific or otherwise unset variables while being sourced
 - the final heredoc-based import smoke should not fail with a local quoting `SyntaxError`
 - clean nested submodules should not force parent `reinstall_vllm*` decisions through synthetic gitlink churn alone
+- changing only vllm-ascend files should not uninstall or break the vllm editable install
+- switching vllm to a different commit should trigger both vllm and vllm-ascend reinstall
+- consecutive syncs with no local changes should take the fast path and skip push, materialize, and manifest upload
 
 ## Manual regression checklist
 

--- a/.agents/skills/remote-code-parity/references/behavior.md
+++ b/.agents/skills/remote-code-parity/references/behavior.md
@@ -120,9 +120,11 @@ First-install mutation boundary:
 
 ## Reinstall trigger matrix
 
-Recommended conservative defaults:
+Reinstall fires when **any** of these conditions is true:
 
-### `vllm`
+### Trigger 1 — changed-path pattern match
+
+#### `vllm`
 
 Trigger reinstall on changes matching:
 
@@ -135,13 +137,35 @@ Trigger reinstall on changes matching:
 - `csrc/**`
 - common native-source suffixes such as `*.cu`, `*.cuh`, `*.cpp`, `*.cc`, `*.h`, `*.hpp`
 
-### `vllm-ascend`
+#### `vllm-ascend`
 
 Trigger reinstall on the same set as `vllm`, plus:
 
 - `vllm_ascend/_cann_ops_custom/**`
 
 Everything else defaults to parity-only, no reinstall.
+
+### Trigger 2 — commit drift from last sync
+
+Compare each repo's real HEAD commit with `last_head_commits` in `runtime-state.json`. Synthetic snapshot commits change whenever the working tree is dirty, so drift detection must use the underlying HEAD to avoid false positives from pure-Python edits. If the HEAD differs (e.g. submodule version switch via `git checkout`), trigger reinstall for that repo even when `changed_paths` is empty because the tree matches the new HEAD.
+
+### Trigger 3 — dependency cascade
+
+When `vllm` triggers reinstall (by either trigger above), `vllm-ascend` is also reinstalled because it depends on `vllm` internals.
+
+### Uninstall scope
+
+Only uninstall the packages that will actually be reinstalled:
+
+- `reinstall_vllm` only → uninstall `vllm`
+- `reinstall_vllm_ascend` only → uninstall `vllm-ascend` / `vllm_ascend`
+- both → uninstall all three
+
+On first install the reinstall-branch uninstall step is skipped because `first_install_prepare_script` already removed image-provided packages.
+
+### No-change fast path
+
+When all snapshot commits match `last_snapshot_commits` and no reinstall trigger fires, the sync verifies the container-side commits with a single SSH call and returns `status == ready` immediately, skipping push, materialize, and manifest upload.
 
 ## Exact proof to collect
 

--- a/.agents/skills/remote-code-parity/scripts/common.py
+++ b/.agents/skills/remote-code-parity/scripts/common.py
@@ -5,6 +5,7 @@ import contextlib
 import json
 import os
 import queue
+import re
 import shlex
 import subprocess
 import sys
@@ -15,6 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
+WORKSPACE_ID_PATTERN = re.compile(r'[^A-Za-z0-9._-]+')
 STATE_SUBDIR = Path('.vaws-local/remote-code-parity')
 LEGACY_STATE_DIR = Path('.vaws-local')
 
@@ -39,8 +41,6 @@ DEFAULT_DENYLIST = (
     'Thumbs.db',
 )
 
-HARD_MIN_FREE_BYTES = 512 * 1024 * 1024
-FIRST_INSTALL_MIN_FREE_BYTES = 4 * 1024 * 1024 * 1024
 PROGRESS_SENTINEL = '__VAWS_PARITY_PROGRESS__='
 STATE_LOCK_SUFFIX = '.lock'
 DEFAULT_STATE_LOCK_TIMEOUT_SECONDS = 15.0
@@ -200,16 +200,6 @@ def sanitize_repo_id(relpath: str) -> str:
 
 def json_dump(data: Any) -> str:
     return json.dumps(data, indent=2, sort_keys=True)
-
-
-def human_bytes(value: int) -> str:
-    units = ['B', 'KiB', 'MiB', 'GiB', 'TiB']
-    size = float(value)
-    for unit in units:
-        if size < 1024.0 or unit == units[-1]:
-            return f'{size:.1f} {unit}'
-        size /= 1024.0
-    return f'{value} B'
 
 
 def quoted(script: str) -> str:

--- a/.agents/skills/remote-code-parity/scripts/gc_runtime_cache.py
+++ b/.agents/skills/remote-code-parity/scripts/gc_runtime_cache.py
@@ -11,7 +11,7 @@ from remote_code_parity import DEFAULT_CONTAINER_CACHE_ROOT, cache_workspace_roo
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description='Prune old remote-code-parity manifests inside the container-local cache root.')
+    parser = argparse.ArgumentParser(description='Prune old remote-code-parity manifests inside the container-local cache root.', allow_abbrev=False)
     parser.add_argument('--container-host', required=True)
     parser.add_argument('--container-port', type=int, required=True)
     parser.add_argument('--container-user', required=True)

--- a/.agents/skills/remote-code-parity/scripts/install_consent.py
+++ b/.agents/skills/remote-code-parity/scripts/install_consent.py
@@ -97,7 +97,7 @@ def run_batch_set(args: argparse.Namespace) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description='Manage first-install consent for remote-code-parity.')
+    parser = argparse.ArgumentParser(description='Manage first-install consent for remote-code-parity.', allow_abbrev=False)
     subparsers = parser.add_subparsers(dest='command', required=True)
 
     def add_common(target: argparse.ArgumentParser) -> None:

--- a/.agents/skills/remote-code-parity/scripts/parity_sync.py
+++ b/.agents/skills/remote-code-parity/scripts/parity_sync.py
@@ -5,18 +5,16 @@ import argparse
 import hashlib
 import json
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
-from common import json_dump, repo_root_from
+from common import WORKSPACE_ID_PATTERN, json_dump, repo_root_from
 from remote_code_parity import DEFAULT_CONTAINER_CACHE_ROOT
 
 
 DEFAULT_CONTAINER_USER = 'root'
-WORKSPACE_ID_PATTERN = re.compile(r'[^A-Za-z0-9._-]+')
 
 
 def derive_workspace_id(repo_root: Path) -> str:
@@ -112,7 +110,7 @@ def build_low_level_command(derived: dict[str, Any], args: argparse.Namespace) -
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description='Resolve a managed machine from inventory and run container-only remote-code-parity sync.')
+    parser = argparse.ArgumentParser(description='Resolve a managed machine from inventory and run container-only remote-code-parity sync.', allow_abbrev=False)
     parser.add_argument('--machine', required=True, help='machine alias or host IP from inventory')
     parser.add_argument('--repo-root', default='.')
     parser.add_argument('--workspace-id', default=None)

--- a/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
+++ b/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
@@ -14,6 +14,8 @@ from typing import Any
 
 from common import (
     DEFAULT_DENYLIST,
+    PROGRESS_SENTINEL,
+    WORKSPACE_ID_PATTERN,
     SshEndpoint,
     ensure_local_git_identity,
     git,
@@ -114,8 +116,6 @@ DEFAULT_MARKER_DIRNAME = '.remote-code-parity'
 DEFAULT_ROOT_PRESERVE_PATHS = ('Mooncake',)
 STATE_FILENAME = 'runtime-state.json'
 CONSENT_FILENAME = 'install-consents.json'
-WORKSPACE_ID_PATTERN = re.compile(r'[^A-Za-z0-9._-]+')
-PROGRESS_SENTINEL = '__VAWS_PARITY_PROGRESS__='
 PARITY_BRANCH_NAME = 'parity-current'
 
 
@@ -406,18 +406,19 @@ def marker_path_for(runtime_root: str, marker_dirname: str) -> str:
     return str(Path(runtime_root) / marker_dirname / 'runtime-install.json')
 
 
-def ensure_remote_bare_repo(container: SshEndpoint, mirror_path: str, dry_run: bool) -> None:
-    if dry_run:
+def ensure_remote_bare_repos(container: SshEndpoint, mirror_paths: list[str], dry_run: bool) -> None:
+    if dry_run or not mirror_paths:
         return
-    script = '\n'.join(
-        [
-            'set -eo pipefail',
-            f'mkdir -p {quoted(str(Path(mirror_path).parent))}',
-            f'if [ -e {quoted(mirror_path)} ] && [ ! -d {quoted(str(Path(mirror_path) / "objects"))} ]; then rm -rf {quoted(mirror_path)}; fi',
-            f'if [ ! -d {quoted(mirror_path)} ]; then git init --bare {quoted(mirror_path)} >/dev/null; fi',
-        ]
-    )
-    ssh_exec(container, script)
+    lines = ['set -eo pipefail']
+    for mirror_path in mirror_paths:
+        lines.extend(
+            [
+                f'mkdir -p {quoted(str(Path(mirror_path).parent))}',
+                f'if [ -e {quoted(mirror_path)} ] && [ ! -d {quoted(str(Path(mirror_path) / "objects"))} ]; then rm -rf {quoted(mirror_path)}; fi',
+                f'if [ ! -d {quoted(mirror_path)} ]; then git init --bare {quoted(mirror_path)} >/dev/null; fi',
+            ]
+        )
+    ssh_exec(container, '\n'.join(lines))
 
 
 def push_snapshot_to_mirror(
@@ -429,7 +430,6 @@ def push_snapshot_to_mirror(
     workspace_id: str,
     dry_run: bool,
 ) -> None:
-    ensure_remote_bare_repo(container, mirror_path, dry_run)
     if dry_run:
         return
     remote_url = f'ssh://{container.user}@{container.host}:{container.port}{mirror_path}'
@@ -550,27 +550,24 @@ def materialize_runtime(
             )
         return '\n'.join(lines)
 
-    def walk(record: SnapshotRecord) -> None:
+    def collect_scripts(record: SnapshotRecord, out: list[str]) -> None:
         emit_progress('materialize-repo', relpath=record.relpath)
-        if not dry_run:
-            ssh_exec(container, render_repo_step(record))
+        out.append(render_repo_step(record))
         for child in record.submodules:
             child_relpath = child['path'] if record.relpath in ('', '.') else f"{record.relpath}/{child['path']}"
-            walk(record_by_relpath[child_relpath])
+            collect_scripts(record_by_relpath[child_relpath], out)
 
     if dry_run:
         return
-    ssh_exec(
-        container,
-        '\n'.join(
-            [
-                'set -eo pipefail',
-                f'mkdir -p {quoted(runtime_root)}',
-                f'mkdir -p {quoted(str(Path(runtime_root) / marker_dirname))}',
-            ]
-        ),
-    )
-    walk(root_record)
+    parts: list[str] = [
+        'set -eo pipefail',
+        f'mkdir -p {quoted(runtime_root)}',
+        f'mkdir -p {quoted(str(Path(runtime_root) / marker_dirname))}',
+    ]
+    repo_scripts: list[str] = []
+    collect_scripts(root_record, repo_scripts)
+    parts.extend(repo_scripts)
+    ssh_exec(container, '\n'.join(parts))
 
 def reinstall_required_for_repo(record: SnapshotRecord, patterns: tuple[str, ...]) -> bool:
     return any(glob_match_any(path, patterns) for path in record.changed_paths)
@@ -582,6 +579,7 @@ def runtime_install_step_script(
     marker_dirname: str,
     container_identity: str,
     step: str,
+    uninstall_packages: tuple[str, ...] = (),
 ) -> str:
     lines = ['set -euo pipefail', f'cd {quoted(runtime_root)}']
     lines.extend(DEFAULT_ENV_PREAMBLE)
@@ -745,7 +743,8 @@ def runtime_install_step_script(
         )
 
     if step == 'uninstall':
-        lines.append('$PYTHON -m pip uninstall -y vllm vllm-ascend vllm_ascend >/dev/null 2>&1 || true')
+        pkg_args = ' '.join(uninstall_packages) if uninstall_packages else 'vllm vllm-ascend vllm_ascend'
+        lines.append(f'$PYTHON -m pip uninstall -y {pkg_args} >/dev/null 2>&1 || true')
     elif step == 'install-vllm':
         lines.extend(
             [
@@ -815,12 +814,14 @@ def run_runtime_install_step(
     container_identity: str,
     step: str,
     stream_progress: bool = False,
+    uninstall_packages: tuple[str, ...] = (),
 ) -> None:
     script = runtime_install_step_script(
         runtime_root=runtime_root,
         marker_dirname=marker_dirname,
         container_identity=container_identity,
         step=step,
+        uninstall_packages=uninstall_packages,
     )
     if stream_progress:
         ssh_exec_stream(container, script, stream_progress=True)
@@ -901,9 +902,10 @@ def update_runtime_state(
             'last_sync_at': now_utc(),
             'first_reinstall_completed': first_reinstall_completed,
             'last_snapshot_commits': {record.relpath: record.commit for record in records},
+            'last_head_commits': {record.relpath: record.parent for record in records},
         }
 
-    update_state(repo_root, STATE_FILENAME, {'schema_version': 1, 'servers': {}}, apply_update)
+    update_state(repo_root, STATE_FILENAME, {'schema_version': 2, 'servers': {}}, apply_update)
 
 
 def make_manifest(
@@ -1039,6 +1041,56 @@ def run_sync(args: argparse.Namespace) -> int:
             reinstall_vllm = reinstall_required_for_repo(record_map['vllm'], VLLM_REINSTALL_PATTERNS) if 'vllm' in record_map else False
             reinstall_vllm_ascend = reinstall_required_for_repo(record_map['vllm-ascend'], VLLM_ASCEND_REINSTALL_PATTERNS) if 'vllm-ascend' in record_map else False
 
+            prior_runtime_state = load_runtime_state(workspace_root)
+            last_container_state = (
+                prior_runtime_state
+                .get('servers', {})
+                .get(args.server_name, {})
+                .get('containers', {})
+                .get(args.container_identity, {})
+            )
+            last_commits = last_container_state.get('last_snapshot_commits', {})
+            last_head_commits = last_container_state.get('last_head_commits', {})
+            if 'vllm' in record_map and last_head_commits.get('vllm') and record_map['vllm'].parent != last_head_commits['vllm']:
+                reinstall_vllm = True
+            if 'vllm-ascend' in record_map and last_head_commits.get('vllm-ascend') and record_map['vllm-ascend'].parent != last_head_commits['vllm-ascend']:
+                reinstall_vllm_ascend = True
+            if reinstall_vllm and 'vllm-ascend' in record_map:
+                reinstall_vllm_ascend = True
+
+            snapshot_commits = {record.relpath: record.commit for record in records}
+            if (
+                not args.dry_run
+                and not reinstall_vllm
+                and not reinstall_vllm_ascend
+                and last_commits
+                and snapshot_commits == last_commits
+            ):
+                current_phase = 'fast-path-verify'
+                emit_progress(current_phase, snapshot_commits=snapshot_commits)
+                observed = verify_runtime_commits(
+                    container=container,
+                    runtime_root=runtime_root,
+                    records=records,
+                    dry_run=False,
+                )
+                if observed == snapshot_commits:
+                    emit_progress('complete', status='ready', fast_path=True)
+                    summary = summary_payload(
+                        status='ready',
+                        server_name=args.server_name,
+                        container_identity=args.container_identity,
+                        workspace_id=workspace_id,
+                        container_cache_root=container_cache_root,
+                        records=records,
+                        reinstall_status='not-needed',
+                        reason=None,
+                        first_install=False,
+                        observed_runtime_commits=observed,
+                    )
+                    print(json_dump(summary))
+                    return 0
+
             current_phase = 'read-runtime-marker'
             emit_progress(current_phase, runtime_root=runtime_root)
             marker = read_runtime_install_marker(
@@ -1109,6 +1161,8 @@ def run_sync(args: argparse.Namespace) -> int:
             try:
                 current_phase = 'push-mirrors'
                 emit_progress(current_phase, repo_count=len(records))
+                all_mirror_paths = [mirror_path_for(container_cache_root, workspace_id, r) for r in records]
+                ensure_remote_bare_repos(container, all_mirror_paths, args.dry_run)
                 for record in records:
                     emit_progress('push-mirror', relpath=record.relpath)
                     push_snapshot_to_mirror(
@@ -1151,15 +1205,22 @@ def run_sync(args: argparse.Namespace) -> int:
                         reinstall_vllm=reinstall_vllm,
                         reinstall_vllm_ascend=reinstall_vllm_ascend,
                     )
-                    emit_progress('runtime-install-uninstall', packages=['vllm', 'vllm-ascend'])
-                    run_runtime_install_step(
-                        container=container,
-                        runtime_root=runtime_root,
-                        marker_dirname=marker_dirname,
-                        container_identity=args.container_identity,
-                        step='uninstall',
-                        stream_progress=False,
-                    )
+                    if not first_install:
+                        uninstall_pkgs: list[str] = []
+                        if reinstall_vllm:
+                            uninstall_pkgs.append('vllm')
+                        if reinstall_vllm_ascend:
+                            uninstall_pkgs.extend(['vllm-ascend', 'vllm_ascend'])
+                        emit_progress('runtime-install-uninstall', packages=uninstall_pkgs)
+                        run_runtime_install_step(
+                            container=container,
+                            runtime_root=runtime_root,
+                            marker_dirname=marker_dirname,
+                            container_identity=args.container_identity,
+                            step='uninstall',
+                            stream_progress=False,
+                            uninstall_packages=tuple(uninstall_pkgs),
+                        )
                     if reinstall_vllm:
                         emit_progress('runtime-install-vllm', package='vllm')
                         run_runtime_install_step(
@@ -1255,7 +1316,7 @@ def run_sync(args: argparse.Namespace) -> int:
                     marker_dirname=marker_dirname,
                     records=records,
                     first_reinstall_completed=first_install
-                    or load_runtime_state(workspace_root).get('servers', {}).get(args.server_name, {}).get('containers', {}).get(args.container_identity, {}).get('first_reinstall_completed', False)
+                    or last_container_state.get('first_reinstall_completed', False)
                     or reinstall_status == 'performed',
                 )
                 current_phase = 'finalize-manifest'
@@ -1295,7 +1356,7 @@ def run_sync(args: argparse.Namespace) -> int:
         cleanup_synthetic_refs(workspace_root, records)
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description='Prepare or enforce remote code parity for a ready runtime.')
+    parser = argparse.ArgumentParser(description='Prepare or enforce remote code parity for a ready runtime.', allow_abbrev=False)
     subparsers = parser.add_subparsers(dest='command', required=True)
 
     def add_shared_arguments(target: argparse.ArgumentParser) -> None:


### PR DESCRIPTION
## Summary

- **修复非对称卸载 bug**：之前无论只改了 vllm-ascend 还是同时改了 vllm，都会把两个包都卸载，导致只改 vllm-ascend 时 vllm 被意外卸载。现在只卸载将要重装的包。
- **新增 HEAD-based commit drift 检测**：用真实 HEAD commit（`record.parent`）而非 synthetic snapshot commit 来检测子模块版本切换（如 `git checkout v0.8.0`），避免纯 Python 文件编辑误触发重装。
- **新增依赖级联重装**：vllm 触发重装时自动级联重装 vllm-ascend。
- **性能优化**：无变更快速路径、批量 SSH 调用、复用 runtime state 读取结果。
- **代码清理**：常量去重到 common.py、移除死代码、统一 schema_version、禁用 argparse 前缀缩写。

## Changes

| 文件 | 说明 |
|------|------|
| `scripts/remote_code_parity.py` | 核心逻辑：on-demand uninstall、commit drift、fast path、batch SSH |
| `scripts/common.py` | 常量去重、移除死代码 |
| `scripts/parity_sync.py` | 导入去重、allow_abbrev |
| `scripts/install_consent.py` | allow_abbrev |
| `scripts/gc_runtime_cache.py` | allow_abbrev |
| `SKILL.md` | 新增 Trigger 2/3、uninstall scope、fast path 文档 |
| `references/behavior.md` | 同步更新重装触发矩阵 |
| `references/acceptance.md` | 新增验收标准和回归检查项 |

## Test plan

在两台 A2 机器（173.131.1.2、173.125.1.2）的容器上完成了完整测试：

- [x] 首次同步无 consent → blocked（2s）
- [x] 授权后首次完整同步 → ready, performed（309s）
- [x] 无变更再同步 → not-needed（9s）
- [x] 纯 Python 文件改动 → 仅 parity，不重装（10s）
- [x] csrc 文件改动 → 仅重装 vllm-ascend，vllm 不动（200s）
- [x] vllm commit 切换（HEAD~5）→ 重装 vllm + vllm-ascend 级联（274s）
- [x] 第二台机器首次同步 → ready, performed（318s）
- [x] 第二台机器无变更 → not-needed（10s）


Made with [Cursor](https://cursor.com)