### PR TITLE
feat: add sync_mode gate to skip parity when using image-provided packages

### DIFF
--- a/.agents/skills/remote-code-parity/SKILL.md
+++ b/.agents/skills/remote-code-parity/SKILL.md
@@ -105,7 +105,17 @@ Reference files:
 
 ## Workflow
 
-### 1. Resolve the ready target from inventory
+### 1. Check sync mode before anything else
+
+Before running parity for a container, check the persisted `sync_mode`:
+
+- `unset` (first use): the agent must proactively ask the user whether to sync local code (`local`) or use the container's image-provided vllm + vllm-ascend (`image`). Record the choice via `install_consent.py set-sync-mode --approved-by-user`.
+- `local`: proceed with the full parity flow below.
+- `image`: `parity_sync.py` returns `status: skipped` immediately. The agent skips parity and proceeds with remote execution using image-provided packages.
+
+The user can switch sync mode at any time. `--force-reinstall` overrides `image` mode.
+
+### 2. Resolve the ready target from inventory
 
 For normal agent work, start from `parity_sync.py`.
 
@@ -119,7 +129,7 @@ Collect from local machine inventory:
 
 Stop if the request is not actually about imminent remote execution.
 
-### 2. Capture synthetic snapshot refs
+### 3. Capture synthetic snapshot refs
 
 Create synthetic Git commits for the workspace repo and nested submodules in **postorder**:
 
@@ -138,7 +148,7 @@ For each repo:
 
 Ignored files stay ignored. The snapshot source of truth is tracked + untracked non-ignored.
 
-### 3. Publish mirrors directly into the container cache
+### 4. Publish mirrors directly into the container cache
 
 For each repo in scope:
 
@@ -154,7 +164,7 @@ Preferred scope:
 - `vllm-ascend/`
 - recursive nested populated submodules if discovered
 
-### 4. Handle first-time runtime replacement
+### 5. Handle first-time runtime replacement
 
 Use a container-side marker under `/vllm-workspace/.remote-code-parity/` to detect whether editable replacement already happened.
 
@@ -170,7 +180,7 @@ If the user already approved this container identity:
 - delete `/vllm-workspace/vllm` and `/vllm-workspace/vllm-ascend`
 - do **not** delete the entire `/vllm-workspace`
 
-### 5. Materialize the mirrors in place inside `/vllm-workspace`
+### 6. Materialize the mirrors in place inside `/vllm-workspace`
 
 Inside the container:
 
@@ -184,7 +194,7 @@ Inside the container:
 
 Do not claim success before the container-side commit ids match the snapshot manifest.
 
-### 6. Reinstall only when required after first install
+### 7. Reinstall only when required after first install
 
 After the first approved replacement, reinstall only when one of the following triggers fires:
 
@@ -230,7 +240,7 @@ pip install -r requirements.txt  # mirror-aware fallback: Tsinghua -> Aliyun -> 
 pip install -v -e . --no-build-isolation
 ```
 
-### 7. Finish with proof, not assumptions
+### 8. Finish with proof, not assumptions
 
 - Finish with real import smoke (`import vllm`, `import vllm_ascend`, `import torch_npu`) instead of `find_spec()` only, and keep the generated smoke snippet syntactically valid under shell heredoc quoting.
 

--- a/.agents/skills/remote-code-parity/references/acceptance.md
+++ b/.agents/skills/remote-code-parity/references/acceptance.md
@@ -51,6 +51,14 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 - the normal agent-facing entrypoint can resolve the target from machine inventory through `parity_sync.py`
 - the skill does not create or reuse a flat shared host path such as `/home/vaws`
 
+### Sync mode gate
+
+- when `sync_mode` is `unset`, the agent proactively asks the user before running parity
+- when `sync_mode` is `image`, `parity_sync.py` returns `status: skipped` without any remote operations
+- when `sync_mode` is `local`, the full parity flow proceeds normally
+- `--force-reinstall` overrides `image` mode and forces a full sync + reinstall
+- the user can switch sync mode at any time
+
 ### Consent and first install
 
 - first sync on a fresh container without recorded approval ends with `status == blocked`

--- a/.agents/skills/remote-code-parity/references/behavior.md
+++ b/.agents/skills/remote-code-parity/references/behavior.md
@@ -13,6 +13,16 @@ This file defines the durable behavior of `remote-code-parity`.
 - Stream phase progress on `stderr` as `__VAWS_PARITY_PROGRESS__=<json>` and keep one final JSON payload on `stdout`.
 - Keep runtime-install phases attributable instead of collapsing them into one opaque step: uninstall, `vllm`, `vllm-ascend` requirements, `vllm-ascend`, import verification, and marker write should each surface their own progress event.
 
+## Sync mode gate
+
+Before invoking parity for a container, the agent checks the persisted `sync_mode` in `install-consents.json`:
+
+- `unset`: first use — agent must ask the user whether to sync local code (`local`) or use image-provided packages (`image`), then record via `install_consent.py set-sync-mode`.
+- `local`: proceed with the full parity flow.
+- `image`: `parity_sync.py` returns `status: skipped` immediately; the agent proceeds with remote execution using image-provided packages without syncing or installing.
+
+`--force-reinstall` overrides `image` mode. The user can switch sync mode at any time.
+
 ## Scope and routing
 
 `remote-code-parity` is an internal execution skill.

--- a/.agents/skills/remote-code-parity/references/command-recipes.md
+++ b/.agents/skills/remote-code-parity/references/command-recipes.md
@@ -4,6 +4,34 @@ All parity helpers stream phase progress on `stderr` as `__VAWS_PARITY_PROGRESS_
 
 Prefer the helper scripts in `scripts/` when possible.
 
