### PR TITLE
[Bugfix] Harden repo-init against uninitialized submodule and missing checkpoint question

### DIFF
--- a/.agents/skills/repo-init/SKILL.md
+++ b/.agents/skills/repo-init/SKILL.md
@@ -96,10 +96,12 @@ That checkpoint must cover:
    - recommended fork mode
    - community-only mode
 3. whether to initialize submodules now
-4. vllm submodule version alignment (only when submodules will be initialized)
+4. vllm submodule version alignment — **always include this question in the grouped checkpoint when the probe shows submodules are not yet initialized**. Since all questions are asked in a single batch, you cannot wait for the answer to question 3 before deciding whether to include question 4. If the user later chooses not to initialize submodules, simply ignore their version-alignment answer. Options:
    - **CI-pinned** (default): check out `vllm/` at the commit CI actually tests against — from `vllm_version` matrix in `vllm-ascend/.github/workflows/pr_test_full.yaml`; cross-reference with `main_vllm_commit` in `vllm-ascend/docs/source/conf.py`
    - **upstream main**: both submodules track their respective upstream `main` HEAD
    - **keep current**: leave `vllm/` at whatever commit it is already on
+
+Skip question 4 only when the probe shows submodules are already initialized (nothing to align).
 
 If the user only asked for a narrow GitHub auth / `gh` task, skip the machine-profile and version-alignment questions.
 

--- a/.agents/skills/repo-init/SKILL.md
+++ b/.agents/skills/repo-init/SKILL.md
@@ -153,17 +153,19 @@ After recursive submodule init completes, if the user chose CI-pinned alignment:
 - Check out `vllm/` at that commit.
 - Report the active version combination (vllm commit + vllm-ascend branch) in the finish summary.
 
-### 4. Apply approved changes by category
+### 4. Apply approved changes in order
 
-Typical categories:
+Execute categories in the order listed below. **Submodule init must complete before remote rewiring of submodule repos**, because uninitialized submodule directories are not independent git repositories — running `repo_topology.py configure --repo <submodule>` on an uninitialized submodule will silently resolve to the parent workspace repo and corrupt its remotes.
 
-- local machine profile creation or change
-- `gh` install / configure
-- GitHub auth
-- recursive submodule init
-- remote rewiring
-- branch tracking updates
-- optional fork sync
+1. local machine profile creation or change
+2. `gh` install / configure
+3. GitHub auth
+4. recursive submodule init (`git submodule sync --recursive && git submodule update --init --recursive`)
+5. vllm submodule version alignment (CI-pinned checkout, if chosen)
+6. remote rewiring for workspace repo
+7. remote rewiring for `vllm` and `vllm-ascend` submodule repos (only after step 4)
+8. branch tracking updates
+9. optional fork sync
 
 ### 5. Finish compactly
 

--- a/.agents/skills/repo-init/references/acceptance.md
+++ b/.agents/skills/repo-init/references/acceptance.md
@@ -38,6 +38,7 @@ A successful run should satisfy all applicable items below.
   - machine username choice if the profile is missing
   - repo topology choice
   - submodule-init choice
+  - vllm version alignment choice (when the probe shows submodules are uninitialized)
 - the machine-username branch uses exactly three options:
   - `git-username`
   - `random`

--- a/.agents/skills/repo-init/references/acceptance.md
+++ b/.agents/skills/repo-init/references/acceptance.md
@@ -67,6 +67,8 @@ A successful run should satisfy all applicable items below.
 ### Submodules and topology
 
 - initializes submodules recursively when the user approved it
+- completes submodule init before configuring submodule remotes
+- `repo_topology.py configure --repo <submodule>` errors out when the submodule is not initialized (git root mismatch)
 - preserves nonstandard remotes
 - keeps tracked files on community URLs
 - uses quiet remote comparison instead of broad prune-heavy fetches

--- a/.agents/skills/repo-init/references/behavior.md
+++ b/.agents/skills/repo-init/references/behavior.md
@@ -98,13 +98,16 @@ Always use recursive sync + init for this repo.
 
 Use `repo_topology.py configure` for remote mutations.
 
