### PR TITLE
feat: add vllm-ascend-benchmark skill

### DIFF
--- a/.agents/skills/vllm-ascend-benchmark/SKILL.md
+++ b/.agents/skills/vllm-ascend-benchmark/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: vllm-ascend-benchmark
+description: Run vLLM online-serving benchmarks on a workspace-managed remote container. Use for requests like "跑个 benchmark", "对比性能", "压测一下", "测下吞吐", or "看下有没有性能回退". Do not use for accuracy tests, nightly CI matrix runs, offline inference, or service-only lifecycle.
+---
+
+# vLLM Ascend Benchmark
+
+Run `vllm bench serve` on a **ready** workspace-managed remote container and produce structured performance results. Supports single-run benchmarks and A/B comparisons.
+
+## Use this skill when
+
+- the user asks to run a performance benchmark / throughput test on a managed machine
+- the user asks to compare performance before and after a code change (A/B)
+- the user asks to verify there is no performance regression for a PR or commit
+
+## Do not use this skill when
+
+- the task is accuracy testing (aisbench domain)
+- the task is running a full nightly CI matrix
+- the task is offline / batch inference
+- the user only wants to start or stop a service without benchmarking (use `vllm-ascend-serving`)
+- the machine is not yet ready in inventory (use `machine-management` first)
+
+## Critical rules
+
+- Benchmark parameters are assembled by the agent based on user intent and executed through the scripts below. The agent must not construct raw `vllm bench serve` commands and run them directly on the remote.
+- **User intent takes priority** over nightly configs. Nightly YAML files under `vllm-ascend/tests/e2e/nightly/single_node/models/configs/` are a **reference source** for discovering how to configure a given model or feature (MTP, graph mode, TP count, etc.), not an execution template to run verbatim.
+- Nightly configs are used as a **fallback** only when the user specifies a model but provides no other parameters.
+- A/B comparisons must use identical core benchmark parameters (model, tp, bench-args) for both sides — only the code state changes. However, the patched side may carry additional environment variables (debug switches, feature flags) via `--patched-extra-env`, and the env difference must be recorded in the output.
+- After benchmarking, the service is automatically stopped. No residual processes should remain.
+- Progress goes to `stderr` as `__VAWS_BENCHMARK_PROGRESS__=<json>`. Final result goes to `stdout` as JSON.
+- Keep local benchmark state only under `.vaws-local/benchmark/`.
+
+## Cross-platform launcher rule
+
+- macOS / Linux / WSL: `python3 ...`
+- Windows: `py -3 ...`
+
+## Public entry points
+
+### Single-run benchmark
+
+```bash
+python3 .agents/skills/vllm-ascend-benchmark/scripts/bench_run.py \
+  --machine <alias-or-ip> \
+  --model <remote-weight-path> \
+  [--tp <N>] \
+  [--serve-args <arg> ...] \
+  [--bench-args <arg> ...] \
+  [--extra-env KEY=VALUE ...] \
+  [--refer-nightly <yaml-name>] \
+  [--port <N>] \
+  [--skip-parity]
+```
+
+- `--serve-args`: extra arguments forwarded to `vllm serve` (e.g. `--async-scheduling`, `--compilation-config '...'`)
+- `--bench-args`: extra arguments forwarded to `vllm bench serve` (e.g. `--num-prompts 128`, `--max-concurrency 32`)
+- `--extra-env`: environment variables for the service (e.g. `HCCL_BUFFSIZE=1024`)
+- `--refer-nightly`: name of a nightly YAML (without path prefix) to use as a configuration reference; user-provided args override anything from the YAML
+
+### A/B comparison
+
+```bash
+python3 .agents/skills/vllm-ascend-benchmark/scripts/bench_compare.py \
+  --machine <alias-or-ip> \
+  --baseline-ref <branch-or-commit> \
+  --patched-ref <branch-or-commit> \
+  --repo <vllm-ascend|vllm> \
+  --model <remote-weight-path> \
+  [--patched-extra-env KEY=VALUE ...] \
+  [--tp <N>] \
+  [--serve-args <arg> ...] \
+  [--bench-args <arg> ...] \
+  [--extra-env KEY=VALUE ...] \
+  [--refer-nightly <yaml-name>] \
+  [--port <N>]
+```
+
+- `--patched-extra-env`: environment variables applied **only** to the patched side (e.g. a debug flag the patched branch introduces). The env difference is recorded in the output.
+- Core benchmark parameters are shared between both runs.
+
+## Workflow
+
+### 1. Resolve the target machine
+
+The `--machine` argument is looked up in the local machine inventory. The machine must already be managed and ready.
+
+### 2. Assemble configuration
+
+Configuration is built with this priority:
+
+1. User-provided CLI args (highest priority)
+2. Agent-assembled args based on conversation context
+3. Nightly YAML as fallback when `--refer-nightly` is given and no user args override
+
+When `--refer-nightly` is used, the YAML is parsed for `server_cmd`, `envs`, and `benchmarks.perf` fields. Any user-provided `--serve-args`, `--bench-args`, or `--extra-env` override the corresponding YAML values.
+
+### 3. Stop any existing service
+
+If a service is already running on the target machine, stop it before proceeding.
+
+### 4. Start the service
+
+Uses `serve_start.py` internally to launch the vLLM service with the assembled configuration. Parity sync is handled automatically by the serving skill.
+
+### 5. Run `vllm bench serve`
+
+Executes `vllm bench serve` via SSH on the remote container against the running service endpoint.
+
+### 6. Collect results
+
+Parses the benchmark output JSON for key metrics: `output_throughput`, `mean_tpot_ms`, `mean_ttft_ms`, and (when applicable) `acceptance_rate`.
+
+### 7. Stop the service
+
+Calls `serve_stop.py` to clean up.
+
+### 8. Return structured JSON
+
+Single-run output:
+
+```json
+{
+  "status": "ok",
+  "machine": "173.131.1.2",
+  "model": "/home/weights/Qwen3.5-35B",
+  "metrics": {
+    "output_throughput": 1234.5,
+    "mean_tpot_ms": 12.3,
+    "mean_ttft_ms": 45.6,
+    "acceptance_rate": 0.85
+  },
+  "config": { "tp": 4, "serve_args": [...], "bench_args": [...], "env": {...} }
+}
+```
+
+A/B comparison output:
+
+```json
+{
+  "status": "ok",
+  "machine": "173.131.1.2",
+  "model": "/home/weights/Qwen3.5-35B",
+  "baseline": { "ref": "main", "metrics": {...}, "env": {...} },
+  "patched":  { "ref": "feat/xxx", "metrics": {...}, "env": {...} },
+  "delta": {
+    "output_throughput": "+3.2%",
+    "mean_tpot_ms": "-1.5%"
+  },
+  "env_diff": { "patched_only": ["VLLM_XXX=1"] },
+  "regression": false
+}
+```
+
+## Reference files
+
+- `.agents/skills/vllm-ascend-benchmark/references/behavior.md`
+- `.agents/skills/vllm-ascend-benchmark/references/command-recipes.md`
+- `.agents/skills/vllm-ascend-benchmark/references/acceptance.md`

