### PR TITLE
feat: add ascend-memory-profiling skill with mandatory msprof collection

### DIFF
--- a/.agents/skills/ascend-memory-profiling/SKILL.md
+++ b/.agents/skills/ascend-memory-profiling/SKILL.md
@@ -29,7 +29,7 @@ Collect and analyze HBM memory usage on Ascend NPU devices running vLLM serving 
 | P0 | `msprof --application` wrapping | Full component breakdown (APP, HCCL, RUNTIME, SLOG) | Highest -- sees memory torch cannot manage |
 | P1 | `npu-smi info` | Static baseline + phased delta | High -- hardware-level |
 | P2 | vLLM startup logs | Weights, KV cache, num_gpu_blocks | Medium-high -- application-reported |
-| P3 | `safetensors` file headers | Exact tensor shapes, dtypes, per-component breakdown | High -- byte-accurate |
+| P3 | `safetensors` file headers | Tensor shapes, dtypes, byte sizes (byte-accurate); component classification and shard strategy are rule-based inference | High for byte sizes; medium for per-device attribution |
 | P4 | Model `config.json` | Theoretical weight calculation (fallback) | Reference only |
 
 ## Memory components
@@ -40,8 +40,8 @@ Collect and analyze HBM memory usage on Ascend NPU devices running vLLM serving 
 | Model weights | safetensors + vLLM logs | `weight_inspector.py` 解析文件头 → 按 TP/EP/DP 分片 → 与 vLLM `DeviceMemoryProfiler` 交叉验证 |
 | KV cache | vLLM logs | "Available KV cache memory: X GiB" |
 | ACL Graph 编译缓冲 | vLLM logs | "Graph capturing finished in X secs, took Y GiB" |
-| HCCL buffers | msprof | npu_module_mem.csv Component=HCCL |
-| CANN Runtime | msprof | npu_module_mem.csv Component=RUNTIME |
+| HCCL buffers | msprof | npu_module_mem.csv Component=HCCL (per-device when PROF→device mapping available, otherwise process-level) |
+| CANN Runtime | msprof | npu_module_mem.csv Component=RUNTIME (same scoping as HCCL) |
 | Activations | npu-smi delta | HBM during inference minus HBM at idle |
 | 未归因残差 | Residual | 所有已知组件加总后的余量 (有 msprof 时通常 < 200 MB) |
 
@@ -119,14 +119,15 @@ python3 .agents/skills/vllm-ascend-serving/scripts/serve_stop.py --machine <alia
 
 ### Step 4: Collect msprof data
 
-After stop, run `mem_collect --attach` again. It detects the msprof wrapper from the serving state, automatically runs `msprof --export`, and downloads the resulting CSVs:
+After stop, run `mem_collect --attach` again **with `--resume-run`** pointing to the run directory from Step 2. This merges the msprof CSV data into the same run, producing a single manifest with both live npu-smi data and post-stop msprof CSVs:
 
 ```bash
 python3 .agents/skills/ascend-memory-profiling/scripts/mem_collect.py \
-  --machine <alias> --attach --tag <same-experiment-name>
+  --machine <alias> --attach \
+  --resume-run .vaws-local/memory-profiling/<run-dir-from-step-2>/
 ```
 
-This works because attach mode accepts stopped services — it skips health check and inference, and focuses on collecting msprof CSVs that are now available.
+This works because attach mode accepts stopped services — it skips health check and inference, and focuses on collecting msprof CSVs that are now available. The `--resume-run` flag ensures all data lands in one directory.
 
 ### Step 5: Analyze and generate report
 
@@ -209,7 +210,7 @@ CANN Runtime                   |      125.3 |      0.122 |   0.4% | msprof npu_m
 
 ## Weight analysis methodology
 
-The skill uses `weight_inspector.py` to parse safetensors file headers on the remote machine, extracting exact tensor names, shapes, dtypes, and byte sizes. This provides a **byte-accurate** breakdown of model weights by component.
+The skill uses `weight_inspector.py` to parse safetensors file headers on the remote machine, extracting tensor names, shapes, dtypes, and byte sizes. Individual tensor byte sizes are **byte-accurate** from the file headers. Component classification (e.g. "Attention Q", "MoE Expert") and shard strategy assignment (col/row/expert parallel) are **rule-based inferences** from tensor name patterns, not direct measurements.
 
 ### How it works
 

