### PR TITLE
feat: add ascend-profiling-collection skill

### DIFF
--- a/.agents/skills/ascend-profiling-collection/SKILL.md
+++ b/.agents/skills/ascend-profiling-collection/SKILL.md
@@ -38,7 +38,10 @@ This skill is **only** about collection: start a profiled service, bracket a wor
 - The serving skill must remain profiling-agnostic. Never push profiler-window control or `analyse()` invocation into it.
 - `--profiler-config` is the only profiling-related thing the serving skill knows about, and only because vLLM accepts it as an opaque blob.
 - Run profiling **inside the remote container**. Never copy raw `*_ascend_pt` directories back to the local Mac.
-- Hard-fail when any rank's `kernel_details.csv` is missing after `analyse()` — see "Failure policy" below.
+- Hard-fail in three cases (all detailed in "Failure policy"):
+  1. any rank's `kernel_details.csv` is missing after `analyse()`
+  2. number of `*_ascend_pt` directories does not match `tp * (dp or 1)`
+  3. workload was not real — follow-up request failed or benchmark wave fell below `--benchmark-success-threshold`
 - Progress on `stderr` as `__VAWS_PROFILING_COLLECTION_PROGRESS__=<json>`. Final manifest on `stdout` as one JSON object.
 - Local state lives **only** under `.vaws-local/ascend-profiling-collection/runs/`.
 
@@ -62,6 +65,7 @@ python3 .agents/skills/ascend-profiling-collection/scripts/collect_torch_profile
   [--api-server-count <N>] \
   [--prompt-tokens <N>] [--followup-output-tokens <N>] \
   [--benchmark-total-requests <N>] [--benchmark-concurrency <N>] \
+  [--benchmark-success-threshold <f>] \
   [--request-timeout <s>] [--profile-control-timeout <s>] \
   [--torch-profiler-dir <relpath>] [--torch-profiler-with-stack] \
   [--image-path <local-path>] [--image-height <px>] \
@@ -106,10 +110,13 @@ The script reads the service port from `.vaws-local/serving/<alias>.json`. A ser
 
 ```bash
 python3 .agents/skills/ascend-profiling-collection/scripts/run_remote_analyse.py \
-  --machine <alias> --profile-root <remote-path>
+  --machine <alias> --profile-root <remote-path> \
+  [--expected-ranks <N>]
 ```
 
 Discovers every `*_ascend_pt` under `--profile-root`, runs `torch_npu.profiler.profiler.analyse()` on each, and verifies that `ASCEND_PROFILER_OUTPUT/kernel_details.csv` and `trace_view.json` landed. Exits non-zero if any rank is incomplete.
+
+Always pass `--expected-ranks` (typically `tp * (dp or 1)`) when running this against a fresh capture: without it a partial collection where some ranks never produced a directory looks "clean" because every directory that *did* land was complete. The orchestrator passes this automatically.
 
 ## Workflow
 
@@ -127,14 +134,24 @@ Discovers every `*_ascend_pt` under `--profile-root`, runs `torch_npu.profiler.p
 
 ## Failure policy
 
-Accuracy beats coverage. The script exits non-zero (status `failed`) when:
+Accuracy beats coverage. The script exits non-zero (status `failed`) when **any** of:
 
 - the service did not become `ready`
 - `/start_profile` or `/stop_profile` returned non-2xx
-- any benchmark request raised before the profile window closed (recorded but not by itself fatal — agent decides)
-- any rank's `kernel_details.csv` is missing after `analyse()` — `analysis_status == missing_kernel_details`
+- **workload was not real**: `workload_status.status != "ok"`, i.e. the
+  follow-up request failed or the benchmark wave's success rate was below
+  `--benchmark-success-threshold` (default 0.8). Without real traffic during
+  the profile window the trace records nothing useful.
+- **rank count mismatch**: number of `*_ascend_pt` directories `!= tp * (dp or 1)`
+  → `analysis_status == "rank_count_mismatch"`. Some rank never dumped its
+  profiler data; even if every directory that *did* land is complete, the
+  topology is broken and downstream cross-rank analysis would be wrong.
+- any rank's `kernel_details.csv` is missing after `analyse()` →
+  `analysis_status == "missing_kernel_details"`
 
-The third condition is the canonical "device-side data did not land" failure documented in `doc/profiling-inventory.md`. Treat it as **re-collect required**, not as something the analysis skill can recover from.
+The last condition is the canonical "device-side data did not land" failure
+documented in `doc/profiling-inventory.md`. Treat all of the above as
+**re-collect required**, not as something the analysis skill can recover from.
 
 If the orchestrator fails after `serve_start`, it always tries to stop the service (graceful, then `--force`) so no orphan vLLM process is left behind.
 
@@ -148,16 +165,19 @@ The manifest is the input contract for the analysis skill. Important fields:
 | `tag`, `started_at`, `completed_at` / `failed_at` | Run identity |
 | `machine`, `model`, `served_model_name`, `tp`, `dp` | Hardware / model identity |
 | `mode`, `speculative_tokens`, `speculative_method`, `enable_expert_parallel`, `api_server_count` | What was profiled |
-| `request_kind`, `prompt_tokens`, `benchmark_output_tokens`, `followup_output_tokens`, `benchmark_total_requests`, `benchmark_concurrency` | What workload produced the trace |
+| `request_kind`, `prompt_tokens`, `benchmark_output_tokens`, `followup_output_tokens`, `benchmark_total_requests`, `benchmark_concurrency`, `benchmark_success_threshold` | What workload produced the trace and what success bar it had to clear |
+| `expected_ranks` | `tp * (dp or 1)` — what `analyse()` was told to enforce |
 | `torch_profiler_with_stack`, `torch_profiler_dir` | Profiler depth and on-disk location |
 | `serve_args` | Exact `serve_start.py` argv (audit trail) |
 | `service_result`, `start_profile`, `stop_profile`, `stop_result` | Sub-call outputs |
 | `benchmark_results`, `followup_result` | Per-request status / latency / response body |
+| `workload_status` | `{status, bench_total, bench_ok, bench_success_rate, bench_threshold, followup_ok}` — workload hard gate |
 | `remote_profile_root` | Path the analysis skill passes to its `analyze.py` |
 | `remote_profile_dirs` | Per-rank `{path, outputs, analysis_status}` |
-| `analysis_status` | `ok` / `partial` / `missing_kernel_details` — the hard gate |
-| `status` | `ok` / `failed` |
-| `error` | Set when `status == failed` |
+| `rank_count` | Number of `*_ascend_pt` directories actually found |
+| `analysis_status` | `ok` / `partial` / `rank_count_mismatch` / `missing_kernel_details` — analysis hard gate |
+| `status` | `ok` / `failed`. `ok` requires both `analysis_status == "ok"` and `workload_status.status == "ok"` |
+| `error` | Set when `status == failed`; lists which gate(s) tripped |
 
 ## Reference files
 

--- a/.agents/skills/ascend-profiling-collection/SKILL.md
+++ b/.agents/skills/ascend-profiling-collection/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: ascend-profiling-collection
+description: Collect one Ascend torch-profiler case end-to-end on a workspace-managed remote NPU container. Starts a profiled vLLM service, brackets a workload with /start_profile and /stop_profile, runs analyse(), verifies kernel_details.csv landed, and writes a manifest the analysis skill can consume. Use for requests like "采集 profiling", "torch profiler 跑一个 case", "采一份 profile 出来", "采 profiling 给我分析". Do not use for pure performance benchmarking, HBM/memory profiling, or for analysing already-collected profiling data (that is the analysis skill's job).
+---
+
+# Ascend Profiling Collection
+
+Collect one torch-profiler case on a workspace-managed remote Ascend NPU container.
+
+This skill is **only** about collection: start a profiled service, bracket a workload with `/start_profile` and `/stop_profile`, run `torch_npu.profiler.profiler.analyse(...)`, verify the device-side data actually landed, and write a manifest. Interpreting the resulting `kernel_details.csv` is a separate concern owned by the analysis skill.
+
+## Use this skill when
+
+- the user asks to collect / capture an Ascend torch-profiler trace for a specific config
+- another skill (the analysis skill) needs a fresh profiling root with verified outputs
+- the user wants to reproduce an existing root with a new model / mode / TP / DP
+
+## Do not use this skill when
+
+- the task is performance benchmarking only — use `vllm-ascend-benchmark`
+- the task is HBM / memory analysis — use `ascend-memory-profiling`
+- the task is analysing an already-collected profiling root (no need to re-collect)
+- the machine is not yet ready in inventory — use `machine-management`
+
+## Boundary with other skills
+
+| Skill | Owns | This skill uses it for |
+| --- | --- | --- |
+| `vllm-ascend-serving` | Service lifecycle, `--profiler-config` passthrough | `serve_start.py` / `serve_stop.py` only; serving is **agnostic** to the profiler window |
+| `remote-code-parity` | Local-to-container code sync | Implicit — invoked by `serve_start.py` |
+| `vllm-ascend-benchmark` | `vllm bench serve` performance numbers | Not used; benchmark skill must not learn the profiler control plane |
+| `ascend-memory-profiling` | HBM attribution via msprof | Independent; not invoked |
+
+`/start_profile` and `/stop_profile` exist *because of* profiling, so the control-plane client lives here, not in `vllm-ascend-serving`.
+
+## Critical rules
+
+- The serving skill must remain profiling-agnostic. Never push profiler-window control or `analyse()` invocation into it.
+- `--profiler-config` is the only profiling-related thing the serving skill knows about, and only because vLLM accepts it as an opaque blob.
+- Run profiling **inside the remote container**. Never copy raw `*_ascend_pt` directories back to the local Mac.
+- Hard-fail when any rank's `kernel_details.csv` is missing after `analyse()` — see "Failure policy" below.
+- Progress on `stderr` as `__VAWS_PROFILING_COLLECTION_PROGRESS__=<json>`. Final manifest on `stdout` as one JSON object.
+- Local state lives **only** under `.vaws-local/ascend-profiling-collection/runs/`.
+
+## Public entry point
+
+```bash
+python3 .agents/skills/ascend-profiling-collection/scripts/collect_torch_profile_case.py \
+  --machine <alias-or-ip> \
+  --model <remote-weight-path> \
+  --served-model-name <name> \
+  --tp <N> \
+  --tag <stable-id> \
+  --mode {enforce_eager|full_decode_only|piecewise_graph} \
+  --request-kind {text|vl} \
+  --benchmark-output-tokens <N> \
+  [--dp <N>] \
+  [--enable-expert-parallel] \
+  [--speculative-tokens <N>] [--speculative-method <name>] \
+  [--gpu-memory-utilization <f>] \
+  [--max-model-len <N>] [--max-num-seqs <N>] [--max-num-batched-tokens <N>] \
+  [--api-server-count <N>] \
+  [--prompt-tokens <N>] [--followup-output-tokens <N>] \
+  [--benchmark-total-requests <N>] [--benchmark-concurrency <N>] \
+  [--request-timeout <s>] [--profile-control-timeout <s>] \
+  [--torch-profiler-dir <relpath>] [--torch-profiler-with-stack] \
+  [--image-path <local-path>] [--image-height <px>] \
+  [--skip-parity]
+```
+
+### Required parameters and why
+
+The script intentionally has no Qwen-specific defaults. The agent must always pass:
+
+| Required arg | Why |
+| --- | --- |
+| `--machine` | Target container; resolved through inventory |
+| `--model` / `--served-model-name` | Different cases need different models, no safe default |
+| `--tp` | Hardware shape; never assume it |
+| `--mode` | The profile is meaningless without recording which graph mode produced it |
+| `--request-kind` | Determines payload assembly (text vs VL) |
+| `--benchmark-output-tokens` | Decode length is the dominant knob for what the trace looks like |
+| `--tag` | Stable identifier folded into the run-dir name and manifest |
+
+`--speculative-tokens 0` (the default) means "do not pass `--speculative-config` at all". Set to a positive integer to enable MTP/Eagle.
+
+## Auxiliary entry points
+
+The agent can call these directly if it already has a service running and only wants to flip the profiler window or re-run `analyse()` on an existing root.
+
+### Flip the profiler window
+
+```bash
+# Start a profile window on a service that the serving skill already launched
+python3 .agents/skills/ascend-profiling-collection/scripts/profile_control.py \
+  --machine <alias> --action start_profile [--timeout 900]
+
+# Close it
+python3 .agents/skills/ascend-profiling-collection/scripts/profile_control.py \
+  --machine <alias> --action stop_profile [--timeout 900]
+```
+
+The script reads the service port from `.vaws-local/serving/<alias>.json`. A service must be running.
+
+### Re-run `analyse()` on an existing root
+
+```bash
+python3 .agents/skills/ascend-profiling-collection/scripts/run_remote_analyse.py \
+  --machine <alias> --profile-root <remote-path>
+```
+
+Discovers every `*_ascend_pt` under `--profile-root`, runs `torch_npu.profiler.profiler.analyse()` on each, and verifies that `ASCEND_PROFILER_OUTPUT/kernel_details.csv` and `trace_view.json` landed. Exits non-zero if any rank is incomplete.
+
+## Workflow
+
+1. **Resolve machine** via inventory; container endpoint comes from `machine-management`.
+2. **Build serving args** — encode `--profiler-config` (always written) and the chosen graph mode.
+3. **Start service** by shelling out to `serve_start.py`. Parity sync is automatic via the serving skill.
+4. **Open SSH tunnel** to the service port so workload requests can be assembled locally (multimodal payloads need local image encoding).
+5. **POST `/start_profile`** with the long control-plane timeout.
+6. **Send benchmark wave** (concurrent chat-completions) followed by **one follow-up tail request**. The follow-up is intentionally short to capture a clean steady-state step.
+7. **POST `/stop_profile`**.
+8. **Stop service** by shelling out to `serve_stop.py`.
+9. **Discover and analyse** every `*_ascend_pt` under `<runtime_dir>/<torch_profiler_dir>` via `run_remote_analyse.py`.
+10. **Verify outputs** per rank; classify each as `ok | partial | missing_kernel_details`.
+11. **Write manifest** to `.vaws-local/ascend-profiling-collection/runs/<timestamp>_<tag>/manifest.json`.
+
+## Failure policy
+
+Accuracy beats coverage. The script exits non-zero (status `failed`) when:
+
+- the service did not become `ready`
+- `/start_profile` or `/stop_profile` returned non-2xx
+- any benchmark request raised before the profile window closed (recorded but not by itself fatal — agent decides)
+- any rank's `kernel_details.csv` is missing after `analyse()` — `analysis_status == missing_kernel_details`
+
+The third condition is the canonical "device-side data did not land" failure documented in `doc/profiling-inventory.md`. Treat it as **re-collect required**, not as something the analysis skill can recover from.
+
+If the orchestrator fails after `serve_start`, it always tries to stop the service (graceful, then `--force`) so no orphan vLLM process is left behind.
+
+## Manifest schema
+
+The manifest is the input contract for the analysis skill. Important fields:
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Bumped when fields are renamed or removed |
+| `tag`, `started_at`, `completed_at` / `failed_at` | Run identity |
+| `machine`, `model`, `served_model_name`, `tp`, `dp` | Hardware / model identity |
+| `mode`, `speculative_tokens`, `speculative_method`, `enable_expert_parallel`, `api_server_count` | What was profiled |
+| `request_kind`, `prompt_tokens`, `benchmark_output_tokens`, `followup_output_tokens`, `benchmark_total_requests`, `benchmark_concurrency` | What workload produced the trace |
+| `torch_profiler_with_stack`, `torch_profiler_dir` | Profiler depth and on-disk location |
+| `serve_args` | Exact `serve_start.py` argv (audit trail) |
+| `service_result`, `start_profile`, `stop_profile`, `stop_result` | Sub-call outputs |
+| `benchmark_results`, `followup_result` | Per-request status / latency / response body |
+| `remote_profile_root` | Path the analysis skill passes to its `analyze.py` |
+| `remote_profile_dirs` | Per-rank `{path, outputs, analysis_status}` |
+| `analysis_status` | `ok` / `partial` / `missing_kernel_details` — the hard gate |
+| `status` | `ok` / `failed` |
+| `error` | Set when `status == failed` |
+
+## Reference files
+
+- `references/command-recipes.md` — common `collect_torch_profile_case.py` invocations
+- `references/behavior.md` — control-plane timing, mode mapping, image encoding caveats
+- `references/acceptance.md` — manual checks before marking a collection good

--- a/.agents/skills/ascend-profiling-collection/references/acceptance.md
+++ b/.agents/skills/ascend-profiling-collection/references/acceptance.md
@@ -34,11 +34,23 @@ A non-2xx status here means the profiler window was never actually open, even if
 ## 4. Workload actually executed during the window
 
 ```jsonc