--- a/.agents/skills/vllm-ascend-benchmark/references/acceptance.md
+++ b/.agents/skills/vllm-ascend-benchmark/references/acceptance.md
@@ -1,0 +1,39 @@
+# Benchmark Skill Acceptance Criteria
+
+## Single-run (`bench_run.py`)
+
+- [ ] Service is started via `serve_start.py` (not raw SSH).
+- [ ] `vllm bench serve` executes on the remote container and returns a result JSON.
+- [ ] Output JSON has `status: "ok"` with `metrics` containing at least `output_throughput`.
+- [ ] Service is stopped after benchmark completes (no residual processes).
+- [ ] If service fails to start, output has `status: "failed"` with `phase: "serve_start"`.
+- [ ] If benchmark fails, service is still stopped (force-kill if needed).
+- [ ] User-provided `--serve-args` and `--bench-args` appear in the final config.
+- [ ] When `--refer-nightly` is given, nightly values fill in missing args only.
+- [ ] When user args AND nightly are both given, user args win.
+
+## A/B comparison (`bench_compare.py`)
+
+- [ ] Baseline ref is checked out and benchmarked first.
+- [ ] Patched ref is checked out and benchmarked second.
+- [ ] Core benchmark parameters (model, tp, bench-args) are identical for both runs.
+- [ ] `--patched-extra-env` values appear only in the patched run's env.
+- [ ] Output JSON contains `baseline.metrics`, `patched.metrics`, and `delta`.
+- [ ] `env_diff.patched_only` lists the extra env vars applied to patched side.
+- [ ] `regression` field is `true` when patched throughput < baseline * 0.97.
+- [ ] Submodule is restored to its original HEAD in the `finally` block.
+- [ ] If either run fails, service is stopped and error is reported.
+
+## Progress reporting
+
+- [ ] Progress lines go to stderr as `__VAWS_BENCHMARK_PROGRESS__=<json>`.
+- [ ] Final JSON goes to stdout only.
+- [ ] Serving progress lines are forwarded to stderr.
+
+## Configuration priority
+
+- [ ] User `--serve-args` overrides nightly `server_cmd`.
+- [ ] User `--bench-args` overrides nightly `benchmarks.perf`.
+- [ ] User `--extra-env` overrides nightly `envs`.
+- [ ] `--tp` overrides nightly `--tensor-parallel-size`.
+- [ ] When no user args and no nightly ref: defaults to `--num-prompts 64 --max-concurrency 16`.

--- a/.agents/skills/vllm-ascend-benchmark/references/behavior.md
+++ b/.agents/skills/vllm-ascend-benchmark/references/behavior.md
@@ -1,0 +1,70 @@
+# Benchmark Skill Behavior
+
+## Lifecycle
+
+1. **Resolve machine** from local inventory (same as serving).
+2. **Assemble config** from user args + optional nightly reference.
+3. **Stop existing service** on the target machine if any.
+4. **Start service** via `serve_start.py` (which handles parity sync internally).
+5. **Run `vllm bench serve`** via SSH on the remote container.
+6. **Collect results** from the bench output JSON.
+7. **Stop service** via `serve_stop.py`.
+8. **Output structured JSON** on stdout.
+
+## Configuration Priority
+
+User-provided arguments always take priority:
+
+```
+user CLI args  >  agent-assembled context  >  nightly YAML fallback
+```
+
+Nightly YAML is a reference source for discovering how to configure a model/feature, not an execution template. When `--refer-nightly` is given:
+
+- `server_cmd` and `server_cmd_extra` are merged (minus `--tensor-parallel-size` and `--port`, which are handled separately).
+- `envs` are used as a base, with user `--extra-env` overriding.
+- `benchmarks.perf` fields (`num_prompts`, `max_out_len`, `batch_size`) are mapped to bench CLI args.
+- User-provided `--serve-args` / `--bench-args` completely override the nightly values.
+
+## A/B Comparison
+
+The A/B flow runs two complete benchmark cycles (start -> bench -> stop) sequentially:
+
+1. Checkout `baseline-ref` in the target submodule, run full bench cycle.
+2. Checkout `patched-ref`, run full bench cycle.
+3. Compute delta and regression status.
+4. Restore the submodule to its original HEAD.
+
+### Patched Extra Env
+
+The patched side can carry additional environment variables via `--patched-extra-env`. These are:
+
+- Applied only to the patched service launch.
+- Recorded in the output under `env_diff.patched_only`.
+- Typical use case: the patched branch introduces a new feature flag (e.g., `VLLM_ENABLE_NEW_OPT=1`) that must be set for the optimization to take effect.
+
+### Core Parameters Invariant
+
+Both runs share identical:
+- Model path and served model name
+- TP / port configuration
+- Bench args (num-prompts, concurrency, output-len, etc.)
+- Base environment variables (from `--extra-env`)
+
+Only the code state and `--patched-extra-env` differ.
+
+## Remote Execution
+
+`vllm bench serve` runs inside the container via SSH. The result JSON file is written to `/tmp/` and `cat`-ed back through the SSH session. The script parses the last JSON object from stdout.
+
+## Defaults
+
+When the user provides no bench args and no nightly reference:
+- `--num-prompts 64`
+- `--max-concurrency 16`
+
+These are conservative defaults suitable for a quick smoke test. For production benchmarking, users should specify explicit parameters.
+
+## State Management
+
+Benchmark results are not persisted locally by default. The structured JSON is returned on stdout for the agent or user to consume. The serving skill handles its own state under `.vaws-local/serving/`.

