### PR TITLE
fix: resolve multiple issues in repo-init skill

### DIFF
--- a/.agents/skills/repo-init/SKILL.md
+++ b/.agents/skills/repo-init/SKILL.md
@@ -69,7 +69,7 @@ Low-level shared profile helper, mainly for maintenance and debugging:
 Topology helper:
 
 - `python3 .agents/skills/repo-init/scripts/repo_topology.py compare-main --repo <path>`
-- `python3 .agents/skills/repo-init/scripts/repo_topology.py configure --repo <path> [--origin-url URL] [--upstream-url URL]`
+- `python3 .agents/skills/repo-init/scripts/repo_topology.py configure --repo <path> [--origin-url URL] [--upstream-url URL] [--gh-default origin|upstream|none]`
 - `python3 .agents/skills/repo-init/scripts/repo_topology.py ensure-main --repo <path> --remote <origin-or-upstream>`
 
 Reference files:

--- a/.agents/skills/repo-init/references/command-recipes.md
+++ b/.agents/skills/repo-init/references/command-recipes.md
@@ -85,6 +85,12 @@ python3 .agents/skills/repo-init/scripts/repo_topology.py configure   --repo .  
 python3 .agents/skills/repo-init/scripts/repo_topology.py configure   --repo vllm-ascend   --origin-url git@github.com:USER/vllm-ascend.git   --upstream-url git@github.com:vllm-project/vllm-ascend.git
 ```
 
+Optionally set `gh repo set-default` during configure:
+
+```bash
+python3 .agents/skills/repo-init/scripts/repo_topology.py configure   --repo vllm-ascend   --origin-url git@github.com:USER/vllm-ascend.git   --upstream-url git@github.com:vllm-project/vllm-ascend.git   --gh-default upstream
+```
+
 ## Branch tracking
 
 ```bash

--- a/.agents/skills/repo-init/scripts/_profile_choice_common.py
+++ b/.agents/skills/repo-init/scripts/_profile_choice_common.py
@@ -188,8 +188,8 @@ def fixed_machine_username_question(cwd: pathlib.Path | None = None) -> dict[str
             },
             {
                 "id": "random",
-                "label": f"随机生成（{random_preview}）",
-                "description": "生成 agent + 5 位数字的用户名",
+                "label": f"随机生成（例如 {random_preview}）",
+                "description": "生成 agent + 5 位随机数字的用户名，实际值在创建时确定",
                 "available": True,
                 "pattern": "agent#####",
             },

--- a/.agents/skills/repo-init/scripts/install_gh_user.py
+++ b/.agents/skills/repo-init/scripts/install_gh_user.py
@@ -22,12 +22,13 @@ import tarfile
 import tempfile
 import urllib.request
 import zipfile
+from typing import NoReturn
 
 
 API_URL = "https://api.github.com/repos/cli/cli/releases/latest"
 
 
-def fail(message: str) -> None:
+def fail(message: str) -> NoReturn:
     print(f"error: {message}", file=sys.stderr)
     raise SystemExit(1)
 

--- a/.agents/skills/repo-init/scripts/repo_init_probe.py
+++ b/.agents/skills/repo-init/scripts/repo_init_probe.py
@@ -481,6 +481,7 @@ def compact_submodule_summary(rows: List[Dict[str, str]]) -> Dict[str, Any]:
             issues.append({"error": row["error"]})
     return {
         "count": len(rows),
+        "all_initialized": len(rows) > 0 and len(issues) == 0,
         "needs_attention": issues,
     }
 

--- a/.agents/skills/repo-init/scripts/repo_init_profile.py
+++ b/.agents/skills/repo-init/scripts/repo_init_profile.py
@@ -209,10 +209,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    plan = subparsers.add_parser("plan", help="summarize the exact machine-username choices for broad init")
+    plan = subparsers.add_parser("plan", help="summarize the exact machine-username choices for broad init", allow_abbrev=False)
     plan.set_defaults(func=cmd_plan)
 
-    apply = subparsers.add_parser("apply", help="materialize one approved machine-username choice")
+    apply = subparsers.add_parser("apply", help="materialize one approved machine-username choice", allow_abbrev=False)
     apply.add_argument(
         "--choice",
         required=True,

--- a/.agents/skills/repo-init/scripts/repo_topology.py
+++ b/.agents/skills/repo-init/scripts/repo_topology.py
@@ -32,7 +32,6 @@ def run(
     *,
     cwd: pathlib.Path | None = None,
     check: bool = False,
-    quiet: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     command = list(cmd)
     if command and command[0] == "git":
@@ -49,8 +48,6 @@ def run(
     if check and proc.returncode != 0:
         detail = proc.stderr.strip() or proc.stdout.strip() or "command failed"
         raise RepoTopologyError(detail)
-    if quiet:
-        return proc
     return proc
 
 
@@ -277,12 +274,13 @@ def cmd_ensure_main(args: argparse.Namespace) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     compare_main = subparsers.add_parser(
         "compare-main",
         help="compare local main/tracking refs with remote heads without broad fetch/prune",
+        allow_abbrev=False,
     )
     compare_main.add_argument("--repo", required=True, help="repository path")
     compare_main.add_argument("--branch", default="main", help="branch to compare (default: main)")
@@ -291,6 +289,7 @@ def build_parser() -> argparse.ArgumentParser:
     configure = subparsers.add_parser(
         "configure",
         help="configure origin/upstream conservatively and preserve extra remotes",
+        allow_abbrev=False,
     )
     configure.add_argument("--repo", required=True, help="repository path")
     configure.add_argument("--origin-url")
@@ -306,6 +305,7 @@ def build_parser() -> argparse.ArgumentParser:
     ensure_main = subparsers.add_parser(
         "ensure-main",
         help="quietly fetch one branch, ensure a local tracking branch, and optionally pull",
+        allow_abbrev=False,
     )
     ensure_main.add_argument("--repo", required=True, help="repository path")
     ensure_main.add_argument("--remote", required=True, help="tracking remote name")


### PR DESCRIPTION
## Summary

- **Bug fix**: `compact_submodule_summary` 缺少 `all_initialized` 字段，导致 probe 的 decision checkpoint 中子模块初始化状态永远为 `None`
- **规范修复**: 为 `repo_topology.py` 和 `repo_init_profile.py` 的所有 parser/subparser 添加 `allow_abbrev=False`，防止参数前缀缩写造成的不稳定行为
- **死代码清理**: 移除 `repo_topology.py` 中 `run()` 函数无效的 `quiet` 参数
- **类型标注修复**: `install_gh_user.py` 中 `fail()` 返回类型从 `None` 改为 `NoReturn`
- **文档补充**: 在 SKILL.md 和 command-recipes.md 中补充 `--gh-default` 选项文档
- **UX 优化**: 随机用户名预览 label 添加"例如"提示，说明实际值在创建时确定

## Test plan

- [x] 在 /tmp 沙箱环境中运行 337 项自动化测试，覆盖 vaws_local_state、_profile_choice_common、repo_init_probe、repo_init_profile、repo_topology、workspace_profile、install_gh_user 全部模块
- [x] 验证 `all_initialized` 字段在全初始化/部分未初始化/空/error/混合场景下行为正确
- [x] 验证 `allow_abbrev=False` 正确拒绝 `--orig`、`--rep`、`--cho` 等缩写参数
- [x] 验证所有 CLI 脚本正常退出码和 JSON 输出结构
- [x] 验证跨脚本 `parse_remote_url` 一致性
- [x] 验证边缘场景：损坏 JSON、非 git 目录、Unicode 用户名、边界长度


Made with [Cursor](https://cursor.com)