+## Check sync mode for a container
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/install_consent.py resolve-sync-mode \
+  --server-name blue-a \
+  --container-identity vaws-blue@/vllm-workspace
+```
+
+## Set sync mode to use image-provided packages (skip parity)
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/install_consent.py set-sync-mode \
+  --server-name blue-a \
+  --container-identity vaws-blue@/vllm-workspace \
+  --sync-mode image \
+  --approved-by-user
+```
+
+## Set sync mode to sync local code
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/install_consent.py set-sync-mode \
+  --server-name blue-a \
+  --container-identity vaws-blue@/vllm-workspace \
+  --sync-mode local \
+  --approved-by-user
+```
+
 ## Inspect the current consent state
 
 ```bash

--- a/.agents/skills/remote-code-parity/scripts/install_consent.py
+++ b/.agents/skills/remote-code-parity/scripts/install_consent.py
@@ -40,6 +40,34 @@ def set_decision(
     }
 
 
+def resolve_sync_mode(state: dict[str, Any], server_name: str, container_identity: str) -> str:
+    return (
+        state.get('consents', {})
+        .get(server_name, {})
+        .get('containers', {})
+        .get(container_identity, {})
+        .get('sync_mode', 'unset')
+    )
+
+
+def set_sync_mode(
+    state: dict[str, Any],
+    server_name: str,
+    container_identity: str,
+    sync_mode: str,
+    note: str | None,
+    *,
+    approved_by_user: bool,
+) -> None:
+    if not approved_by_user:
+        raise RuntimeError('explicit --approved-by-user is required before writing sync-mode')
+    container = state.setdefault('consents', {}).setdefault(server_name, {}).setdefault('containers', {}).setdefault(container_identity, {})
+    container['sync_mode'] = sync_mode
+    container['sync_mode_updated_at'] = now_utc()
+    if note:
+        container['sync_mode_note'] = note
+
+
 def run_resolve(args: argparse.Namespace) -> int:
     repo_root = repo_root_from(Path(args.repo_root))
     state = load_consent_state(repo_root)
@@ -68,6 +96,36 @@ def run_set(args: argparse.Namespace) -> int:
 
     _, path, _ = update_state(repo_root, FILENAME, {'schema_version': 1, 'consents': {}}, apply_update)
     print(json_dump({'status': 'updated', 'path': str(path)}))