--- a/.agents/skills/vllm-ascend-benchmark/references/command-recipes.md
+++ b/.agents/skills/vllm-ascend-benchmark/references/command-recipes.md
@@ -1,0 +1,88 @@
+# Benchmark Command Recipes
+
+## Single-run: minimal
+
+```bash
+python3 .agents/skills/vllm-ascend-benchmark/scripts/bench_run.py \
+  --machine 173.131.1.2 \
+  --model /home/weights/Qwen3.5-0.8B \
+  --tp 1
+```
+
+## Single-run: full-featured (MTP + graph mode)
+
+```bash
+python3 .agents/skills/vllm-ascend-benchmark/scripts/bench_run.py \
+  --machine 173.131.1.2 \
+  --model /home/weights/Qwen3-Next-80B-A3B-Instruct \
+  --tp 4 \
+  --extra-env OMP_NUM_THREADS=10 \
+  --extra-env HCCL_BUFFSIZE=1024 \
+  --extra-env PYTORCH_NPU_ALLOC_CONF=expandable_segments:True \
+  --serve-args \
+    --max-model-len 40960 \
+    --trust-remote-code \
+    --async-scheduling \
+    --no-enable-prefix-caching \
+    --enable-expert-parallel \
+    --gpu-memory-utilization 0.8 \
+    --max-num-seqs 64 \
+    --compilation_config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+    --speculative_config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}' \
+  --bench-args \
+    --num-prompts 256 \
+    --max-concurrency 64 \
+    --output-len 1500
+```
+
+## Single-run: with nightly reference as fallback
+
+```bash
+python3 .agents/skills/vllm-ascend-benchmark/scripts/bench_run.py \
+  --machine 173.131.1.2 \
+  --model /home/weights/Qwen3-Next-80B-A3B-Instruct \
+  --refer-nightly Qwen3-Next-80B-A3B-Instruct-A2
+```
+
+## A/B comparison: same code, different env
+
+```bash
+python3 .agents/skills/vllm-ascend-benchmark/scripts/bench_compare.py \
+  --machine 173.125.1.2 \
+  --baseline-ref main \
+  --patched-ref main \
+  --repo vllm-ascend \
+  --model /home/weights/Qwen3.5-0.8B \
+  --tp 1 \
+  --patched-extra-env VLLM_LOGGING_LEVEL=DEBUG
+```
+
+## A/B comparison: PR vs main
+
+```bash
+python3 .agents/skills/vllm-ascend-benchmark/scripts/bench_compare.py \
+  --machine 173.131.1.2 \
+  --baseline-ref main \
+  --patched-ref feat/optimize-decode \
+  --repo vllm-ascend \
+  --model /home/weights/Qwen3-Next-80B-A3B-Instruct \
+  --tp 4 \
+  --extra-env HCCL_BUFFSIZE=1024 \
+  --serve-args \
+    --max-model-len 40960 \
+    --async-scheduling \
+    --compilation_config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+```
+
+## A/B comparison: patched branch needs a feature flag
+
+```bash
+python3 .agents/skills/vllm-ascend-benchmark/scripts/bench_compare.py \
+  --machine 173.125.1.2 \
+  --baseline-ref main \
+  --patched-ref feat/new-scheduler \
+  --repo vllm-ascend \
+  --model /home/weights/Qwen3.5-0.8B \
+  --tp 1 \
+  --patched-extra-env VLLM_ENABLE_NEW_SCHEDULER=1
+```

