### PR TITLE
feat: add --force-reinstall flag to remote-code-parity sync

### DIFF
--- a/.agents/skills/remote-code-parity/SKILL.md
+++ b/.agents/skills/remote-code-parity/SKILL.md
@@ -206,9 +206,13 @@ When `vllm` triggers reinstall (by either trigger), `vllm-ascend` is also reinst
 
 Only uninstall the packages that will actually be reinstalled. If only `vllm-ascend` needs reinstall, `vllm` is not uninstalled. On first install, the uninstall step is skipped because `first_install_prepare_script` already handled it.
 
+**Force reinstall:**
+
+Pass `--force-reinstall` to `parity_sync.py` to unconditionally reinstall both `vllm` and `vllm-ascend` regardless of what changed. This overrides all trigger logic above but still runs the full sync flow (snapshot, push, materialize, install, verify).
+
 **No-change fast path:**
 
-If all snapshot commits match `last_snapshot_commits` and no reinstall is needed, the sync verifies container-side commits with a single SSH call and returns `status == ready` immediately, skipping push, materialize, and manifest upload.
+If all snapshot commits match `last_snapshot_commits` and no reinstall is needed (and `--force-reinstall` is not set), the sync verifies container-side commits with a single SSH call and returns `status == ready` immediately, skipping push, materialize, and manifest upload.
 
 Use these commands inside the container when required. The normal path first unifies the runtime Python across `python`, `python3`, CMake, and CANN helper tools, sources optional Ascend env scripts under a `set +u` / `set -u` guard, then tries the in-place environment, and finally does one bounded packaging refresh / retry when legacy packaging metadata blocks editable install. Pip resolution should prefer Tsinghua, then Aliyun, then the public PyPI index:
 

--- a/.agents/skills/remote-code-parity/references/acceptance.md
+++ b/.agents/skills/remote-code-parity/references/acceptance.md
@@ -75,6 +75,7 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 - uninstall only removes packages that will be reinstalled; changing only vllm-ascend does not uninstall vllm
 - first install does not run the reinstall-branch uninstall step because `first_install_prepare_script` already handled it
 - when nothing changed since last sync (snapshot commits == last_snapshot_commits, no reinstall needed), the sync verifies the container with a single SSH call and returns `status == ready` immediately
+- `--force-reinstall` unconditionally triggers full reinstall of both vllm and vllm-ascend even when no files changed
 - a successful run ends with `status == ready`
 - runtime install uses dynamic Python discovery plus a shell-safe env preamble and guarded env-script sourcing instead of one hard-coded Python patch path
 - packaging-metadata failures from stale image toolchains trigger one bounded packaging-stack refresh / retry before the skill reports `failed`

--- a/.agents/skills/remote-code-parity/references/behavior.md
+++ b/.agents/skills/remote-code-parity/references/behavior.md
@@ -163,9 +163,13 @@ Only uninstall the packages that will actually be reinstalled:
 
 On first install the reinstall-branch uninstall step is skipped because `first_install_prepare_script` already removed image-provided packages.
 
+### Force reinstall
+
+`--force-reinstall` unconditionally sets `reinstall_vllm` and `reinstall_vllm_ascend` to true, overriding all trigger logic. The full sync flow still runs (snapshot, push, materialize, install, verify). Useful for recovering from a broken editable install or validating the install pipeline without touching source files.
+
 ### No-change fast path
 
-When all snapshot commits match `last_snapshot_commits` and no reinstall trigger fires, the sync verifies the container-side commits with a single SSH call and returns `status == ready` immediately, skipping push, materialize, and manifest upload.
+When all snapshot commits match `last_snapshot_commits` and no reinstall trigger fires (and `--force-reinstall` is not set), the sync verifies the container-side commits with a single SSH call and returns `status == ready` immediately, skipping push, materialize, and manifest upload.
 
 ## Exact proof to collect
 