+    return 0
+
+
+def run_resolve_sync_mode(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from(Path(args.repo_root))
+    state = load_consent_state(repo_root)
+    mode = resolve_sync_mode(state, args.server_name, args.container_identity)
+    payload = {
+        'server_name': args.server_name,
+        'container_identity': args.container_identity,
+        'sync_mode': mode,
+    }
+    print(json_dump(payload))
+    return 0
+
+
+def run_set_sync_mode(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from(Path(args.repo_root))
+    def apply_update(state: dict[str, Any]) -> None:
+        set_sync_mode(
+            state,
+            args.server_name,
+            args.container_identity,
+            args.sync_mode,
+            args.note,
+            approved_by_user=args.approved_by_user,
+        )
+
+    _, path, _ = update_state(repo_root, FILENAME, {'schema_version': 1, 'consents': {}}, apply_update)
+    print(json_dump({'status': 'updated', 'sync_mode': args.sync_mode, 'path': str(path)}))
     return 0
 
 
@@ -119,6 +177,15 @@ def build_parser() -> argparse.ArgumentParser:
     batch.add_argument('--input', required=True)
     batch.add_argument('--approved-by-user', action='store_true')
 
+    resolve_sm = subparsers.add_parser('resolve-sync-mode')
+    add_common(resolve_sm)
+
+    set_sm = subparsers.add_parser('set-sync-mode')
+    add_common(set_sm)
+    set_sm.add_argument('--sync-mode', required=True, choices=('local', 'image'))
+    set_sm.add_argument('--note', default=None)
+    set_sm.add_argument('--approved-by-user', action='store_true')
+
     return parser
 
 
@@ -132,6 +199,10 @@ def main() -> int:
             return run_set(args)
         if args.command == 'batch-set':
             return run_batch_set(args)
+        if args.command == 'resolve-sync-mode':
+            return run_resolve_sync_mode(args)
+        if args.command == 'set-sync-mode':
+            return run_set_sync_mode(args)
         parser.error(f'unsupported command: {args.command}')
         return 2
     except Exception as exc:

--- a/.agents/skills/remote-code-parity/scripts/parity_sync.py
+++ b/.agents/skills/remote-code-parity/scripts/parity_sync.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from common import WORKSPACE_ID_PATTERN, json_dump, repo_root_from
+from install_consent import load_consent_state, resolve_sync_mode
 from remote_code_parity import DEFAULT_CONTAINER_CACHE_ROOT
 
 
@@ -132,6 +133,20 @@ def main() -> int:
     args = build_parser().parse_args()
     repo_root = repo_root_from(Path(args.repo_root))
     derived = build_derived_args(repo_root, args)
+
+    if not args.force_reinstall:
+        consent_state = load_consent_state(repo_root)
+        mode = resolve_sync_mode(consent_state, derived['server_name'], derived['container_identity'])
+        if mode == 'image':
+            print(json_dump({
+                'status': 'skipped',
+                'reason': 'sync_mode is image — using container-provided packages',
+                'sync_mode': 'image',
+                'server_name': derived['server_name'],
+                'container_identity': derived['container_identity'],
+            }))
+            return 0
+
     low_level_cmd = build_low_level_command(derived, args)
     if args.print_derived_args:
         payload = dict(derived)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,9 +64,13 @@ Repo-local skills live under `.agents/skills/`.
 
 ## Mandatory execution gate
 
-- When a ready managed machine is about to run a remote smoke, service launch, or benchmark, run `remote-code-parity` first. Prefer the inventory-driven `parity_sync.py` entrypoint.
-- Do not continue remote execution unless `remote-code-parity` returned `status == ready`.
-- If the first runtime replacement is blocked by missing consent, stop and get consent instead of silently using the image-provided packages.
+- When a ready managed machine is about to run a remote smoke, service launch, or benchmark for the first time, check the sync mode for that container before running `remote-code-parity`:
+  - If `sync_mode` is `unset` (first use), proactively ask the user: sync local code (`local`) or use the container's image-provided vllm + vllm-ascend (`image`). Record the choice via `install_consent.py set-sync-mode`.
+  - If `sync_mode` is `local`, run `remote-code-parity` normally. Do not continue unless it returned `status == ready`.
+  - If `sync_mode` is `image`, skip `remote-code-parity` entirely and proceed with remote execution using image-provided packages.
+  - `--force-reinstall` overrides `image` mode and forces a full sync + reinstall.
+- If the first runtime replacement is blocked by missing install consent, stop and get consent instead of silently using the image-provided packages.
+- The user can switch sync mode at any time by asking to change it.
 
 ## Skill routing
 


### PR DESCRIPTION
## Summary

- 新增 `sync_mode` 决策点：在首次 parity 同步之前，agent 主动问用户是同步本地代码（`local`）还是用容器镜像自带的 vllm + vllm-ascend（`image`）
- 选择持久化在 `install-consents.json` 中，按容器独立存储，不用每次询问
- `image` 模式下 `parity_sync.py` 直接返回 `status: skipped`，不做任何远端操作
- `--force-reinstall` 可覆盖 `image` 模式

## Changes

| 文件 | 说明 |
|------|------|
| `scripts/install_consent.py` | 新增 `resolve-sync-mode` / `set-sync-mode` 子命令 |
| `scripts/parity_sync.py` | 启动时检查 sync_mode，image 直接返回 skipped |
| `AGENTS.md` | mandatory gate 改为先检查 sync_mode 再决定是否跑 parity |
| `SKILL.md` | 新增 step 1: check sync mode，后续步骤重新编号 |
| `references/behavior.md` | 新增 Sync mode gate 段落 |
| `references/acceptance.md` | 新增 sync mode 验收标准 |
| `references/command-recipes.md` | 新增 sync mode 操作示例 |

## Test plan

在两台 A2 机器（173.131.1.2、173.125.1.2）上从头测试（删除机器→重新配置→完整流程）：

- [x] 新容器 sync_mode 默认 `unset`
- [x] 设 `image` → parity 返回 `skipped`（0.2s，无远端操作）
- [x] `image` + `--force-reinstall` → 绕过 image 模式（consent 仍生效）
- [x] 设 `local` → 完整首次同步 `ready + performed`
- [x] 从 `local` 切回 `image` → 立即 `skipped`
- [x] 两台机器 sync_mode 互相独立


Made with [Cursor](https://cursor.com)