--- a/.agents/skills/vllm-ascend-benchmark/scripts/_common.py
+++ b/.agents/skills/vllm-ascend-benchmark/scripts/_common.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Shared utilities for vllm-ascend-benchmark scripts."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[4]
+
+SERVING_SCRIPTS = ROOT / ".agents" / "skills" / "vllm-ascend-serving" / "scripts"
+NIGHTLY_CONFIGS_DIR = (
+    ROOT / "vllm-ascend" / "tests" / "e2e" / "nightly"
+    / "single_node" / "models" / "configs"
+)
+BENCHMARK_STATE_DIR = ROOT / ".vaws-local" / "benchmark"
+PROGRESS_SENTINEL = "__VAWS_BENCHMARK_PROGRESS__="
+
+
+# ---------------------------------------------------------------------------
+# Progress / output helpers
+# ---------------------------------------------------------------------------
+
+def emit_progress(phase: str, message: str, **extra: Any) -> None:
+    payload: dict[str, Any] = {"phase": phase, "message": message}
+    payload.update({k: v for k, v in extra.items() if v is not None})
+    sys.stderr.write(PROGRESS_SENTINEL + json.dumps(payload, ensure_ascii=False) + "\n")
+    sys.stderr.flush()
+
+
+def print_json(data: dict[str, Any]) -> None:
+    print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def now_utc() -> str:
+    from datetime import datetime, timezone
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Nightly YAML parsing (reference-only, not an execution template)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class NightlyReference:
+    """Parsed reference from a nightly YAML config.
+
+    Fields may be None when the YAML does not define them.
+    """
+    name: str = ""
+    model: str = ""
+    envs: dict[str, str] = field(default_factory=dict)
+    server_cmd: list[str] = field(default_factory=list)
+    bench_config: dict[str, Any] = field(default_factory=dict)
+    baseline: float | None = None
+    threshold: float | None = None
+
+
+def _try_yaml_import():
+    try:
+        import yaml  # noqa: F811
+        return yaml
+    except ImportError:
+        return None
+
+
+def parse_nightly_yaml(yaml_name: str) -> NightlyReference | None:
+    """Parse a nightly config YAML as a reference source.
+
+    Returns the first test case's config. Returns None if the file or
+    required library is unavailable.
+    """
+    yaml_mod = _try_yaml_import()
+    if yaml_mod is None:
+        emit_progress("nightly", "PyYAML not available, skipping nightly reference")
+        return None
+
+    yaml_path = NIGHTLY_CONFIGS_DIR / yaml_name
+    if not yaml_path.suffix:
+        yaml_path = yaml_path.with_suffix(".yaml")
+    if not yaml_path.exists():
+        emit_progress("nightly", f"nightly config not found: {yaml_path.name}")
+        return None
+
+    with open(yaml_path, "r", encoding="utf-8") as f:
+        data = yaml_mod.safe_load(f)
+
+    cases = data.get("test_cases")
+    if not cases:
+        return None
+
+    case = cases[0]
+    ref = NightlyReference(name=case.get("name", yaml_name))
+    ref.model = case.get("model", "")
+
+    raw_envs = case.get("envs", {})
+    ref.envs = {k: str(v) for k, v in raw_envs.items() if k != "SERVER_PORT"}
+
+    cmd_parts = list(case.get("server_cmd", []))
+    cmd_parts.extend(case.get("server_cmd_extra", []))
+    ref.server_cmd = [str(s) for s in cmd_parts]
+
+    benchmarks = case.get("benchmarks", {})
+    perf = benchmarks.get("perf", {})
+    if perf:
+        ref.bench_config = {
+            k: v for k, v in perf.items()
+            if k not in ("case_type", "baseline", "threshold")
+        }
+        ref.baseline = perf.get("baseline")
+        ref.threshold = perf.get("threshold")
+
+    return ref
+
+
+# ---------------------------------------------------------------------------
+# Configuration assembly
+# ---------------------------------------------------------------------------
+
+@dataclass
+class BenchConfig:
+    """Assembled benchmark configuration ready for execution."""
+    machine: str = ""
+    model: str = ""
+    tp: int | None = None
+    port: int | None = None
+    serve_args: list[str] = field(default_factory=list)
+    bench_args: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
+    skip_parity: bool = False
+    nightly_ref: NightlyReference | None = None
+
+    def to_serve_start_args(self) -> list[str]:
+        """Build CLI args for serve_start.py."""
+        args = ["--machine", self.machine, "--model", self.model]
+        if self.tp is not None:
+            args.extend(["--tp", str(self.tp)])
+        if self.port is not None:
+            args.extend(["--port", str(self.port)])
+        for k, v in self.env.items():
+            args.extend(["--extra-env", f"{k}={v}"])
+        if self.skip_parity:
+            args.append("--skip-parity")
+        if self.serve_args:
+            args.append("--")
+            args.extend(self.serve_args)
+        return args
+
+    def to_bench_serve_args(
+        self, base_url: str, served_model_name: str,
+    ) -> list[str]:
+        """Build CLI args for `vllm bench serve`."""
+        from urllib.parse import urlparse
+        parsed = urlparse(base_url)
+        host = parsed.hostname or "localhost"
+        port = str(parsed.port or 8000)
+
+        args = [
+            "vllm", "bench", "serve",
+            "--backend", "openai-chat",
+            "--endpoint", "/v1/chat/completions",
+            "--host", host,
+            "--port", port,
+            "--model", served_model_name,
+            "--tokenizer", self.model,
+            "--save-result",
+        ]
+        has_num_prompts = any(a.startswith("--num-prompts") for a in self.bench_args)
+        has_concurrency = any(a.startswith("--max-concurrency") for a in self.bench_args)
+
+        if not has_num_prompts:
+            args.extend(["--num-prompts", "64"])
+        if not has_concurrency:
+            args.extend(["--max-concurrency", "16"])
+
+        args.extend(self.bench_args)
+        return args
+
+    def summary_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"machine": self.machine, "model": self.model}
+        if self.tp is not None:
+            d["tp"] = self.tp
+        if self.serve_args:
+            d["serve_args"] = self.serve_args
+        if self.bench_args:
+            d["bench_args"] = self.bench_args
+        if self.env:
+            d["env"] = self.env
+        return d
+
+
+def assemble_config(
+    *,
+    machine: str,
+    model: str,
+    tp: int | None = None,
+    port: int | None = None,
+    serve_args: list[str] | None = None,
+    bench_args: list[str] | None = None,
+    extra_env: list[str] | None = None,
+    refer_nightly: str | None = None,
+    skip_parity: bool = False,
+) -> BenchConfig:
+    """Assemble a BenchConfig with user > nightly priority."""
+    nightly_ref: NightlyReference | None = None
+    if refer_nightly:
+        nightly_ref = parse_nightly_yaml(refer_nightly)
+
+    cfg = BenchConfig(
+        machine=machine,
+        model=model,
+        skip_parity=skip_parity,
+        nightly_ref=nightly_ref,
+    )
+
+    # --- TP ---
+    if tp is not None:
+        cfg.tp = tp
+    elif nightly_ref and "--tensor-parallel-size" in nightly_ref.server_cmd:
+        idx = nightly_ref.server_cmd.index("--tensor-parallel-size")
+        if idx + 1 < len(nightly_ref.server_cmd):
+            cfg.tp = int(nightly_ref.server_cmd[idx + 1])
+
+    # --- Port ---
+    cfg.port = port
+
+    # --- Serve args: user provided overrides nightly ---
+    if serve_args:
+        cfg.serve_args = list(serve_args)
+    elif nightly_ref:
+        filtered = []
+        skip_next = False
+        for i, arg in enumerate(nightly_ref.server_cmd):
+            if skip_next:
+                skip_next = False
+                continue
+            if arg in ("--tensor-parallel-size", "--port"):
+                skip_next = True
+                continue
+            filtered.append(arg)
+        cfg.serve_args = filtered
+
+    # --- Bench args: user provided overrides nightly ---
+    if bench_args:
+        cfg.bench_args = list(bench_args)
+    elif nightly_ref and nightly_ref.bench_config:
+        bc = nightly_ref.bench_config
+        assembled: list[str] = []
+        if "num_prompts" in bc:
+            assembled.extend(["--num-prompts", str(bc["num_prompts"])])
+        if "max_out_len" in bc:
+            assembled.extend(["--output-len", str(bc["max_out_len"])])
+        if "batch_size" in bc:
+            assembled.extend(["--max-concurrency", str(bc["batch_size"])])
+        cfg.bench_args = assembled
+
+    # --- Env: merge nightly base + user overrides ---
+    env: dict[str, str] = {}
+    if nightly_ref:
+        env.update(nightly_ref.envs)
+    if extra_env:
+        for item in extra_env:
+            if "=" in item:
+                k, v = item.split("=", 1)
+                env[k] = v
+    cfg.env = env
+
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Serving skill wrappers
+# ---------------------------------------------------------------------------
+
+def call_serve_start(config: BenchConfig) -> dict[str, Any]:
+    """Call serve_start.py and return its JSON output."""
+    script = str(SERVING_SCRIPTS / "serve_start.py")
+    cmd = [sys.executable, script] + config.to_serve_start_args()
+
+    emit_progress("serve_start", f"starting service: {config.model}")
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(ROOT))
+
+    for line in result.stderr.splitlines():
+        if "__VAWS_SERVING_PROGRESS__=" in line or "__VAWS_PARITY_PROGRESS__=" in line:
+            sys.stderr.write(line + "\n")
+
+    if not result.stdout.strip():
+        raise RuntimeError(
+            f"serve_start.py produced no output (rc={result.returncode}):\n"
+            f"{result.stderr[:2000]}"
+        )
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        raise RuntimeError(
+            f"serve_start.py output is not JSON (rc={result.returncode}):\n"
+            f"stdout: {result.stdout[:1000]}\nstderr: {result.stderr[:1000]}"
+        )
+    return data
+
+
+def call_serve_stop(machine: str, force: bool = False) -> dict[str, Any]:
+    """Call serve_stop.py and return its JSON output."""
+    script = str(SERVING_SCRIPTS / "serve_stop.py")
+    cmd = [sys.executable, script, "--machine", machine]
+    if force:
+        cmd.append("--force")
+
+    emit_progress("serve_stop", "stopping service")
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(ROOT))
+    if not result.stdout.strip():
+        return {"status": "unknown", "message": "no output from serve_stop"}
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {"status": "unknown", "message": result.stdout[:500]}
+
+
+# ---------------------------------------------------------------------------
+# Remote benchmark execution
+# ---------------------------------------------------------------------------
+
+def _get_ssh_endpoint(machine: str) -> tuple[str, int]:
+    """Resolve container SSH host and port from inventory."""
+    lib_dir = str(ROOT / ".agents" / "lib")
+    mm_dir = str(ROOT / ".agents" / "skills" / "machine-management" / "scripts")
+    for p in (lib_dir, mm_dir):
+        if p not in sys.path:
+            sys.path.insert(0, p)
+    import inventory as inv_store
+    read_path = inv_store.read_inventory_path(
+        inv_store.preferred_inventory_path(inv_store.DEFAULT_PATH)
+    )
+    inv = inv_store.load_inventory(read_path)
+    matches = inv_store._find_matches(inv, identifier=machine)
+    if not matches:
+        raise RuntimeError(f"machine {machine!r} not found in inventory")
+    rec = matches[0]
+    return rec["host"]["ip"], rec["container"]["ssh_port"]
+
+
+def _ascend_env_preamble() -> str:
+    """Shell preamble that sources the Ascend CANN environment."""
+    return (
+        "set -e; "
+        "if [ -f /etc/profile.d/vaws-ascend-env.sh ]; then"
+        "  set +u; source /etc/profile.d/vaws-ascend-env.sh; set -u;"
+        " fi; "
+        'export LD_LIBRARY_PATH='
+        '"/usr/local/Ascend/driver/lib64/driver'
+        ':/usr/local/Ascend/driver/lib64'
+        '${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"; '
+    )
+
+
+def run_bench_on_remote(
+    config: BenchConfig,
+    base_url: str,
+    served_model_name: str,
+    container_ip: str,
+    container_port: int,
+) -> dict[str, Any]:
+    """Run vllm bench serve on the remote container via SSH."""
+    import shlex
+
+    bench_cmd_parts = config.to_bench_serve_args(base_url, served_model_name)
+    result_filename = f"result_bench_{now_utc().replace(':', '-')}.json"
+    bench_cmd_parts.extend(["--result-filename", result_filename])
+
+    bench_cmd = " ".join(shlex.quote(str(s)) for s in bench_cmd_parts)
+
+    remote_script = (
+        _ascend_env_preamble()
+        + f"cd /tmp && {bench_cmd} 2>&1 && cat /tmp/{result_filename}"
+    )
+
+    ssh_cmd = [
+        "ssh",
+        "-o", "BatchMode=yes",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", "LogLevel=ERROR",
+        "-p", str(container_port),
+        f"root@{container_ip}",
+        "bash", "-c", shlex.quote(remote_script),
+    ]
+
+    emit_progress("bench_run", f"running vllm bench serve on {config.machine}")
+    proc = subprocess.run(ssh_cmd, capture_output=True, text=True, timeout=1200)
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"vllm bench serve failed (rc={proc.returncode}):\n"
+            f"stdout: {proc.stdout[-2000:]}\n"
+            f"stderr: {proc.stderr[-2000:]}"
+        )
+
+    stdout = proc.stdout
+    json_start = stdout.rfind("\n{")
+    if json_start == -1:
+        json_start = 0 if stdout.startswith("{") else -1
+    else:
+        json_start += 1
+
+    if json_start == -1:
+        raise RuntimeError(
+            f"cannot find JSON result in bench output:\n{stdout[-2000:]}"
+        )
+
+    try:
+        result_data = json.loads(stdout[json_start:])
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"cannot parse bench result JSON: {e}\n{stdout[json_start:json_start+500]}"
+        )
+
+    return result_data
+
+
+# ---------------------------------------------------------------------------
+# Metrics extraction
+# ---------------------------------------------------------------------------
+
+def extract_metrics(raw_result: dict[str, Any]) -> dict[str, Any]:
+    """Extract key metrics from vllm bench serve result JSON."""
+    metrics: dict[str, Any] = {}
+
+    for key in ("output_throughput", "mean_tpot_ms", "mean_ttft_ms",
+                "median_tpot_ms", "median_ttft_ms", "acceptance_rate",
+                "total_input", "total_output", "request_throughput",
+                "mean_e2el_ms", "median_e2el_ms"):
+        if key in raw_result:
+            val = raw_result[key]
+            if isinstance(val, str):
+                try:
+                    val = float(val)
+                except ValueError:
+                    pass
+            metrics[key] = val
+
+    return metrics
+
+
+def compute_delta(baseline: dict[str, Any], patched: dict[str, Any]) -> dict[str, str]:
+    """Compute percentage delta between baseline and patched metrics."""
+    delta: dict[str, str] = {}
+    for key in baseline:
+        if key not in patched:
+            continue
+        try:
+            bv = float(baseline[key])
+            pv = float(patched[key])
+        except (TypeError, ValueError):
+            continue
+        if bv == 0:
+            delta[key] = "N/A (baseline=0)"
+            continue
+        pct = (pv - bv) / abs(bv) * 100
+        sign = "+" if pct >= 0 else ""
+        delta[key] = f"{sign}{pct:.2f}%"
+    return delta
+
+
+def check_regression(
+    baseline_metrics: dict[str, Any],
+    patched_metrics: dict[str, Any],
+    threshold: float = 0.97,
+) -> bool:
+    """Return True if patched throughput regressed below threshold."""
+    bv = baseline_metrics.get("output_throughput")
+    pv = patched_metrics.get("output_throughput")
+    if bv is None or pv is None:
+        return False
+    try:
+        return float(pv) < float(bv) * threshold
+    except (TypeError, ValueError):
+        return False

