### PR TITLE
feat: harden skills based on PR conflict resolution session lessons

### DIFF
--- a/.agents/skills/remote-code-parity/SKILL.md
+++ b/.agents/skills/remote-code-parity/SKILL.md
@@ -39,6 +39,8 @@ Keep a **ready** remote runtime in exact code parity with the local `vllm-ascend
 - If a child repo snapshot has no tree changes, reuse its original `HEAD` commit instead of inventing a new gitlink-only delta that bubbles into the parent repo.
 - Use dynamic Python / pip discovery plus a shell-safe env preamble, and source optional Ascend env scripts under a `set +u` / `set -u` guard instead of relying on shell-specific variables.
 - If editable install fails because the image packaging stack is too old, attempt one bounded packaging-stack refresh before failing closed.
+- Before invoking parity, confirm the local working tree represents the **intended deployment state**. If any submodule source files have uncommitted changes made for temporary debugging or hypothesis testing, revert them before syncing — do not sync exploratory patches to the remote.
+- If a previous parity sync in this session led to a failed remote execution and the agent subsequently modified local code, do not re-sync until the root cause of the failure is confirmed from remote logs (not from hypothesis).
 - Fail closed if parity cannot be proven.
 - First replacement of image-provided `vllm` / `vllm-ascend` requires explicit user consent for that logical container identity.
 - `install_consent.py set` and `batch-set` must include `--approved-by-user`.
@@ -219,6 +221,10 @@ Only uninstall the packages that will actually be reinstalled. If only `vllm-asc
 **Force reinstall:**
 
 Pass `--force-reinstall` to `parity_sync.py` to unconditionally reinstall both `vllm` and `vllm-ascend` regardless of what changed. This overrides all trigger logic above but still runs the full sync flow (snapshot, push, materialize, install, verify).
+
+**`--force-reinstall` usage discipline:**
+
+Use `--force-reinstall` only when (a) it is the first sync to a new container, (b) the previous install is known to be broken, or (c) the user explicitly requests it. Do not default to `--force-reinstall` as a precaution — the trigger matrix above already handles normal cases, and unnecessary force-reinstall adds 5–15 minutes of remote compilation time per invocation.
 
 **No-change fast path:**
 

--- a/.agents/skills/repo-init/SKILL.md
+++ b/.agents/skills/repo-init/SKILL.md
@@ -96,8 +96,12 @@ That checkpoint must cover:
    - recommended fork mode
    - community-only mode
 3. whether to initialize submodules now
+4. vllm submodule version alignment (only when submodules will be initialized)
+   - **CI-pinned** (default): check out `vllm/` at the commit CI actually tests against — from `vllm_version` matrix in `vllm-ascend/.github/workflows/pr_test_full.yaml`; cross-reference with `main_vllm_commit` in `vllm-ascend/docs/source/conf.py`
+   - **upstream main**: both submodules track their respective upstream `main` HEAD
+   - **keep current**: leave `vllm/` at whatever commit it is already on
 
-If the user only asked for a narrow GitHub auth / `gh` task, skip the machine-profile question.
+If the user only asked for a narrow GitHub auth / `gh` task, skip the machine-profile and version-alignment questions.
 
 ## Recommended topology
 
@@ -139,6 +143,15 @@ Do not silently fall back from `custom` to the detected Git username.
 Do not mutate in the same step as the first probe summary for broad init.
 
 If the request was just “初始化仓库” or similarly broad, do not silently assume a generated username or the recommended remotes.
+
+### 3a. Align vllm submodule version after submodule init
+
+After recursive submodule init completes, if the user chose CI-pinned alignment:
+
+- Extract the CI-pinned vllm commit: check `vllm_version` matrix in `vllm-ascend/.github/workflows/pr_test_full.yaml` (ground truth for PR CI), cross-reference with `main_vllm_commit` in `vllm-ascend/docs/source/conf.py`.
+- If the two sources differ, prefer the `pr_test_full.yaml` matrix value.
+- Check out `vllm/` at that commit.
+- Report the active version combination (vllm commit + vllm-ascend branch) in the finish summary.
 
 ### 4. Apply approved changes by category
 

--- a/.agents/skills/vllm-ascend-serving/SKILL.md
+++ b/.agents/skills/vllm-ascend-serving/SKILL.md
@@ -140,6 +140,15 @@ NPU availability is checked via `npu-smi info` on the **bare-metal host** (not t
 
 The script polls `/health` and `/v1/models` until both return success or the timeout expires.
 
+### 6a. Diagnose launch failure before any code change
+
+If the service fails during engine initialization or health check timeout:
+
+- Read **both** `stdout.log` and `stderr.log` from the remote runtime directory — vllm often logs the actual Python exception to stdout, not stderr.
+- Identify the actual exception type and message before hypothesizing a cause.
+- Do not modify source code to work around a launch failure until the root cause is confirmed from logs.
+- If the root cause is unclear, try the simplest launch configuration first (e.g. tp-only, no speculative decoding, no graph mode) and incrementally add features to isolate the failing component.
+
 ### 7. Return structured JSON
 
 On success:


### PR DESCRIPTION
## Summary

基于一次实际的 PR 解冲突 + 远端 benchmark 会话（Codex + GPT-5.4，~8.5h）中暴露的问题，对三个仓库级 skill 做针对性加固：

- **remote-code-parity**: 新增 pre-sync 意图确认规则（禁止同步临时 debug 代码到远端）和 `--force-reinstall` 使用纪律（减少不必要的远端编译）
- **repo-init**: 新增 vllm 子模块版本对齐步骤，CI-pinned 为默认策略（从 `pr_test_full.yaml` 取 commit），修复之前两个子模块默认对齐到 upstream main 的设计问题
- **vllm-ascend-serving**: 新增 launch 失败诊断路径（先读日志确认异常，不确定时从最简配置渐进叠加）

改动量约 30 行，全部是 SKILL.md 文本规则，不涉及脚本变更。

## Motivation

该会话中主要的时间浪费来自三个模式：
1. Agent 在临时修改代码后触发 parity sync，脏状态同步到远端后又要重做（~30-60min）
2. 子模块默认对齐到 upstream main 而非 CI-pinned commit，导致错误的版本配套上浪费大量兼容性调试（~75min）
3. 服务启动失败后不看日志直接猜原因改代码（~20min）

## Test plan

- [ ] 确认三个 SKILL.md 格式正确、markdown 渲染无问题
- [ ] 确认 repo-init 决策检查点新增的第 4 项（版本对齐）与现有 probe 脚本的输出兼容

Made with [Cursor](https://cursor.com)