+**Prerequisite**: Stage 5 (submodule init) must be complete before configuring submodule remotes. `repo_topology.py` will refuse to operate on a path whose git root resolves to a different directory (e.g. an uninitialized submodule falling through to the parent workspace).
+
 Rules:
 
 - do not delete nonstandard remotes
 - add `upstream` only when it helps the chosen workflow
 - `vllm` user fork is optional
 - `vllm-ascend` user fork is recommended but not mandatory
-- if the user chose “keep current”, do not rewrite remotes just because the recommended topology differs
+- if the user chose "keep current", do not rewrite remotes just because the recommended topology differs
+- configure workspace remotes first, then submodule remotes (after submodule init)
 
 ### Stage 7: main-branch comparison and tracking
 
@@ -144,5 +147,5 @@ A successful run usually ends with:
 - `gh` installed or a fallback provided
 - GitHub auth valid
 - recursive submodules initialized when the user approved it
-- remotes matching the user’s selected topology
+- remotes matching the user's selected topology
 - local `main` tracking the selected working remote where the user approved branch movement

--- a/.agents/skills/repo-init/references/behavior.md
+++ b/.agents/skills/repo-init/references/behavior.md
@@ -57,6 +57,7 @@ That question must cover:
 - machine username choice when the profile is missing
 - repo topology mode: keep current, recommended fork mode, or community-only
 - whether to initialize submodules now
+- vllm submodule version alignment (CI-pinned / upstream main / keep current) — always include this when the probe shows submodules are uninitialized, because all questions are asked in one batch and you cannot wait for the submodule-init answer first; ignore the answer if the user later declines submodule init
 
 For the machine username branch, use the fixed three-option model from `repo_init_profile.py plan`:
 

--- a/.agents/skills/repo-init/scripts/repo_topology.py
+++ b/.agents/skills/repo-init/scripts/repo_topology.py
@@ -63,10 +63,20 @@ def parse_repo_url(url: str | None) -> str | None:
 
 def resolve_repo(path_value: str) -> pathlib.Path:
     path = pathlib.Path(path_value).expanduser().resolve()
+    if not path.is_dir():
+        raise RepoTopologyError(f"path does not exist or is not a directory: {path}")
     proc = run(["git", "rev-parse", "--show-toplevel"], cwd=path)
     if proc.returncode != 0 or not proc.stdout.strip():
         raise RepoTopologyError(f"not a git repository: {path}")
-    return pathlib.Path(proc.stdout.strip()).resolve()
+    git_root = pathlib.Path(proc.stdout.strip()).resolve()
+    if git_root != path:
+        raise RepoTopologyError(
+            f"path '{path_value}' is not a git repository root; "
+            f"git root resolved to {git_root} instead of {path}. "
+            f"If this is a submodule, initialize it first with "
+            f"'git submodule update --init --recursive'."
+        )
+    return git_root
 
 
 def branch_exists(repo: pathlib.Path, branch: str) -> bool:


### PR DESCRIPTION
## Summary

- `repo_topology.py` 的 `resolve_repo()` 新增 git-root 一致性检查：当 `--repo <path>` 解析出的 git 根目录与传入路径不一致时（如未初始化的子模块会穿透到父仓库），拒绝执行并给出明确错误信息
- SKILL.md Step 4 从无序列表改为有序列表，明确标注 submodule init 必须在 remote rewiring 之前完成
- 将 vllm 版本对齐问题（CI-pinned / upstream main / keep current）改为当 probe 显示子模块未初始化时始终包含在分组 checkpoint 中，解决因批量提问无法动态添加问题导致 question 4 被跳过的问题

## Test plan

- [x] `resolve_repo(".")` 正常返回 workspace 根目录
- [x] `resolve_repo("vllm")` 对已初始化子模块正常工作
- [x] `resolve_repo("docs")` 对非 git 根子目录正确拒绝（git root mismatch）
- [x] `resolve_repo("nonexistent")` 对不存在的路径正确拒绝
- [ ] 在干净的 workspace clone 上跑一次完整 repo-init，确认 4 个 checkpoint 问题都被询问


Made with [Cursor](https://cursor.com)