--- a/.agents/skills/remote-code-parity/references/command-recipes.md
+++ b/.agents/skills/remote-code-parity/references/command-recipes.md
@@ -73,6 +73,16 @@ The runtime-install path sources Ascend env scripts under a `set +u` / `set -u` 
 The final verification path is a heredoc-based Python import smoke, so the generated snippet must remain valid Python after shell quoting.
 Clean child repos reuse their original `HEAD` commit during snapshotting, so a nested submodule like `csrc/third_party/catlass` does not by itself force a parent reinstall.
 
+## Force full reinstall without code changes
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/parity_sync.py \
+  --machine blue-a \
+  --force-reinstall
+```
+
+Unconditionally reinstalls both `vllm` and `vllm-ascend` even when no files changed. Useful for recovering from a broken editable install or validating the install pipeline.
+
 ## Dry-run sync without remote mutation
 
 ```bash

--- a/.agents/skills/remote-code-parity/scripts/parity_sync.py
+++ b/.agents/skills/remote-code-parity/scripts/parity_sync.py
@@ -104,6 +104,8 @@ def build_low_level_command(derived: dict[str, Any], args: argparse.Namespace) -
         cmd.extend(['--snapshot-id', args.snapshot_id])
     if args.print_manifest:
         cmd.append('--print-manifest')
+    if args.force_reinstall:
+        cmd.append('--force-reinstall')
     if args.dry_run:
         cmd.append('--dry-run')
     return cmd
@@ -120,6 +122,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument('--preserve-path', action='append', default=[])
     parser.add_argument('--snapshot-id', default=None)
     parser.add_argument('--print-manifest', action='store_true')
+    parser.add_argument('--force-reinstall', action='store_true', help='Force reinstall of vllm and vllm-ascend regardless of what changed.')
     parser.add_argument('--dry-run', action='store_true')
     parser.add_argument('--print-derived-args', action='store_true')
     return parser

--- a/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
+++ b/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
@@ -1058,6 +1058,12 @@ def run_sync(args: argparse.Namespace) -> int:
             if reinstall_vllm and 'vllm-ascend' in record_map:
                 reinstall_vllm_ascend = True
 
+            if args.force_reinstall:
+                if 'vllm' in record_map:
+                    reinstall_vllm = True
+                if 'vllm-ascend' in record_map:
+                    reinstall_vllm_ascend = True
+
             snapshot_commits = {record.relpath: record.commit for record in records}
             if (
                 not args.dry_run
@@ -1379,6 +1385,7 @@ def build_parser() -> argparse.ArgumentParser:
     sync.add_argument('--container-host', required=True)
     sync.add_argument('--container-port', type=int, required=True)
     sync.add_argument('--container-user', required=True)
+    sync.add_argument('--force-reinstall', action='store_true', help='Force reinstall of vllm and vllm-ascend regardless of what changed.')
     sync.add_argument('--dry-run', action='store_true')
     sync.add_argument('--print-manifest', action='store_true')
 


### PR DESCRIPTION
## Summary

- 新增 `--force-reinstall` 参数，无需改动代码即可强制走完整的同步 + 重新安装流程
- 覆盖所有触发逻辑（changed-path、commit drift、dependency cascade），但仍执行完整 sync 流程
- 适用场景：editable install 损坏恢复、安装流水线验证

## Changes

| 文件 | 说明 |
|------|------|
| `scripts/remote_code_parity.py` | sync 子命令新增 `--force-reinstall`，在触发判断后强制覆盖 |
| `scripts/parity_sync.py` | 新增 `--force-reinstall` 参数并透传 |
| `SKILL.md` | 文档新增 Force reinstall 段落 |
| `references/behavior.md` | 同步更新 |
| `references/acceptance.md` | 新增验收标准 |
| `references/command-recipes.md` | 新增用法示例 |

## Usage

```bash
python3 .agents/skills/remote-code-parity/scripts/parity_sync.py \
  --machine 173.131.1.2 \
  --force-reinstall
```

## Test plan

- [x] 代码审查：flag 在 commit drift / changed-path 判断之后、fast path 之前注入
- [x] 确认 `--force-reinstall` 不影响 consent 流程（首次仍需 consent）
- [x] 确认不传该 flag 时行为与之前完全一致


Made with [Cursor](https://cursor.com)