### PR TITLE
fix: preserve .vaws-runtime across parity refreshes

### DIFF
--- a/.agents/skills/remote-code-parity/SKILL.md
+++ b/.agents/skills/remote-code-parity/SKILL.md
@@ -31,7 +31,7 @@ Keep a **ready** remote runtime in exact code parity with the local `vllm-ascend
 - Keep the sync path **container-only** after machine attach: no host storage root, no host mirror, no host lock.
 - Use synthetic snapshot refs so dirty working trees can move through Git transport.
 - Keep container cache / lock / manifest paths isolated by `workspace_id` under a container-local cache root.
-- Preserve runtime-private paths under `/vllm-workspace`, especially `Mooncake`.
+- Preserve runtime-private paths under `/vllm-workspace`, in particular `Mooncake/` (image-provided runtime) and `.vaws-runtime/` (workspace-managed runtime artifacts such as profiler dumps consumed by downstream skills). The exact list lives in `DEFAULT_ROOT_PRESERVE_PATHS` in `scripts/remote_code_parity.py`.
 - Keep `stdout` reserved for one final JSON summary and stream phase progress on `stderr` as `__VAWS_PARITY_PROGRESS__=<json>`.
 - Runtime install progress should be attributable at the package-step level: uninstall, `vllm`, `vllm-ascend` requirements, `vllm-ascend`, import smoke, and marker write.
 - Publish each synthetic snapshot to both the parity ref and an advertised branch ref inside the container-local mirror.
@@ -191,7 +191,7 @@ Inside the container:
 - force the runtime repo to the synthetic parity ref
 - rewrite submodule URLs to container-local mirror paths
 - rewrite submodule URLs to those mirror paths and recursively materialize child repos explicitly
-- preserve runtime-private paths such as `Mooncake` and `.remote-code-parity`
+- preserve runtime-private paths such as `Mooncake`, `.vaws-runtime`, and `.remote-code-parity`
 - ensure the checked-out commits match the manifest
 
 Do not claim success before the container-side commit ids match the snapshot manifest.

--- a/.agents/skills/remote-code-parity/references/acceptance.md
+++ b/.agents/skills/remote-code-parity/references/acceptance.md
@@ -74,7 +74,7 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 
 - `/vllm-workspace` is updated in place instead of being replaced wholesale
 - nested repos are materialized explicitly instead of relying on `git submodule update` for synthetic child commits
-- runtime-private paths such as `Mooncake` survive root cleanups
+- runtime-private paths such as `Mooncake` and `.vaws-runtime` survive root cleanups
 - final `git rev-parse HEAD` values inside the container match the synthetic snapshot commits exactly
 - reinstall runs only when the trigger matrix says it should, except for the mandatory first approved replacement on a fresh container
 - switching a submodule to a different commit (e.g. `git checkout v0.8.0` in `vllm/`) triggers reinstall via HEAD-based commit drift detection (comparing real HEAD, not synthetic snapshot commit), even when the new checkout is clean
@@ -98,7 +98,7 @@ These specific mistakes should no longer be part of the normal path:
 - temporary parity index files should be cleaned up after snapshot construction
 - missing or unpopulated required submodules should return a compact failure payload instead of a raw Git traceback
 - the main snapshot path should not force ignored files into the synthetic snapshot
-- root cleanups inside `/vllm-workspace` should not delete `Mooncake`
+- root cleanups inside `/vllm-workspace` should not delete `Mooncake` or `.vaws-runtime`
 - runtime-install should not fail closed just because Ascend env scripts reference shell-specific or otherwise unset variables while being sourced
 - the final heredoc-based import smoke should not fail with a local quoting `SyntaxError`
 - clean nested submodules should not force parent `reinstall_vllm*` decisions through synthetic gitlink churn alone

--- a/.agents/skills/remote-code-parity/references/behavior.md
+++ b/.agents/skills/remote-code-parity/references/behavior.md
@@ -104,7 +104,7 @@ Materialization requirements:
 - rewrite submodule URLs to container-local mirror paths
 - materialize child repos explicitly instead of relying on `git submodule update` to fetch synthetic child commits
 - when a child repo snapshot has the same tree as its original `HEAD`, reuse that original commit so parent repos do not see a gitlink-only synthetic delta
-- preserve runtime-private sibling paths such as `Mooncake`
+- preserve runtime-private sibling paths such as `Mooncake` (image-provided runtime) and `.vaws-runtime` (workspace-managed runtime artifacts, e.g. profiler dumps that downstream skills consume after parity refreshes)
 - preserve `.remote-code-parity` so the container-side marker survives root cleanups
 - do not delete the entire runtime root as part of normal sync
 
@@ -126,7 +126,7 @@ First-install mutation boundary:
 - uninstall image packages best-effort
 - delete `/vllm-workspace/vllm`
 - delete `/vllm-workspace/vllm-ascend`
-- keep the rest of `/vllm-workspace`, including `Mooncake`
+- keep the rest of `/vllm-workspace`, including `Mooncake` and `.vaws-runtime`
 
 ## Reinstall trigger matrix
 

--- a/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
+++ b/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
@@ -114,7 +114,9 @@ PIP_MIRROR_CANDIDATES = (
 
 DEFAULT_CONTAINER_CACHE_ROOT = '/root/.cache/vaws/remote-code-parity'
 DEFAULT_MARKER_DIRNAME = '.remote-code-parity'
-DEFAULT_ROOT_PRESERVE_PATHS = ('Mooncake',)
+# Keep runtime-private state and profiling artifacts that may be needed for
+# post-run analysis across parity refreshes.
+DEFAULT_ROOT_PRESERVE_PATHS = ('Mooncake', '.vaws-runtime')
 STATE_FILENAME = 'runtime-state.json'
 CONSENT_FILENAME = 'install-consents.json'
 PARITY_BRANCH_NAME = 'parity-current'


### PR DESCRIPTION
## Summary
- Add `.vaws-runtime` to `DEFAULT_ROOT_PRESERVE_PATHS` so that a parity refresh keeps it alongside `Mooncake/`.
- `.vaws-runtime/` is the container-side scratch root for runtime-private artifacts (notably profiler dumps from `ascend-profiling-collection`) that downstream analysis may need long after the parity sync that produced them; without preservation those artifacts get wiped on the next parity sync.

## Test plan
- [x] `python -m py_compile .agents/skills/remote-code-parity/scripts/remote_code_parity.py`
- [x] Co-validated end-to-end with the new `ascend-profiling-collection` skill on `173.131.1.2`: profiler outputs under `.vaws-runtime/profiler/...` survived the next parity refresh and were available to the remote `analyse(...)` step.

Made with [Cursor](https://cursor.com)