--- a/.agents/skills/ascend-memory-profiling/SKILL.md
+++ b/.agents/skills/ascend-memory-profiling/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: ascend-memory-profiling
+description: Profile and attribute HBM memory usage on Ascend NPU for vLLM serving scenarios. Breaks down memory into fixed overhead, model weights, KV cache, HCCL buffers, activations, and runtime, with traceable evidence chains. Use for requests like "分析显存占用", "显存 profiling", "HBM 用了多少", "内存各部分拆分". Do not use for performance profiling (kernel timing, throughput), offline inference, or non-Ascend hardware.
+---
+
+# Ascend Memory Profiling
+
+Collect and analyze HBM memory usage on Ascend NPU devices running vLLM serving workloads. Produces a structured breakdown of memory by component, with every value traceable to its data source.
+
+## Use this skill when
+
+- the user asks to profile or analyze GPU/NPU memory (显存) usage
+- the user wants to understand what consumes HBM in a vLLM serving scenario
+- the user asks "权重/KV cache/HCCL/激活各占多少显存"
+- the user wants to verify memory allocation against theoretical expectations
+- the user asks to compare memory usage across different configurations
+
+## Do not use this skill when
+
+- the task is performance profiling (kernel timing, bubble analysis) → use `ascend-profiling-anomaly`
+- the task is starting/stopping a service without memory analysis → use `vllm-ascend-serving`
+- the task involves non-Ascend hardware
+- the task is offline (non-serving) inference only
+
+## Data source priority
+
+| Priority | Source | Role | Trustworthiness |
+|----------|--------|------|-----------------|
+| P0 | `msprof --application` wrapping | Full component breakdown (APP, HCCL, RUNTIME, SLOG) | Highest -- sees memory torch cannot manage |
+| P1 | `npu-smi info` | Static baseline + phased delta | High -- hardware-level |
+| P2 | vLLM startup logs | Weights, KV cache, num_gpu_blocks | Medium-high -- application-reported |
+| P3 | `safetensors` file headers | Exact tensor shapes, dtypes, per-component breakdown | High -- byte-accurate |
+| P4 | Model `config.json` | Theoretical weight calculation (fallback) | Reference only |
+
+## Memory components
+
+| Component | Source | How derived |
+|-----------|--------|-------------|
+| Fixed overhead (driver) | npu-smi Phase 0 | HBM_Used with no user process |
+| Model weights | safetensors + vLLM logs | `weight_inspector.py` 解析文件头 → 按 TP/EP/DP 分片 → 与 vLLM `DeviceMemoryProfiler` 交叉验证 |
+| KV cache | vLLM logs | "Available KV cache memory: X GiB" |
+| ACL Graph 编译缓冲 | vLLM logs | "Graph capturing finished in X secs, took Y GiB" |
+| HCCL buffers | msprof | npu_module_mem.csv Component=HCCL |
+| CANN Runtime | msprof | npu_module_mem.csv Component=RUNTIME |
+| Activations | npu-smi delta | HBM during inference minus HBM at idle |
+| 未归因残差 | Residual | 所有已知组件加总后的余量 (有 msprof 时通常 < 200 MB) |
+
+### Residual handling
+
+All memory attribution is based on measured data — **no estimation or guessing** is performed.
+
+- **With msprof**: HCCL, RUNTIME, SLOG are precise msprof measurements. Any remaining residual after all components is small (typically < 200 MB) and reported as "未归因残差".
+- **Without msprof**: The residual is reported as "未归因 (缺少 msprof 数据)" with an explicit note that msprof collection is needed for a complete breakdown. No attempt is made to split the residual into sub-components.
+
+## Workflow
+
+**Always use the `vllm-ascend-serving` skill for service lifecycle management.** This profiling skill only collects and analyzes data — it attaches to a running service. **msprof wrapping is mandatory** for a complete, traceable memory breakdown.
+
+### Step 0: Check msprof availability
+
+Before starting the service, verify that msprof is available on the remote machine:
+
+```bash
+python3 -c "
+import sys; sys.path.insert(0, '.agents/skills/ascend-memory-profiling/scripts')
+from _common import resolve_machine, endpoint_from_machine, check_msprof_available
+ep = endpoint_from_machine(resolve_machine('<alias>'))
+print(check_msprof_available(ep))
+"
+```
+
+If this fails, stop and fix the remote environment before proceeding.
+
+### Step 1: Prepare the service with msprof (via `vllm-ascend-serving`)
+
+Upload the msprof wrapper, then start the service with `--wrap-script`:
+
+```bash
+# Upload msprof wrapper to remote
+python3 -c "
+import sys; sys.path.insert(0, '.agents/skills/ascend-memory-profiling/scripts')
+from _common import resolve_machine, endpoint_from_machine, upload_msprof_wrapper
+ep = endpoint_from_machine(resolve_machine('<alias>'))
+print(upload_msprof_wrapper(ep, mem_freq=50))
+"
+# Start service with msprof wrapping
+python3 .agents/skills/vllm-ascend-serving/scripts/serve_start.py \
+  --machine <alias> --model <path> --tp <N> \
+  --wrap-script /tmp/_vaws_msprof_wrap.sh \
+  [-- --speculative-config '...' --compilation-config '...' ...]
+```
+
+Note: `upload_msprof_wrapper` internally calls `check_msprof_available` as a safety net.
+
+For baseline npu-smi data, collect `npu-smi info` **before** starting the service.
+
+### Step 2: Collect memory data (attach mode)
+
+```bash
+python3 .agents/skills/ascend-memory-profiling/scripts/mem_collect.py \
+  --machine <alias-or-ip> \
+  --attach \
+  [--baseline-from <previous-run-dir>] \
+  [--tag <experiment-name>]
+```
+
+What happens:
+- Reads `.vaws-local/serving/<alias>.json` to discover port, PID, model path, tp/dp, extra args
+- Auto-extracts `--speculative-config`, `--compilation-config`, etc. from the serving state
+- Collects npu-smi snapshot, vLLM logs (from serving's runtime dir), weight manifest
+- Sends inference request to collect activation delta
+- **Does NOT** start or stop the service
+
+### Step 3: Stop service (via `vllm-ascend-serving`)
+
+```bash
+python3 .agents/skills/vllm-ascend-serving/scripts/serve_stop.py --machine <alias>
+```
+
+### Step 4: Collect msprof data
+
+After stop, run `mem_collect --attach` again. It detects the msprof wrapper from the serving state, automatically runs `msprof --export`, and downloads the resulting CSVs:
+
+```bash
+python3 .agents/skills/ascend-memory-profiling/scripts/mem_collect.py \
+  --machine <alias> --attach --tag <same-experiment-name>
+```
+
+This works because attach mode accepts stopped services — it skips health check and inference, and focuses on collecting msprof CSVs that are now available.
+
+### Step 5: Analyze and generate report
+
+```bash
+python3 .agents/skills/ascend-memory-profiling/scripts/mem_analyze.py \
+  .vaws-local/memory-profiling/<run-dir>/
+```
+
+### Baseline strategy
+
+| Situation | How to get baseline |
+|-----------|-------------------|
+| Fresh profiling | Collect `npu-smi info` before `serve_start`, save to file, use `--baseline-from` |
+| Repeat profiling on same machine | Reuse baseline from a previous run via `--baseline-from <old-run-dir>` |
+| Quick analysis (no baseline needed) | Omit `--baseline-from` — report shows "固定开销" as 0 with note |
+
+### Fallback: Standalone mode
+
+When the serving skill is unavailable (e.g. bootstrap scenario), `mem_collect.py` can manage the service internally. This is a **fallback** — prefer the serving skill workflow above.
+
+```bash
+python3 .agents/skills/ascend-memory-profiling/scripts/mem_collect.py \
+  --machine <alias-or-ip> \
+  --model <remote-weight-path> \
+  --tp <N> [--dp <N>] [--tag <name>] \
+  [--speculative-config '...'] [--compilation-config '...'] ...
+```
+
+This runs all phases internally: baseline → start (with msprof) → health check → snapshot → inference → stop → msprof export. msprof is always enabled in standalone mode; a pre-flight check verifies msprof availability before starting.
+
+### Standalone: Analyze and generate report
+
+```bash
+python3 .agents/skills/ascend-memory-profiling/scripts/mem_analyze.py \
+  .vaws-local/memory-profiling/<run-dir>/
+```
+
+Outputs:
+- `report.txt` -- human-readable report with evidence chains
+- `report.json` -- machine-readable structured report
+
+### Example output (S2: MoE 35B, TP=4, DP=2, MTP=3, FULL_DECODE_ONLY, with msprof)
+
+```
+[Device 0] 总 HBM: 32.00 GiB | 已用: 27.42 GiB
+
+组件                           |    占用 (MB) |   占用 (GiB) |     占比 | 主数据源
+--------------------------------------------------------------------------------------------------------------
+固定开销 (driver/runtime)        |     2930.0 |      2.861 |  10.4% | npu-smi Phase 0 (baseline)
+模型权重                         |     9692.6 |      9.465 |  34.5% | safetensors 文件头精确计算
+KV Cache 预留                  |    14080.0 |     13.750 |  50.2% | vLLM 日志
+ACL Graph 编译缓冲               |      501.8 |      0.490 |   1.8% | vLLM 日志
+HCCL 缓冲                      |      597.7 |      0.584 |   2.1% | msprof npu_module_mem
+CANN Runtime                   |      125.3 |      0.122 |   0.4% | msprof npu_module_mem
+激活峰值                         |       72.0 |      0.070 |   0.3% | npu-smi delta
+  └ 未归因残差                    |       74.7 |      0.073 |   0.3% | 残差
+
+[交叉验证]
+  npu-smi 已用:          28,074 MB
+  组件加总:              27,999.3 MB
+  未归因:                74.7 MB (0.3%)
+  msprof APP:            27,500 MB
+```
+
+## Interaction with other skills
+
+| Skill | Interaction |
+|-------|-------------|
+| `vllm-ascend-serving` | **Service lifecycle**: Use `serve_start.py` to start (with `--wrap-script` for msprof), `serve_stop.py` to stop. This skill reads serving state from `.vaws-local/serving/<alias>.json`. The serving skill is agnostic to msprof — it only knows about the wrapper script. |
+| `machine-management` | **SSH endpoint resolution**: Both skills share the machine inventory via `inventory` from `.agents/lib/`. |
+| `remote-code-parity` | **Automatic via serving**: The serving skill calls parity sync before service start. |
+
+## Critical rules
+
+- **Service lifecycle belongs to `vllm-ascend-serving`** — this skill only collects and analyzes data.
+- In attach mode, `mem_collect` will **never** start or stop the service itself. Service stop is done by the agent calling `serve_stop.py` directly. After stop, `mem_collect --attach` can be run again to export and collect msprof data.
+- In standalone mode (fallback), the service is started and stopped within the profiling run.
+- `msprof` export (8 卡) 可能需要几分钟。
+- Keep collected data under `.vaws-local/memory-profiling/` only (untracked).
+
+## Weight analysis methodology
+
+The skill uses `weight_inspector.py` to parse safetensors file headers on the remote machine, extracting exact tensor names, shapes, dtypes, and byte sizes. This provides a **byte-accurate** breakdown of model weights by component.
+
+### How it works
+
+1. **Parse safetensors headers**: Each `.safetensors` file starts with a JSON header containing tensor metadata (name, shape, dtype, offsets). No weight data is read — only the header (typically a few KB per file).
+
+2. **Classify tensors**: Each tensor is categorized by name pattern:
+   - `embed_tokens` → Embedding
+   - `self_attn.{q,k,v,o}_proj` → Full Attention
+   - `linear_attn.{in_proj_qkv,in_proj_z,out_proj,conv1d,...}` → Linear/Mamba Attention
+   - `mlp.experts.*` → MoE Experts
+   - `mlp.shared_expert.*` → MoE Shared Expert
+   - `visual.*` → Vision Encoder
+   - `mtp.*` → MTP (Multi-Token Prediction)
+   - `norm`, `layernorm` → Layer Norms
+
+3. **Determine shard strategy**: Each tensor is assigned a parallelism strategy:
+   - `col_parallel` / `row_parallel` → divided by TP
+   - `expert_parallel` → divided by EP (= TP × DP when EP enabled)
+   - `replicated` → full copy on each device (norms, gates, small params)
+
+4. **Calculate per-device weight**: Sum up per-device bytes across all tensors.
+
+5. **Cross-validate with vLLM**: Compare safetensors-derived per-device value with vLLM's `DeviceMemoryProfiler` measurement. Expected differences:
+   - **MTP embedding/lm_head sharing**: MTP reuses base model's embeddings (reduces actual memory)
+   - **F32 → BF16 conversion**: Some small parameters (A_log, dt_bias) stored as F32 but may load as BF16
+   - **Vision encoder in text-only mode**: Still loaded for multimodal architectures
+
+### When the script isn't sufficient
+
+If the safetensors-based analysis shows unexpected results, the agent should:
+1. Check `weight_manifest.json` for unclassified ("other") tensors
+2. Inspect vLLM's model implementation (`load_weights`) for weight sharing or skipping logic
+3. Compare `model.named_parameters()` output on the remote machine with the safetensors manifest
+4. Check if `enable_ep_weight_filter` affects loading behavior
+
+## Limitations
+
+- Activation measurement relies on npu-smi delta between idle and inference states. This captures peak but not fine-grained activation lifetime.
+- `torch_npu.profiler` via vLLM's `/start_profile`/`/stop_profile` endpoints currently does not produce device-side data (device_0/data is empty). Use msprof wrapping instead.
+- msprof wrapping profiles the main process only. TP worker processes are separate -- each gets its own PROF directory with per-device data.
+- msprof export for 8-card runs may take several minutes. The timeout is set to 1800s.
+
+## References
+
+- `references/methodology.md` -- Detailed methodology and data source descriptions
+- `references/msprof_fields.md` -- msprof CSV field reference

--- a/.agents/skills/ascend-memory-profiling/references/methodology.md
+++ b/.agents/skills/ascend-memory-profiling/references/methodology.md
@@ -1,0 +1,108 @@
+# Methodology: Ascend NPU Memory Profiling
+
+## Core Principle
+
+**msprof is the primary data source.** It observes memory allocations at the CANN runtime level, capturing components that PyTorch's allocator cannot see (HCCL communication buffers, CANN runtime internal allocations, system logging buffers). npu-smi provides hardware-level ground truth for total HBM usage. vLLM logs provide application-level attribution for weights and KV cache.
+
+## Phased Collection
+
+### Phase 0: Static Baseline
+
+**Tool:** `npu-smi info`  
+**When:** Before any vLLM process starts  
+**What it measures:** Driver and base runtime memory that persists regardless of workload  
+**Typical values:** ~2800-3000 MB per 910B4 device  
+**Why needed:** Establishes the floor for delta calculations
+
+### Phase 1: Service Startup with msprof
+
+**Tool:** `msprof --application --sys-hardware-mem=on`  
+**When:** Wraps the vLLM serve process from start to finish  
+**What it captures:**
+- `npu_module_mem_*.csv`: Per-component (APP, HCCL, RUNTIME, SLOG, etc.) memory timeline at configurable sampling frequency
+- `npu_mem_*.csv`: Device-level and APP-level HBM timeline
+- `op_summary_*.csv`: Operator execution data
+- `communication_statistic_*.csv`: HCCL communication data
+
+**Key insight:** msprof creates one PROF directory per process. With TP=4, you get 4 PROF directories, one per worker. Each contains device-specific data.
+
+### Phase 2: Service Ready State
+
+**Tool:** `npu-smi info` + vLLM startup log parsing  
+**When:** After vLLM reports "Available routes are" (service ready)  
+**What it measures:**
+- Total HBM after model load + KV cache allocation
+- vLLM self-reported: "Loading model weights took X GB"
+- vLLM self-reported: "Available KV cache memory: X GiB"
+- vLLM self-reported: "GPU KV cache size: N tokens"
+
+### Phase 3: Under Inference Load
+
+**Tool:** `npu-smi info` + inference request  
+**When:** During active inference  
+**What it measures:** Peak HBM including activations  
+**Delta from Phase 2:** Activation memory estimate
+
+### Phase 4-5: Stop and Export
+
+**Tool:** Process termination + `msprof --export`  
+**What it does:** Converts binary PROF data to readable CSV format
+
+## Component Attribution Logic
+
+### Fixed Overhead
+```
+fixed_overhead = npu_smi_phase0.HBM_Used
+```
+This includes driver, base CANN runtime, and system services.
+
+### Model Weights
+```
+weights = vllm_log."Loading model weights took X GB"
+theory  = sum(param_count × bytes_per_element) / TP_size
+```
+Cross-validation: `|weights - theory| / theory < 5%` is expected.
+
+### KV Cache
+```
+kv_cache = vllm_log."Available KV cache memory: X GiB"
+```
+This is pre-allocated by the vLLM KV cache allocator. For MoE models, KV cache is shared across experts.
+
+### HCCL Buffers
+```
+hccl = max(msprof.npu_module_mem where Component=HCCL)
+```
+Communication buffers for tensor parallel all-reduce operations. Scale with TP size.
+
+### CANN Runtime
+```
+runtime = max(msprof.npu_module_mem where Component=RUNTIME)
+```
+CANN runtime's internal memory management overhead.
+
+### Activations
+```
+activations = npu_smi_phase3.HBM_Used - npu_smi_phase2.HBM_Used
+```
+Transient memory for intermediate computations during inference.
+
+### Unattributed
+```
+unattributed = npu_smi_ready.HBM_Used - sum(all_components)
+```
+Explicitly reported with percentage. Should be < 5% for a well-attributed profile.
+
+## Cross-Validation Strategy
+
+1. **npu-smi total vs component sum**: `|npu_smi - sum(components)| / npu_smi < 5%`
+2. **msprof APP vs vLLM (weights+KV)**: `APP ≈ weights + KV + minor_overhead`
+3. **Weights vs theory**: `|log_weight - theory_weight| / theory < 5%`
+4. **msprof Device vs npu-smi**: Should be close but may differ by timing
+
+## Known Behaviors
+
+- **msprof wrapping adds overhead**: ~50-60s extra startup time due to sys-hardware-mem sampling initialization
+- **npu-smi baseline varies**: The "fixed overhead" includes small transient allocations from other system services. Repeat measurement recommended.
+- **MoE models (e.g., Qwen3.5-35B-A3B)**: With EP=TP, each device holds a fraction of experts. Weight size per device may be counter-intuitive for MoE.
+- **expandable_segments**: vLLM sets `PYTORCH_NPU_ALLOC_CONF=expandable_segments:True`, meaning the PyTorch allocator may reserve more HBM than currently allocated. msprof APP tracks reserved (not just allocated).

--- a/.agents/skills/ascend-memory-profiling/references/msprof_fields.md
+++ b/.agents/skills/ascend-memory-profiling/references/msprof_fields.md
@@ -1,0 +1,101 @@
+# msprof Memory CSV Field Reference
+
+Based on Ascend CANN documentation and empirical verification.
+
+## 1. `npu_module_mem_*.csv` -- Component-Level Memory
+
+Automatically collected when `--sys-hardware-mem=on` is passed to msprof or when using `torch_npu.profiler`. Records per-component memory occupation over time.
+
+| Field | Description | Unit |
+|-------|-------------|------|
+| Device_id | Logical device index | -- |
+| Component | Module name (see table below) | -- |
+| Timestamp(us) | Sample timestamp | microseconds |
+| Total Reserved(KB) | Memory reserved by this component | KB (PROF dir) or MB (ASCEND_PROFILER_OUTPUT) |
+| Device | Device type and ID | e.g., "NPU:0" |
+
+### Key Components
+
+| Component | What it represents | Typical range (910B4) |
+|-----------|-------------------|----------------------|
+| APP | All application-level memory (PyTorch allocator + GE) | 10-25 GB |
+| HCCL | Communication buffers for collective ops (all-reduce, etc.) | 200-500 MB |
+| RUNTIME | CANN runtime internal allocations | 50-100 MB |
+| SLOG | System logging buffers | 100-150 MB |
+| GE | Graph Engine internal memory | Variable |
+| FE | Frontend memory | Small |
+| DEVMM | Device Memory Management | Small |
+| Others | AICPU, CCE, TBE, TS, etc. | Usually 0 |
+
+## 2. `npu_mem_*.csv` -- Device & APP Timeline
+
+Records overall device-level and application-level HBM usage over time.
+
+| Field | Description | Unit |
+|-------|-------------|------|
+| Device_id | Logical device index | -- |
+| event | "Device" (total HBM) or "APP" (application only) | -- |
+| ddr(KB) | DDR memory | KB |
+| hbm(KB) | HBM memory | KB |
+| memory(KB) | Total memory (usually = hbm) | KB |
+| timestamp(us) | Sample timestamp | microseconds |
+
+### Usage
+
+- `event=Device` rows show total HBM including driver/runtime
+- `event=APP` rows show only application-allocated memory
+- `Device - APP` ≈ system overhead (driver, runtime, HCCL, SLOG)
+
+## 3. `memory_record.csv` -- PTA/GE Allocation Timeline
+
+Requires `profile_memory=True` in `torch_npu.profiler`. Records PyTorch Allocator (PTA) and Graph Engine (GE) allocation events.
+
+| Field | Description | Unit |
+|-------|-------------|------|
+| Component | PTA / GE / PTA+GE (operator-level) / APP (process-level) | -- |
+| Timestamp(us) | Allocation start time | microseconds |
+| Total Allocated(MB) | Total memory allocated at this point | MB |
+| Total Reserved(MB) | Total memory reserved at this point | MB |
+| Total Active(MB) | Total active memory (including reused) | MB |
+| Stream Ptr | AscendCL stream memory address | -- |
+| Device Type | Device type and ID | e.g., "NPU:0" |
+
+### Notes
+- APP rows are sampled at regular intervals (process-level snapshot)
+- PTA rows appear at each allocation/deallocation event
+- PTA+GE rows combine both components for a unified view
+- `Reserved > Allocated` is normal due to PyTorch's caching allocator
+
+## 4. `operator_memory.csv` -- Per-Operator Memory
+
+Requires `profile_memory=True`. Records memory lifecycle for each operator.
+
+| Field | Description | Unit |
+|-------|-------------|------|
+| Name | Operator name (aten::* = PTA, cann::* = GE) | -- |
+| Size(KB) | Memory allocated by this operator | KB |
+| Allocation Time(us) | When memory was allocated | microseconds |
+| Release Time(us) | When memory was released (empty if not released) | microseconds |
+| Duration(us) | How long memory was held | microseconds |
+| Allocation Total Allocated(MB) | Global allocated total at allocation time | MB |
+| Allocation Total Reserved(MB) | Global reserved total at allocation time | MB |
+| Device Type | Device type and ID | -- |
+
+### Key patterns
+- `aten::empty` with large Size → weight tensor allocation
+- `aten::empty` without Release Time → permanent allocation (likely weights or KV cache)
+- `aten::matmul` with small Size → activation tensors (transient)
+
+## Collection Method Comparison
+
+| Feature | msprof --application | torch_npu.profiler | npu-smi |
+|---------|---------------------|-------------------|---------|
+| npu_module_mem | ✓ (auto) | ✓ (auto) | ✗ |
+| npu_mem | ✓ (auto) | ✓ (auto) | ✗ |
+| memory_record | ✗ | ✓ (needs profile_memory) | ✗ |
+| operator_memory | ✗ | ✓ (needs profile_memory) | ✗ |
+| Component breakdown | ✓ (HCCL, RUNTIME, etc.) | ✓ (60+ components) | ✗ |
+| Full lifecycle coverage | ✓ | Depends on schedule | ✗ |
+| Multi-process (TP>1) | ✓ (per-process PROF) | Depends on integration | ✓ |
+| Total HBM | Via npu_mem | Via npu_mem | ✓ |
+| Overhead | Moderate | Moderate | Minimal |

--- a/.agents/skills/ascend-memory-profiling/scripts/_common.py
+++ b/.agents/skills/ascend-memory-profiling/scripts/_common.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Shared utilities for ascend-memory-profiling scripts."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB_DIR = ROOT / ".agents" / "lib"
+MM_SCRIPTS = ROOT / ".agents" / "skills" / "machine-management" / "scripts"
+
+for _p in (str(LIB_DIR), str(MM_SCRIPTS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import inventory as inventory_store  # noqa: E402
+from vaws_local_state import ensure_state_dir  # noqa: E402
+
+MEMPROF_STATE_DIR = ROOT / ".vaws-local" / "memory-profiling"
+SERVING_STATE_DIR = ROOT / ".vaws-local" / "serving"
+PROGRESS_SENTINEL = "__VAWS_MEMPROF_PROGRESS__="
+
+ENV_PREAMBLE = (
+    "source /usr/local/Ascend/ascend-toolkit/set_env.sh 2>/dev/null; "
+    "source /usr/local/Ascend/nnal/atb/set_env.sh 2>/dev/null; "
+    "export LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64/common:"
+    "/usr/local/Ascend/driver/lib64/driver:"
+    "/usr/local/Ascend/driver/lib64:${LD_LIBRARY_PATH}; "
+)
+
+
+@dataclass(frozen=True)
+class SshEndpoint:
+    host: str
+    port: int
+    user: str = "root"
+
+    def destination(self) -> str:
+        return f"{self.user}@{self.host}"
+
+
+def _ssh_base_cmd(endpoint: SshEndpoint) -> list[str]:
+    return [
+        "ssh",
+        "-o", "BatchMode=yes",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", "LogLevel=ERROR",
+        "-p", str(endpoint.port),
+        endpoint.destination(),
+    ]
+
+
+def ssh_exec(
+    endpoint: SshEndpoint,
+    script: str,
+    *,
+    check: bool = True,
+    timeout: int | None = None,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [*_ssh_base_cmd(endpoint), "bash", "-c", shlex.quote(script)]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=timeout)
+    if check and result.returncode != 0:
+        raise RuntimeError(
+            f"remote command failed (rc={result.returncode}):\n"
+            f"stderr: {result.stderr[:2000]}"
+        )
+    return result
+
+
+def ssh_upload(endpoint: SshEndpoint, local_path: Path, remote_path: str) -> None:
+    """Upload a file to the remote machine via stdin redirect."""
+    cmd = [*_ssh_base_cmd(endpoint), f"cat > {shlex.quote(remote_path)}"]
+    with open(local_path, "rb") as f:
+        subprocess.run(cmd, stdin=f, check=True, capture_output=True)
+
+
+def ssh_write_text(endpoint: SshEndpoint, content: str, remote_path: str) -> None:
+    """Write text content to a remote file via stdin (avoids shell quoting issues)."""
+    cmd = [*_ssh_base_cmd(endpoint), f"cat > {shlex.quote(remote_path)}"]
+    subprocess.run(cmd, input=content.encode(), check=True, capture_output=True)
+
+
+def ssh_bg_exec(
+    endpoint: SshEndpoint,
+    script: str,
+) -> subprocess.Popen:
+    cmd = [*_ssh_base_cmd(endpoint), "bash", "-c", shlex.quote(script)]
+    return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+
+def progress(msg: str, **extra: Any) -> None:
+    payload = {"msg": msg, **extra}
+    print(f"{PROGRESS_SENTINEL}{json.dumps(payload, ensure_ascii=False)}", file=sys.stderr, flush=True)
+
+
+def resolve_machine(identifier: str) -> dict[str, Any]:
+    read_path = inventory_store.read_inventory_path(
+        inventory_store.preferred_inventory_path(inventory_store.DEFAULT_PATH)
+    )
+    inv = inventory_store.load_inventory(read_path)
+    for m in inv.get("machines", []):
+        alias = m.get("alias", "")
+        host_ip = m.get("host", {}).get("ip", "") if isinstance(m.get("host"), dict) else m.get("host", "")
+        if alias == identifier or host_ip == identifier:
+            return m
+    raise ValueError(f"Machine '{identifier}' not found in inventory")
+
+
+def endpoint_from_machine(machine: dict[str, Any]) -> SshEndpoint:
+    host_info = machine.get("host", {})
+    container_info = machine.get("container", {})
+
+    if isinstance(host_info, dict):
+        ip = host_info.get("ip", "")
+        host_port = host_info.get("port", 22)
+        user = host_info.get("user", "root")
+    else:
+        ip = host_info
+        host_port = 22
+        user = "root"
+
+    ssh_port = container_info.get("ssh_port", host_port)
+
+    return SshEndpoint(host=ip, port=ssh_port, user=user)
+
+
+def ensure_run_dir(tag: str = "") -> Path:
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    name = f"{ts}_{tag}" if tag else ts
+    d = MEMPROF_STATE_DIR / name
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def find_python(endpoint: SshEndpoint) -> str:
+    """Detect the Python binary with torch_npu on the remote machine."""
+    for candidate in [
+        "/usr/local/python3.11.14/bin/python3",
+        "/usr/local/python3.10/bin/python3",
+        "python3",
+    ]:
+        r = ssh_exec(endpoint, f"{ENV_PREAMBLE} {candidate} -c 'import torch_npu' 2>/dev/null && echo OK", check=False)
+        if "OK" in r.stdout:
+            return candidate
+    raise RuntimeError("No Python with torch_npu found on remote machine")
+
+
+def load_serving_state(machine_alias: str) -> dict[str, Any] | None:
+    """Read the serving skill's persisted state for a given machine.
+
+    Returns None if no state file exists or it's unparseable.
+    The state dict contains: model, pid, port, runtime_dir, log_stdout,
+    log_stderr, tp, dp, devices, status, started_at, etc.
+    """
+    path = SERVING_STATE_DIR / f"{machine_alias}.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def get_machine_alias(machine: dict[str, Any]) -> str:
+    """Extract the alias from a machine inventory entry."""
+    return machine.get("alias", machine.get("host", {}).get("ip", "unknown"))
+
+
+# ---------------------------------------------------------------------------
+# msprof environment check
+# ---------------------------------------------------------------------------
+
+def check_msprof_available(ep: SshEndpoint) -> dict[str, Any]:
+    """Verify that msprof is available on the remote machine.
+
+    Returns {"available": True, "path": str, "version": str} on success.
+    Raises RuntimeError with actionable fix instructions on failure.
+    """
+    r = ssh_exec(
+        ep,
+        f"{ENV_PREAMBLE} which msprof 2>/dev/null && msprof --version 2>&1 | head -3",
+        check=False,
+    )
+    lines = [l.strip() for l in r.stdout.strip().splitlines() if l.strip()]
+    if r.returncode != 0 or not lines:
+        raise RuntimeError(
+            "msprof 在远端不可用。显存 profiling 依赖 msprof 采集组件级内存数据。\n"
+            "请确认:\n"
+            "  1. CANN (ascend-toolkit) 已正确安装\n"
+            "  2. /usr/local/Ascend/ascend-toolkit/set_env.sh 可正常 source\n"
+            "  3. msprof 在 PATH 中 (通常位于 ascend-toolkit/bin/)\n"
+            f"远端输出: stdout={r.stdout[:300]!r}  stderr={r.stderr[:300]!r}"
+        )
+    msprof_path = lines[0]
+    version_info = " ".join(lines[1:]) if len(lines) > 1 else "unknown"
+    progress(f"msprof available: {msprof_path} ({version_info})")
+    return {"available": True, "path": msprof_path, "version": version_info}
+
+
+# ---------------------------------------------------------------------------
+# msprof wrapping helpers
+# ---------------------------------------------------------------------------
+
+MSPROF_WRAPPER_REMOTE_PATH = "/tmp/_vaws_msprof_wrap.sh"
+
+
+MSPROF_REPORTS_REMOTE_PATH = "/tmp/_vaws_msprof_reports.json"
+
+_MSPROF_REPORTS_CONFIG = json.dumps({
+    "json_process": {
+        "ascend": False, "acc_pmu": False, "cann": False, "ddr": False,
+        "stars_chip_trans": False, "hbm": True, "communication": False,
+        "hccs": False, "os_runtime_api": False, "network_usage": False,
+        "disk_usage": False, "memory_usage": False, "cpu_usage": False,
+        "msproftx": False, "npu_mem": True, "overlap_analyse": False,
+        "pcie": False, "sio": False, "stars_soc": False,
+        "step_trace": False, "freq": False, "llc": False,
+        "nic": False, "roce": False, "qos": False, "device_tx": False,
+    }
+}, indent=2)
+
+
+def upload_msprof_wrapper(ep: SshEndpoint, mem_freq: int = 1) -> str:
+    """Generate and upload an msprof wrapper script to the remote machine.
+
+    The wrapper receives two arguments from the serving skill's --wrap-script:
+      $1 = path to _serve.sh (the vLLM launch script)
+      $2 = runtime_dir
+
+    Calls check_msprof_available() first to fail fast if msprof is missing.
+    Returns the remote path to the uploaded wrapper.
+    """
+    check_msprof_available(ep)
+    script = f"""\
+#!/bin/bash
+# msprof wrapper — generated by ascend-memory-profiling skill.
+# $1 = serve script path, $2 = runtime dir
+SERVE_SCRIPT="$1"
+RUNTIME_DIR="$2"
+MSPROF_OUT="$RUNTIME_DIR/msprof_data"
+exec msprof --output="$MSPROF_OUT" \\
+  --sys-hardware-mem=on --sys-hardware-mem-freq={mem_freq} \\
+  --task-time=off \\
+  --ai-core=off \\
+  --ascendcl=off \\
+  --application="bash $SERVE_SCRIPT"
+"""
+    ssh_write_text(ep, script, MSPROF_WRAPPER_REMOTE_PATH)
+    ssh_exec(ep, f"chmod +x {MSPROF_WRAPPER_REMOTE_PATH}")
+    ssh_write_text(ep, _MSPROF_REPORTS_CONFIG, MSPROF_REPORTS_REMOTE_PATH)
+    return MSPROF_WRAPPER_REMOTE_PATH
+
+
+def run_msprof_export(
+    ep: SshEndpoint,
+    msprof_output_dir: str,
+    timeout: int = 1800,
+) -> list[str]:
+    """Run msprof --export on all PROF directories under *msprof_output_dir*.
+
+    A single ``msprof --export=on --output=<dir>`` call exports **every**
+    PROF_* subdirectory inside *dir*, so we only invoke it once regardless
+    of how many PROF directories exist.
+    """
+    progress("Running msprof export...")
+    r = ssh_exec(ep, f"find {shlex.quote(msprof_output_dir)} -maxdepth 1 -name 'PROF_*' -type d 2>/dev/null", check=False)
+    prof_dirs = [d.strip() for d in r.stdout.strip().splitlines() if d.strip()]
+    if not prof_dirs:
+        progress("WARNING: No PROF directories found for msprof export")
+        return []
+
+    progress(f"Exporting {len(prof_dirs)} PROF directories (timeout={timeout}s)...")
+    log_file = f"{msprof_output_dir}/_export.log"
+    reports_arg = ""
+    r_chk = ssh_exec(ep, f"test -f {MSPROF_REPORTS_REMOTE_PATH} && echo YES || echo NO", check=False)
+    if "YES" in r_chk.stdout:
+        reports_arg = f" --reports={MSPROF_REPORTS_REMOTE_PATH}"
+    ssh_exec(
+        ep,
+        f"{ENV_PREAMBLE} msprof --export=on --output={shlex.quote(msprof_output_dir)}"
+        f"{reports_arg} > {log_file} 2>&1 &",
+        check=False,
+        timeout=30,
+    )
+    import time as _time
+    deadline = _time.monotonic() + timeout
+    poll_interval = 10
+    while _time.monotonic() < deadline:
+        _time.sleep(poll_interval)
+        r = ssh_exec(ep, "pgrep -f '[m]sprof.*--export' >/dev/null 2>&1 && echo RUNNING || echo DONE", check=False, timeout=15)
+        if "DONE" in r.stdout:
+            break
+        poll_interval = min(poll_interval * 1.5, 60)
+    else:
+        progress("WARNING: msprof export timed out, proceeding with available CSVs")
+
+    progress(f"msprof export complete: {len(prof_dirs)} PROF directories")
+    return prof_dirs

--- a/.agents/skills/ascend-memory-profiling/scripts/mem_analyze.py
+++ b/.agents/skills/ascend-memory-profiling/scripts/mem_analyze.py
@@ -514,6 +514,7 @@ def generate_device_report(
     weight_theory: dict,
     weight_precise: dict,
     tp: int,
+    msprof_scope: str = "process-level",
 ) -> DeviceReport:
     """Generate a memory breakdown report for a single device."""
     baseline = baseline_hbm.get(dev_id, {})
@@ -610,12 +611,14 @@ def generate_device_report(
         evidence=kv_evidence,
     ))
 
+    scope_label = f" [{msprof_scope}]" if msprof_scope != "per-device" else ""
+
     # HCCL
     if hccl_mb > 0:
         report.components.append(MemoryComponent(
             name="HCCL 缓冲",
             value_mb=hccl_mb,
-            source="msprof npu_module_mem Component=HCCL",
+            source=f"msprof npu_module_mem Component=HCCL{scope_label}",
             evidence=f"npu_module_mem.csv: HCCL max = {hccl_mb:.2f} MB",
         ))
 
@@ -624,7 +627,7 @@ def generate_device_report(
         report.components.append(MemoryComponent(
             name="CANN Runtime",
             value_mb=runtime_mb,
-            source="msprof npu_module_mem Component=RUNTIME",
+            source=f"msprof npu_module_mem Component=RUNTIME{scope_label}",
             evidence=f"npu_module_mem.csv: RUNTIME max = {runtime_mb:.2f} MB",
         ))
 
@@ -633,7 +636,7 @@ def generate_device_report(
         report.components.append(MemoryComponent(
             name="SLOG (系统日志)",
             value_mb=slog_mb,
-            source="msprof npu_module_mem Component=SLOG",
+            source=f"msprof npu_module_mem Component=SLOG{scope_label}",
             evidence=f"npu_module_mem.csv: SLOG max = {slog_mb:.2f} MB",
         ))
 
@@ -642,7 +645,7 @@ def generate_device_report(
         report.components.append(MemoryComponent(
             name="其他 msprof 组件",
             value_mb=other_msprof,
-            source="msprof npu_module_mem (minor components)",
+            source=f"msprof npu_module_mem (minor components){scope_label}",
             evidence=f"Sum of minor components = {other_msprof:.2f} MB",
         ))
 
@@ -857,14 +860,32 @@ def main() -> None:
     log_path = run_dir / "vllm_serve.log"
     vllm_info = parse_vllm_logs(log_path.read_text()) if log_path.exists() else {}
 
-    # Parse msprof data — merge all npu_module_mem slices (slice_0 has
-    # APP/HCCL/RUNTIME/SLOG, slice_1 may have FFTS/other minor components)
-    msprof_components: dict[str, float] = {}
+    # Parse msprof data — build per-device component dicts.
+    # The manifest's __prof_device_map__ maps CSV filenames to device IDs,
+    # allowing per-device attribution when DP > 1 (multiple PROF directories).
+    prof_device_map: dict[str, list[int]] = {}
+    msprof_csvs_meta = manifest.get("msprof_csvs", {})
+    if isinstance(msprof_csvs_meta, dict):
+        prof_device_map = msprof_csvs_meta.get("__prof_device_map__", {})
+
+    per_device_msprof: dict[int, dict[str, float]] = {}
+    global_msprof: dict[str, float] = {}
+
     for csv_path in find_all_msprof_csvs(run_dir, "npu_module_mem"):
         partial = parse_npu_module_mem_csv(csv_path)
+        devs = prof_device_map.get(csv_path.name, [])
+
+        if devs:
+            for dev_id in devs:
+                if dev_id not in per_device_msprof:
+                    per_device_msprof[dev_id] = {}
+                for comp, val in partial.items():
+                    if val > per_device_msprof[dev_id].get(comp, 0):
+                        per_device_msprof[dev_id][comp] = val
+        # Always merge into global for fallback / cross-validation
         for comp, val in partial.items():
-            if val > msprof_components.get(comp, 0):
-                msprof_components[comp] = val
+            if val > global_msprof.get(comp, 0):
+                global_msprof[comp] = val
 
     # Weight analysis: prefer safetensors manifest, fallback to config estimate
     tp = manifest.get("tp", 1)
@@ -906,16 +927,18 @@ def main() -> None:
     for dev_id in devices:
         if isinstance(dev_id, int) and dev_id >= total_devices:
             continue
+        device_msprof = per_device_msprof.get(dev_id, global_msprof)
         report = generate_device_report(
             dev_id=dev_id,
             baseline_hbm=baseline_hbm,
             after_ready_hbm=after_ready_hbm,
             after_infer_hbm=after_infer_hbm,
-            msprof_components=msprof_components,
+            msprof_components=device_msprof,
             vllm_info=vllm_info,
             weight_theory=weight_theory,
             weight_precise=weight_precise,
             tp=tp,
+            msprof_scope="per-device" if dev_id in per_device_msprof else "process-level",
         )
         reports.append(report)
 
@@ -927,7 +950,8 @@ def main() -> None:
     json_report = {
         "manifest": manifest,
         "vllm_info": vllm_info,
-        "msprof_components": {k: round(v, 2) for k, v in msprof_components.items()},
+        "msprof_components_global": {k: round(v, 2) for k, v in global_msprof.items()},
+        "msprof_per_device": {str(d): {k: round(v, 2) for k, v in comps.items()} for d, comps in per_device_msprof.items()},
         "weight_theory": weight_theory,
         "weight_precise": weight_precise,
         "devices": [asdict(r) for r in reports],

--- a/.agents/skills/ascend-memory-profiling/scripts/mem_analyze.py
+++ b/.agents/skills/ascend-memory-profiling/scripts/mem_analyze.py
@@ -1,0 +1,942 @@
+#!/usr/bin/env python3
+"""
+Ascend Memory Profiling -- Analysis & Report Generator.
+
+Reads the data collected by mem_collect.py and produces a structured memory
+breakdown report with cross-validation and evidence chains.
+
+Input: path to a collection run directory (containing manifest.json)
+Output: printed report + saved report.json / report.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class MemoryComponent:
+    name: str
+    value_mb: float
+    source: str
+    evidence: str = ""
+    corroboration: str = ""
+    delta_pct: float = 0.0
+
+
+@dataclass
+class DeviceReport:
+    device_id: int
+    total_hbm_mb: float
+    used_hbm_mb: float
+    components: list[MemoryComponent] = field(default_factory=list)
+    cross_validation: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# npu-smi parsing
+# ---------------------------------------------------------------------------
+
+def parse_npu_smi_hbm(data: dict[str, dict]) -> dict[int, dict]:
+    """Parse npu-smi HBM data from manifest."""
+    result = {}
+    for dev_str, info in data.items():
+        dev_id = int(dev_str) if isinstance(dev_str, str) and dev_str.isdigit() else dev_str
+        result[dev_id] = info
+    return result
+
+
+# ---------------------------------------------------------------------------
+# vLLM log parsing
+# ---------------------------------------------------------------------------
+
+_WEIGHT_RE = re.compile(r"Loading model weights took\s+([\d.]+)\s*G[Bi]")
+_KV_AVAIL_RE = re.compile(r"Available KV cache memory:\s+([\d.]+)\s*GiB")
+_KV_TOKENS_RE = re.compile(r"GPU KV cache size:\s+([\d,]+)\s*tokens")
+_WEIGHT_LOAD_TIME_RE = re.compile(r"Loading weights took\s+([\d.]+)\s*seconds")
+_GRAPH_CAPTURE_RE = re.compile(r"Graph capturing finished in (\d+) secs, took ([\d.]+) GiB")
+_COMPILE_WARMUP_RE = re.compile(r"torch\.compile and initial profiling/warmup run together took ([\d.]+) s")
+_ENCODER_CACHE_RE = re.compile(r"Encoder cache will be initialized with a budget of (\d+) tokens")
+_ACL_GRAPH_SIZES_RE = re.compile(r"with (\d+) sizes")
+
+
+def parse_vllm_logs(log_text: str) -> dict[str, Any]:
+    """Extract memory-related info from vLLM startup logs."""
+    info: dict[str, Any] = {}
+    graph_capture_gibs: list[float] = []
+
+    for line in log_text.splitlines():
+        m = _WEIGHT_RE.search(line)
+        if m:
+            info["weights_gb"] = float(m.group(1))
+
+        m = _KV_AVAIL_RE.search(line)
+        if m:
+            info["kv_cache_available_gib"] = float(m.group(1))
+
+        m = _KV_TOKENS_RE.search(line)
+        if m:
+            info["kv_cache_tokens"] = int(m.group(1).replace(",", ""))
+
+        m = _WEIGHT_LOAD_TIME_RE.search(line)
+        if m:
+            info["weight_load_seconds"] = float(m.group(1))
+
+        m = _GRAPH_CAPTURE_RE.search(line)
+        if m:
+            graph_capture_gibs.append(float(m.group(2)))
+
+        m = _COMPILE_WARMUP_RE.search(line)
+        if m and "compile_warmup_seconds" not in info:
+            info["compile_warmup_seconds"] = float(m.group(1))
+
+        m = _ENCODER_CACHE_RE.search(line)
+        if m:
+            info["encoder_cache_tokens"] = int(m.group(1))
+
+        m = _ACL_GRAPH_SIZES_RE.search(line)
+        if m and "acl_graph_sizes_count" not in info:
+            info["acl_graph_sizes_count"] = int(m.group(1))
+
+        if "gpu_memory_utilization" in line:
+            m2 = re.search(r"gpu_memory_utilization['\"]?\s*[:=]\s*([\d.]+)", line)
+            if m2:
+                info["gpu_memory_utilization"] = float(m2.group(1))
+
+        if "num_gpu_blocks" in line:
+            m2 = re.search(r"num_gpu_blocks\s*[:=]\s*(\d+)", line)
+            if m2:
+                info["num_gpu_blocks"] = int(m2.group(1))
+
+    if graph_capture_gibs:
+        info["graph_capture_gib"] = max(graph_capture_gibs)
+        info["graph_capture_count"] = len(graph_capture_gibs)
+
+    return info
+
+
+# ---------------------------------------------------------------------------
+# msprof CSV parsing
+# ---------------------------------------------------------------------------
+
+def parse_npu_module_mem_csv(csv_path: Path) -> dict[str, float]:
+    """Parse npu_module_mem CSV, return {component: max_reserved_mb}."""
+    components: dict[str, float] = {}
+    with open(csv_path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            comp = row.get("Component", "").strip()
+            unit_key = "Total Reserved(MB)"
+            if unit_key not in row:
+                unit_key = "Total Reserved(KB)"
+            raw = row.get(unit_key, "0").strip()
+            try:
+                val = float(raw)
+            except ValueError:
+                continue
+            if "KB" in unit_key:
+                val /= 1024.0
+            if val > components.get(comp, 0):
+                components[comp] = val
+    return components
+
+
+def parse_npu_mem_csv(csv_path: Path) -> dict[str, list[dict]]:
+    """Parse npu_mem CSV, return {event: [{timestamp, hbm_kb}]}."""
+    events: dict[str, list[dict]] = {}
+    with open(csv_path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            event = row.get("event", "").strip()
+            hbm = row.get("hbm(KB)", "0").strip()
+            ts = row.get("timestamp(us)", "0").strip()
+            try:
+                hbm_val = float(hbm)
+                ts_val = float(ts)
+            except ValueError:
+                continue
+            events.setdefault(event, []).append({"timestamp_us": ts_val, "hbm_kb": hbm_val})
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Safetensors-based precise weight analysis
+# ---------------------------------------------------------------------------
+
+_SHARD_COL = "col_parallel"
+_SHARD_ROW = "row_parallel"
+_SHARD_EP = "expert_parallel"
+_SHARD_REPL = "replicated"
+
+_CATEGORY_DISPLAY = {
+    "embedding": "Embedding",
+    "lm_head": "LM Head",
+    "attn_q": "Attention Q",
+    "attn_k": "Attention K",
+    "attn_v": "Attention V",
+    "attn_o": "Attention O",
+    "attn_conv": "Attention Conv",
+    "attn_kv_compress": "Attention KV Compress",
+    "attn_other": "Attention Other",
+    "linear_attn_qkv": "Linear Attn QKV",
+    "linear_attn_proj": "Linear Attn Proj (Z/O)",
+    "linear_attn_conv": "Linear Attn Conv1d",
+    "linear_attn_param": "Linear Attn Param",
+    "ffn": "FFN (Dense)",
+    "moe_expert": "MoE Experts",
+    "moe_shared_expert": "MoE Shared Expert",
+    "moe_gate": "MoE Router Gate",
+    "moe_other": "MoE Other",
+    "norm": "LayerNorm / RMSNorm",
+    "vision": "Vision Encoder",
+    "mtp_expert": "MTP Experts",
+    "mtp_shared_expert": "MTP Shared Expert",
+    "mtp_gate": "MTP Router Gate",
+    "mtp_attn": "MTP Attention",
+    "mtp_fc": "MTP FC Proj",
+    "mtp_norm": "MTP Norm",
+    "mtp_other": "MTP Other",
+    "quant_param": "Quant Scales/ZP",
+    "other": "Other",
+}
+
+_GROUP_ORDER = [
+    "embedding", "lm_head",
+    "attn_q", "attn_k", "attn_v", "attn_o",
+    "attn_conv", "attn_kv_compress", "attn_other",
+    "linear_attn_qkv", "linear_attn_proj", "linear_attn_conv", "linear_attn_param",
+    "ffn",
+    "moe_expert", "moe_shared_expert", "moe_gate", "moe_other",
+    "norm", "vision",
+    "mtp_expert", "mtp_shared_expert", "mtp_gate", "mtp_attn", "mtp_fc", "mtp_norm", "mtp_other",
+    "quant_param", "other",
+]
+
+
+def compute_weight_from_manifest(
+    weight_manifest: dict,
+    tp: int,
+    dp: int = 1,
+    enable_ep: bool = False,
+) -> dict[str, Any]:
+    """Compute per-device weight size from safetensors manifest.
+
+    Returns a dict with total bytes, per-device bytes, and per-category breakdown.
+    """
+    if not weight_manifest or "tensors" not in weight_manifest:
+        return {}
+
+    ep = tp * dp if enable_ep else tp
+    tensors = weight_manifest["tensors"]
+
+    total_bytes = 0
+    per_device_bytes = 0
+    categories: dict[str, dict] = {}
+
+    for t in tensors:
+        cat = t.get("category", "other")
+        strategy = t.get("shard_strategy", _SHARD_REPL)
+        bsz = t.get("byte_size", 0)
+
+        total_bytes += bsz
+
+        if strategy in (_SHARD_COL, _SHARD_ROW):
+            dev_bytes = bsz / tp
+        elif strategy == _SHARD_EP:
+            dev_bytes = bsz / ep
+        else:
+            dev_bytes = bsz
+
+        per_device_bytes += dev_bytes
+
+        if cat not in categories:
+            categories[cat] = {
+                "total_bytes": 0,
+                "per_device_bytes": 0.0,
+                "tensor_count": 0,
+                "dtypes": set(),
+                "shard_strategy": strategy,
+            }
+        categories[cat]["total_bytes"] += bsz
+        categories[cat]["per_device_bytes"] += dev_bytes
+        categories[cat]["tensor_count"] += t.get("numel", 0)
+        categories[cat]["dtypes"].add(t.get("dtype", "?"))
+
+    for cat in categories:
+        categories[cat]["dtypes"] = sorted(categories[cat]["dtypes"])
+
+    sorted_cats = []
+    for key in _GROUP_ORDER:
+        if key in categories:
+            c = categories[key]
+            sorted_cats.append({
+                "category": key,
+                "display_name": _CATEGORY_DISPLAY.get(key, key),
+                "total_bytes": c["total_bytes"],
+                "total_gib": round(c["total_bytes"] / (1024**3), 4),
+                "per_device_bytes": c["per_device_bytes"],
+                "per_device_gib": round(c["per_device_bytes"] / (1024**3), 4),
+                "dtypes": c["dtypes"],
+            })
+
+    return {
+        "source": "safetensors_manifest",
+        "total_bytes": total_bytes,
+        "total_gib": round(total_bytes / (1024**3), 4),
+        "per_device_bytes": per_device_bytes,
+        "per_device_gib": round(per_device_bytes / (1024**3), 4),
+        "tp": tp,
+        "dp": dp,
+        "ep": ep,
+        "categories": sorted_cats,
+    }
+
+
+def format_weight_breakdown(weight_info: dict, vllm_gb: float = 0) -> list[str]:
+    """Format the per-category weight breakdown as text lines."""
+    lines = []
+    lines.append("[权重精确分析] (数据源: safetensors 文件头)")
+    per_dev_gib = weight_info['per_device_gib']
+    per_dev_gb = per_dev_gib * 1024**3 / 10**9
+    lines.append(f"  总权重(文件): {weight_info['total_gib']:.4f} GiB | "
+                 f"每设备(理论分片): {per_dev_gib:.4f} GiB ({per_dev_gb:.4f} GB)")
+    lines.append(f"  分片策略: TP={weight_info['tp']}, DP={weight_info['dp']}, "
+                 f"EP={weight_info['ep']}")
+    if vllm_gb:
+        vllm_gib = vllm_gb * 10**9 / 1024**3
+        diff_gib = per_dev_gib - vllm_gib
+        diff_pct = abs(diff_gib) / vllm_gib * 100 if vllm_gib else 0
+        lines.append(f"  vLLM 实际加载: {vllm_gb:.4f} GB ({vllm_gib:.4f} GiB)")
+        sign = "+" if diff_gib > 0 else ""
+        lines.append(f"  差值(safetensors vs vLLM): {sign}{diff_gib:.4f} GiB ({diff_pct:.1f}%)")
+        if diff_gib > 0.1:
+            lines.append("  说明: safetensors 高于 vLLM 实际值，可能原因:")
+            lines.append("    - MTP 模块复用 base model 的 embed_tokens/lm_head (共享内存)")
+            lines.append("    - 部分 F32 参数在加载时被转为 BF16")
+            lines.append("    - vision encoder 在纯文本推理下可能未加载")
+    lines.append("")
+    lines.append(f"  {'组件':<28} | {'总量 (GiB)':>10} | {'每设备 (GiB)':>12} | {'占比':>6} | dtypes")
+    lines.append("  " + "-" * 90)
+
+    total_dev = weight_info["per_device_bytes"]
+    for cat in weight_info.get("categories", []):
+        pct = cat["per_device_bytes"] / total_dev * 100 if total_dev else 0
+        lines.append(
+            f"  {cat['display_name']:<28} | {cat['total_gib']:>10.4f} | "
+            f"{cat['per_device_gib']:>12.4f} | {pct:>5.1f}% | {', '.join(cat['dtypes'])}"
+        )
+    lines.append("")
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Model config / fallback theoretical weight calculation
+# ---------------------------------------------------------------------------
+
+DTYPE_BYTES = {"bfloat16": 2, "float16": 2, "float32": 4, "float8": 1, "int8": 1, "int4": 0.5}
+
+
+def _estimate_vision_params(config: dict) -> int:
+    """Estimate parameter count for the vision encoder (ViT)."""
+    vc = config.get("vision_config")
+    if not vc or not isinstance(vc, dict):
+        return 0
+    hidden = vc.get("hidden_size", 0)
+    inter = vc.get("intermediate_size", 0)
+    depth = vc.get("depth", 0)
+    patch = vc.get("patch_size", 16)
+    in_ch = vc.get("in_channels", 3)
+    temp_patch = vc.get("temporal_patch_size", 2)
+    out_hidden = vc.get("out_hidden_size", hidden)
+    num_pos = vc.get("num_position_embeddings", 0)
+
+    if not (hidden and depth):
+        return 0
+
+    patch_embed = in_ch * temp_patch * patch * patch * hidden
+    pos_embed = num_pos * hidden if num_pos else 0
+
+    per_block = (
+        hidden * 3 * hidden  # QKV
+        + hidden * hidden     # proj
+        + 2 * hidden * inter  # MLP (fc1 + fc2)
+        + 4 * hidden          # norms
+    )
+    merger = out_hidden * hidden * 4 if out_hidden != hidden else 0
+    return patch_embed + pos_embed + depth * per_block + merger
+
+
+def _estimate_mtp_params(tc: dict) -> int:
+    """Estimate parameter count for MTP (multi-token prediction) heads."""
+    mtp_layers = tc.get("mtp_num_hidden_layers", 0)
+    if not mtp_layers:
+        return 0
+    hidden = tc.get("hidden_size", 0)
+    intermediate = tc.get("intermediate_size") or (hidden * 4)
+    vocab_size = tc.get("vocab_size", 0)
+    use_dedicated_embed = tc.get("mtp_use_dedicated_embeddings", False)
+
+    per_mtp_layer = (
+        hidden * hidden  # proj
+        + 3 * hidden * intermediate  # FFN
+        + 4 * hidden  # norms
+    )
+    mtp_lm_head = vocab_size * hidden if not tc.get("tie_word_embeddings", True) else 0
+    mtp_embed = vocab_size * hidden if use_dedicated_embed else 0
+    return mtp_layers * (per_mtp_layer + mtp_lm_head + mtp_embed)
+
+
+def estimate_weight_size(config: dict, tp: int, dp: int = 1) -> dict[str, Any]:
+    """Estimate theoretical model weight size from config.json."""
+    tc = config.get("text_config", config)
+    hidden = tc.get("hidden_size", 0)
+    num_layers = tc.get("num_hidden_layers", 0)
+    vocab_size = tc.get("vocab_size", 0)
+    intermediate = tc.get("intermediate_size") or 0
+    moe_intermediate = tc.get("moe_intermediate_size") or 0
+    shared_expert_intermediate = tc.get("shared_expert_intermediate_size") or 0
+    num_experts = tc.get("num_experts") or 0
+    num_kv_heads = tc.get("num_key_value_heads") or 0
+    num_attn_heads = tc.get("num_attention_heads") or 0
+    head_dim = tc.get("head_dim") or (hidden // num_attn_heads if num_attn_heads else 0)
+    dtype = tc.get("dtype", config.get("torch_dtype", "bfloat16"))
+    bpe = DTYPE_BYTES.get(dtype, 2)
+
+    if not (hidden and num_layers and vocab_size):
+        return {"error": "missing config fields", "dtype": dtype}
+
+    tie = tc.get("tie_word_embeddings", config.get("tie_word_embeddings", False))
+    embed_params = vocab_size * hidden
+    lm_head_params = 0 if tie else vocab_size * hidden
+
+    # Attention -- handle hybrid linear/full attention
+    linear_key_head_dim = tc.get("linear_key_head_dim", 0)
+    linear_num_kv_heads = tc.get("linear_num_key_heads", 0)
+    layer_types = tc.get("layer_types", [])
+
+    def _attn_params(layer_type: str = "full_attention") -> int:
+        if layer_type == "linear_attention" and linear_key_head_dim and linear_num_kv_heads:
+            lv_dim = tc.get("linear_value_head_dim", linear_key_head_dim)
+            return (
+                hidden * num_attn_heads * head_dim  # Q
+                + hidden * linear_num_kv_heads * linear_key_head_dim  # K
+                + hidden * linear_num_kv_heads * lv_dim  # V
+                + num_attn_heads * head_dim * hidden  # O
+                + hidden * tc.get("linear_conv_kernel_dim", 4)  # conv
+            )
+        return (
+            hidden * num_attn_heads * head_dim
+            + hidden * num_kv_heads * head_dim
+            + hidden * num_kv_heads * head_dim
+            + num_attn_heads * head_dim * hidden
+        )
+
+    total_attn_params = 0
+    if layer_types:
+        for lt in layer_types:
+            total_attn_params += _attn_params(lt)
+    else:
+        total_attn_params = num_layers * _attn_params()
+
+    norm_params_per_layer = hidden * 4
+    total_norm_params = num_layers * norm_params_per_layer
+
+    if num_experts and num_experts > 1:
+        expert_ff = moe_intermediate or intermediate
+        expert_params_per_layer = num_experts * 3 * hidden * expert_ff
+        shared_params_per_layer = 3 * hidden * shared_expert_intermediate if shared_expert_intermediate else 0
+        gate_params_per_layer = hidden * num_experts
+        ff_params_per_layer = expert_params_per_layer + shared_params_per_layer + gate_params_per_layer
+    else:
+        ff_intermediate = intermediate or (hidden * 4)
+        ff_params_per_layer = 3 * hidden * ff_intermediate
+
+    total_ff_params = num_layers * ff_params_per_layer
+
+    vision_params = _estimate_vision_params(config)
+    mtp_params = _estimate_mtp_params(tc)
+
+    total_params = (
+        embed_params + lm_head_params
+        + total_attn_params + total_ff_params + total_norm_params
+        + vision_params + mtp_params
+    )
+    total_bytes = total_params * bpe
+
+    # Per-device calculation
+    if num_experts and num_experts > 1 and tp > 1:
+        ep = tp * dp
+        attn_bytes = total_attn_params * bpe / tp
+        expert_bytes = num_layers * num_experts * 3 * hidden * (moe_intermediate or intermediate) * bpe / ep
+        shared_bytes = num_layers * 3 * hidden * shared_expert_intermediate * bpe / tp if shared_expert_intermediate else 0
+        gate_bytes = num_layers * hidden * num_experts * bpe
+        embed_bytes = (embed_params + lm_head_params) * bpe / tp
+        norm_bytes = total_norm_params * bpe
+        vision_bytes = vision_params * bpe
+        mtp_bytes = mtp_params * bpe
+        per_device_bytes = attn_bytes + expert_bytes + shared_bytes + gate_bytes + embed_bytes + norm_bytes + vision_bytes + mtp_bytes
+    else:
+        per_device_bytes = total_bytes / tp if tp else total_bytes
+
+    return {
+        "total_params_estimate": total_params,
+        "dtype": dtype,
+        "bytes_per_element": bpe,
+        "total_weight_bytes": total_bytes,
+        "per_device_weight_bytes": per_device_bytes,
+        "per_device_weight_gib": per_device_bytes / (1024 ** 3),
+        "tp": tp,
+        "is_moe": bool(num_experts and num_experts > 1),
+        "num_experts": num_experts,
+        "vision_params": vision_params,
+        "mtp_params": mtp_params,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+def generate_device_report(
+    dev_id: int,
+    baseline_hbm: dict,
+    after_ready_hbm: dict,
+    after_infer_hbm: dict,
+    msprof_components: dict[str, float],
+    vllm_info: dict,
+    weight_theory: dict,
+    weight_precise: dict,
+    tp: int,
+) -> DeviceReport:
+    """Generate a memory breakdown report for a single device."""
+    baseline = baseline_hbm.get(dev_id, {})
+    ready = after_ready_hbm.get(dev_id, {})
+    infer = after_infer_hbm.get(dev_id, {})
+
+    total_mb = ready.get("total_mb", 32768)
+    used_mb = ready.get("used_mb", 0)
+    baseline_mb = baseline.get("used_mb", 0)
+
+    report = DeviceReport(
+        device_id=dev_id,
+        total_hbm_mb=total_mb,
+        used_hbm_mb=used_mb,
+    )
+
+    # Fixed overhead (driver/runtime base)
+    if baseline_mb > 0:
+        report.components.append(MemoryComponent(
+            name="固定开销 (driver/runtime)",
+            value_mb=baseline_mb,
+            source="npu-smi Phase 0 (baseline, 无用户进程)",
+            evidence=f"baseline_npu_smi.txt: Device {dev_id} HBM_Used = {baseline_mb} MB",
+        ))
+    else:
+        report.components.append(MemoryComponent(
+            name="固定开销 (driver/runtime)",
+            value_mb=0,
+            source="不可用 (attach 模式无基线数据)",
+            evidence="服务已在运行，无法获取空载基线; 可通过 --baseline-from 复用历史数据",
+        ))
+
+    # msprof component breakdown
+    app_mb = msprof_components.get("APP", 0)
+    hccl_mb = msprof_components.get("HCCL", 0)
+    runtime_mb = msprof_components.get("RUNTIME", 0)
+    slog_mb = msprof_components.get("SLOG", 0)
+    other_msprof = sum(v for k, v in msprof_components.items()
+                       if k not in ("APP", "HCCL", "RUNTIME", "SLOG") and v > 0)
+
+    # Weight analysis: prefer vLLM log (actual measurement), fall back to
+    # safetensors-precise, then config theory.  vLLM's DeviceMemoryProfiler
+    # captures the real memory delta during weight loading, which accounts
+    # for weight sharing, dtype conversion, and load-time filtering.
+    weights_gb = vllm_info.get("weights_gb", 0)
+    precise_gib = weight_precise.get("per_device_gib", 0) if weight_precise else 0
+    theory_gib = weight_theory.get("per_device_weight_gib", 0)
+
+    if weights_gb:
+        weights_mb = weights_gb * 1024
+        weight_source = "vLLM DeviceMemoryProfiler"
+        weight_evidence = f"vllm_serve.log: Loading model weights took {weights_gb:.4f} GB"
+    elif precise_gib:
+        weights_mb = precise_gib * 1024
+        weight_source = "safetensors 文件头精确计算"
+        weight_evidence = f"weight_manifest.json: per_device = {precise_gib:.4f} GiB"
+    else:
+        weights_mb = 0
+        weight_source = "不可用"
+        weight_evidence = "无 vLLM 日志且无 safetensors 数据"
+
+    weight_corr = []
+    if precise_gib:
+        weight_corr.append(f"safetensors 精确值: {precise_gib:.4f} GiB")
+    if weights_gb:
+        weight_corr.append(f"vLLM 日志: {weights_gb:.4f} GB")
+    if precise_gib and weights_gb:
+        diff_pct = abs(weights_gb - precise_gib) / precise_gib * 100 if precise_gib else 0
+        weight_corr.append(f"safetensors vs vLLM 误差: {diff_pct:.1f}%")
+    elif theory_gib and weights_gb:
+        diff_pct = abs(weights_gb - theory_gib) / theory_gib * 100 if theory_gib else 0
+        weight_corr.append(f"config 理论值: {theory_gib:.2f} GiB / 误差: {diff_pct:.1f}%")
+
+    report.components.append(MemoryComponent(
+        name="模型权重",
+        value_mb=weights_mb,
+        source=weight_source,
+        evidence=weight_evidence,
+        corroboration=" / ".join(weight_corr) if weight_corr else "",
+    ))
+
+    # KV cache
+    kv_gib = vllm_info.get("kv_cache_available_gib", 0)
+    kv_mb = kv_gib * 1024
+    kv_tokens = vllm_info.get("kv_cache_tokens", 0)
+    kv_evidence = f"vllm_serve.log: Available KV cache = {kv_gib:.2f} GiB"
+    if kv_tokens:
+        kv_evidence += f", {kv_tokens:,} tokens"
+
+    report.components.append(MemoryComponent(
+        name="KV Cache 预留",
+        value_mb=kv_mb,
+        source="vLLM 日志 'Available KV cache memory'",
+        evidence=kv_evidence,
+    ))
+
+    # HCCL
+    if hccl_mb > 0:
+        report.components.append(MemoryComponent(
+            name="HCCL 缓冲",
+            value_mb=hccl_mb,
+            source="msprof npu_module_mem Component=HCCL",
+            evidence=f"npu_module_mem.csv: HCCL max = {hccl_mb:.2f} MB",
+        ))
+
+    # RUNTIME
+    if runtime_mb > 0:
+        report.components.append(MemoryComponent(
+            name="CANN Runtime",
+            value_mb=runtime_mb,
+            source="msprof npu_module_mem Component=RUNTIME",
+            evidence=f"npu_module_mem.csv: RUNTIME max = {runtime_mb:.2f} MB",
+        ))
+
+    # SLOG
+    if slog_mb > 0:
+        report.components.append(MemoryComponent(
+            name="SLOG (系统日志)",
+            value_mb=slog_mb,
+            source="msprof npu_module_mem Component=SLOG",
+            evidence=f"npu_module_mem.csv: SLOG max = {slog_mb:.2f} MB",
+        ))
+
+    # Other msprof components
+    if other_msprof > 0.5:
+        report.components.append(MemoryComponent(
+            name="其他 msprof 组件",
+            value_mb=other_msprof,
+            source="msprof npu_module_mem (minor components)",
+            evidence=f"Sum of minor components = {other_msprof:.2f} MB",
+        ))
+
+    # ACL graph capture memory (from vLLM log)
+    graph_gib = vllm_info.get("graph_capture_gib", 0)
+    graph_mb = graph_gib * 1024
+    if graph_mb > 0:
+        graph_sizes = vllm_info.get("acl_graph_sizes_count", "?")
+        report.components.append(MemoryComponent(
+            name="ACL Graph 编译缓冲",
+            value_mb=graph_mb,
+            source="vLLM 日志 'Graph capturing took X GiB'",
+            evidence=f"vllm_serve.log: graph capture = {graph_gib:.2f} GiB, {graph_sizes} sizes",
+        ))
+
+    # Activation estimate (delta between inference and ready states)
+    infer_mb = infer.get("used_mb", used_mb)
+    activation_mb = max(0, infer_mb - used_mb)
+    if activation_mb > 0:
+        report.components.append(MemoryComponent(
+            name="激活峰值",
+            value_mb=activation_mb,
+            source="npu-smi delta (inference - ready)",
+            evidence=f"after_infer={infer_mb} MB - after_ready={used_mb} MB = {activation_mb} MB",
+        ))
+
+    # Compute unattributed and try to sub-attribute it
+    component_sum = sum(c.value_mb for c in report.components)
+    unattributed = used_mb - component_sum
+
+    has_msprof = app_mb > 0
+    _handle_residual(report, unattributed, has_msprof)
+
+    # Cross-validation
+    report.cross_validation = {
+        "npu_smi_used_mb": used_mb,
+        "component_sum_mb": round(component_sum, 1),
+        "unattributed_mb": round(unattributed, 1),
+        "unattributed_pct": round(abs(unattributed) / used_mb * 100, 1) if used_mb else 0,
+    }
+    if app_mb > 0:
+        report.cross_validation["msprof_app_mb"] = round(app_mb, 1)
+        weight_kv_mb = weights_mb + kv_mb
+        report.cross_validation["vllm_weight_plus_kv_mb"] = round(weight_kv_mb, 1)
+        app_vs_wkv_diff = app_mb - weight_kv_mb
+        report.cross_validation["app_minus_weight_kv_mb"] = round(app_vs_wkv_diff, 1)
+
+    # Compute percentages
+    for c in report.components:
+        c.delta_pct = round(c.value_mb / used_mb * 100, 1) if used_mb else 0
+
+    return report
+
+
+def _handle_residual(
+    report: DeviceReport,
+    unattributed: float,
+    has_msprof: bool,
+) -> None:
+    """Handle unattributed memory in the report.
+
+    When msprof data is available, HCCL/RUNTIME/SLOG are already precise
+    components — the residual should be small and is reported as-is.
+    When msprof data is missing, the residual is marked as untraceable.
+    No estimation or guessing is performed in either case.
+    """
+    if abs(unattributed) <= 1:
+        return
+
+    if has_msprof:
+        report.components.append(MemoryComponent(
+            name="  └ 未归因残差",
+            value_mb=unattributed,
+            source="残差: npu-smi 已用 - 所有已知组件加总",
+            evidence=f"残差 {unattributed:.0f} MB, 可能来源: 算子 workspace、分配器对齐开销、碎片等",
+        ))
+    else:
+        report.components.append(MemoryComponent(
+            name="  └ 未归因 (缺少 msprof 数据)",
+            value_mb=unattributed,
+            source="不可追溯: 缺少 msprof npu_module_mem 数据，无法拆分为 HCCL/RUNTIME/SLOG",
+            evidence=f"残差 {unattributed:.0f} MB, 需使用 msprof 采集后重新分析以获得精确拆分",
+        ))
+
+
+def format_report_text(
+    reports: list[DeviceReport],
+    manifest: dict,
+    weight_precise: dict | None = None,
+) -> str:
+    """Format reports as human-readable text."""
+    lines = []
+    lines.append("=" * 70)
+    lines.append("  Ascend 显存 Profiling 报告")
+    lines.append("=" * 70)
+    lines.append(f"模型: {manifest.get('model', '?')}")
+    dp = manifest.get('dp', 1)
+    tp_dp_str = f"TP={manifest.get('tp', '?')}"
+    if dp and dp > 1:
+        tp_dp_str += f", DP={dp}"
+    tp_dp_str += f" | 设备: {manifest.get('devices', '?')}"
+    spec_cfg = manifest.get('speculative_config', '')
+    if spec_cfg:
+        tp_dp_str += f"\n推测解码: {spec_cfg}"
+    comp_cfg = manifest.get('compilation_config', '')
+    if comp_cfg:
+        tp_dp_str += f"\n编译配置: {comp_cfg}"
+    quant = manifest.get('quantization', '')
+    if quant:
+        tp_dp_str += f"\n量化方式: {quant}"
+    lines.append(tp_dp_str)
+    mode = manifest.get("mode", "standalone")
+    lines.append(f"采集模式: {'attach (挂载已有服务)' if mode == 'attach' else 'standalone (独立管理服务)'}")
+    lines.append(f"msprof 采集: {'是' if manifest.get('msprof_enabled') else '否'}")
+    if mode == "attach":
+        baseline_src = manifest.get("baseline_source", "unavailable")
+        if baseline_src == "unavailable":
+            lines.append("基线数据: 不可用 (attach 模式，建议通过 --baseline-from 复用历史基线)")
+        else:
+            lines.append(f"基线数据: 复用自 {baseline_src}")
+        svc_ref = manifest.get("serving_state_ref", "")
+        if svc_ref:
+            lines.append(f"服务状态: {svc_ref}")
+    lines.append("")
+
+    for r in reports:
+        lines.append(f"[Device {r.device_id}] 总 HBM: {r.total_hbm_mb / 1024:.2f} GiB | "
+                     f"已用: {r.used_hbm_mb / 1024:.2f} GiB")
+        lines.append("")
+        lines.append(f"{'组件':<28} | {'占用 (MB)':>10} | {'占用 (GiB)':>10} | {'占比':>6} | 主数据源")
+        lines.append("-" * 110)
+
+        for c in r.components:
+            lines.append(
+                f"{c.name:<28} | {c.value_mb:>10.1f} | {c.value_mb/1024:>10.3f} | "
+                f"{c.delta_pct:>5.1f}% | {c.source}"
+            )
+        lines.append("")
+
+        lines.append("[交叉验证]")
+        cv = r.cross_validation
+        lines.append(f"  npu-smi 已用:          {cv.get('npu_smi_used_mb', 0):,.0f} MB")
+        lines.append(f"  组件加总:              {cv.get('component_sum_mb', 0):,.1f} MB")
+        lines.append(f"  未归因:                {cv.get('unattributed_mb', 0):,.1f} MB "
+                     f"({cv.get('unattributed_pct', 0):.1f}%)")
+        if "msprof_app_mb" in cv:
+            lines.append(f"  msprof APP:            {cv['msprof_app_mb']:,.1f} MB")
+            lines.append(f"  vLLM 权重+KV:          {cv.get('vllm_weight_plus_kv_mb', 0):,.1f} MB")
+            lines.append(f"  APP - (权重+KV):       {cv.get('app_minus_weight_kv_mb', 0):,.1f} MB "
+                         "(含激活/内部缓冲)")
+        lines.append("")
+
+        lines.append("[证据链]")
+        for c in r.components:
+            lines.append(f"  {c.name}:")
+            lines.append(f"    来源: {c.source}")
+            lines.append(f"    证据: {c.evidence}")
+            if c.corroboration:
+                lines.append(f"    印证: {c.corroboration}")
+        lines.append("")
+        lines.append("=" * 70)
+
+    if weight_precise and weight_precise.get("categories"):
+        vllm_gb = 0
+        for r in reports:
+            for c in r.components:
+                if "权重" in c.name:
+                    vllm_gb = c.value_mb / 1024
+                    break
+            if vllm_gb:
+                break
+        lines.append("")
+        lines.extend(format_weight_breakdown(weight_precise, vllm_gb))
+        lines.append("=" * 70)
+
+    return "\n".join(lines)
+
+
+def find_msprof_csv(run_dir: Path, pattern: str) -> Path | None:
+    """Find a msprof CSV file matching a pattern (returns first match)."""
+    csv_dir = run_dir / "msprof_csvs"
+    if not csv_dir.exists():
+        return None
+    for f in csv_dir.iterdir():
+        if pattern in f.name and f.suffix == ".csv":
+            return f
+    return None
+
+
+def find_all_msprof_csvs(run_dir: Path, pattern: str) -> list[Path]:
+    """Find all msprof CSV files matching a pattern."""
+    csv_dir = run_dir / "msprof_csvs"
+    if not csv_dir.exists():
+        return []
+    return sorted(f for f in csv_dir.iterdir() if pattern in f.name and f.suffix == ".csv")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Analyze Ascend memory profiling data")
+    p.add_argument("run_dir", help="Path to collection run directory")
+    args = p.parse_args()
+
+    run_dir = Path(args.run_dir)
+    manifest_path = run_dir / "manifest.json"
+    if not manifest_path.exists():
+        print(f"ERROR: {manifest_path} not found", file=sys.stderr)
+        sys.exit(1)
+
+    manifest = json.loads(manifest_path.read_text())
+
+    # Parse vLLM logs
+    log_path = run_dir / "vllm_serve.log"
+    vllm_info = parse_vllm_logs(log_path.read_text()) if log_path.exists() else {}
+
+    # Parse msprof data — merge all npu_module_mem slices (slice_0 has
+    # APP/HCCL/RUNTIME/SLOG, slice_1 may have FFTS/other minor components)
+    msprof_components: dict[str, float] = {}
+    for csv_path in find_all_msprof_csvs(run_dir, "npu_module_mem"):
+        partial = parse_npu_module_mem_csv(csv_path)
+        for comp, val in partial.items():
+            if val > msprof_components.get(comp, 0):
+                msprof_components[comp] = val
+
+    # Weight analysis: prefer safetensors manifest, fallback to config estimate
+    tp = manifest.get("tp", 1)
+    dp = manifest.get("dp", 1)
+
+    weight_manifest_path = run_dir / "weight_manifest.json"
+    weight_manifest = {}
+    if weight_manifest_path.exists():
+        weight_manifest = json.loads(weight_manifest_path.read_text())
+
+    mc = manifest.get("model_config", {})
+    has_experts = bool(
+        mc.get("num_experts", 0)
+        or mc.get("text_config", {}).get("num_experts", 0)
+    )
+    ep_flag = manifest.get("enable_expert_parallel")
+    enable_ep = ep_flag if ep_flag is not None else has_experts
+    weight_precise = compute_weight_from_manifest(weight_manifest, tp, dp, enable_ep) if weight_manifest else {}
+
+    model_config = manifest.get("model_config", {})
+    if not model_config:
+        cfg_path = run_dir / "model_config.json"
+        if cfg_path.exists():
+            model_config = json.loads(cfg_path.read_text())
+    weight_theory = estimate_weight_size(model_config, tp, dp) if model_config else {}
+
+    # Parse npu-smi data
+    baseline_hbm = parse_npu_smi_hbm(manifest.get("baseline_hbm", {}))
+    after_ready_hbm = parse_npu_smi_hbm(manifest.get("after_ready_hbm", {}))
+    after_infer_hbm = parse_npu_smi_hbm(manifest.get("after_infer_hbm", {}))
+
+    # Generate per-device reports
+    total_devices = tp * dp
+    devices = sorted(set(list(baseline_hbm.keys()) + list(after_ready_hbm.keys())))
+    if not devices:
+        devices = list(range(total_devices))
+
+    reports = []
+    for dev_id in devices:
+        if isinstance(dev_id, int) and dev_id >= total_devices:
+            continue
+        report = generate_device_report(
+            dev_id=dev_id,
+            baseline_hbm=baseline_hbm,
+            after_ready_hbm=after_ready_hbm,
+            after_infer_hbm=after_infer_hbm,
+            msprof_components=msprof_components,
+            vllm_info=vllm_info,
+            weight_theory=weight_theory,
+            weight_precise=weight_precise,
+            tp=tp,
+        )
+        reports.append(report)
+
+    # Format and save report
+    text_report = format_report_text(reports, manifest, weight_precise)
+    print(text_report)
+    (run_dir / "report.txt").write_text(text_report)
+
+    json_report = {
+        "manifest": manifest,
+        "vllm_info": vllm_info,
+        "msprof_components": {k: round(v, 2) for k, v in msprof_components.items()},
+        "weight_theory": weight_theory,
+        "weight_precise": weight_precise,
+        "devices": [asdict(r) for r in reports],
+    }
+    (run_dir / "report.json").write_text(json.dumps(json_report, indent=2, ensure_ascii=False))
+
+    print(f"\nReport saved to: {run_dir / 'report.txt'}", file=sys.stderr)
+    print(f"JSON report:     {run_dir / 'report.json'}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/ascend-memory-profiling/scripts/mem_collect.py
+++ b/.agents/skills/ascend-memory-profiling/scripts/mem_collect.py
@@ -85,6 +85,8 @@ def parse_args() -> argparse.Namespace:
                    help="Attach to a running service managed by the serving skill")
     p.add_argument("--baseline-from", default="",
                    help="Path to a previous run directory to reuse baseline npu-smi data (for attach mode)")
+    p.add_argument("--resume-run", default="",
+                   help="Path to a previous run directory to merge new data into (for two-phase attach)")
     return p.parse_args()
 
 
@@ -272,44 +274,6 @@ def stop_service(ep: SshEndpoint) -> None:
     ), check=False)
 
 
-def export_msprof(ep: SshEndpoint, remote_dir: str) -> list[str]:
-    """Run msprof --export once for all PROF directories under remote_dir/msprof_data."""
-    from _common import MSPROF_REPORTS_REMOTE_PATH
-    progress("Running msprof export...")
-    msprof_data = f"{remote_dir}/msprof_data"
-    r = ssh_exec(ep, f"find {msprof_data} -maxdepth 1 -name 'PROF_*' -type d", check=False)
-    prof_dirs = [d.strip() for d in r.stdout.strip().splitlines() if d.strip()]
-    if not prof_dirs:
-        progress("WARNING: No PROF directories found")
-        return []
-
-    progress(f"Exporting {len(prof_dirs)} PROF directories...")
-    reports_arg = ""
-    r_chk = ssh_exec(ep, f"test -f {MSPROF_REPORTS_REMOTE_PATH} && echo YES || echo NO", check=False)
-    if "YES" in r_chk.stdout:
-        reports_arg = f" --reports={MSPROF_REPORTS_REMOTE_PATH}"
-    log_file = f"{msprof_data}/_export.log"
-    ssh_exec(
-        ep,
-        f"{ENV_PREAMBLE} msprof --export=on --output={msprof_data}"
-        f"{reports_arg} > {log_file} 2>&1 &",
-        check=False, timeout=30,
-    )
-    import time as _time
-    deadline = _time.monotonic() + 1800
-    poll_interval = 10
-    while _time.monotonic() < deadline:
-        _time.sleep(poll_interval)
-        r = ssh_exec(ep, "pgrep -f '[m]sprof.*--export' >/dev/null 2>&1 && echo RUNNING || echo DONE", check=False, timeout=15)
-        if "DONE" in r.stdout:
-            break
-        poll_interval = min(poll_interval * 1.5, 60)
-    else:
-        progress("WARNING: msprof export timed out, proceeding with available CSVs")
-
-    return prof_dirs
-
-
 def collect_vllm_logs(ep: SshEndpoint, remote_dir: str, local_path: Path) -> str:
     """Fetch vLLM serve logs from remote."""
     for logname in ["msprof_stdout.log", "vllm_serve.log"]:
@@ -318,6 +282,39 @@ def collect_vllm_logs(ep: SshEndpoint, remote_dir: str, local_path: Path) -> str
             (local_path / "vllm_serve.log").write_text(r.stdout)
             return r.stdout
     return ""
+
+
+def _discover_prof_device_map(
+    ep: SshEndpoint,
+    search_root: str,
+) -> dict[str, list[int]]:
+    """Map PROF directory names to device IDs they cover.
+
+    Returns e.g. {"PROF_000001_...": [0,1,2,3], "PROF_000002_...": [4,5,6,7]}.
+    Device IDs are discovered from ``device_*`` subdirectories within each PROF.
+    """
+    r = ssh_exec(
+        ep,
+        f"find {search_root} -maxdepth 1 -name 'PROF_*' -type d",
+        check=False,
+    )
+    prof_dirs = [d.strip() for d in r.stdout.strip().splitlines() if d.strip()]
+    mapping: dict[str, list[int]] = {}
+    for pdir in prof_dirs:
+        prof_name = Path(pdir).name
+        r2 = ssh_exec(
+            ep,
+            f"find {shlex.quote(pdir)} -maxdepth 1 -name 'device_*' -type d "
+            f"| sed 's|.*/device_||'",
+            check=False,
+        )
+        devs = []
+        for tok in r2.stdout.strip().splitlines():
+            tok = tok.strip()
+            if tok.isdigit():
+                devs.append(int(tok))
+        mapping[prof_name] = sorted(devs)
+    return mapping
 
 
 def collect_msprof_csvs(
@@ -332,14 +329,21 @@ def collect_msprof_csvs(
     When *msprof_data_subdir* is True (default, standalone mode), CSVs are found
     under ``remote_dir/msprof_data/``.  When False (attach mode), *remote_dir*
     already points to the msprof data directory itself.
+
+    The manifest maps ``local_filename`` → ``relative_path`` and additionally
+    stores a ``__prof_device_map__`` key mapping each CSV to the device IDs
+    of its parent PROF directory (for per-device attribution).
     """
     csv_dir = local_path / "msprof_csvs"
     csv_dir.mkdir(exist_ok=True)
 
     search_root = f"{remote_dir}/msprof_data" if msprof_data_subdir else remote_dir
+    prof_device_map = _discover_prof_device_map(ep, search_root)
+
     r = ssh_exec(ep, f"find {search_root} -name '*.csv' -size +100c", check=False)
     csvs = [f.strip() for f in r.stdout.strip().splitlines() if f.strip()]
-    manifest = {}
+    manifest: dict[str, Any] = {}
+    csv_device_map: dict[str, list[int]] = {}
 
     for remote_csv in csvs:
         basename = Path(remote_csv).name
@@ -354,8 +358,14 @@ def collect_msprof_csvs(
                     local_csv = csv_dir / f"{stem}_{idx}{suffix}"
                     idx += 1
             local_csv.write_text(r2.stdout)
-            manifest[basename] = str(local_csv.relative_to(local_path))
+            manifest[local_csv.name] = str(local_csv.relative_to(local_path))
 
+            for prof_name, devs in prof_device_map.items():
+                if prof_name in remote_csv:
+                    csv_device_map[local_csv.name] = devs
+                    break
+
+    manifest["__prof_device_map__"] = csv_device_map
     return manifest
 
 
@@ -514,7 +524,13 @@ def _main_attach(
     _extract_serve_config_from_extra_args(args, svc_extra_args)
 
     model_tag = Path(model).name.replace("/", "_")
-    run_dir = ensure_run_dir(tag=args.tag or f"attach_{model_tag}")
+    if args.resume_run:
+        run_dir = Path(args.resume_run)
+        if not run_dir.exists():
+            raise SystemExit(f"--resume-run directory does not exist: {run_dir}")
+        progress(f"Resuming into existing run: {run_dir}")
+    else:
+        run_dir = ensure_run_dir(tag=args.tag or f"attach_{model_tag}")
     remote_dir = f"/tmp/vaws_memprof_{int(time.time())}"
 
     progress(f"Output directory: {run_dir}")
@@ -567,11 +583,11 @@ def _main_attach(
     if service_alive:
         # Full collection: health check, npu-smi, logs, inference
         try:
-            wait_for_health(ep, port, timeout=30)
+            wait_for_health(ep, port, timeout=args.health_timeout)
         except TimeoutError:
             raise SystemExit(
-                f"Service on port {port} is not responding to /health. "
-                "Check service status with the serving skill."
+                f"Service on port {port} is not responding to /health after "
+                f"{args.health_timeout}s. Check service status with the serving skill."
             )
 
         manifest["after_ready_hbm"] = collect_npu_smi(ep, "after_ready", run_dir)
@@ -618,6 +634,17 @@ def _main_attach(
         progress("Attach-mode collection complete (service left running)")
     else:
         progress("Attach-mode collection complete (service was stopped, collected available data)")
+
+    # When resuming, merge into the existing manifest so both phases
+    # contribute to a single complete run.
+    existing_manifest_path = run_dir / "manifest.json"
+    if args.resume_run and existing_manifest_path.exists():
+        existing = json.loads(existing_manifest_path.read_text())
+        for key, val in manifest.items():
+            if val in (None, {}, [], "", False, 0) and existing.get(key) not in (None, {}, [], "", False, 0):
+                continue
+            existing[key] = val
+        manifest = existing
 
     (run_dir / "manifest.json").write_text(json.dumps(manifest, indent=2, ensure_ascii=False))
     progress(f"Data saved to {run_dir}")
@@ -743,8 +770,8 @@ def _main_standalone(
     stop_service(ep)
     time.sleep(5)
 
-    # Phase 5: msprof export
-    export_msprof(ep, remote_dir)
+    # Phase 5: msprof export (via shared helper)
+    run_msprof_export(ep, f"{remote_dir}/msprof_data")
     manifest["msprof_csvs"] = collect_msprof_csvs(ep, remote_dir, run_dir)
 
     # Phase 6: model config + weight manifest

--- a/.agents/skills/ascend-memory-profiling/scripts/mem_collect.py
+++ b/.agents/skills/ascend-memory-profiling/scripts/mem_collect.py
@@ -1,0 +1,762 @@
+#!/usr/bin/env python3
+"""
+Ascend Memory Profiling -- Data Collection Orchestrator.
+
+Two modes of operation:
+
+**Standalone mode** (default):
+  Phase 0: npu-smi baseline (no user process)
+  Phase 1: Start vLLM serve with msprof wrapping (mandatory)
+  Phase 2: npu-smi after service ready + vLLM startup logs
+  Phase 3: Send inference requests + npu-smi during inference
+  Phase 4: Stop service, msprof flushes
+  Phase 5: msprof export → CSV files
+  Phase 6: Save all raw data locally
+
+**Attach mode** (--attach):
+  Attach to a service already managed by the vllm-ascend-serving skill.
+  Reads service state (port, PID, log paths, model config) from
+  `.vaws-local/serving/<alias>.json`.  Skips service start/stop.
+  If the service was launched with --wrap-script pointing to the msprof
+  wrapper, attach mode detects this, runs msprof export, and collects CSVs.
+  When the service was NOT launched with msprof, a warning is emitted and the
+  report will mark component-level memory as untraceable.
+
+Progress on stderr, final JSON manifest on stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import sys
+import time
+from pathlib import Path
+
+from _common import (
+    ENV_PREAMBLE,
+    MSPROF_WRAPPER_REMOTE_PATH,
+    SshEndpoint,
+    check_msprof_available,
+    endpoint_from_machine,
+    ensure_run_dir,
+    find_python,
+    get_machine_alias,
+    load_serving_state,
+    progress,
+    resolve_machine,
+    run_msprof_export,
+    ssh_exec,
+    ssh_upload,
+    ssh_write_text,
+    upload_msprof_wrapper,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Collect Ascend NPU memory profiling data")
+    p.add_argument("--machine", required=True, help="Machine alias or IP")
+    p.add_argument("--model", default="", help="Remote model weight path (auto-detected in attach mode)")
+    p.add_argument("--tp", type=int, default=None, help="Tensor parallel size (auto-detected in attach mode)")
+    p.add_argument("--dp", type=int, default=None, help="Data parallel size (auto-detected in attach mode)")
+    p.add_argument("--devices", default="", help="Comma-separated device IDs (default: auto)")
+    p.add_argument("--gpu-memory-utilization", type=float, default=0.85)
+    p.add_argument("--max-model-len", type=int, default=2048)
+    p.add_argument("--port", type=int, default=None, help="Service port (auto-detected in attach mode)")
+    p.add_argument("--enable-expert-parallel", action="store_true")
+    p.add_argument("--enforce-eager", action="store_true", default=False)
+    p.add_argument("--max-tokens", type=int, default=128, help="Max tokens per inference request")
+    p.add_argument("--prompt", default="Explain transformer attention mechanism in detail.",
+                   help="Prompt for inference request")
+    p.add_argument("--image-url", default="", help="Image URL for VL model inference (triggers chat completion)")
+    p.add_argument("--tag", default="", help="Tag for the output directory name")
+    p.add_argument("--health-timeout", type=int, default=300, help="Seconds to wait for service ready")
+    p.add_argument("--msprof-mem-freq", type=int, default=50, help="msprof hardware memory sampling freq (Hz)")
+    p.add_argument("--speculative-config", default="", help="JSON string for SpeculativeConfig (e.g. MTP)")
+    p.add_argument("--compilation-config", default="", help="JSON string for CompilationConfig (e.g. cudagraph_mode)")
+    p.add_argument("--additional-config", default="", help="JSON string for AscendConfig additional_config")
+    p.add_argument("--quantization", default="", help="Quantization method (e.g. 'ascend' for W8A8)")
+    p.add_argument("--extra-serve-args", nargs="*", default=[], help="Extra arguments for vLLM serve command")
+
+    # Attach mode: profile a service already managed by vllm-ascend-serving
+    p.add_argument("--attach", action="store_true",
+                   help="Attach to a running service managed by the serving skill")
+    p.add_argument("--baseline-from", default="",
+                   help="Path to a previous run directory to reuse baseline npu-smi data (for attach mode)")
+    return p.parse_args()
+
+
+def collect_npu_smi(ep: SshEndpoint, label: str, local_path: Path) -> dict:
+    """Run npu-smi info and save output, return parsed HBM data."""
+    progress(f"Collecting npu-smi snapshot: {label}")
+    r = ssh_exec(ep, f"{ENV_PREAMBLE} npu-smi info", timeout=30)
+    (local_path / f"{label}_npu_smi.txt").write_text(r.stdout)
+
+    hbm = {}
+    lines = r.stdout.splitlines()
+    current_npu = None
+    for line in lines:
+        stripped = line.strip().strip("|").strip()
+        if not stripped or stripped.startswith("+") or stripped.startswith("="):
+            continue
+        parts = [p.strip() for p in stripped.split("|")]
+        # Line with NPU ID and name (e.g., "0     910B4")
+        col0 = parts[0].strip() if parts else ""
+        tokens = col0.split()
+        if len(tokens) >= 2 and tokens[0].isdigit() and any(c.isalpha() for c in tokens[1]):
+            current_npu = int(tokens[0])
+            continue
+        # Line with HBM data: look for "XXXX / YYYYY" pattern in last column
+        if current_npu is not None:
+            hbm_match = re.search(r"(\d+)\s*/\s*(\d+)\s*$", stripped)
+            if hbm_match:
+                used = int(hbm_match.group(1))
+                total = int(hbm_match.group(2))
+                if total > 1000:  # HBM is typically > 1000 MB
+                    hbm[current_npu] = {"used_mb": used, "total_mb": total}
+                    current_npu = None
+    return hbm
+
+
+def build_serve_command(args: argparse.Namespace, python: str) -> str:
+    """Build the vLLM serve command string."""
+    parts = [
+        python, "-m", "vllm.entrypoints.openai.api_server",
+        "--model", args.model,
+        "--tensor-parallel-size", str(args.tp),
+        "--trust-remote-code",
+        "--gpu-memory-utilization", str(args.gpu_memory_utilization),
+        "--max-model-len", str(args.max_model_len),
+        "--port", str(args.port),
+    ]
+    if args.dp > 1:
+        parts.extend(["--data-parallel-size", str(args.dp)])
+    if args.enable_expert_parallel:
+        parts.append("--enable-expert-parallel")
+    if args.enforce_eager:
+        parts.append("--enforce-eager")
+    if args.speculative_config:
+        parts.extend(["--speculative-config", shlex.quote(args.speculative_config)])
+    if args.compilation_config:
+        parts.extend(["--compilation-config", shlex.quote(args.compilation_config)])
+    if args.additional_config:
+        parts.extend(["--additional-config", shlex.quote(args.additional_config)])
+    if args.quantization:
+        parts.extend(["--quantization", args.quantization])
+    parts.extend(args.extra_serve_args)
+    return " ".join(parts)
+
+
+def _compute_devices(args: argparse.Namespace) -> str:
+    """Compute ASCEND_RT_VISIBLE_DEVICES string."""
+    if args.devices:
+        return args.devices
+    total = args.tp * args.dp
+    return ",".join(str(i) for i in range(total))
+
+
+def start_service_with_msprof(
+    ep: SshEndpoint,
+    args: argparse.Namespace,
+    python: str,
+    remote_dir: str,
+) -> None:
+    """Start vLLM serve wrapped by msprof for component-level memory data."""
+    serve_cmd = build_serve_command(args, python)
+    devices = _compute_devices(args)
+
+    script_path = f"{remote_dir}/_serve.sh"
+    script_content = (
+        f"#!/bin/bash\n"
+        f"{ENV_PREAMBLE}\n"
+        f"export PATH=$(dirname {python}):$PATH\n"
+        f"export ASCEND_RT_VISIBLE_DEVICES={devices}\n"
+        f"exec {serve_cmd}\n"
+    )
+    ssh_write_text(ep, script_content, script_path)
+    ssh_exec(ep, f"chmod +x {script_path}")
+
+    msprof_cmd = (
+        f"{ENV_PREAMBLE} "
+        f"cd /tmp; "
+        f"nohup msprof --output={remote_dir}/msprof_data "
+        f"--sys-hardware-mem=on --sys-hardware-mem-freq={args.msprof_mem_freq} "
+        f'--application="bash {script_path}" '
+        f"> {remote_dir}/msprof_stdout.log 2>&1 & "
+        f"echo $!"
+    )
+    r = ssh_exec(ep, msprof_cmd)
+    progress(f"msprof started, PID hint: {r.stdout.strip()}")
+
+
+def wait_for_health(ep: SshEndpoint, port: int, timeout: int) -> float:
+    """Wait for vLLM service to become healthy. Returns elapsed seconds."""
+    progress("Waiting for service health check...")
+    t0 = time.time()
+    for i in range(timeout):
+        r = ssh_exec(ep, f"curl -sf -o /dev/null -w '%{{http_code}}' http://localhost:{port}/health 2>/dev/null || true", check=False, timeout=10)
+        if "200" in r.stdout:
+            elapsed = time.time() - t0
+            progress(f"Service ready in {elapsed:.0f}s")
+            return elapsed
+        if i % 30 == 0 and i > 0:
+            progress(f"Still waiting... ({i}s elapsed)")
+        time.sleep(1)
+    raise TimeoutError(f"Service not ready after {timeout}s")
+
+
+def send_inference(
+    ep: SshEndpoint,
+    args: argparse.Namespace,
+    *,
+    model_name: str = "",
+    port: int | None = None,
+) -> dict:
+    """Send inference request (text completion or multimodal chat).
+
+    *model_name* overrides args.model for the API request body (useful when
+    the serving skill sets --served-model-name to something different from the
+    weight path).  *port* overrides args.port.
+    """
+    api_model = model_name or args.model
+    api_port = port or args.port
+
+    if args.image_url:
+        progress("Sending multimodal (VL) inference request...")
+        payload = json.dumps({
+            "model": api_model,
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": args.image_url}},
+                    {"type": "text", "text": args.prompt or "Describe this image in detail."},
+                ],
+            }],
+            "max_tokens": args.max_tokens,
+            "temperature": 0.7,
+        })
+        api_endpoint = f"http://localhost:{api_port}/v1/chat/completions"
+    else:
+        progress("Sending text inference request...")
+        payload = json.dumps({
+            "model": api_model,
+            "prompt": args.prompt,
+            "max_tokens": args.max_tokens,
+            "temperature": 0.7,
+        })
+        api_endpoint = f"http://localhost:{api_port}/v1/completions"
+
+    cmd = (
+        f"curl -s {api_endpoint} "
+        f'-H "Content-Type: application/json" '
+        f"-d '{payload}'"
+    )
+    r = ssh_exec(ep, cmd, timeout=180)
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return {"raw": r.stdout[:500]}
+
+
+def stop_service(ep: SshEndpoint) -> None:
+    """Kill all vLLM and msprof processes."""
+    progress("Stopping service and msprof...")
+    ssh_exec(ep, (
+        "pkill -f 'vllm.entrypoints' 2>/dev/null; "
+        "sleep 3; "
+        "pkill -9 -f 'vllm.entrypoints' 2>/dev/null; "
+        "sleep 2; "
+        "true"
+    ), check=False)
+
+
+def export_msprof(ep: SshEndpoint, remote_dir: str) -> list[str]:
+    """Run msprof --export once for all PROF directories under remote_dir/msprof_data."""
+    from _common import MSPROF_REPORTS_REMOTE_PATH
+    progress("Running msprof export...")
+    msprof_data = f"{remote_dir}/msprof_data"
+    r = ssh_exec(ep, f"find {msprof_data} -maxdepth 1 -name 'PROF_*' -type d", check=False)
+    prof_dirs = [d.strip() for d in r.stdout.strip().splitlines() if d.strip()]
+    if not prof_dirs:
+        progress("WARNING: No PROF directories found")
+        return []
+
+    progress(f"Exporting {len(prof_dirs)} PROF directories...")
+    reports_arg = ""
+    r_chk = ssh_exec(ep, f"test -f {MSPROF_REPORTS_REMOTE_PATH} && echo YES || echo NO", check=False)
+    if "YES" in r_chk.stdout:
+        reports_arg = f" --reports={MSPROF_REPORTS_REMOTE_PATH}"
+    log_file = f"{msprof_data}/_export.log"
+    ssh_exec(
+        ep,
+        f"{ENV_PREAMBLE} msprof --export=on --output={msprof_data}"
+        f"{reports_arg} > {log_file} 2>&1 &",
+        check=False, timeout=30,
+    )
+    import time as _time
+    deadline = _time.monotonic() + 1800
+    poll_interval = 10
+    while _time.monotonic() < deadline:
+        _time.sleep(poll_interval)
+        r = ssh_exec(ep, "pgrep -f '[m]sprof.*--export' >/dev/null 2>&1 && echo RUNNING || echo DONE", check=False, timeout=15)
+        if "DONE" in r.stdout:
+            break
+        poll_interval = min(poll_interval * 1.5, 60)
+    else:
+        progress("WARNING: msprof export timed out, proceeding with available CSVs")
+
+    return prof_dirs
+
+
+def collect_vllm_logs(ep: SshEndpoint, remote_dir: str, local_path: Path) -> str:
+    """Fetch vLLM serve logs from remote."""
+    for logname in ["msprof_stdout.log", "vllm_serve.log"]:
+        r = ssh_exec(ep, f"cat {remote_dir}/{logname} 2>/dev/null", check=False)
+        if r.stdout.strip():
+            (local_path / "vllm_serve.log").write_text(r.stdout)
+            return r.stdout
+    return ""
+
+
+def collect_msprof_csvs(
+    ep: SshEndpoint,
+    remote_dir: str,
+    local_path: Path,
+    *,
+    msprof_data_subdir: bool = True,
+) -> dict:
+    """Download key msprof CSV files and return a manifest.
+
+    When *msprof_data_subdir* is True (default, standalone mode), CSVs are found
+    under ``remote_dir/msprof_data/``.  When False (attach mode), *remote_dir*
+    already points to the msprof data directory itself.
+    """
+    csv_dir = local_path / "msprof_csvs"
+    csv_dir.mkdir(exist_ok=True)
+
+    search_root = f"{remote_dir}/msprof_data" if msprof_data_subdir else remote_dir
+    r = ssh_exec(ep, f"find {search_root} -name '*.csv' -size +100c", check=False)
+    csvs = [f.strip() for f in r.stdout.strip().splitlines() if f.strip()]
+    manifest = {}
+
+    for remote_csv in csvs:
+        basename = Path(remote_csv).name
+        r2 = ssh_exec(ep, f"cat {shlex.quote(remote_csv)}", check=False)
+        if r2.stdout.strip():
+            local_csv = csv_dir / basename
+            if local_csv.exists():
+                stem = local_csv.stem
+                suffix = local_csv.suffix
+                idx = 1
+                while local_csv.exists():
+                    local_csv = csv_dir / f"{stem}_{idx}{suffix}"
+                    idx += 1
+            local_csv.write_text(r2.stdout)
+            manifest[basename] = str(local_csv.relative_to(local_path))
+
+    return manifest
+
+
+def collect_model_config(ep: SshEndpoint, model_path: str, local_path: Path) -> dict:
+    """Fetch model config.json for theoretical weight calculation."""
+    r = ssh_exec(ep, f"cat {model_path}/config.json 2>/dev/null", check=False)
+    if r.stdout.strip():
+        (local_path / "model_config.json").write_text(r.stdout)
+        try:
+            return json.loads(r.stdout)
+        except json.JSONDecodeError:
+            pass
+    return {}
+
+
+def collect_weight_manifest(ep: SshEndpoint, python: str, model_path: str, local_path: Path) -> dict:
+    """Run weight_inspector.py on remote to extract safetensors tensor metadata."""
+    progress("Inspecting model weight files (safetensors headers)...")
+    inspector_src = (Path(__file__).parent / "weight_inspector.py").read_text()
+
+    remote_script = "/tmp/_vaws_weight_inspector.py"
+    ssh_write_text(ep, inspector_src, remote_script)
+    r = ssh_exec(ep, f"{python} {remote_script} {shlex.quote(model_path)}", check=False, timeout=120)
+
+    if r.returncode != 0:
+        progress(f"WARNING: weight inspector failed: {r.stderr[:500]}")
+        return {}
+
+    try:
+        manifest = json.loads(r.stdout)
+        (local_path / "weight_manifest.json").write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False)
+        )
+        progress(f"Weight manifest: {manifest.get('total_tensors', 0)} tensors, "
+                 f"{manifest.get('total_gib', 0)} GiB total")
+        return manifest
+    except json.JSONDecodeError:
+        progress(f"WARNING: weight inspector output not valid JSON")
+        return {}
+
+
+def _resolve_attach_state(machine: dict, args: argparse.Namespace) -> dict:
+    """Load and validate serving state for attach mode.
+
+    Accepts 'ready', 'started', or 'stopped'.  When stopped, only msprof CSV
+    collection and weight/config analysis are possible (no health check, no
+    inference).
+    """
+    alias = get_machine_alias(machine)
+    state = load_serving_state(alias)
+    if state is None:
+        raise SystemExit(
+            f"No serving state found for machine '{alias}'. "
+            "Start a service first with the vllm-ascend-serving skill, "
+            "or run in standalone mode (without --attach)."
+        )
+
+    status = state.get("status", "unknown")
+    if status not in ("ready", "started", "stopped"):
+        raise SystemExit(
+            f"Service on '{alias}' has status '{status}'. "
+            "Expected 'ready', 'started', or 'stopped'. "
+            "Start a service first with the vllm-ascend-serving skill."
+        )
+
+    return state
+
+
+def _load_baseline_from(baseline_path: str, run_dir: Path) -> dict:
+    """Reuse baseline npu-smi data from a previous profiling run."""
+    src = Path(baseline_path) / "baseline_npu_smi.txt"
+    if not src.exists():
+        manifest_path = Path(baseline_path) / "manifest.json"
+        if manifest_path.exists():
+            m = json.loads(manifest_path.read_text())
+            return m.get("baseline_hbm", {})
+        return {}
+
+    import shutil
+    shutil.copy2(src, run_dir / "baseline_npu_smi.txt")
+
+    manifest_path = Path(baseline_path) / "manifest.json"
+    if manifest_path.exists():
+        m = json.loads(manifest_path.read_text())
+        return m.get("baseline_hbm", {})
+    return {}
+
+
+def _collect_serving_logs(ep: SshEndpoint, serving_state: dict, local_path: Path) -> str:
+    """Fetch vLLM logs from the serving skill's runtime directory.
+
+    Combines both stdout and stderr since critical memory info (weight load
+    size, KV cache size, graph capture) is logged to stdout while warnings
+    and progress bars go to stderr.
+    """
+    combined = []
+    for key in ("log_stdout", "log_stderr"):
+        remote_log = serving_state.get(key, "")
+        if not remote_log:
+            continue
+        r = ssh_exec(ep, f"cat {shlex.quote(remote_log)} 2>/dev/null", check=False)
+        if r.stdout.strip():
+            combined.append(r.stdout)
+    full_log = "\n".join(combined)
+    if full_log.strip():
+        (local_path / "vllm_serve.log").write_text(full_log)
+    return full_log
+
+
+def main() -> None:
+    args = parse_args()
+    machine = resolve_machine(args.machine)
+    ep = endpoint_from_machine(machine)
+
+    if args.attach:
+        _main_attach(args, machine, ep)
+    else:
+        _main_standalone(args, machine, ep)
+
+
+def _main_attach(
+    args: argparse.Namespace,
+    machine: dict,
+    ep: SshEndpoint,
+) -> None:
+    """Attach mode: profile a service already managed by vllm-ascend-serving."""
+    serving_state = _resolve_attach_state(machine, args)
+    alias = get_machine_alias(machine)
+
+    svc_model = serving_state.get("model", "")
+    svc_port = serving_state.get("port", 8000)
+    svc_tp = serving_state.get("tp")
+    svc_dp = serving_state.get("dp")
+    svc_devices = serving_state.get("devices", "")
+    svc_extra_args = serving_state.get("extra_args", [])
+    served_model_name = serving_state.get("served_model_name", "")
+
+    model = args.model or svc_model
+    if not model:
+        raise SystemExit("Cannot determine model path. Provide --model or ensure serving state has it.")
+    tp = args.tp if args.tp is not None else (svc_tp or 1)
+    dp = args.dp if args.dp is not None else (svc_dp or 1)
+    port = args.port if args.port is not None else svc_port
+    devices = args.devices or svc_devices or ",".join(str(i) for i in range(tp * dp))
+
+    svc_status = serving_state.get("status", "unknown")
+    service_alive = svc_status in ("ready", "started")
+
+    progress(f"Attaching to service on '{alias}' (port={port}, model={model})")
+    progress(f"  tp={tp}, dp={dp}, devices={devices}, status={svc_status}")
+    if served_model_name:
+        progress(f"  served_model_name={served_model_name}")
+    if not service_alive:
+        progress("  Service is stopped — will only collect msprof CSVs, weight manifest, and config")
+
+    _extract_serve_config_from_extra_args(args, svc_extra_args)
+
+    model_tag = Path(model).name.replace("/", "_")
+    run_dir = ensure_run_dir(tag=args.tag or f"attach_{model_tag}")
+    remote_dir = f"/tmp/vaws_memprof_{int(time.time())}"
+
+    progress(f"Output directory: {run_dir}")
+    ssh_exec(ep, f"mkdir -p {remote_dir}")
+
+    python = find_python(ep)
+
+    # Detect msprof: serving used our wrapper → msprof data at runtime_dir/msprof_data
+    svc_wrap = serving_state.get("wrap_script", "")
+    svc_runtime_dir = serving_state.get("runtime_dir", "")
+    msprof_used = MSPROF_WRAPPER_REMOTE_PATH in svc_wrap
+    msprof_data_dir = f"{svc_runtime_dir}/msprof_data" if msprof_used and svc_runtime_dir else ""
+    if not msprof_used:
+        progress(
+            "WARNING: 服务未使用 msprof wrapper 启动，报告中将无法提供组件级内存拆分。"
+            "建议使用 msprof wrapper 重新启动服务以获得完整的可追溯数据。"
+        )
+
+    manifest: dict = {
+        "mode": "attach",
+        "model": model,
+        "tp": tp,
+        "dp": dp,
+        "devices": devices,
+        "port": port,
+        "served_model_name": served_model_name,
+        "msprof_enabled": msprof_used,
+        "msprof_output_dir": msprof_data_dir,
+        "run_dir": str(run_dir),
+        "serving_state_ref": f".vaws-local/serving/{alias}.json",
+        "serving_runtime_dir": svc_runtime_dir,
+        "speculative_config": args.speculative_config,
+        "compilation_config": args.compilation_config,
+        "additional_config": args.additional_config,
+        "quantization": args.quantization,
+        "enforce_eager": args.enforce_eager,
+        "image_url": args.image_url,
+        "service_alive": service_alive,
+    }
+
+    # Baseline: reuse from previous run or skip
+    if args.baseline_from:
+        progress(f"Reusing baseline from: {args.baseline_from}")
+        manifest["baseline_hbm"] = _load_baseline_from(args.baseline_from, run_dir)
+        manifest["baseline_source"] = args.baseline_from
+    else:
+        manifest["baseline_hbm"] = {}
+        manifest["baseline_source"] = "unavailable"
+
+    if service_alive:
+        # Full collection: health check, npu-smi, logs, inference
+        try:
+            wait_for_health(ep, port, timeout=30)
+        except TimeoutError:
+            raise SystemExit(
+                f"Service on port {port} is not responding to /health. "
+                "Check service status with the serving skill."
+            )
+
+        manifest["after_ready_hbm"] = collect_npu_smi(ep, "after_ready", run_dir)
+        _collect_serving_logs(ep, serving_state, run_dir)
+
+        api_model = served_model_name or model
+        manifest["inference_response"] = send_inference(
+            ep, args, model_name=api_model, port=port,
+        )
+        manifest["after_infer_hbm"] = collect_npu_smi(ep, "after_infer", run_dir)
+    else:
+        # Service stopped — collect logs (may still exist on disk) but skip
+        # health check, npu-smi, and inference
+        manifest["after_ready_hbm"] = {}
+        manifest["after_infer_hbm"] = {}
+        _collect_serving_logs(ep, serving_state, run_dir)
+
+    # Model config + weight manifest (always possible regardless of service state)
+    manifest["model_config"] = collect_model_config(ep, model, run_dir)
+    manifest["weight_manifest_collected"] = bool(
+        collect_weight_manifest(ep, python, model, run_dir)
+    )
+
+    # Collect msprof CSVs if service was wrapped with msprof
+    if msprof_used and msprof_data_dir:
+        r = ssh_exec(ep, f"find {shlex.quote(msprof_data_dir)} -name '*.csv' -size +100c 2>/dev/null | head -1", check=False)
+        if r.stdout.strip():
+            progress("Collecting msprof CSVs from serving runtime...")
+            manifest["msprof_csvs"] = collect_msprof_csvs(
+                ep, msprof_data_dir, run_dir, msprof_data_subdir=False,
+            )
+        elif not service_alive:
+            # Service stopped but CSVs not found → run export first
+            progress("Running msprof export (service stopped, data not yet exported)...")
+            run_msprof_export(ep, msprof_data_dir)
+            manifest["msprof_csvs"] = collect_msprof_csvs(
+                ep, msprof_data_dir, run_dir, msprof_data_subdir=False,
+            )
+        else:
+            progress("msprof data will be available after service stop + export")
+            manifest["msprof_csvs_pending"] = True
+
+    if service_alive:
+        progress("Attach-mode collection complete (service left running)")
+    else:
+        progress("Attach-mode collection complete (service was stopped, collected available data)")
+
+    (run_dir / "manifest.json").write_text(json.dumps(manifest, indent=2, ensure_ascii=False))
+    progress(f"Data saved to {run_dir}")
+    print(json.dumps(manifest, indent=2, ensure_ascii=False))
+
+
+def _extract_serve_config_from_extra_args(
+    args: argparse.Namespace,
+    extra_args: list[str],
+) -> None:
+    """Populate args.speculative_config etc. from serving state's extra_args
+    if not already set via CLI.  This makes the manifest and analysis accurate
+    when the user only specified --attach without repeating every flag."""
+    flag_map = {
+        "--speculative-config": "speculative_config",
+        "-sc": "speculative_config",
+        "--compilation-config": "compilation_config",
+        "--additional-config": "additional_config",
+        "--quantization": "quantization",
+        "--gpu-memory-utilization": "gpu_memory_utilization",
+        "--max-model-len": "max_model_len",
+        "--enable-expert-parallel": "enable_expert_parallel",
+        "--enforce-eager": "enforce_eager",
+    }
+    i = 0
+    while i < len(extra_args):
+        token = extra_args[i]
+        attr = flag_map.get(token)
+        if attr is None:
+            i += 1
+            continue
+        if token in ("--enable-expert-parallel", "--enforce-eager"):
+            if not getattr(args, attr, False):
+                setattr(args, attr, True)
+            i += 1
+        elif i + 1 < len(extra_args):
+            current = getattr(args, attr, "")
+            if not current or current == "" or (isinstance(current, float) and attr == "gpu_memory_utilization"):
+                val = extra_args[i + 1]
+                field_type = type(getattr(args, attr))
+                if field_type == float:
+                    setattr(args, attr, float(val))
+                elif field_type == int:
+                    setattr(args, attr, int(val))
+                else:
+                    setattr(args, attr, val)
+            i += 2
+        else:
+            i += 1
+
+
+def _main_standalone(
+    args: argparse.Namespace,
+    machine: dict,
+    ep: SshEndpoint,
+) -> None:
+    """Standalone mode: start service, profile, stop."""
+    if not args.model:
+        raise SystemExit("--model is required in standalone mode")
+    tp = args.tp if args.tp is not None else 1
+    dp = args.dp if args.dp is not None else 1
+    port = args.port if args.port is not None else 8901
+    args.tp = tp
+    args.dp = dp
+    args.port = port
+
+    model_tag = Path(args.model).name.replace("/", "_")
+    run_dir = ensure_run_dir(tag=args.tag or model_tag)
+    remote_dir = f"/tmp/vaws_memprof_{int(time.time())}"
+
+    progress(f"Output directory: {run_dir}")
+    ssh_exec(ep, f"mkdir -p {remote_dir}")
+
+    python = find_python(ep)
+    progress(f"Python: {python}")
+
+    # Pre-flight: verify msprof is available
+    check_msprof_available(ep)
+
+    manifest: dict = {
+        "mode": "standalone",
+        "model": args.model,
+        "tp": tp,
+        "dp": dp,
+        "devices": _compute_devices(args),
+        "gpu_memory_utilization": args.gpu_memory_utilization,
+        "max_model_len": args.max_model_len,
+        "msprof_enabled": True,
+        "run_dir": str(run_dir),
+        "speculative_config": args.speculative_config,
+        "compilation_config": args.compilation_config,
+        "additional_config": args.additional_config,
+        "quantization": args.quantization,
+        "enforce_eager": args.enforce_eager,
+        "image_url": args.image_url,
+    }
+
+    # Phase 0: baseline
+    manifest["baseline_hbm"] = collect_npu_smi(ep, "baseline", run_dir)
+
+    # Phase 1: start service (always with msprof for traceable memory data)
+    start_service_with_msprof(ep, args, python, remote_dir)
+
+    try:
+        manifest["startup_seconds"] = wait_for_health(ep, port, args.health_timeout)
+    except TimeoutError as e:
+        progress(f"ERROR: {e}")
+        collect_vllm_logs(ep, remote_dir, run_dir)
+        stop_service(ep)
+        manifest["error"] = str(e)
+        print(json.dumps(manifest, indent=2, ensure_ascii=False))
+        sys.exit(1)
+
+    # Phase 2: after ready
+    manifest["after_ready_hbm"] = collect_npu_smi(ep, "after_ready", run_dir)
+    collect_vllm_logs(ep, remote_dir, run_dir)
+
+    # Phase 3: inference
+    manifest["inference_response"] = send_inference(ep, args, port=port)
+    manifest["after_infer_hbm"] = collect_npu_smi(ep, "after_infer", run_dir)
+
+    # Phase 4: stop service
+    stop_service(ep)
+    time.sleep(5)
+
+    # Phase 5: msprof export
+    export_msprof(ep, remote_dir)
+    manifest["msprof_csvs"] = collect_msprof_csvs(ep, remote_dir, run_dir)
+
+    # Phase 6: model config + weight manifest
+    manifest["model_config"] = collect_model_config(ep, args.model, run_dir)
+    manifest["weight_manifest_collected"] = bool(
+        collect_weight_manifest(ep, python, args.model, run_dir)
+    )
+
+    (run_dir / "manifest.json").write_text(json.dumps(manifest, indent=2, ensure_ascii=False))
+    progress(f"Collection complete. Data saved to {run_dir}")
+    print(json.dumps(manifest, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/ascend-memory-profiling/scripts/weight_inspector.py
+++ b/.agents/skills/ascend-memory-profiling/scripts/weight_inspector.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+Remote weight inspector -- reads safetensors file headers to extract
+exact tensor shapes, dtypes, and sizes. Designed to run ON the remote
+machine where model weights live.
+
+Input: model directory path
+Output: JSON on stdout with full tensor manifest
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import struct
+import sys
+from pathlib import Path
+
+DTYPE_SIZES = {
+    "F64": 8, "F32": 4, "F16": 2, "BF16": 2,
+    "F8_E5M2": 1, "F8_E4M3": 1, "I64": 8, "I32": 4,
+    "I16": 2, "I8": 1, "U8": 1, "BOOL": 1,
+}
+
+
+def read_safetensors_header(filepath: str) -> dict:
+    """Read the JSON header from a safetensors file."""
+    with open(filepath, "rb") as f:
+        header_len_bytes = f.read(8)
+        if len(header_len_bytes) < 8:
+            return {}
+        header_len = struct.unpack("<Q", header_len_bytes)[0]
+        if header_len > 100_000_000:
+            return {}
+        header_bytes = f.read(header_len)
+        return json.loads(header_bytes)
+
+
+def parse_tensor_info(header: dict) -> list[dict]:
+    """Extract tensor metadata from a safetensors header."""
+    tensors = []
+    for name, info in header.items():
+        if name == "__metadata__":
+            continue
+        dtype = info.get("dtype", "F16")
+        shape = info.get("shape", [])
+        offsets = info.get("data_offsets", [0, 0])
+        byte_size = offsets[1] - offsets[0] if len(offsets) == 2 else 0
+        numel = 1
+        for d in shape:
+            numel *= d
+        tensors.append({
+            "name": name,
+            "dtype": dtype,
+            "shape": shape,
+            "numel": numel,
+            "byte_size": byte_size,
+            "bytes_per_element": DTYPE_SIZES.get(dtype, 2),
+        })
+    return tensors
+
+
+def classify_tensor(name: str) -> str:
+    """Classify a tensor name into a component category."""
+    n = name.lower()
+
+    if "visual" in n or "vision" in n or "vit." in n or "image_encoder" in n:
+        return "vision"
+
+    # MTP (multi-token prediction) — further sub-classify
+    if "mtp" in n:
+        if ".experts." in n and "shared_expert" not in n:
+            return "mtp_expert"
+        if "shared_expert" in n:
+            return "mtp_shared_expert"
+        if ".gate." in n or "shared_expert_gate" in n:
+            return "mtp_gate"
+        if "norm" in n:
+            return "mtp_norm"
+        if ".self_attn." in n or ".attention." in n:
+            return "mtp_attn"
+        if ".fc." in n:
+            return "mtp_fc"
+        return "mtp_other"
+
+    if "embed_tokens" in n or "wte." in n:
+        return "embedding"
+    if "lm_head" in n:
+        return "lm_head"
+
+    # Linear / Mamba-style attention (hybrid architectures like Qwen3.5)
+    if ".linear_attn." in n:
+        if "in_proj_qkv" in n:
+            return "linear_attn_qkv"
+        if "in_proj_z" in n or "out_proj" in n:
+            return "linear_attn_proj"
+        if "conv" in n:
+            return "linear_attn_conv"
+        return "linear_attn_param"
+
+    # Standard self-attention
+    if ".self_attn." in n or ".attention." in n or ".attn." in n:
+        if "q_proj" in n or "q_a_proj" in n or "q_b_proj" in n:
+            return "attn_q"
+        if "k_proj" in n or "k_a_proj" in n or "k_b_proj" in n:
+            return "attn_k"
+        if "v_proj" in n or "v_a_proj" in n or "v_b_proj" in n:
+            return "attn_v"
+        if "o_proj" in n or "out_proj" in n:
+            return "attn_o"
+        if "conv" in n:
+            return "attn_conv"
+        if "kv_a_layernorm" in n or "kv_b_proj" in n:
+            return "attn_kv_compress"
+        return "attn_other"
+
+    if ".mlp." in n or ".feed_forward." in n or ".ffn." in n:
+        if "expert" in n:
+            if "shared_expert" in n:
+                return "moe_shared_expert"
+            return "moe_expert"
+        if "gate" in n and ("proj" not in n and "up" not in n and "down" not in n):
+            return "moe_gate"
+        return "ffn"
+
+    if "block_sparse_moe" in n or "moe" in n:
+        if "expert" in n:
+            if "shared" in n:
+                return "moe_shared_expert"
+            return "moe_expert"
+        if "gate" in n:
+            return "moe_gate"
+        return "moe_other"
+
+    if "layernorm" in n or "layer_norm" in n or "norm" in n or "ln_" in n:
+        return "norm"
+
+    if "scale" in n or "zero_point" in n or "quant_" in n:
+        return "quant_param"
+
+    return "other"
+
+
+SHARD_COL_PARALLEL = "col_parallel"
+SHARD_ROW_PARALLEL = "row_parallel"
+SHARD_EXPERT_PARALLEL = "expert_parallel"
+SHARD_REPLICATED = "replicated"
+
+
+def classify_shard_strategy(name: str, category: str) -> str:
+    """Determine how a tensor is sharded across TP/EP devices."""
+    if category in ("norm", "quant_param", "moe_gate", "attn_conv", "attn_other"):
+        return SHARD_REPLICATED
+
+    if category == "moe_expert":
+        return SHARD_EXPERT_PARALLEL
+
+    if category in ("attn_q", "attn_k", "attn_v", "attn_kv_compress"):
+        return SHARD_COL_PARALLEL
+    if category == "attn_o":
+        return SHARD_ROW_PARALLEL
+
+    # Linear attention (Mamba-style hybrid)
+    if category == "linear_attn_qkv":
+        return SHARD_COL_PARALLEL
+    if category == "linear_attn_proj":
+        n = name.lower()
+        if "out_proj" in n:
+            return SHARD_ROW_PARALLEL
+        return SHARD_COL_PARALLEL
+    if category in ("linear_attn_conv", "linear_attn_param"):
+        return SHARD_COL_PARALLEL
+
+    if category == "ffn" or category == "moe_shared_expert":
+        n = name.lower()
+        if "gate_proj" in n or "up_proj" in n or "w1" in n or "w3" in n:
+            return SHARD_COL_PARALLEL
+        if "down_proj" in n or "w2" in n:
+            return SHARD_ROW_PARALLEL
+        return SHARD_COL_PARALLEL
+
+    if category == "embedding":
+        return SHARD_COL_PARALLEL
+    if category == "lm_head":
+        return SHARD_COL_PARALLEL
+
+    if category == "vision":
+        n = name.lower()
+        if "norm" in n or "patch_embed" in n or "pos_embed" in n:
+            return SHARD_REPLICATED
+        if "qkv" in n or "linear_fc1" in n or "gate_up" in n:
+            return SHARD_COL_PARALLEL
+        if "proj.weight" in n or "proj.bias" in n or "linear_fc2" in n or "down_proj" in n:
+            return SHARD_ROW_PARALLEL
+        return SHARD_COL_PARALLEL
+
+    if category == "mtp_expert":
+        return SHARD_EXPERT_PARALLEL
+    if category == "mtp_shared_expert":
+        n = name.lower()
+        if "down_proj" in n or "w2" in n:
+            return SHARD_ROW_PARALLEL
+        return SHARD_COL_PARALLEL
+    if category in ("mtp_gate", "mtp_norm"):
+        return SHARD_REPLICATED
+    if category == "mtp_attn":
+        n = name.lower()
+        if "o_proj" in n or "out_proj" in n:
+            return SHARD_ROW_PARALLEL
+        return SHARD_COL_PARALLEL
+    if category in ("mtp_fc", "mtp_other"):
+        return SHARD_COL_PARALLEL
+
+    return SHARD_REPLICATED
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: weight_inspector.py <model_dir>", file=sys.stderr)
+        sys.exit(1)
+
+    model_dir = sys.argv[1]
+
+    st_files = sorted(glob.glob(os.path.join(model_dir, "*.safetensors")))
+    if not st_files:
+        print(json.dumps({"error": "no safetensors files found"}))
+        sys.exit(1)
+
+    all_tensors = []
+    for sf in st_files:
+        header = read_safetensors_header(sf)
+        tensors = parse_tensor_info(header)
+        for t in tensors:
+            t["source_file"] = os.path.basename(sf)
+            t["category"] = classify_tensor(t["name"])
+            t["shard_strategy"] = classify_shard_strategy(t["name"], t["category"])
+        all_tensors.extend(tensors)
+
+    categories = {}
+    for t in all_tensors:
+        cat = t["category"]
+        if cat not in categories:
+            categories[cat] = {
+                "total_bytes": 0, "total_params": 0,
+                "tensor_count": 0, "dtypes": set()
+            }
+        categories[cat]["total_bytes"] += t["byte_size"]
+        categories[cat]["total_params"] += t["numel"]
+        categories[cat]["tensor_count"] += 1
+        categories[cat]["dtypes"].add(t["dtype"])
+
+    for cat in categories:
+        categories[cat]["dtypes"] = sorted(categories[cat]["dtypes"])
+
+    total_bytes = sum(t["byte_size"] for t in all_tensors)
+    total_params = sum(t["numel"] for t in all_tensors)
+
+    result = {
+        "model_dir": model_dir,
+        "num_safetensors_files": len(st_files),
+        "total_tensors": len(all_tensors),
+        "total_bytes": total_bytes,
+        "total_params": total_params,
+        "total_gib": round(total_bytes / (1024**3), 4),
+        "categories": categories,
+        "tensors": all_tensors,
+    }
+    print(json.dumps(result, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/vllm-ascend-benchmark/SKILL.md
+++ b/.agents/skills/vllm-ascend-benchmark/SKILL.md
@@ -42,7 +42,7 @@ Run `vllm bench serve` on a **ready** workspace-managed remote container and pro
 python3 .agents/skills/vllm-ascend-benchmark/scripts/bench_run.py \
   --machine <alias-or-ip> \
   --model <remote-weight-path> \
-  [--tp <N>] \
+  [--tp <N>] [--dp <N>] \
   [--runs <N>] \
   [--warmup-runs <M>] \
   [--serve-args <arg> ...] \

--- a/.agents/skills/vllm-ascend-benchmark/scripts/_common.py
+++ b/.agents/skills/vllm-ascend-benchmark/scripts/_common.py
@@ -133,6 +133,7 @@ class BenchConfig:
     machine: str = ""
     model: str = ""
     tp: int | None = None
+    dp: int | None = None
     port: int | None = None
     serve_args: list[str] = field(default_factory=list)
     bench_args: list[str] = field(default_factory=list)
@@ -145,6 +146,8 @@ class BenchConfig:
         args = ["--machine", self.machine, "--model", self.model]
         if self.tp is not None:
             args.extend(["--tp", str(self.tp)])
+        if self.dp is not None:
+            args.extend(["--dp", str(self.dp)])
         if self.port is not None:
             args.extend(["--port", str(self.port)])
         for k, v in self.env.items():
@@ -204,6 +207,7 @@ def assemble_config(
     machine: str,
     model: str,
     tp: int | None = None,
+    dp: int | None = None,
     port: int | None = None,
     serve_args: list[str] | None = None,
     bench_args: list[str] | None = None,
@@ -230,6 +234,14 @@ def assemble_config(
         idx = nightly_ref.server_cmd.index("--tensor-parallel-size")
         if idx + 1 < len(nightly_ref.server_cmd):
             cfg.tp = int(nightly_ref.server_cmd[idx + 1])
+
+    # --- DP ---
+    if dp is not None:
+        cfg.dp = dp
+    elif nightly_ref and "--data-parallel-size" in nightly_ref.server_cmd:
+        idx = nightly_ref.server_cmd.index("--data-parallel-size")
+        if idx + 1 < len(nightly_ref.server_cmd):
+            cfg.dp = int(nightly_ref.server_cmd[idx + 1])
 
     # --- Port ---
     cfg.port = port

--- a/.agents/skills/vllm-ascend-benchmark/scripts/bench_run.py
+++ b/.agents/skills/vllm-ascend-benchmark/scripts/bench_run.py
@@ -61,6 +61,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--machine", required=True, help="machine alias or IP")
     p.add_argument("--model", required=True, help="remote model weight path")
     p.add_argument("--tp", "--tensor-parallel-size", type=int, default=None)
+    p.add_argument("--dp", "--data-parallel-size", type=int, default=None)
     p.add_argument("--port", type=int, default=None)
     p.add_argument("--extra-env", action="append", default=None,
                    help="KEY=VALUE env vars for the service (repeatable)")
@@ -152,6 +153,7 @@ def main(argv: list[str] | None = None) -> int:
             machine=args.machine,
             model=args.model,
             tp=args.tp,
+            dp=args.dp,
             port=args.port,
             serve_args=serve_args,
             bench_args=bench_args,

--- a/.agents/skills/vllm-ascend-serving/SKILL.md
+++ b/.agents/skills/vllm-ascend-serving/SKILL.md
@@ -15,6 +15,7 @@ This skill takes structured parameters, handles all SSH escaping and remote exec
 - the user asks to restart or relaunch a service (possibly with changed flags or env)
 - the user asks to check if a running service is alive / ready
 - the user asks to stop a running service
+- another skill needs to start a service (e.g. `ascend-memory-profiling`)
 
 ## Do not use this skill when
 
@@ -51,8 +52,17 @@ python3 .agents/skills/vllm-ascend-serving/scripts/serve_start.py \
   [--extra-env KEY=VALUE ...] \
   [--port <N>] \
   [--health-timeout <seconds>] \
+  [--wrap-script <remote-path>] \
   [-- <extra vllm serve args>]
 ```
+
+#### Launch wrapping (`--wrap-script`)
+
+The serving skill supports a generic `--wrap-script` mechanism. When provided, the vLLM launch command is written as `_serve.sh` in the runtime directory, and the wrapper script is called with two arguments: `$1` = serve script path, `$2` = runtime directory.
+
+This is used by other skills (e.g. `ascend-memory-profiling`) to wrap the service launch process without the serving skill needing to know the wrapping details. The serving skill is agnostic to what the wrapper does.
+
+The `wrap_script` path is recorded in the serving state so downstream skills can detect it.
 
 ### Relaunch with previous config
 
@@ -105,7 +115,7 @@ python3 .agents/skills/vllm-ascend-serving/scripts/serve_stop.py \
 
 Per-machine launch state is stored under `.vaws-local/serving/<alias>.json`.
 
-This file records the last successful launch parameters (model, tp, devices, env, extra args, port, pid, log paths). It is the basis for `--relaunch`.
+This file records the last successful launch parameters (model, tp, devices, env, extra args, port, pid, log paths, runtime_dir, wrap_script). It is the basis for `--relaunch` and is read by other skills (e.g. `ascend-memory-profiling`) in attach mode.
 
 ## Workflow
 
@@ -126,7 +136,7 @@ Unless `--skip-parity` is passed, `parity_sync.py` is called to ensure the conta
 NPU availability is checked via `npu-smi info` on the **bare-metal host** (not the container). Host-level probing sees processes from all containers, bypassing PID namespace isolation. Devices with HBM usage above 4 GB are also marked busy to catch cross-container occupancy:
 
 - If `--devices` is specified, those devices are verified to be free. If any are busy, start is blocked with the conflict details.
-- If `--devices` is not specified but `--tp` is given, the first N free devices are automatically selected.
+- If `--devices` is not specified but `--tp` is given, the first N free devices are automatically selected, where N = TP × DP (defaults to TP when DP is not set).
 - If NPU probe fails (e.g. driver issue), it is treated as a non-fatal warning and launch continues with user-specified devices.
 
 ### 5. Validate and launch

--- a/.agents/skills/vllm-ascend-serving/scripts/_common.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/_common.py
@@ -249,6 +249,7 @@ def select_devices(
     *,
     requested_devices: str | None,
     tp: int | None,
+    dp: int | None = None,
 ) -> tuple[str | None, str | None]:
     """Validate or auto-select NPU devices.
 
@@ -274,12 +275,13 @@ def select_devices(
     if tp is None:
         return None, None
 
-    if len(free) < tp:
+    need = tp * (dp or 1)
+    if len(free) < need:
         return None, (
-            f"need {tp} free NPUs but only {len(free)} available; "
+            f"need {need} free NPUs (tp={tp}, dp={dp or 1}) but only {len(free)} available; "
             f"free={free}, busy={list(busy.keys())}"
         )
-    selected = free[:tp]
+    selected = free[:need]
     return ",".join(str(d) for d in selected), None
 
 

--- a/.agents/skills/vllm-ascend-serving/scripts/serve_start.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/serve_start.py
@@ -130,6 +130,7 @@ def build_launch_script(
     devices: str | None,
     extra_env: dict[str, str],
     extra_args: list[str],
+    wrap_script: str = "",
 ) -> str:
     lines: list[str] = ["set -e"]
 
@@ -191,12 +192,32 @@ def build_launch_script(
     stderr_log = f"{runtime_dir}/stderr.log"
     pid_file = f"{runtime_dir}/pid"
 
-    lines.append(
-        f"nohup {cmd_str}"
-        f" > {shlex.quote(stdout_log)}"
-        f" 2> {shlex.quote(stderr_log)}"
-        f" </dev/null &"
-    )
+    # Always write the vLLM command as a standalone script for clean quoting
+    serve_script = f"{runtime_dir}/_serve.sh"
+    lines.append(f"cat > {shlex.quote(serve_script)} << 'VAWS_SERVE_EOF'")
+    lines.append("#!/bin/bash")
+    lines.append(f"exec {cmd_str}")
+    lines.append("VAWS_SERVE_EOF")
+    lines.append(f"chmod +x {shlex.quote(serve_script)}")
+
+    if wrap_script:
+        # External wrapper: receives serve script path and runtime dir as args.
+        # The wrapper decides how to launch (e.g. msprof wrapping, strace, etc.)
+        lines.append(
+            f"nohup bash {shlex.quote(wrap_script)}"
+            f" {shlex.quote(serve_script)} {shlex.quote(runtime_dir)}"
+            f" > {shlex.quote(stdout_log)}"
+            f" 2> {shlex.quote(stderr_log)}"
+            f" </dev/null &"
+        )
+    else:
+        lines.append(
+            f"nohup bash {shlex.quote(serve_script)}"
+            f" > {shlex.quote(stdout_log)}"
+            f" 2> {shlex.quote(stderr_log)}"
+            f" </dev/null &"
+        )
+
     lines.append("_PID=$!")
     lines.append("disown $_PID")
     lines.append(f"echo $_PID > {shlex.quote(pid_file)}")
@@ -388,6 +409,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--health-timeout", type=int, default=DEFAULT_HEALTH_TIMEOUT,
         help=f"seconds to wait for /health + /v1/models (default: {DEFAULT_HEALTH_TIMEOUT})",
     )
+    p.add_argument(
+        "--wrap-script", default="",
+        help="remote path to a wrapper script that receives the serve script path "
+        "and runtime dir as $1 and $2. The wrapper controls how the service is launched "
+        "(e.g. msprof wrapping). The serving skill is agnostic to what the wrapper does.",
+    )
     return p
 
 
@@ -504,7 +531,7 @@ def main(argv: list[str] | None = None) -> int:
 
         if npu_info is not None:
             resolved_devices, device_error = select_devices(
-                npu_info, requested_devices=devices, tp=tp,
+                npu_info, requested_devices=devices, tp=tp, dp=dp,
             )
             if device_error:
                 print_json({
@@ -546,7 +573,11 @@ def main(argv: list[str] | None = None) -> int:
         instance_ts = now_utc().replace(":", "").replace("-", "").replace("T", "_").replace("Z", "")
         runtime_dir = f"{runtime_base}/{RUNTIME_DIR_BASE}/{instance_ts}"
 
-        emit_progress("launch", "starting vllm serve")
+        wrap_script = getattr(args, "wrap_script", "") or ""
+        if wrap_script:
+            emit_progress("launch", f"starting vllm serve (wrapped by {wrap_script})")
+        else:
+            emit_progress("launch", "starting vllm serve")
         script = build_launch_script(
             runtime_dir=runtime_dir,
             model=model,
@@ -556,6 +587,7 @@ def main(argv: list[str] | None = None) -> int:
             devices=devices,
             extra_env=launch_env,
             extra_args=launch_extra_args,
+            wrap_script=wrap_script,
         )
         result = ssh_exec(ep, script, check=False)
         if result.returncode != 0:
@@ -604,6 +636,8 @@ def main(argv: list[str] | None = None) -> int:
             "started_at": now_utc(),
             "status": "ready" if readiness["ready"] else "started",
         }
+        if wrap_script:
+            state["wrap_script"] = wrap_script
         save_serving_state(alias, state)
 
         # ---- build output ----
@@ -629,6 +663,8 @@ def main(argv: list[str] | None = None) -> int:
             output["env"] = launch_env
         if launch_extra_args:
             output["extra_args"] = launch_extra_args
+        if wrap_script:
+            output["wrap_script"] = wrap_script
         if not readiness["ready"]:
             output["stderr_tail"] = read_remote_tail(ep, f"{runtime_dir}/stderr.log")
 


### PR DESCRIPTION
## Summary

- Add `ascend-memory-profiling` skill for traceable HBM memory attribution on Ascend NPU vLLM serving scenarios
- msprof is mandatory — all memory data must be traceable to concrete sources (msprof, npu-smi, vLLM logs, safetensors headers), no estimation allowed
- Fix msprof export to call once instead of per-PROF-directory loop, and use background polling instead of blocking pipe
- Fix msprof CSV parsing to merge all `npu_module_mem` slices instead of using only the first match
- Cross-skill fixes: serving `--wrap-script` parameter, DP-aware device selection, benchmark `--dp` passthrough

## Test plan

- [x] Case 1: Serving only — `serve_start` (status=ready) + `serve_stop` with Qwen3.5-35B TP=4 DP=2
- [x] Case 2: Serving + Benchmark — `bench_run` with random dataset, throughput=342 tok/s, 20/20 requests completed
- [x] Case 3: Serving + Profiling — full msprof workflow (check → wrapper → start → attach collect → stop → export → CSV collect → analyze), report shows HCCL/RUNTIME/SLOG from msprof with zero estimation values
- [x] Syntax check on all modified Python files


Made with [Cursor](https://cursor.com)