-"benchmark_results": [ { "ok": true, ... }, ... ],
-"followup_result":   { "ok": true, ... }
+"workload_status": {
+  "status": "ok",
+  "bench_total": <int>,
+  "bench_ok":    <int>,
+  "bench_success_rate": <float>,
+  "bench_threshold":    <float>,
+  "followup_ok": true
+}
 ```
 
-If most benchmark requests have `ok=false`, the model was not under load when the profiler was active. Inspect `error` / `body` fields and decide whether the request shape (`--prompt-tokens`, `--benchmark-output-tokens`, `--max-model-len`) was wrong for the model.
+`workload_status.status != "ok"` is a top-level hard gate (orchestrator already sets `status=failed`). Possible non-ok values:
+
+- `followup_failed` — the single tail request failed; the trace ends in an error path, not in steady-state decode
+- `benchmark_below_threshold` — fewer than `--benchmark-success-threshold` of the benchmark wave succeeded; the model was not under load for most of the window
+- `no_benchmark_requests` — defensive: the orchestrator was asked to run zero benchmark requests
+
+Inspect `benchmark_results[*].error` / `body` to decide whether the request shape (`--prompt-tokens`, `--benchmark-output-tokens`, `--max-model-len`) was wrong for the model before re-collecting.
 
 ## 5. Every rank produced kernel_details.csv
 
@@ -60,9 +72,13 @@ Any per-rank `analysis_status` other than `ok` invalidates the whole root for do
 
 ## 6. Number of rank dirs matches expected topology
 
-`len(remote_profile_dirs) == tp * (dp or 1)`.
+```jsonc
+"expected_ranks": <tp * (dp or 1)>,
+"rank_count":     <observed>,
+"analysis_status": "ok"   // not "rank_count_mismatch"
+```
 
-Mismatch usually means one rank's profiler thread crashed or its `*_ascend_pt` directory landed somewhere unexpected. SSH into the container and inspect `<remote_profile_root>` directly before re-collecting.
+The orchestrator passes `--expected-ranks = tp * (dp or 1)` to `run_remote_analyse.py` and the script sets `analysis_status = "rank_count_mismatch"` (and the top-level `status = failed`) when the count is off — even if every directory that *did* land was complete. Mismatch usually means one rank's profiler thread crashed or its `*_ascend_pt` directory landed somewhere unexpected. SSH into the container and inspect `<remote_profile_root>` directly before re-collecting.
 
 ## 7. Service was stopped cleanly
 
@@ -77,6 +93,8 @@ If `stop_result.status` is `failed`, an orphan vLLM process may still be holding
 The following symptoms cannot be fixed offline:
 
 - `analysis_status == "missing_kernel_details"` on any rank
+- `analysis_status == "rank_count_mismatch"` (a rank failed to dump anything)
+- `workload_status.status != "ok"` (no real model traffic during the window)
 - `*_ascend_pt/PROF_*/device_*/data` is suspiciously small (kilobytes vs. expected MB)
 - `FRAMEWORK/torch.op_range` missing
 - profile window was shorter than the actual model warmup (rare but seen with first-call lazy compilation)

--- a/.agents/skills/ascend-profiling-collection/references/acceptance.md
+++ b/.agents/skills/ascend-profiling-collection/references/acceptance.md
@@ -1,0 +1,91 @@
+# Acceptance Checks
+
+A collection run is "good" when **all** of the following hold. The agent should verify these before reporting success.
+
+## 1. Top-level status
+
+```jsonc
+{
+  "status": "ok",
+  "analysis_status": "ok",
+  ...
+}
+```
+
+`status == "failed"` or `analysis_status != "ok"` ⇒ collection is not usable. Re-collect.
+
+## 2. Service did become ready
+
+```jsonc
+"service_result": { "status": "ready", "port": <int>, "runtime_dir": "..." }
+```
+
+If `service_result.status` is anything else (`failed`, `needs_input`, ...) the run did not actually capture anything; the manifest will already be `status=failed` but verify this is the cause before retrying.
+
+## 3. Profile window opened and closed cleanly
+
+```jsonc
+"start_profile": { "ok": true, "status": 200, ... },
+"stop_profile":  { "ok": true, "status": 200, ... }
+```
+
+A non-2xx status here means the profiler window was never actually open, even if other steps succeeded. The captured trace may still exist but is meaningless.
+
+## 4. Workload actually executed during the window
+
+```jsonc
+"benchmark_results": [ { "ok": true, ... }, ... ],
+"followup_result":   { "ok": true, ... }
+```
+
+If most benchmark requests have `ok=false`, the model was not under load when the profiler was active. Inspect `error` / `body` fields and decide whether the request shape (`--prompt-tokens`, `--benchmark-output-tokens`, `--max-model-len`) was wrong for the model.
+
+## 5. Every rank produced kernel_details.csv
+
+```jsonc
+"remote_profile_dirs": [
+  {
+    "path": "...rank.../ascend_pt",
+    "outputs": {
+      "kernel_details_csv": { "exists": true, ... },
+      "trace_view_json":    { "exists": true, ... }
+    },
+    "analysis_status": "ok"
+  },
+  ...
+]
+```
+
+Any per-rank `analysis_status` other than `ok` invalidates the whole root for downstream analysis. The orchestrator will already have set the top-level `analysis_status` accordingly.
+
+## 6. Number of rank dirs matches expected topology
+
+`len(remote_profile_dirs) == tp * (dp or 1)`.
+
+Mismatch usually means one rank's profiler thread crashed or its `*_ascend_pt` directory landed somewhere unexpected. SSH into the container and inspect `<remote_profile_root>` directly before re-collecting.
+
+## 7. Service was stopped cleanly
+
+```jsonc
+"stop_result": { "status": "stopped", ... }
+```
+
+If `stop_result.status` is `failed`, an orphan vLLM process may still be holding NPUs. Run `serve_stop.py --machine <alias> --force` and re-check `serve_probe_npus.py` before launching the next collection.
+
+## When you need to re-collect (not re-analyse)
+
+The following symptoms cannot be fixed offline:
+
+- `analysis_status == "missing_kernel_details"` on any rank
+- `*_ascend_pt/PROF_*/device_*/data` is suspiciously small (kilobytes vs. expected MB)
+- `FRAMEWORK/torch.op_range` missing
+- profile window was shorter than the actual model warmup (rare but seen with first-call lazy compilation)
+
+These all originate at capture time. `run_remote_analyse.py` cannot recover them.
+
+## When re-analyse is enough
+
+- The capture finished cleanly but `analyse()` was never run (rare; the orchestrator always runs it).
+- An old root collected by the now-removed prototype script (under `.vaws-local/service-torch-profiler/`) needs to be re-verified under the new output contract.
+
+In those cases, point `run_remote_analyse.py --profile-root` at the root and let it run. Verification will tell you whether the data was salvageable.

--- a/.agents/skills/ascend-profiling-collection/references/behavior.md
+++ b/.agents/skills/ascend-profiling-collection/references/behavior.md
@@ -42,6 +42,24 @@ The `sips` image resizer is macOS-only. The collection skill assumes the agent r
 
 `--api-server-count` is exposed because vLLM's multi-api-server mode has historically had control-plane routing quirks: a `/start_profile` POST may be answered by an API server that is not the one driving the worker processes. When investigating a "trace empty" symptom, set `--api-server-count 1` to eliminate this variable before blaming the profiler.
 
+## Workload success gate
+
+`benchmark_results` and `followup_result` are not just diagnostic data — the
+orchestrator computes a `workload_status` over them and the top-level
+`status` is `failed` whenever:
+
+- the follow-up tail request did not return 2xx (`workload_status.status ==
+  "followup_failed"`), or
+- the benchmark wave's success rate fell below
+  `--benchmark-success-threshold` (default 0.8) — `bench_success_rate <
+  bench_threshold` ⇒ `workload_status.status == "benchmark_below_threshold"`.
+
+A profile window that ran with no real model traffic produces a trace that
+*looks* fine to `analyse()` (kernel_details.csv lands, only it describes
+nothing useful). The gate prevents that root from leaking into downstream
+analysis. Lower the threshold only when you explicitly expect flakiness in
+the wave.
+
 ## Output verification
 
 After `analyse()`, every `*_ascend_pt` directory is expected to contain:
@@ -50,6 +68,13 @@ After `analyse()`, every `*_ascend_pt` directory is expected to contain:
 - `ASCEND_PROFILER_OUTPUT/trace_view.json`
 
 `profiling-inventory.md` documents several captures where `analyse()` "succeeded" but produced no `kernel_details.csv` because the profile window was too short or `FRAMEWORK/torch.op_range` never made it to disk. The skill turns that into `analysis_status == missing_kernel_details` and fails the run. Re-collection is the only fix; offline `analyse()` cannot recover the missing device data.
+
+In addition, the orchestrator passes `--expected-ranks = tp * (dp or 1)` to
+`run_remote_analyse.py`. When the actual `*_ascend_pt` count differs from the
+expected number, `analysis_status` becomes `rank_count_mismatch`. Without
+this gate a partial capture (e.g. only rank 0 dumped) can look "clean"
+because every directory that *did* land was complete, masking a topology
+failure.
 
 ## Post-stop flush window
 

--- a/.agents/skills/ascend-profiling-collection/references/behavior.md
+++ b/.agents/skills/ascend-profiling-collection/references/behavior.md
@@ -1,0 +1,74 @@
+# Behavior Reference
+
+## Why profiler control lives here, not in the serving skill
+
+`/start_profile` and `/stop_profile` only exist because vLLM has a built-in torch profiler. Moving the control client into `vllm-ascend-serving` would force serving to grow profiling-specific knobs (multi-rank long timeout, multi-api-server quirks). The serving skill stays simple by treating `--profiler-config` as an opaque blob it forwards to `vllm serve`. Anything that flips, waits on, or interprets the profiler window belongs here.
+
+## Mode → vLLM flag mapping
+
+| `--mode` | Forwarded to `vllm serve` |
+| --- | --- |
+| `enforce_eager` | `--enforce-eager` |
+| `full_decode_only` | `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` |
+| `piecewise_graph` | `--compilation-config '{"cudagraph_mode":"PIECEWISE"}'` |
+
+`CUDAGraphMode` enum values come from `vllm/vllm/config/compilation.py`. Add a new mode here only after verifying the underlying enum value still exists in the active `vllm/` submodule.
+
+## Speculative config
+
+`--speculative-tokens 0` (the default) means **omit** `--speculative-config` entirely. A positive value writes:
+
+```json
+{"method": "<--speculative-method>", "num_speculative_tokens": <N>}
+```
+
+Old prototypes always wrote a config block with `num_speculative_tokens=3`; that became confusing for non-MTP cases. The collection skill is now explicit.
+
+## Control-plane timeout
+
+`/start_profile` and `/stop_profile` setup/finalization touches every rank. With TP=8 it is normal to see 60+ seconds of latency on each call. The default `--profile-control-timeout 600` covers most cases; bump to 1200–1800 for large-scale runs. `--request-timeout` is independent and applies only to the chat-completions requests during the profile window.
+
+## Request wave shape
+
+The default wave is `--benchmark-total-requests 10` at `--benchmark-concurrency 5`, followed by exactly one `--followup-output-tokens 5` tail request. The follow-up exists so the resulting trace contains a clean steady-state step that is not contaminated by the wave's tail decay. The analysis skill relies on this shape for its tail-step detection.
+
+## Workload transport
+
+Chat requests are sent from the local machine through an ephemeral `ssh -L` tunnel. This is so multimodal (`--request-kind vl`) payloads — base64 image data URLs — can be assembled locally without round-tripping through SSH heredocs. For `--request-kind text` the tunnel is still used (consistency); request bodies stay small so there is no transport cost.
+
+The `sips` image resizer is macOS-only. The collection skill assumes the agent runs on a Mac workstation. If the workstation is ever Linux, swap `_parse_sips_dimensions` / `_build_image_data_url` for a PIL implementation.
+
+## Multi-api-server interactions
+
+`--api-server-count` is exposed because vLLM's multi-api-server mode has historically had control-plane routing quirks: a `/start_profile` POST may be answered by an API server that is not the one driving the worker processes. When investigating a "trace empty" symptom, set `--api-server-count 1` to eliminate this variable before blaming the profiler.
+
+## Output verification
+
+After `analyse()`, every `*_ascend_pt` directory is expected to contain:
+
+- `ASCEND_PROFILER_OUTPUT/kernel_details.csv`
+- `ASCEND_PROFILER_OUTPUT/trace_view.json`
+
+`profiling-inventory.md` documents several captures where `analyse()` "succeeded" but produced no `kernel_details.csv` because the profile window was too short or `FRAMEWORK/torch.op_range` never made it to disk. The skill turns that into `analysis_status == missing_kernel_details` and fails the run. Re-collection is the only fix; offline `analyse()` cannot recover the missing device data.
+
+## Post-stop flush window
+
+The orchestrator sleeps `POST_STOP_FLUSH_SECONDS` (5s) between `/stop_profile` returning and `serve_stop.py` being called. `/stop_profile` should already block until profiler threads quiesce, but historical traces show flush latency on some CANN versions. The window is short enough not to bother humans and long enough to cover known races.
+
+## Local state layout
+
+```
+.vaws-local/ascend-profiling-collection/runs/
+  <YYYYmmdd_HHMMSS>_<tag>/
+    manifest.json
+```
+
+One directory per invocation. Nothing else is ever written here. The remote profiling root (`<runtime_dir>/<torch_profiler_dir>`) lives on the container and is referenced from the manifest via `remote_profile_root`.
+
+## Interaction with `remote-code-parity`
+
+Code parity is enforced transitively through `serve_start.py`. The collection skill must not call parity itself. The `.vaws-runtime` preserve carve-out and the `uv pip install --system` fix that profiling needed are owned by the parity skill — see `.agents/skills/remote-code-parity/SKILL.md`.
+
+## Manifest schema versioning
+
+`schema_version` starts at 1. Bump only when a field is renamed or removed. Adding new fields (e.g. richer profiler config knobs) does not require a bump; the analysis skill should treat unknown fields as advisory.

--- a/.agents/skills/ascend-profiling-collection/references/command-recipes.md
+++ b/.agents/skills/ascend-profiling-collection/references/command-recipes.md
@@ -1,0 +1,103 @@
+# Command Recipes
+
+These are the expected shapes the agent should call. Every invocation is a single shot — there is no "warm collection" mode.
+
+## Minimal text case in eager mode
+
+```bash
+python3 .agents/skills/ascend-profiling-collection/scripts/collect_torch_profile_case.py \
+  --machine blue-a \
+  --model /home/weights/Qwen3-8B \
+  --served-model-name Qwen3-8B \
+  --tp 1 \
+  --tag qwen3_8b_eager_text \
+  --mode enforce_eager \
+  --request-kind text \
+  --benchmark-output-tokens 64
+```
+
+## Full-decode-only graph mode with MTP=3 speculative decoding
+
+```bash
+python3 .agents/skills/ascend-profiling-collection/scripts/collect_torch_profile_case.py \
+  --machine blue-a \
+  --model /home/weights/Qwen3.5-35B-A3B \
+  --served-model-name Qwen3.5-35B-A3B \
+  --tp 4 --dp 2 --enable-expert-parallel \
+  --tag qwen35_35b_dp2tp4_fdo_mtp3 \
+  --mode full_decode_only \
+  --speculative-tokens 3 --speculative-method qwen3_5_mtp \
+  --request-kind text \
+  --benchmark-output-tokens 256 \
+  --benchmark-total-requests 10 --benchmark-concurrency 5 \
+  --max-num-seqs 2 --max-num-batched-tokens 1024
+```
+
+## Piecewise graph mode with VL workload
+
+```bash
+python3 .agents/skills/ascend-profiling-collection/scripts/collect_torch_profile_case.py \
+  --machine blue-b \
+  --model /home/weights/Qwen3.5-VL \
+  --served-model-name Qwen3.5-VL \
+  --tp 4 \
+  --tag qwen35_vl_piecewise_vl \
+  --mode piecewise_graph \
+  --request-kind vl \
+  --benchmark-output-tokens 64 \
+  --image-height 480
+```
+
+`--image-path` defaults to `vllm-ascend/tests/e2e/310p/data/qwen.png` so VL collection works without extra args. Override only if the agent wants a different test image.
+
+## Long control-plane timeout for many ranks
+
+```bash
+python3 .agents/skills/ascend-profiling-collection/scripts/collect_torch_profile_case.py \
+  --machine blue-a \
+  --model /home/weights/DeepSeek-V3 \
+  --served-model-name DeepSeek-V3 \
+  --tp 8 \
+  --tag dsv3_tp8_fdo \
+  --mode full_decode_only \
+  --request-kind text \
+  --benchmark-output-tokens 64 \
+  --profile-control-timeout 1800 --request-timeout 1800
+```
+
+Multi-rank torch profiler setup/finalization can take several minutes. Bump `--profile-control-timeout` whenever TP × DP grows.
+
+## Re-analyse an already-collected root
+
+Use this when a previous collection ran but `analyse()` was skipped or the agent wants to re-verify outputs without re-collecting.
+
+```bash
+python3 .agents/skills/ascend-profiling-collection/scripts/run_remote_analyse.py \
+  --machine blue-a \
+  --profile-root /vllm-workspace/.vaws-runtime/serving/<timestamp>/vllm_profile
+```
+
+Exit 0 means every rank produced `kernel_details.csv` and `trace_view.json`. Non-zero means re-collection is needed.
+
+## Manually flip the profiler window on a service the agent already started
+
+For debugging the control plane in isolation. The serving skill must have launched a service with a `--profiler-config` argument first.
+
+```bash
+python3 .agents/skills/ascend-profiling-collection/scripts/profile_control.py \
+  --machine blue-a --action start_profile --timeout 900
+
+# ... agent sends workload via curl / openai client / etc ...
+
+python3 .agents/skills/ascend-profiling-collection/scripts/profile_control.py \
+  --machine blue-a --action stop_profile --timeout 900
+```
+
+The script reads the service port from `.vaws-local/serving/<alias>.json`.
+
+## What NOT to do
+
+- Do not run `collect_torch_profile_case.py` against a machine the user has not added to inventory. Route via `machine-management` first.
+- Do not pass `--profiler-config` through `--serve-args` of `vllm-ascend-benchmark` to "sneak" profiling into a benchmark run; benchmarks should not own profiler windows.
+- Do not call `torch_npu.profiler.profiler.analyse()` from the local Mac. The collection / re-analyse scripts run it inside the container.
+- Do not share state with `.vaws-local/service-torch-profiler/` (the old prototype location). The new skill writes only to `.vaws-local/ascend-profiling-collection/runs/`.

--- a/.agents/skills/ascend-profiling-collection/references/command-recipes.md
+++ b/.agents/skills/ascend-profiling-collection/references/command-recipes.md
@@ -74,10 +74,11 @@ Use this when a previous collection ran but `analyse()` was skipped or the agent
 ```bash
 python3 .agents/skills/ascend-profiling-collection/scripts/run_remote_analyse.py \
   --machine blue-a \
