### PR TITLE
feat: add structured env-diagnosis on service startup failure

### DIFF
--- a/.agents/skills/ascend-memory-profiling/scripts/mem_collect.py
+++ b/.agents/skills/ascend-memory-profiling/scripts/mem_collect.py
@@ -55,6 +55,36 @@ from _common import (
 )
 
 
+_ENV_ERROR_PATTERNS = [
+    "Failed to infer device type",
+    "No module named 'vllm_ascend'",
+    "No module named 'vllm'",
+    "No module named 'torch_npu'",
+    "cannot open shared object file",
+    "libhccl.so",
+    "ImportError",
+    "ModuleNotFoundError",
+]
+
+
+def _emit_env_recovery_hint(log_text: str, machine: str) -> None:
+    """If log_text contains environment error patterns, emit structured recovery guidance."""
+    if not log_text:
+        return
+    if not any(pat in log_text for pat in _ENV_ERROR_PATTERNS):
+        return
+    recovery_cmd = (
+        f"python3 .agents/skills/remote-code-parity/scripts/parity_sync.py "
+        f"--machine {machine} --force-reinstall"
+    )
+    progress(
+        "ENV_ERROR_DETECTED: Remote Python environment is broken. "
+        f"Recovery: run `{recovery_cmd}`. "
+        "Do NOT run bare `pip install` inside the container — "
+        "parity sync has the correct install flags."
+    )
+
+
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Collect Ascend NPU memory profiling data")
     p.add_argument("--machine", required=True, help="Machine alias or IP")
@@ -623,6 +653,8 @@ def _main_attach(
         try:
             wait_for_health(ep, port, timeout=args.health_timeout)
         except TimeoutError:
+            log_text = _collect_serving_logs(ep, serving_state, run_dir)
+            _emit_env_recovery_hint(log_text, args.machine)
             raise SystemExit(
                 f"Service on port {port} is not responding to /health after "
                 f"{args.health_timeout}s. Check service status with the serving skill."
@@ -790,8 +822,9 @@ def _main_standalone(
         manifest["startup_seconds"] = wait_for_health(ep, port, args.health_timeout)
     except TimeoutError as e:
         progress(f"ERROR: {e}")
-        collect_vllm_logs(ep, remote_dir, run_dir)
+        log_text = collect_vllm_logs(ep, remote_dir, run_dir)
         stop_service(ep)
+        _emit_env_recovery_hint(log_text, args.machine)
         manifest["error"] = str(e)
         print(json.dumps(manifest, indent=2, ensure_ascii=False))
         sys.exit(1)

--- a/.agents/skills/vllm-ascend-serving/scripts/serve_start.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/serve_start.py
@@ -261,6 +261,61 @@ def read_remote_tail(ep: SshEndpoint, remote_path: str, lines: int = 30) -> str:
     return r.stdout.strip()
 
 
+# ---------------------------------------------------------------------------
+# Environment error diagnosis
+# ---------------------------------------------------------------------------
+
+_ENV_ERROR_PATTERNS: list[tuple[str, str]] = [
+    ("Failed to infer device type", "device-type"),
+    ("No module named 'vllm_ascend'", "missing-vllm-ascend"),
+    ("No module named 'vllm'", "missing-vllm"),
+    ("No module named 'torch_npu'", "missing-torch-npu"),
+    ("cannot open shared object file", "missing-so"),
+    ("libhccl.so", "missing-so"),
+    ("torch_npu", "torch-npu-error"),
+    ("ImportError", "import-error"),
+    ("ModuleNotFoundError", "module-not-found"),
+]
+
+
+def diagnose_env_failure(stderr_tail: str, machine: str) -> dict[str, Any] | None:
+    """Scan stderr for environment-related errors and return structured recovery guidance.
+
+    Returns a dict with diagnosis details, or None if the error
+    doesn't look environment-related.
+    """
+    if not stderr_tail:
+        return None
+
+    matched_tags: list[str] = []
+    for pattern, tag in _ENV_ERROR_PATTERNS:
+        if pattern in stderr_tail:
+            matched_tags.append(tag)
+
+    if not matched_tags:
+        return None
+
+    return {
+        "error_tags": sorted(set(matched_tags)),
+        "cause": "remote Python package version mismatch",
+        "recovery_command": (
+            f"python3 .agents/skills/remote-code-parity/scripts/parity_sync.py "
+            f"--machine {machine} --force-reinstall"
+        ),
+        "recovery_description": (
+            "Re-run parity sync with --force-reinstall to rebuild "
+            "vllm and vllm-ascend in the correct order with pinned dependencies."
+        ),
+        "warning": (
+            "Do NOT run bare `pip install` inside the container. "
+            "The container has exact version locks between torch, torch_npu, "
+            "vllm, and vllm-ascend. Manual pip install will break the "
+            "dependency graph. Parity sync uses the correct install flags "
+            "(--no-build-isolation, VLLM_TARGET_DEVICE=empty, uv acceleration)."
+        ),
+    }
+
+
 def wait_for_ready(
     ep: SshEndpoint,
     pid: int,
@@ -666,17 +721,29 @@ def main(argv: list[str] | None = None) -> int:
         if wrap_script:
             output["wrap_script"] = wrap_script
         if not readiness["ready"]:
-            output["stderr_tail"] = read_remote_tail(ep, f"{runtime_dir}/stderr.log")
+            stderr_tail = readiness.get("stderr_tail") or read_remote_tail(ep, f"{runtime_dir}/stderr.log")
+            output["stderr_tail"] = stderr_tail
+            diagnosis = diagnose_env_failure(stderr_tail, alias)
+            if diagnosis:
+                output["env_diagnosis"] = diagnosis
+                emit_progress("diagnosis", diagnosis["recovery_command"],
+                              error_tags=diagnosis["error_tags"])
 
         print_json(output)
         return 0 if readiness["ready"] else 1
 
     except Exception as exc:
-        print_json({
+        error_msg = str(exc)
+        machine_id = getattr(args, "machine", None) or ""
+        result: dict[str, Any] = {
             "status": "failed",
-            "error": str(exc),
-            "machine": getattr(args, "machine", None),
-        })
+            "error": error_msg,
+            "machine": machine_id,
+        }
+        diagnosis = diagnose_env_failure(error_msg, machine_id)
+        if diagnosis:
+            result["env_diagnosis"] = diagnosis
+        print_json(result)
         return 2
 
 


### PR DESCRIPTION
## Summary

- When vLLM service startup fails, `serve_start.py` now scans stderr for environment error patterns (missing modules, broken `torch_npu`, device-type inference failure, missing `.so` files) and returns structured `env_diagnosis` in JSON output with `recovery_command`, `error_tags`, and `warning`
- `mem_collect.py` emits the same recovery hint on health-check timeouts in both standalone and attach modes
- Guides agents to use `parity_sync.py --force-reinstall` instead of manual `pip install` inside the container

## Motivation

During a profiling session, a broken remote environment led to a cascade of manual `pip install` attempts that destroyed the container's pinned dependency graph (torch/torch_npu/vllm/vllm-ascend). The existing uv-based parity sync mechanism had the correct install logic but was not discoverable at the point of failure.

## Test plan
- [ ] Verify `serve_start.py` output includes `env_diagnosis` when stderr contains `Failed to infer device type`
- [ ] Verify `mem_collect.py` emits `ENV_ERROR_DETECTED` progress on health-check timeout with environment errors
- [ ] Normal startup path (no env errors) should be unaffected — no `env_diagnosis` field in output


Made with [Cursor](https://cursor.com)