--- a/.agents/skills/vllm-ascend-benchmark/scripts/bench_compare.py
+++ b/.agents/skills/vllm-ascend-benchmark/scripts/bench_compare.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""A/B benchmark comparison on a workspace-managed remote container.
+
+Checks out baseline and patched refs in a submodule, runs vllm bench serve
+for each, and outputs a comparison JSON with delta percentages.
+
+Usage example:
+
+    python3 bench_compare.py \\
+        --machine 173.125.1.2 \\
+        --baseline-ref main \\
+        --patched-ref feat/my-opt \\
+        --repo vllm-ascend \\
+        --model /home/weights/Qwen3.5-0.8B \\
+        --tp 1 \\
+        --patched-extra-env VLLM_LOGGING_LEVEL=DEBUG
+
+Progress on stderr as __VAWS_BENCHMARK_PROGRESS__=<json>.
+Final result on stdout as a single JSON object.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import traceback
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from _common import (
+    ROOT,
+    BenchConfig,
+    assemble_config,
+    call_serve_start,
+    call_serve_stop,
+    check_regression,
+    compute_delta,
+    emit_progress,
+    extract_metrics,
+    now_utc,
+    print_json,
+    run_bench_on_remote,
+    _get_ssh_endpoint,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="A/B benchmark comparison.",
+        allow_abbrev=False,
+    )
+    p.add_argument("--machine", required=True, help="machine alias or IP")
+    p.add_argument("--baseline-ref", required=True, help="baseline branch/commit")
+    p.add_argument("--patched-ref", required=True, help="patched branch/commit")
+    p.add_argument("--repo", required=True, choices=["vllm-ascend", "vllm"],
+                   help="which submodule to switch refs on")
+    p.add_argument("--model", required=True, help="remote model weight path")
+    p.add_argument("--tp", "--tensor-parallel-size", type=int, default=None)
+    p.add_argument("--port", type=int, default=None)
+    p.add_argument("--extra-env", action="append", default=None,
+                   help="KEY=VALUE env for BOTH sides (repeatable)")
+    p.add_argument("--patched-extra-env", action="append", default=None,
+                   help="KEY=VALUE env for patched side ONLY (repeatable)")
+    p.add_argument("--refer-nightly", default=None)
+    return p
+
+
+def _split_sections(argv: list[str]) -> tuple[list[str], list[str] | None, list[str] | None]:
+    """Split argv into (main_args, serve_args, bench_args)."""
+    delimiters = {"--serve-args", "--bench-args"}
+    sections: dict[str, list[str]] = {}
+    main_args: list[str] = []
+    current_key: str | None = None
+
+    for token in argv:
+        if token in delimiters:
+            current_key = token
+            sections[current_key] = []
+        elif current_key is not None:
+            sections[current_key].append(token)
+        else:
+            main_args.append(token)
+
+    return (
+        main_args,
+        sections.get("--serve-args"),
+        sections.get("--bench-args"),
+    )
+
+
+def _checkout_ref(repo: str, ref: str) -> str:
+    """Checkout a ref in the given submodule. Returns the resolved commit hash."""
+    repo_path = ROOT / repo
+    if not repo_path.exists():
+        raise RuntimeError(f"submodule directory not found: {repo_path}")
+
+    subprocess.run(
+        ["git", "fetch", "--all", "--quiet"],
+        cwd=str(repo_path), check=False, capture_output=True,
+    )
+
+    result = subprocess.run(
+        ["git", "checkout", ref],
+        cwd=str(repo_path), check=False, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        result = subprocess.run(
+            ["git", "checkout", f"origin/{ref}"],
+            cwd=str(repo_path), check=False, capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"cannot checkout {ref!r} in {repo}: {result.stderr[:500]}"
+            )
+
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(repo_path), capture_output=True, text=True, check=True,
+    )
+    return commit.stdout.strip()
+
+
+def _run_single_bench(
+    config: BenchConfig,
+    label: str,
+) -> dict[str, Any]:
+    """Run one benchmark cycle: start -> bench -> stop. Returns metrics + raw."""
+    from typing import Any
+
+    emit_progress(f"{label}_start", f"[{label}] starting service")
+    start_result = call_serve_start(config)
+    if start_result.get("status") != "ready":
+        raise RuntimeError(
+            f"[{label}] service did not become ready: "
+            f"{start_result.get('error', str(start_result))}"
+        )
+
+    base_url = start_result["base_url"]
+    served_model = start_result.get("served_model_name", Path(config.model).name)
+    container_ip, container_port = _get_ssh_endpoint(config.machine)
+
+    emit_progress(f"{label}_bench", f"[{label}] running vllm bench serve")
+    try:
+        raw_result = run_bench_on_remote(
+            config, base_url, served_model, container_ip, container_port,
+        )
+    except Exception:
+        call_serve_stop(config.machine, force=True)
+        raise
+
+    emit_progress(f"{label}_stop", f"[{label}] stopping service")
+    call_serve_stop(config.machine)
+
+    metrics = extract_metrics(raw_result)
+    emit_progress(f"{label}_done", f"[{label}] throughput={metrics.get('output_throughput', 'N/A')}")
+    return {"metrics": metrics, "raw_result": raw_result}
+
+
+def main(argv: list[str] | None = None) -> int:
+    raw_argv = argv if argv is not None else sys.argv[1:]
+    main_argv, manual_serve_args, manual_bench_args = _split_sections(raw_argv)
+    args = build_parser().parse_args(main_argv)
+    serve_args = manual_serve_args if manual_serve_args is not None else args.serve_args
+    bench_args = manual_bench_args if manual_bench_args is not None else args.bench_args
+
+    original_head: str | None = None
+
+    try:
+        repo_path = ROOT / args.repo
+        original_head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(repo_path), capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+        base_config = assemble_config(
+            machine=args.machine,
+            model=args.model,
+            tp=args.tp,
+            port=args.port,
+            serve_args=serve_args,
+            bench_args=bench_args,
+            extra_env=args.extra_env,
+            refer_nightly=args.refer_nightly,
+            skip_parity=False,
+        )
+
+        # --- Baseline ---
+        emit_progress("checkout", f"checking out baseline: {args.baseline_ref}")
+        baseline_commit = _checkout_ref(args.repo, args.baseline_ref)
+        emit_progress("checkout", f"baseline at {baseline_commit[:12]}")
+
+        baseline_result = _run_single_bench(base_config, "baseline")
+
+        # --- Patched ---
+        emit_progress("checkout", f"checking out patched: {args.patched_ref}")
+        patched_commit = _checkout_ref(args.repo, args.patched_ref)
+        emit_progress("checkout", f"patched at {patched_commit[:12]}")
+
+        patched_config = assemble_config(
+            machine=args.machine,
+            model=args.model,
+            tp=args.tp,
+            port=args.port,
+            serve_args=serve_args,
+            bench_args=bench_args,
+            extra_env=args.extra_env,
+            refer_nightly=args.refer_nightly,
+            skip_parity=False,
+        )
+
+        patched_env_additions: dict[str, str] = {}
+        if args.patched_extra_env:
+            for item in args.patched_extra_env:
+                if "=" in item:
+                    k, v = item.split("=", 1)
+                    patched_config.env[k] = v
+                    patched_env_additions[k] = v
+
+        patched_result = _run_single_bench(patched_config, "patched")
+
+        # --- Comparison ---
+        baseline_metrics = baseline_result["metrics"]
+        patched_metrics = patched_result["metrics"]
+        delta = compute_delta(baseline_metrics, patched_metrics)
+        regression = check_regression(baseline_metrics, patched_metrics)
+
+        env_diff: dict[str, Any] = {}
+        if patched_env_additions:
+            env_diff["patched_only"] = [f"{k}={v}" for k, v in patched_env_additions.items()]
+
+        emit_progress("done", f"comparison complete, regression={regression}")
+
+        print_json({
+            "status": "ok",
+            "machine": args.machine,
+            "model": args.model,
+            "repo": args.repo,
+            "baseline": {
+                "ref": args.baseline_ref,
+                "commit": baseline_commit,
+                "metrics": baseline_metrics,
+                "env": base_config.env,
+            },
+            "patched": {
+                "ref": args.patched_ref,
+                "commit": patched_commit,
+                "metrics": patched_metrics,
+                "env": patched_config.env,
+            },
+            "delta": delta,
+            "env_diff": env_diff,
+            "regression": regression,
+            "config": base_config.summary_dict(),
+            "timestamp": now_utc(),
+        })
+        return 0
+
+    except Exception as e:
+        try:
+            call_serve_stop(args.machine, force=True)
+        except Exception:
+            pass
+        print_json({
+            "status": "failed",
+            "error": str(e),
+            "traceback": traceback.format_exc(),
+        })
+        return 2
+
+    finally:
+        if original_head:
+            subprocess.run(
+                ["git", "checkout", original_head],
+                cwd=str(ROOT / args.repo),
+                check=False, capture_output=True,
+            )
+            emit_progress("cleanup", f"restored {args.repo} to {original_head[:12]}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/vllm-ascend-benchmark/scripts/bench_run.py
+++ b/.agents/skills/vllm-ascend-benchmark/scripts/bench_run.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Run a single vllm bench serve benchmark on a workspace-managed remote container.
+
+Usage examples:
+
+    # Minimal: model + machine
+    python3 bench_run.py --machine 173.131.1.2 --model /home/weights/Qwen3.5-35B
+
+    # With explicit serve and bench args
+    python3 bench_run.py --machine 173.131.1.2 --model /home/weights/Qwen3.5-35B \\
+        --tp 4 --serve-args --async-scheduling --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \\
+        --bench-args --num-prompts 128 --max-concurrency 32 --output-len 1500
+
+    # Using a nightly config as reference
+    python3 bench_run.py --machine 173.131.1.2 --model /home/weights/Qwen3.5-35B \\
+        --refer-nightly Qwen3-Next-80B-A3B-Instruct-A2
+
+Progress on stderr as __VAWS_BENCHMARK_PROGRESS__=<json>.
+Final result on stdout as a single JSON object.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import traceback
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from _common import (
+    assemble_config,
+    call_serve_start,
+    call_serve_stop,
+    emit_progress,
+    extract_metrics,
+    now_utc,
+    print_json,
+    run_bench_on_remote,
+    _get_ssh_endpoint,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Run a single vllm bench serve benchmark.",
+        allow_abbrev=False,
+    )
+    p.add_argument("--machine", required=True, help="machine alias or IP")
+    p.add_argument("--model", required=True, help="remote model weight path")
+    p.add_argument("--tp", "--tensor-parallel-size", type=int, default=None)
+    p.add_argument("--port", type=int, default=None)
+    p.add_argument("--extra-env", action="append", default=None,
+                   help="KEY=VALUE env vars for the service (repeatable)")
+    p.add_argument("--refer-nightly", default=None,
+                   help="nightly YAML name as configuration reference")
+    p.add_argument("--skip-parity", action="store_true")
+    return p
+
+
+def _split_sections(argv: list[str]) -> tuple[list[str], list[str] | None, list[str] | None]:
+    """Split argv into (main_args, serve_args, bench_args).
+
+    Recognizes --serve-args and --bench-args as section delimiters in any order.
+    """
+    delimiters = {"--serve-args", "--bench-args"}
+    sections: dict[str, list[str]] = {}
+    main_args: list[str] = []
+    current_key: str | None = None
+
+    for token in argv:
+        if token in delimiters:
+            current_key = token
+            sections[current_key] = []
+        elif current_key is not None:
+            sections[current_key].append(token)
+        else:
+            main_args.append(token)
+
+    return (
+        main_args,
+        sections.get("--serve-args"),
+        sections.get("--bench-args"),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    raw_argv = argv if argv is not None else sys.argv[1:]
+    main_argv, manual_serve_args, manual_bench_args = _split_sections(raw_argv)
+
+    args = build_parser().parse_args(main_argv)
+
+    serve_args = manual_serve_args if manual_serve_args is not None else args.serve_args
+    bench_args = manual_bench_args if manual_bench_args is not None else args.bench_args
+
+    try:
+        config = assemble_config(
+            machine=args.machine,
+            model=args.model,
+            tp=args.tp,
+            port=args.port,
+            serve_args=serve_args,
+            bench_args=bench_args,
+            extra_env=args.extra_env,
+            refer_nightly=args.refer_nightly,
+            skip_parity=args.skip_parity,
+        )
+
+        # --- Start service ---
+        emit_progress("start", "launching vllm service")
+        start_result = call_serve_start(config)
+
+        if start_result.get("status") != "ready":
+            print_json({
+                "status": "failed",
+                "phase": "serve_start",
+                "error": start_result.get("error", "service did not become ready"),
+                "serve_result": start_result,
+            })
+            return 1
+
+        base_url = start_result["base_url"]
+        served_model = start_result.get("served_model_name", Path(args.model).name)
+        container_ip, container_port = _get_ssh_endpoint(args.machine)
+
+        # --- Run benchmark ---
+        emit_progress("bench", "running vllm bench serve")
+        try:
+            raw_result = run_bench_on_remote(
+                config, base_url, served_model, container_ip, container_port,
+            )
+        except Exception as e:
+            emit_progress("bench", f"benchmark failed: {e}")
+            call_serve_stop(args.machine, force=True)
+            print_json({
+                "status": "failed",
+                "phase": "bench_run",
+                "error": str(e),
+                "config": config.summary_dict(),
+            })
+            return 1
+
+        # --- Stop service ---
+        emit_progress("stop", "stopping service")
+        call_serve_stop(args.machine)
+
+        # --- Output ---
+        metrics = extract_metrics(raw_result)
+        emit_progress("done", f"benchmark complete, throughput={metrics.get('output_throughput', 'N/A')}")
+
+        print_json({
+            "status": "ok",
+            "machine": args.machine,
+            "model": args.model,
+            "metrics": metrics,
+            "config": config.summary_dict(),
+            "raw_result": raw_result,
+            "timestamp": now_utc(),
+        })
+        return 0
+
+    except Exception as e:
+        call_serve_stop(args.machine, force=True)
+        print_json({
+            "status": "failed",
+            "phase": "unexpected",
+            "error": str(e),
+            "traceback": traceback.format_exc(),
+        })
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,9 @@ Repo-local skills live under `.agents/skills/`.
 - `machine-management`: add, verify, repair, or remove a workspace-managed remote NPU machine and its managed container.
 - `remote-code-parity`: automatically ensure a ready remote runtime uses the exact current local workspace state before any remote smoke, service launch, or benchmark.
 - `vllm-ascend-serving`: start, check, or stop a single-node colocated vLLM Ascend online service on a workspace-managed ready remote container.
+- `vllm-ascend-benchmark`: run `vllm bench serve` performance benchmarks on a workspace-managed remote container, supporting single-run and A/B comparison modes.
 
-`repo-init` and `machine-management` are optional. `remote-code-parity` is an automatic pre-execution gate only for ready-machine remote execution. `vllm-ascend-serving` handles service lifecycle after parity. Do not force any of them as a gate before normal local coding, docs work, or unrelated Git / SSH tasks.
+`repo-init` and `machine-management` are optional. `remote-code-parity` is an automatic pre-execution gate only for ready-machine remote execution. `vllm-ascend-serving` handles service lifecycle after parity. `vllm-ascend-benchmark` orchestrates serving + benchmarking end-to-end. Do not force any of them as a gate before normal local coding, docs work, or unrelated Git / SSH tasks.
 
 ## Repo-wide operating rules
 
@@ -34,6 +35,9 @@ Repo-local skills live under `.agents/skills/`.
   - `.agents/skills/vllm-ascend-serving/scripts/serve_status.py`
   - `.agents/skills/vllm-ascend-serving/scripts/serve_stop.py`
   - `.agents/skills/vllm-ascend-serving/scripts/serve_probe_npus.py`
+- For normal benchmark work, prefer the task wrappers:
+  - `.agents/skills/vllm-ascend-benchmark/scripts/bench_run.py`
+  - `.agents/skills/vllm-ascend-benchmark/scripts/bench_compare.py`
 - Treat `.agents/skills/machine-management/scripts/inventory.py` and `.agents/skills/machine-management/scripts/manage_machine.py` as low-level maintenance helpers, not the default agent-facing surface.
 - For machine bootstrap, never default the image silently. Ask the user to choose `rc`, `main`, `stable`, or a concrete custom image reference.
 - `rc` is the recommended developer track: resolve the newest official prerelease `vllm-ascend` tag at execution time, then try `quay.nju.edu.cn/ascend/vllm-ascend:<tag>` first and `quay.io/ascend/vllm-ascend:<tag>` second.
@@ -109,6 +113,14 @@ Use `vllm-ascend-serving` when the user asks to:
 - stop a running service
 
 Do not use `vllm-ascend-serving` for machine attach, environment bootstrap, code sync, benchmark orchestration, or offline inference.
+
+Use `vllm-ascend-benchmark` when the user asks to:
+
+- run a performance benchmark / throughput test on a managed machine
+- compare performance before and after a code change (A/B)
+- verify there is no performance regression for a PR or commit
+
+Do not use `vllm-ascend-benchmark` for accuracy tests, nightly CI matrix runs, offline inference, or service-only lifecycle without benchmarking.
 
 ## Maintenance rule
 


### PR DESCRIPTION
## Summary

- New `vllm-ascend-benchmark` skill for running `vllm bench serve` performance benchmarks on workspace-managed remote containers
- Supports **single-run** (`bench_run.py`) and **A/B comparison** (`bench_compare.py`) modes
- User intent takes priority over nightly configs (nightly YAML is reference-only, not an execution template)
- A/B mode supports `--patched-extra-env` for testing feature flags, with env diff recorded in output
- Internally delegates to `vllm-ascend-serving` for service lifecycle (start/stop)
- Updated `AGENTS.md` with skill routing rules

## Validation

Validated on remote 910B A2 machine (173.131.1.2):

- **Single-run**: Qwen3.5-35B-A3B with TP=4, `output_throughput: 38.6 tok/s`
- **A/B comparison**: Same commit, patched side with `VLLM_LOGGING_LEVEL=DEBUG` — baseline `63.8 tok/s` vs patched `56.4 tok/s`, delta `-11.47%`, `regression: true` correctly detected, `env_diff` correctly recorded

## Bugs fixed during validation

1. Arg splitting: `--serve-args` and `--bench-args` now handled by custom section splitter (not argparse REMAINDER)
2. Tokenizer path: `--tokenizer <full-path>` added for offline containers
3. API endpoint: explicit `--endpoint /v1/chat/completions` for openai-chat backend
4. CANN env: Ascend env preamble sourced before remote bench execution

## Test plan

- [x] `bench_run.py` single-run on 131 with Qwen3.5-35B-A3B
- [x] `bench_compare.py` A/B on 131 with patched-extra-env
- [x] Service cleanup verified after both success and failure
- [x] Progress reporting on stderr, JSON on stdout
- [ ] Machine 125 blocked by pre-existing CANN custom ops env issue (not skill-related)


Made with [Cursor](https://cursor.com)