-  --profile-root /vllm-workspace/.vaws-runtime/serving/<timestamp>/vllm_profile
+  --profile-root /vllm-workspace/.vaws-runtime/serving/<timestamp>/vllm_profile \
+  --expected-ranks 8
 ```
 
-Exit 0 means every rank produced `kernel_details.csv` and `trace_view.json`. Non-zero means re-collection is needed.
+Exit 0 means every rank produced `kernel_details.csv` and `trace_view.json` AND the directory count matched `--expected-ranks` (typically `tp * (dp or 1)`). Non-zero means re-collection is needed. Always pass `--expected-ranks` against fresh roots — without it a partial capture where some ranks never produced a directory looks "clean".
 
 ## Manually flip the profiler window on a service the agent already started
 

--- a/.agents/skills/ascend-profiling-collection/scripts/_common.py
+++ b/.agents/skills/ascend-profiling-collection/scripts/_common.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Shared utilities for ascend-profiling-collection scripts.
+
+This module owns helpers that exist *because of profiling*: the SSH +
+ascend-env preamble, the local SSH tunnel for sending workload requests, the
+profile-control client, and progress / state-dir conventions.
+
+Inventory resolution and SSH primitives are reused from the serving skill's
+``_common`` so we do not maintain a second copy.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import json
+import socket
+import subprocess
+import sys
+import textwrap
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB_DIR = ROOT / ".agents" / "lib"
+MM_SCRIPTS = ROOT / ".agents" / "skills" / "machine-management" / "scripts"
+SERVING_SCRIPTS = ROOT / ".agents" / "skills" / "vllm-ascend-serving" / "scripts"
+
+PROGRESS_SENTINEL = "__VAWS_PROFILING_COLLECTION_PROGRESS__="
+COLLECTION_STATE_DIR = ROOT / ".vaws-local" / "ascend-profiling-collection" / "runs"
+
+
+# ---------------------------------------------------------------------------
+# Lazy import of serving _common (single source of truth for SSH + inventory)
+# ---------------------------------------------------------------------------
+
+def _load_serving_common():
+    """Load the serving skill's _common.py without polluting sys.path.
+
+    We import it as ``vaws_profcoll_serving_common`` so it does not collide
+    with this skill's own ``_common`` module name.
+    """
+    module_name = "vaws_profcoll_serving_common"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    src = SERVING_SCRIPTS / "_common.py"
+    spec = importlib.util.spec_from_file_location(module_name, src)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load serving common helpers from {src}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SERVING = _load_serving_common()
+SshEndpoint = SERVING.SshEndpoint
+ssh_exec = SERVING.ssh_exec
+resolve_machine = SERVING.resolve_machine
+container_endpoint = SERVING.container_endpoint
+host_endpoint = SERVING.host_endpoint
+load_serving_state = SERVING.load_serving_state
+
+
+# ---------------------------------------------------------------------------
+# Progress / output
+# ---------------------------------------------------------------------------
+
+def emit_progress(phase: str, message: str, **extra: Any) -> None:
+    payload: dict[str, Any] = {"phase": phase, "message": message}
+    payload.update({k: v for k, v in extra.items() if v is not None})
+    sys.stderr.write(PROGRESS_SENTINEL + json.dumps(payload, ensure_ascii=False) + "\n")
+    sys.stderr.flush()
+
+
+def print_json(data: dict[str, Any]) -> None:
+    print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def now_utc() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Ascend env preamble (mirrors the one in benchmark/_common.py)
+# ---------------------------------------------------------------------------
+
+ASCEND_ENV_PREAMBLE = textwrap.dedent(
+    """\
+    set -e
+    if [ -f /etc/profile.d/vaws-ascend-env.sh ]; then
+      set +u
+      source /etc/profile.d/vaws-ascend-env.sh
+      set -u
+    fi
+    """
+).rstrip("\n")
+
+
+# ---------------------------------------------------------------------------
+# Local SSH tunnel for sending workload requests from the local machine
+# ---------------------------------------------------------------------------
+
+def _find_free_local_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        return int(sock.getsockname()[1])
+
+
+@contextlib.contextmanager
+def open_local_tunnel(ep, remote_port: int):
+    """Open an ephemeral ``ssh -L`` tunnel to ``127.0.0.1:<remote_port>``.
+
+    Yields a dict with ``local_port`` and ``base_url``. Used by the workload
+    sender so multimodal payloads (image data URLs) can be assembled locally
+    and POSTed without round-tripping through SSH heredocs.
+    """
+    local_port = _find_free_local_port()
+    cmd = [
+        "ssh",
+        "-o", "BatchMode=yes",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", "ExitOnForwardFailure=yes",
+        "-o", "LogLevel=ERROR",
+        "-N",
+        "-L", f"127.0.0.1:{local_port}:127.0.0.1:{remote_port}",
+        "-p", str(ep.port),
+        ep.destination(),
+    ]
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.time() + 15
+        last_error = ""
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                stderr = proc.stderr.read() if proc.stderr is not None else ""
+                raise RuntimeError(
+                    f"ssh tunnel exited early (rc={proc.returncode}): {stderr[:2000]}"
+                )
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.settimeout(0.5)
+                try:
+                    sock.connect(("127.0.0.1", local_port))
+                    yield {
+                        "local_port": local_port,
+                        "base_url": f"http://127.0.0.1:{local_port}",
+                    }
+                    return
+                except OSError as exc:
+                    last_error = str(exc)
+                    time.sleep(0.2)
+        raise RuntimeError(
+            f"timed out waiting for ssh tunnel to localhost:{local_port} ({last_error})"
+        )
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# JSON-emitting subprocess wrapper for sibling scripts
+# ---------------------------------------------------------------------------
+
+def call_json_command(cmd: list[str], *, cwd: Path | None = None) -> dict[str, Any]:
+    """Run ``cmd`` and parse its stdout as JSON.
+
+    Stderr is always relayed so the agent sees progress markers from the
+    underlying serving / parity scripts. Raises RuntimeError on non-zero exit
+    or non-JSON output, with both streams attached.
+    """
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=str(cwd or ROOT),
+    )
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+        sys.stderr.flush()
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"command failed (rc={result.returncode}): {' '.join(cmd)}\n"
+            f"stdout={result.stdout[:2000]}\nstderr={result.stderr[:2000]}"
+        )
+    if not result.stdout.strip():
+        raise RuntimeError(
+            f"command produced no output: {' '.join(cmd)}\n"
+            f"stderr={result.stderr[:2000]}"
+        )
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"command returned non-JSON output: {' '.join(cmd)}\n"
+            f"stdout={result.stdout[:2000]}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Convenience wrappers around the serving skill's CLI scripts
+# ---------------------------------------------------------------------------
+
+def call_serve_start(extra_args: list[str]) -> dict[str, Any]:
+    cmd = [sys.executable, str(SERVING_SCRIPTS / "serve_start.py"), *extra_args]
+    return call_json_command(cmd)
+
+
+def call_serve_stop(machine: str, *, force: bool = False) -> dict[str, Any]:
+    cmd = [sys.executable, str(SERVING_SCRIPTS / "serve_stop.py"), "--machine", machine]
+    if force:
+        cmd.append("--force")
+    return call_json_command(cmd)

--- a/.agents/skills/ascend-profiling-collection/scripts/collect_torch_profile_case.py
+++ b/.agents/skills/ascend-profiling-collection/scripts/collect_torch_profile_case.py
@@ -1,0 +1,631 @@
+#!/usr/bin/env python3
+"""Collect one torch-profiler case on a workspace-managed remote NPU container.
+
+This is the single agent-facing entry point for the
+``ascend-profiling-collection`` skill. It chains together what other skills
+already provide:
+
+    1. start a service via vllm-ascend-serving with ``--profiler-config``
+    2. flip ``/start_profile`` (profile_control.py)
+    3. send a benchmark wave + one follow-up tail request
+    4. flip ``/stop_profile`` (profile_control.py)
+    5. stop the service via vllm-ascend-serving
+    6. analyse every ``*_ascend_pt`` directory and verify outputs
+       (run_remote_analyse.py)
+    7. write a manifest the analysis skill can consume
+
+The skill never modifies code in serving / parity / benchmark; it only
+orchestrates them. The serving skill stays profiling-agnostic -- it only
+forwards ``--profiler-config`` to ``vllm serve``.
+
+Failure policy: if any rank's ``kernel_details.csv`` is missing after analyse
+(the canonical "device data did not land" case from
+``profiling-inventory.md``), the run is reported as failed and exits non-zero
+even though every previous step succeeded. Downstream analysis must not
+process degenerate roots silently.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from _common import (
+    COLLECTION_STATE_DIR,
+    ROOT,
+    call_serve_start,
+    call_serve_stop,
+    container_endpoint,
+    emit_progress,
+    ensure_dir,
+    now_utc,
+    open_local_tunnel,
+    print_json,
+    resolve_machine,
+)
+from profile_control import post_remote_action
+from run_remote_analyse import analyse_profile_root
+
+
+DEFAULT_TORCH_PROFILER_DIRNAME = "vllm_profile"
+DEFAULT_PROFILE_CONTROL_TIMEOUT = 600
+DEFAULT_REQUEST_TIMEOUT = 900
+POST_STOP_FLUSH_SECONDS = 5
+
+VL_DEFAULT_IMAGE = (
+    ROOT / "vllm-ascend" / "tests" / "e2e" / "310p" / "data" / "qwen.png"
+)
+
+
+# ---------------------------------------------------------------------------
+# Workload payload helpers (multimodal + text)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RequestResult:
+    index: int
+    ok: bool
+    status: int | None
+    latency_sec: float
+    body: dict[str, Any] | None
+    error: str | None
+
+
+def _post_json(url: str, payload: dict[str, Any], timeout: int) -> tuple[int, bytes]:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.status, resp.read()
+
+
+def _parse_sips_dimensions(path: Path) -> tuple[int, int]:
+    result = subprocess.run(
+        ["sips", "-g", "pixelWidth", "-g", "pixelHeight", str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"failed to inspect image via sips: {result.stderr[:500]}")
+    width = height = None
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("pixelWidth:"):
+            width = int(line.split(":", 1)[1].strip())
+        elif line.startswith("pixelHeight:"):
+            height = int(line.split(":", 1)[1].strip())
+    if width is None or height is None:
+        raise RuntimeError(f"unexpected sips output: {result.stdout}")
+    return width, height
+
+
+def _build_image_data_url(image_path: Path, target_height: int) -> tuple[str, dict[str, Any]]:
+    src_w, src_h = _parse_sips_dimensions(image_path)
+    if src_h != target_height:
+        target_w = max(1, round(src_w * target_height / src_h))
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            resized_path = Path(tmp.name)
+        result = subprocess.run(
+            [
+                "sips",
+                "--resampleHeightWidth", str(target_height), str(target_w),
+                str(image_path),
+                "--out", str(resized_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"failed to resize image via sips: {result.stderr[:500]}")
+        use_path = resized_path
+        final_w, final_h = _parse_sips_dimensions(use_path)
+    else:
+        use_path = image_path
+        final_w, final_h = src_w, src_h
+
+    raw = use_path.read_bytes()
+    data_url = "data:image/png;base64," + base64.b64encode(raw).decode("ascii")
+    meta = {
+        "source_path": str(image_path),
+        "encoded_path": str(use_path),
+        "source_width": src_w,
+        "source_height": src_h,
+        "encoded_width": final_w,
+        "encoded_height": final_h,
+    }
+    return data_url, meta
+
+
+def _build_long_text(token_count: int, *, prefix: str, request_index: int) -> str:
+    filler = " ".join(["hello"] * token_count)
+    return f"{prefix}\nRequest-{request_index:03d}\n{filler}"
+
+
+def _build_chat_payload(
+    *,
+    model: str,
+    prompt_text: str,
+    max_tokens: int,
+    image_url: str | None,
+) -> dict[str, Any]:
+    if image_url:
+        content: list[dict[str, Any]] = [
+            {"type": "image_url", "image_url": {"url": image_url}},
+            {"type": "text", "text": prompt_text},
+        ]
+    else:
+        content = [{"type": "text", "text": prompt_text}]
+    return {
+        "model": model,
+        "messages": [{"role": "user", "content": content}],
+        "max_tokens": max_tokens,
+        "temperature": 0,
+        "top_p": 1,
+    }
+
+
+def _send_chat_request(
+    *,
+    base_url: str,
+    model: str,
+    prompt_text: str,
+    max_tokens: int,
+    image_url: str | None,
+    index: int,
+    timeout: int,
+) -> RequestResult:
+    url = base_url.rstrip("/") + "/v1/chat/completions"
+    payload = _build_chat_payload(
+        model=model, prompt_text=prompt_text,
+        max_tokens=max_tokens, image_url=image_url,
+    )
+    start = time.time()
+    try:
+        status, raw = _post_json(url, payload, timeout=timeout)
+        latency = time.time() - start
+        try:
+            body = json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError:
+            body = {"raw": raw.decode("utf-8", errors="replace")[:2000]}
+        return RequestResult(
+            index=index, ok=200 <= status < 300, status=status,
+            latency_sec=latency, body=body, error=None,
+        )
+    except urllib.error.HTTPError as exc:
+        latency = time.time() - start
+        return RequestResult(
+            index=index, ok=False, status=exc.code,
+            latency_sec=latency, body=None,
+            error=exc.read().decode("utf-8", errors="replace")[:2000],
+        )
+    except Exception as exc:  # noqa: BLE001
+        latency = time.time() - start
+        return RequestResult(
+            index=index, ok=False, status=None,
+            latency_sec=latency, body=None, error=str(exc),
+        )
+
+
+def _run_benchmark_wave(
+    *,
+    base_url: str,
+    model: str,
+    total_requests: int,
+    concurrency: int,
+    input_tokens: int,
+    output_tokens: int,
+    image_url: str | None,
+    prompt_prefix: str,
+    request_timeout: int,
+) -> list[RequestResult]:
+    results: list[RequestResult] = []
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = []
+        for idx in range(total_requests):
+            prompt_text = _build_long_text(
+                input_tokens, prefix=prompt_prefix, request_index=idx,
+            )
+            futures.append(pool.submit(
+                _send_chat_request,
+                base_url=base_url, model=model,
+                prompt_text=prompt_text, max_tokens=output_tokens,
+                image_url=image_url, index=idx, timeout=request_timeout,
+            ))
+        for future in as_completed(futures):
+            results.append(future.result())
+    results.sort(key=lambda item: item.index)
+    return results
+
+
+def _render_request_results(results: list[RequestResult]) -> list[dict[str, Any]]:
+    return [
+        {
+            "index": item.index,
+            "ok": item.ok,
+            "status": item.status,
+            "latency_sec": round(item.latency_sec, 4),
+            "error": item.error,
+            "body": item.body,
+        }
+        for item in results
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Serving args assembly
+# ---------------------------------------------------------------------------
+
+def _build_serve_args(args: argparse.Namespace, profiler_config: dict[str, Any]) -> list[str]:
+    serve_args: list[str] = [
+        "--machine", args.machine,
+        "--model", args.model,
+        "--served-model-name", args.served_model_name,
+        "--tp", str(args.tp),
+    ]
+    if args.dp is not None and args.dp > 1:
+        serve_args.extend(["--dp", str(args.dp)])
+    serve_args.extend([
+        "--extra-env",
+        "PYTORCH_NPU_ALLOC_CONF=expandable_segments:True",
+    ])
+    if args.skip_parity:
+        serve_args.append("--skip-parity")
+
+    serve_args.append("--")
+    serve_args.extend([
+        "--max-model-len", str(args.max_model_len),
+        "--trust-remote-code",
+        "--gpu-memory-utilization", str(args.gpu_memory_utilization),
+        "--max-num-seqs", str(args.max_num_seqs),
+        "--max-num-batched-tokens", str(args.max_num_batched_tokens),
+    ])
+    if args.api_server_count is not None:
+        serve_args.extend(["--api-server-count", str(args.api_server_count)])
+
+    serve_args.extend([
+        "--profiler-config", json.dumps(profiler_config, separators=(",", ":")),
+    ])
+
+    if args.speculative_tokens > 0:
+        serve_args.extend([
+            "--speculative-config",
+            json.dumps(
+                {"method": args.speculative_method,
+                 "num_speculative_tokens": args.speculative_tokens},
+                separators=(",", ":"),
+            ),
+        ])
+
+    if args.enable_expert_parallel:
+        serve_args.append("--enable-expert-parallel")
+
+    if args.mode == "enforce_eager":
+        serve_args.append("--enforce-eager")
+    elif args.mode == "full_decode_only":
+        serve_args.extend([
+            "--compilation-config",
+            json.dumps({"cudagraph_mode": "FULL_DECODE_ONLY"}, separators=(",", ":")),
+        ])
+    elif args.mode == "piecewise_graph":
+        serve_args.extend([
+            "--compilation-config",
+            json.dumps({"cudagraph_mode": "PIECEWISE"}, separators=(",", ":")),
+        ])
+    else:
+        raise ValueError(f"unknown --mode: {args.mode}")
+
+    return serve_args
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+
+    # Required: target + workload identity
+    p.add_argument("--machine", required=True,
+                   help="machine alias or host IP (must be ready in inventory)")
+    p.add_argument("--model", required=True,
+                   help="absolute remote path to model weights")
+    p.add_argument("--served-model-name", required=True,
+                   help="name vLLM exposes via /v1/models")
+    p.add_argument("--tp", type=int, required=True, help="tensor-parallel size")
+    p.add_argument("--tag", required=True,
+                   help="stable identifier for this collection run; used in run dir name")
+    p.add_argument(
+        "--mode",
+        required=True,
+        choices=("enforce_eager", "full_decode_only", "piecewise_graph"),
+        help="graph mode for the service",
+    )
+    p.add_argument(
+        "--request-kind",
+        required=True,
+        choices=("text", "vl"),
+        help="workload kind sent during the profile window",
+    )
+    p.add_argument("--benchmark-output-tokens", type=int, required=True,
+                   help="max_tokens per benchmark-wave request")
+
+    # Optional: parallelism / speculative / EP
+    p.add_argument("--dp", type=int, default=None,
+                   help="data-parallel size (forwarded to serving as --dp)")
+    p.add_argument("--enable-expert-parallel", action="store_true")
+    p.add_argument(
+        "--speculative-tokens", type=int, default=0,
+        help="num_speculative_tokens; 0 disables --speculative-config",
+    )
+    p.add_argument(
+        "--speculative-method", default="qwen3_5_mtp",
+        help="speculative method name; only used when --speculative-tokens > 0",
+    )
+
+    # Optional: vLLM serving knobs
+    p.add_argument("--gpu-memory-utilization", type=float, default=0.85)
+    p.add_argument("--max-model-len", type=int, default=4096)
+    p.add_argument("--max-num-seqs", type=int, default=2)
+    p.add_argument("--max-num-batched-tokens", type=int, default=1024)
+    p.add_argument(
+        "--api-server-count", type=int, default=None,
+        help="override vLLM --api-server-count (for isolating multi-api-server issues)",
+    )
+
+    # Optional: workload shape during the profile window
+    p.add_argument("--prompt-tokens", type=int, default=2000,
+                   help="input length for benchmark wave + follow-up")
+    p.add_argument("--followup-output-tokens", type=int, default=5,
+                   help="max_tokens for the single tail request")
+    p.add_argument("--benchmark-total-requests", type=int, default=10)
+    p.add_argument("--benchmark-concurrency", type=int, default=5)
+    p.add_argument("--request-timeout", type=int, default=DEFAULT_REQUEST_TIMEOUT,
+                   help="per chat-completions request timeout (seconds)")
+    p.add_argument(
+        "--profile-control-timeout", type=int,
+        default=DEFAULT_PROFILE_CONTROL_TIMEOUT,
+        help=("timeout for /start_profile and /stop_profile; multi-rank "
+              "torch profiler setup/finalization can take much longer than "
+              "an ordinary request"),
+    )
+
+    # Optional: profiler depth
+    p.add_argument("--torch-profiler-dir", default=DEFAULT_TORCH_PROFILER_DIRNAME,
+                   help="relative dir under runtime_dir where vLLM writes traces")
+    p.add_argument("--torch-profiler-with-stack", action="store_true")
+
+    # Optional: VL workload
+    p.add_argument(
+        "--image-path", default=None,
+        help="path to image used for --request-kind vl; defaults to the "
+             "qwen.png test image inside vllm-ascend submodule",
+    )
+    p.add_argument("--image-height", type=int, default=480,
+                   help="resize the image to this pixel height before encoding")
+
+    # Optional: parity opt-out (forwarded to serving)
+    p.add_argument("--skip-parity", action="store_true")
+
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    ensure_dir(COLLECTION_STATE_DIR)
+    run_dir = COLLECTION_STATE_DIR / f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{args.tag}"
+    ensure_dir(run_dir)
+
+    prompt_prefix = (
+        "Please describe the image and also summarize the long text context."
+        if args.request_kind == "vl"
+        else "Please continue the following long text."
+    )
+
+    image_url: str | None = None
+    image_meta: dict[str, Any] | None = None
+    if args.request_kind == "vl":
+        image_path = Path(args.image_path) if args.image_path else VL_DEFAULT_IMAGE
+        if not image_path.exists():
+            print_json({
+                "status": "failed",
+                "error": f"image path does not exist: {image_path}",
+                "tag": args.tag,
+            })
+            return 2
+        image_url, image_meta = _build_image_data_url(image_path, args.image_height)
+
+    profiler_config = {
+        "profiler": "torch",
+        "torch_profiler_dir": f"./{args.torch_profiler_dir}",
+        "torch_profiler_with_stack": bool(args.torch_profiler_with_stack),
+    }
+
+    serve_args = _build_serve_args(args, profiler_config)
+
+    manifest: dict[str, Any] = {
+        "schema_version": 1,
+        "started_at": now_utc(),
+        "tag": args.tag,
+        "machine": args.machine,
+        "model": args.model,
+        "served_model_name": args.served_model_name,
+        "tp": args.tp,
+        "dp": args.dp,
+        "mode": args.mode,
+        "request_kind": args.request_kind,
+        "speculative_tokens": args.speculative_tokens,
+        "speculative_method": (
+            args.speculative_method if args.speculative_tokens > 0 else None
+        ),
+        "enable_expert_parallel": bool(args.enable_expert_parallel),
+        "api_server_count": args.api_server_count,
+        "torch_profiler_with_stack": bool(args.torch_profiler_with_stack),
+        "torch_profiler_dir": args.torch_profiler_dir,
+        "prompt_tokens": args.prompt_tokens,
+        "benchmark_output_tokens": args.benchmark_output_tokens,
+        "followup_output_tokens": args.followup_output_tokens,
+        "benchmark_total_requests": args.benchmark_total_requests,
+        "benchmark_concurrency": args.benchmark_concurrency,
+        "profile_control_timeout": args.profile_control_timeout,
+        "run_dir": str(run_dir),
+        "serve_args": serve_args,
+        "image_meta": image_meta,
+    }
+
+    service_result: dict[str, Any] | None = None
+    stop_result: dict[str, Any] | None = None
+    try:
+        emit_progress("serve_start", f"starting service on {args.machine}")
+        service_result = call_serve_start(serve_args)
+        manifest["service_result"] = service_result
+        if service_result.get("status") != "ready":
+            raise RuntimeError(f"service did not become ready: {service_result}")
+
+        runtime_dir = service_result["runtime_dir"]
+        port = int(service_result["port"])
+        profile_root = f"{runtime_dir}/{args.torch_profiler_dir}"
+
+        record = resolve_machine(args.machine)
+        ep = container_endpoint(record)
+
+        with open_local_tunnel(ep, port) as tunnel:
+            manifest["request_tunnel"] = tunnel
+            request_base_url = tunnel["base_url"]
+
+            emit_progress("profile_control", "POST /start_profile")
+            manifest["start_profile"] = post_remote_action(
+                ep, port, "start_profile", args.profile_control_timeout,
+            )
+
+            emit_progress(
+                "workload",
+                f"benchmark wave: {args.benchmark_total_requests} req @ "
+                f"concurrency {args.benchmark_concurrency}",
+            )
+            bench_results = _run_benchmark_wave(
+                base_url=request_base_url,
+                model=args.served_model_name,
+                total_requests=args.benchmark_total_requests,
+                concurrency=args.benchmark_concurrency,
+                input_tokens=args.prompt_tokens,
+                output_tokens=args.benchmark_output_tokens,
+                image_url=image_url,
+                prompt_prefix=prompt_prefix,
+                request_timeout=args.request_timeout,
+            )
+            manifest["benchmark_results"] = _render_request_results(bench_results)
+
+            emit_progress("workload", "follow-up single request")
+            followup_prompt = _build_long_text(
+                args.prompt_tokens,
+                prefix=prompt_prefix + "\nFollow-up request.",
+                request_index=args.benchmark_total_requests,
+            )
+            followup_result = _send_chat_request(
+                base_url=request_base_url,
+                model=args.served_model_name,
+                prompt_text=followup_prompt,
+                max_tokens=args.followup_output_tokens,
+                image_url=image_url,
+                index=args.benchmark_total_requests,
+                timeout=args.request_timeout,
+            )
+            manifest["followup_result"] = _render_request_results([followup_result])[0]
+
+            emit_progress("profile_control", "POST /stop_profile")
+            manifest["stop_profile"] = post_remote_action(
+                ep, port, "stop_profile", args.profile_control_timeout,
+            )
+
+        # Give multi-rank torch profiler a small window to flush trailing data
+        # before the service is torn down. /stop_profile usually blocks until
+        # done, but profiler thread shutdown has historically lagged.
+        time.sleep(POST_STOP_FLUSH_SECONDS)
+
+        emit_progress("serve_stop", "stopping service")
+        stop_result = call_serve_stop(args.machine)
+        manifest["stop_result"] = stop_result
+
+        emit_progress("analyse", f"analysing {profile_root}")
+        analyse_bundle = analyse_profile_root(ep, profile_root)
+        manifest["remote_profile_root"] = profile_root
+        manifest["remote_profile_dirs"] = analyse_bundle["dirs"]
+        manifest["analysis_status"] = analyse_bundle["analysis_status"]
+        manifest["completed_at"] = now_utc()
+
+        # Hard gate: degenerate roots fail loudly so downstream analyze.py is
+        # never asked to interpret them.
+        worst = analyse_bundle["analysis_status"]
+        if worst == "ok":
+            manifest["status"] = "ok"
+            (run_dir / "manifest.json").write_text(
+                json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            print_json(manifest)
+            return 0
+
+        manifest["status"] = "failed"
+        manifest["error"] = (
+            f"profiling collection produced incomplete output (analysis_status="
+            f"{worst}); re-collect required, see profiling-inventory.md"
+        )
+        (run_dir / "manifest.json").write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        print_json(manifest)
+        return 1
+
+    except Exception as exc:  # noqa: BLE001
+        manifest["status"] = "failed"
+        manifest["error"] = str(exc)
+        manifest["failed_at"] = now_utc()
+        if stop_result is None:
+            try:
+                stop_result = call_serve_stop(args.machine)
+                manifest["stop_result"] = stop_result
+            except Exception:  # noqa: BLE001
+                try:
+                    stop_result = call_serve_stop(args.machine, force=True)
+                    manifest["stop_result"] = stop_result
+                except Exception as stop_exc:  # noqa: BLE001
+                    manifest["stop_error"] = str(stop_exc)
+
+        (run_dir / "manifest.json").write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        print_json(manifest)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/ascend-profiling-collection/scripts/collect_torch_profile_case.py
+++ b/.agents/skills/ascend-profiling-collection/scripts/collect_torch_profile_case.py
@@ -273,6 +273,41 @@ def _render_request_results(results: list[RequestResult]) -> list[dict[str, Any]
     ]
 
 
+def _evaluate_workload(
+    bench_results: list[RequestResult],
+    followup_result: RequestResult | None,
+    threshold: float,
+) -> dict[str, Any]:
+    """Decide whether the workload was healthy enough to make the trace useful.
+
+    Hard-fails (returned status != "ok") propagate to the top-level manifest
+    status so downstream analysis never sees a profiling root that was
+    captured with no actual model traffic flowing through it.
+    """
+    bench_total = len(bench_results)
+    bench_ok = sum(1 for r in bench_results if r.ok)
+    rate = (bench_ok / bench_total) if bench_total else 0.0
+    followup_ok = bool(followup_result and followup_result.ok)
+
+    if not followup_ok:
+        status = "followup_failed"
+    elif bench_total == 0:
+        status = "no_benchmark_requests"
+    elif rate < threshold:
+        status = "benchmark_below_threshold"
+    else:
+        status = "ok"
+
+    return {
+        "status": status,
+        "bench_total": bench_total,
+        "bench_ok": bench_ok,
+        "bench_success_rate": round(rate, 4),
+        "bench_threshold": threshold,
+        "followup_ok": followup_ok,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Serving args assembly
 # ---------------------------------------------------------------------------
@@ -401,6 +436,17 @@ def build_parser() -> argparse.ArgumentParser:
                    help="max_tokens for the single tail request")
     p.add_argument("--benchmark-total-requests", type=int, default=10)
     p.add_argument("--benchmark-concurrency", type=int, default=5)
+    p.add_argument(
+        "--benchmark-success-threshold",
+        type=float,
+        default=0.8,
+        help=(
+            "minimum required success rate of the benchmark wave (0..1); "
+            "below this the run is reported as failed because the trace was "
+            "captured without real model traffic. The follow-up request is "
+            "always required to succeed independently of this threshold"
+        ),
+    )
     p.add_argument("--request-timeout", type=int, default=DEFAULT_REQUEST_TIMEOUT,
                    help="per chat-completions request timeout (seconds)")
     p.add_argument(
@@ -493,6 +539,8 @@ def main(argv: list[str] | None = None) -> int:
         "followup_output_tokens": args.followup_output_tokens,
         "benchmark_total_requests": args.benchmark_total_requests,
         "benchmark_concurrency": args.benchmark_concurrency,
+        "benchmark_success_threshold": args.benchmark_success_threshold,
+        "expected_ranks": args.tp * (args.dp if args.dp else 1),
         "profile_control_timeout": args.profile_control_timeout,
         "run_dir": str(run_dir),
         "serve_args": serve_args,
@@ -559,6 +607,11 @@ def main(argv: list[str] | None = None) -> int:
             )
             manifest["followup_result"] = _render_request_results([followup_result])[0]
 
+            workload_status = _evaluate_workload(
+                bench_results, followup_result, args.benchmark_success_threshold,
+            )
+            manifest["workload_status"] = workload_status
+
             emit_progress("profile_control", "POST /stop_profile")
             manifest["stop_profile"] = post_remote_action(
                 ep, port, "stop_profile", args.profile_control_timeout,
@@ -573,17 +626,26 @@ def main(argv: list[str] | None = None) -> int:
         stop_result = call_serve_stop(args.machine)
         manifest["stop_result"] = stop_result
 
-        emit_progress("analyse", f"analysing {profile_root}")
-        analyse_bundle = analyse_profile_root(ep, profile_root)
+        expected_ranks = manifest["expected_ranks"]
+        emit_progress(
+            "analyse",
+            f"analysing {profile_root} (expected_ranks={expected_ranks})",
+        )
+        analyse_bundle = analyse_profile_root(
+            ep, profile_root, expected_ranks=expected_ranks,
+        )
         manifest["remote_profile_root"] = profile_root
         manifest["remote_profile_dirs"] = analyse_bundle["dirs"]
+        manifest["rank_count"] = analyse_bundle.get("rank_count")
         manifest["analysis_status"] = analyse_bundle["analysis_status"]
         manifest["completed_at"] = now_utc()
 
-        # Hard gate: degenerate roots fail loudly so downstream analyze.py is
-        # never asked to interpret them.
-        worst = analyse_bundle["analysis_status"]
-        if worst == "ok":
+        # Hard gate: degenerate roots OR a workload that did not actually
+        # exercise the model both fail loudly so downstream analyze.py is
+        # never asked to interpret a useless trace.
+        analysis_worst = analyse_bundle["analysis_status"]
+        workload_worst = manifest["workload_status"]["status"]
+        if analysis_worst == "ok" and workload_worst == "ok":
             manifest["status"] = "ok"
             (run_dir / "manifest.json").write_text(
                 json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
@@ -592,10 +654,16 @@ def main(argv: list[str] | None = None) -> int:
             print_json(manifest)
             return 0
 
+        reasons: list[str] = []
+        if analysis_worst != "ok":
+            reasons.append(f"analysis_status={analysis_worst}")
+        if workload_worst != "ok":
+            reasons.append(f"workload_status={workload_worst}")
         manifest["status"] = "failed"
         manifest["error"] = (
-            f"profiling collection produced incomplete output (analysis_status="
-            f"{worst}); re-collect required, see profiling-inventory.md"
+            "profiling collection produced an unusable trace ("
+            + "; ".join(reasons)
+            + "); re-collect required, see profiling-inventory.md"
         )
         (run_dir / "manifest.json").write_text(
             json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",

--- a/.agents/skills/ascend-profiling-collection/scripts/profile_control.py
+++ b/.agents/skills/ascend-profiling-collection/scripts/profile_control.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""POST /start_profile or /stop_profile against a running vllm-ascend service.
+
+Profiler control is part of the *profiling collection* workflow, not part of
+service lifecycle, so this client lives inside the profiling-collection skill
+rather than the serving skill. The serving skill is intentionally agnostic:
+it just passes ``--profiler-config`` through to ``vllm serve`` and never
+touches the profiler window.
+
+The POST is executed inside the container via SSH against
+``http://127.0.0.1:<port>``, so no SSH tunnel is required. The port is read
+from the serving skill's recorded state for that machine; a service must
+already be running.
+
+Multi-rank torch profiler setup/finalization can take much longer than an
+ordinary inference request, so the timeout is long by default.
+
+Usage:
+    python3 profile_control.py --machine <alias> --action start_profile
+    python3 profile_control.py --machine <alias> --action stop_profile [--timeout 900]
+
+Progress on stderr, final JSON on stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from _common import (
+    container_endpoint,
+    emit_progress,
+    load_serving_state,
+    print_json,
+    resolve_machine,
+    ssh_exec,
+)
+
+DEFAULT_TIMEOUT_SECONDS = 600
+ALLOWED_ACTIONS = ("start_profile", "stop_profile")
+
+
+def post_remote_action(ep, port: int, action: str, timeout: int) -> dict[str, Any]:
+    """POST http://127.0.0.1:<port>/<action> from inside the container.
+
+    Returns a dict with: ok, status, body. Raises RuntimeError on transport
+    failure (SSH problem, container Python missing, etc.).
+    """
+    if action not in ALLOWED_ACTIONS:
+        raise ValueError(f"unsupported action {action!r}; allowed: {ALLOWED_ACTIONS}")
+
+    py = (
+        "import json, urllib.error, urllib.request\n"
+        f"url = 'http://127.0.0.1:{port}/{action}'\n"
+        "req = urllib.request.Request(url, data=None,\n"
+        "    headers={'Content-Type': 'application/json'}, method='POST')\n"
+        "try:\n"
+        f"    with urllib.request.urlopen(req, timeout={int(timeout)}) as resp:\n"
+        "        body = resp.read().decode('utf-8', errors='replace')\n"
+        "        print(json.dumps({'ok': True, 'status': resp.status, 'body': body}))\n"
+        "except urllib.error.HTTPError as exc:\n"
+        "    body = exc.read().decode('utf-8', errors='replace')\n"
+        "    print(json.dumps({'ok': False, 'status': exc.code, 'body': body}))\n"
+        "    raise SystemExit(2)\n"
+        "except Exception as exc:\n"
+        "    print(json.dumps({'ok': False, 'error': str(exc)}))\n"
+        "    raise SystemExit(3)\n"
+    )
+    script = f"python3 -c {shlex.quote(py)}"
+    result = ssh_exec(ep, script, check=False)
+
+    payload: dict[str, Any] | None = None
+    stdout = (result.stdout or "").strip()
+    if stdout:
+        last_line = stdout.splitlines()[-1]
+        try:
+            payload = json.loads(last_line)
+        except json.JSONDecodeError:
+            payload = None
+
+    if result.returncode != 0:
+        detail: dict[str, Any] = payload or {}
+        detail.setdefault("stdout", (result.stdout or "")[-2000:])
+        detail.setdefault("stderr", (result.stderr or "")[-2000:])
+        detail["rc"] = result.returncode
+        raise RuntimeError(
+            f"remote {action} on 127.0.0.1:{port} failed: "
+            f"{json.dumps(detail, ensure_ascii=False)}"
+        )
+
+    return payload or {"ok": True, "status": 200, "body": ""}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    p.add_argument("--machine", required=True, help="machine alias or host IP")
+    p.add_argument(
+        "--action",
+        required=True,
+        choices=ALLOWED_ACTIONS,
+        help="profiler control action to issue",
+    )
+    p.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help=(
+            "Timeout in seconds for the control-plane HTTP request. "
+            "Multi-rank torch-profiler setup/finalization can take much longer "
+            "than an ordinary inference request."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        record = resolve_machine(args.machine)
+        alias = record["alias"]
+        ep = container_endpoint(record)
+
+        state = load_serving_state(alias)
+        if state is None:
+            print_json({
+                "status": "not_found",
+                "machine": alias,
+                "action": args.action,
+                "message": (
+                    f"no serving state recorded for {alias}; start the service "
+                    "via vllm-ascend-serving first"
+                ),
+            })
+            return 2
+        port = state.get("port")
+        if not port:
+            print_json({
+                "status": "not_found",
+                "machine": alias,
+                "action": args.action,
+                "message": "serving state has no port; service may have failed to launch",
+            })
+            return 2
+
+        emit_progress(
+            "profile_control",
+            f"posting {args.action} to 127.0.0.1:{port}",
+            timeout=args.timeout,
+        )
+        result = post_remote_action(ep, int(port), args.action, args.timeout)
+
+        ok = bool(result.get("ok"))
+        print_json({
+            "status": "ok" if ok else "failed",
+            "machine": alias,
+            "action": args.action,
+            "port": port,
+            "http_status": result.get("status"),
+            "body": result.get("body"),
+            "error": result.get("error"),
+        })
+        return 0 if ok else 1
+
+    except Exception as exc:
+        print_json({
+            "status": "failed",
+            "machine": getattr(args, "machine", None),
+            "action": getattr(args, "action", None),
+            "error": str(exc),
+        })
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/ascend-profiling-collection/scripts/run_remote_analyse.py
+++ b/.agents/skills/ascend-profiling-collection/scripts/run_remote_analyse.py
@@ -18,12 +18,20 @@ verification turns that failure mode into a hard exit instead of letting
 downstream analysis silently process degenerate roots.
 
 Exit codes:
-    0  -- every rank produced kernel_details.csv and trace_view.json
-    1  -- at least one rank is incomplete (missing_kernel_details / partial)
+    0  -- every rank produced kernel_details.csv and trace_view.json AND
+          (when --expected-ranks is given) the rank count matches
+    1  -- at least one rank is incomplete OR the rank count does not match
+          (missing_kernel_details / rank_count_mismatch / partial)
     2  -- the SSH or analyse() call itself failed
 
 Usage:
-    python3 run_remote_analyse.py --machine <alias> --profile-root <path>
+    python3 run_remote_analyse.py --machine <alias> \\
+        --profile-root <path> [--expected-ranks <N>]
+
+The agent should always pass ``--expected-ranks`` when invoking this from a
+collection orchestrator (typically ``tp * (dp or 1)``); otherwise a partial
+capture where some ranks never produced a ``*_ascend_pt`` directory will look
+"clean" because every directory that *did* land was complete.
 
 Progress on stderr, final JSON on stdout.
 """
@@ -115,21 +123,37 @@ def classify_status(outputs: dict[str, Any]) -> str:
     return "ok"
 
 
-def analyse_profile_root(ep, profile_root: str) -> dict[str, Any]:
+def analyse_profile_root(
+    ep,
+    profile_root: str,
+    *,
+    expected_ranks: int | None = None,
+) -> dict[str, Any]:
     """Discover, analyse, and verify every *_ascend_pt under profile_root.
+
+    When ``expected_ranks`` is provided, the rank count is enforced: missing
+    ranks land as ``analysis_status = "rank_count_mismatch"`` even if every
+    directory that *did* exist was complete. This is the canonical "rank N
+    silently failed to dump anything" failure mode.
 
     Returns a dict ready to merge into the collection manifest:
 
         {
           "profile_root": "...",
-          "analysis_status": "ok | missing_kernel_details | partial",
+          "expected_ranks": int | None,
+          "rank_count": int,
+          "analysis_status": "ok | missing_kernel_details |
+                              rank_count_mismatch | partial",
           "dirs": [ {path, outputs, analysis_status}, ... ],
         }
     """
     targets = list_ascend_pt_dirs(ep, profile_root)
+    rank_count = len(targets)
     if not targets:
         return {
             "profile_root": profile_root,
+            "expected_ranks": expected_ranks,
+            "rank_count": 0,
             "analysis_status": "no_profile_dirs",
             "dirs": [],
         }
@@ -146,17 +170,32 @@ def analyse_profile_root(ep, profile_root: str) -> dict[str, Any]:
             "analysis_status": status,
         })
 
-    worst = "ok"
+    # Per-rank classification first: a missing kernel_details.csv on any rank
+    # is the most actionable signal and short-circuits the rest.
+    per_rank_worst = "ok"
     for item in analysed:
         s = item["analysis_status"]
         if s == "missing_kernel_details":
-            worst = "missing_kernel_details"
+            per_rank_worst = "missing_kernel_details"
             break
         if s == "partial":
-            worst = "partial"
+            per_rank_worst = "partial"
+
+    # Worst-of priority: missing_kernel_details > rank_count_mismatch > partial
+    # > ok. rank_count_mismatch is reported only when no per-rank csv is
+    # missing, otherwise the per-rank failure is a strictly more useful
+    # signal (and the count would naturally be off anyway).
+    if per_rank_worst == "missing_kernel_details":
+        worst = "missing_kernel_details"
+    elif expected_ranks is not None and rank_count != expected_ranks:
+        worst = "rank_count_mismatch"
+    else:
+        worst = per_rank_worst
 
     return {
         "profile_root": profile_root,
+        "expected_ranks": expected_ranks,
+        "rank_count": rank_count,
         "analysis_status": worst,
         "dirs": analysed,
     }
@@ -173,6 +212,17 @@ def build_parser() -> argparse.ArgumentParser:
             "(typically <runtime_dir>/<torch_profiler_dir>)."
         ),
     )
+    p.add_argument(
+        "--expected-ranks",
+        type=int,
+        default=None,
+        help=(
+            "expected number of *_ascend_pt directories (typically "
+            "tp * (dp or 1)); when set, a mismatch fails with "
+            "analysis_status=rank_count_mismatch even if every present rank "
+            "was complete"
+        ),
+    )
     return p
 
 
@@ -185,7 +235,9 @@ def main(argv: list[str] | None = None) -> int:
         ep = container_endpoint(record)
 
         emit_progress("discover", f"listing *_ascend_pt under {args.profile_root}")
-        bundle = analyse_profile_root(ep, args.profile_root)
+        bundle = analyse_profile_root(
+            ep, args.profile_root, expected_ranks=args.expected_ranks
+        )
         bundle["machine"] = alias
 
         worst = bundle["analysis_status"]

--- a/.agents/skills/ascend-profiling-collection/scripts/run_remote_analyse.py
+++ b/.agents/skills/ascend-profiling-collection/scripts/run_remote_analyse.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Run torch_npu.profiler.profiler.analyse(...) on the remote container.
+
+vLLM's torch profiler integration writes raw ``*_ascend_pt`` directories under
+the configured ``torch_profiler_dir``. They must be post-processed by
+``torch_npu.profiler.profiler.analyse(...)`` to materialize the
+``ASCEND_PROFILER_OUTPUT/`` files (``kernel_details.csv``,
+``trace_view.json``, ...). This script wraps that single call with a
+shell-safe Ascend env preamble.
+
+The agent always passes ``--profile-root`` (the directory that contains one or
+more ``*_ascend_pt`` subdirectories, typically
+``<runtime_dir>/<torch_profiler_dir>``). Every matching subdirectory is
+analysed in sorted order, then verified -- ``profiling-inventory.md``
+documents several captures where ``analyse`` "succeeded" but produced no
+``kernel_details.csv`` (short capture window, missing FRAMEWORK data), so
+verification turns that failure mode into a hard exit instead of letting
+downstream analysis silently process degenerate roots.
+
+Exit codes:
+    0  -- every rank produced kernel_details.csv and trace_view.json
+    1  -- at least one rank is incomplete (missing_kernel_details / partial)
+    2  -- the SSH or analyse() call itself failed
+
+Usage:
+    python3 run_remote_analyse.py --machine <alias> --profile-root <path>
+
+Progress on stderr, final JSON on stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from _common import (
+    ASCEND_ENV_PREAMBLE,
+    container_endpoint,
+    emit_progress,
+    print_json,
+    resolve_machine,
+    ssh_exec,
+)
+
+EXPECTED_OUTPUTS = {
+    "kernel_details_csv": "ASCEND_PROFILER_OUTPUT/kernel_details.csv",
+    "trace_view_json": "ASCEND_PROFILER_OUTPUT/trace_view.json",
+}
+
+
+def list_ascend_pt_dirs(ep, profile_root: str) -> list[str]:
+    """Return sorted ``*_ascend_pt`` directories directly under profile_root."""
+    cmd = (
+        f"find {shlex.quote(profile_root)} -maxdepth 1 -type d "
+        "-name '*_ascend_pt' | sort"
+    )
+    result = ssh_exec(ep, cmd, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"failed to list profile dirs under {profile_root}: "
+            f"{result.stderr[:1000]}"
+        )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def run_analyse(ep, remote_dir: str) -> None:
+    """Run torch_npu.profiler.profiler.analyse(remote_dir) on the container."""
+    py = (
+        "from torch_npu.profiler.profiler import analyse\n"
+        f"analyse({json.dumps(remote_dir)})\n"
+    )
+    script = f"{ASCEND_ENV_PREAMBLE}\npython3 -c {shlex.quote(py)}\n"
+    result = ssh_exec(ep, script, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"remote analyse({remote_dir!r}) failed (rc={result.returncode}):\n"
+            f"stdout={result.stdout[-2000:]}\nstderr={result.stderr[-2000:]}"
+        )
+
+
+def verify_outputs(ep, remote_dir: str) -> dict[str, Any]:
+    """Check that the expected ASCEND_PROFILER_OUTPUT files exist."""
+    outputs: dict[str, Any] = {}
+    for key, rel in EXPECTED_OUTPUTS.items():
+        path = f"{remote_dir.rstrip('/')}/{rel}"
+        result = ssh_exec(ep, f"test -f {shlex.quote(path)}", check=False)
+        outputs[key] = {
+            "path": path,
+            "exists": result.returncode == 0,
+        }
+    return outputs
+
+
+def classify_status(outputs: dict[str, Any]) -> str:
+    """Map output presence to an ``analysis_status`` value.
+
+    - ``ok``: every expected output present
+    - ``missing_kernel_details``: kernel_details.csv missing (the canonical
+      "analyse ran but device data did not land" case from
+      ``profiling-inventory.md``)
+    - ``partial``: some other expected file is missing
+    """
+    if not outputs["kernel_details_csv"]["exists"]:
+        return "missing_kernel_details"
+    if not all(v["exists"] for v in outputs.values()):
+        return "partial"
+    return "ok"
+
+
+def analyse_profile_root(ep, profile_root: str) -> dict[str, Any]:
+    """Discover, analyse, and verify every *_ascend_pt under profile_root.
+
+    Returns a dict ready to merge into the collection manifest:
+
+        {
+          "profile_root": "...",
+          "analysis_status": "ok | missing_kernel_details | partial",
+          "dirs": [ {path, outputs, analysis_status}, ... ],
+        }
+    """
+    targets = list_ascend_pt_dirs(ep, profile_root)
+    if not targets:
+        return {
+            "profile_root": profile_root,
+            "analysis_status": "no_profile_dirs",
+            "dirs": [],
+        }
+
+    analysed: list[dict[str, Any]] = []
+    for path in targets:
+        emit_progress("analyse", f"analysing {path}")
+        run_analyse(ep, path)
+        outputs = verify_outputs(ep, path)
+        status = classify_status(outputs)
+        analysed.append({
+            "path": path,
+            "outputs": outputs,
+            "analysis_status": status,
+        })
+
+    worst = "ok"
+    for item in analysed:
+        s = item["analysis_status"]
+        if s == "missing_kernel_details":
+            worst = "missing_kernel_details"
+            break
+        if s == "partial":
+            worst = "partial"
+
+    return {
+        "profile_root": profile_root,
+        "analysis_status": worst,
+        "dirs": analysed,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    p.add_argument("--machine", required=True, help="machine alias or host IP")
+    p.add_argument(
+        "--profile-root",
+        required=True,
+        help=(
+            "remote directory containing one or more *_ascend_pt subdirectories "
+            "(typically <runtime_dir>/<torch_profiler_dir>)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        record = resolve_machine(args.machine)
+        alias = record["alias"]
+        ep = container_endpoint(record)
+
+        emit_progress("discover", f"listing *_ascend_pt under {args.profile_root}")
+        bundle = analyse_profile_root(ep, args.profile_root)
+        bundle["machine"] = alias
+
+        worst = bundle["analysis_status"]
+        if worst == "no_profile_dirs":
+            bundle["status"] = "failed"
+            bundle["error"] = "no *_ascend_pt directories found"
+            print_json(bundle)
+            return 1
+
+        bundle["status"] = "ok" if worst == "ok" else worst
+        print_json(bundle)
+        return 0 if worst == "ok" else 1
+
+    except Exception as exc:
+        print_json({
+            "status": "failed",
+            "machine": getattr(args, "machine", None),
+            "profile_root": getattr(args, "profile_root", None),
+            "error": str(exc),
+        })
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Repo-local skills live under `.agents/skills/`. Each has its own `SKILL.md` with
 | `vllm-ascend-serving` | Start / check / stop a vLLM Ascend service on a remote container |
 | `vllm-ascend-benchmark` | Run `vllm bench serve` benchmarks (single-run or multi-run with warmup) |
 | `ascend-memory-profiling` | Profile HBM memory usage on Ascend NPU for vLLM serving scenarios |
+| `ascend-profiling-collection` | Collect one Ascend torch-profiler case end-to-end (start service, bracket workload with `/start_profile` + `/stop_profile`, run `analyse()`, verify outputs, write manifest) |
 
 None of these are gates for normal local coding, docs work, or unrelated Git tasks.
 


### PR DESCRIPTION
## Summary
- New `ascend-profiling-collection` skill that captures one Ascend NPU torch profiler case end-to-end on a workspace-managed remote container: lifecycle (delegated to `vllm-ascend-serving`), profiler start/stop window, workload (text or multimodal), `torch_npu.profiler.profiler.analyse(...)`, output verification, and `manifest.json`.
- Owns the profiler control plane (`/start_profile`, `/stop_profile`) so `vllm-ascend-serving` stays a pure lifecycle skill.
- Hard-fails (`analysis_status: missing_kernel_details`, exit 1) when any rank's `kernel_details.csv` is absent — accuracy beats coverage so downstream analysis never consumes corrupted profiling roots.
- Replaces the prototype `tools/collect_remote_torch_profile_case.py` workflow (was never tracked in git; this skill supersedes it).

## Layout
- `SKILL.md` — purpose, boundaries, critical rules, manifest schema, agent workflow
- `scripts/_common.py` — shared helpers (reuses serving-skill SSH/inventory; local SSH tunnel for workload payloads)
- `scripts/profile_control.py` — POST `/start_profile` / `/stop_profile` via in-container SSH-exec, multi-rank-friendly long timeout
- `scripts/run_remote_analyse.py` — wraps `analyse(...)` over each `*_ascend_pt`, hard-fails on missing `kernel_details.csv`
- `scripts/collect_torch_profile_case.py` — agent-facing orchestrator (required `--machine/--model/--served-model-name/--tp/--tag/--mode/--request-kind/--benchmark-output-tokens`, `--speculative-tokens 0` skips speculative config, mode → `--enforce-eager`/`--compilation-config`, manifest under `.vaws-local/ascend-profiling-collection/runs/<ts>_<tag>/`)
- `references/{command-recipes,behavior,acceptance}.md`

## Test plan
- [x] `python -m py_compile` over all four scripts
- [x] End-to-end smoke on `173.131.1.2`: Qwen3.5-35B, TP=4, `full_decode_only`, text workload — `status: ok`, `analysis_status: ok`, all 4 ranks produced complete `kernel_details.csv` and `trace_view.json`, NPUs released cleanly
- [x] Hard-gate verification of `run_remote_analyse.py` against synthetic remote roots:
  - `missing_kernel_details` (trace present, kernel_details missing) → exit 1, `analysis_status: missing_kernel_details`
  - `partial` (kernel_details present, trace missing) → exit 1, `analysis_status: partial`
  - `no_profile_dirs` (empty root) → exit 1, `analysis_status: no_profile_dirs`

## Notes / follow-ups
- The downstream `ascend-profiling-analysis` skill (will host `tools/ascend_profile/` migration) is a separate PR.
- `tools/ascend_profile/CODE_CLASSIFICATION.md` planning doc ships with that follow-up since it documents the analysis side.

Made with [Cursor](https://cursor.com)