### PR TITLE
[codex] Add session-aware VAWS scaffold tooling

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -18,6 +18,7 @@ This directory contains the repository-local skill layer for Codex, Claude Code,
 - `.agents/lib/vaws_local_state.py` is the shared library for untracked local runtime state.
 - `.agents/lib/vaws_session_id.py` and `.agents/lib/vaws_session_state.py` are the shared libraries for session identity, state, locks, and leases.
 - `.agents/lib/vaws_remote_toolbox.py` is the shared library for remote target resolution, SSH execution, job observation, artifact streaming, sync adapters, service adapters, and cleanup.
+- `.agents/lib/vaws_validate.py` is the shared validation library for agent-facing ids, environment names, path boundaries, and NPU device lists.
 - `AGENTS.md` carries repository-wide routing rules and mandatory decision gates.
 
 ## Script-first convention
@@ -81,6 +82,7 @@ Current primary helpers:
 - `ascend-profiling-analysis/scripts/profile_analyze.py`
 - `ascend-profiling-analysis/scripts/profile_sweep.py`
 - `scripts/workspace_profile.py`
+- `.agents/tests/test_vaws_scaffold_safety.py`
 
 Low-level machine-management helpers remain available for implementation work and debugging:
 
@@ -155,6 +157,8 @@ If you change `remote-toolbox`, update these together:
 - `.agents/scripts/remote_*.py`
 - `.agents/lib/vaws_remote_toolbox.py`
 - affected wrapper scripts that reuse toolbox primitives
+- `.agents/lib/vaws_validate.py` when changing accepted id, env, path, or device syntax
+- `.agents/tests/test_vaws_scaffold_safety.py` when changing safety validation behavior
 - `AGENTS.md`, `README.md`, and this file when routing or output contracts change
 
 If you change `vllm-ascend-serving`, update these together:

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -6,12 +6,18 @@ This directory contains the repository-local skill layer for Codex, Claude Code,
 
 - `.agents/skills/repo-init/` is the source-of-truth skill package for repository initialization.
 - `.agents/skills/machine-management/` is the source-of-truth skill package for remote machine attach, verify, repair, and removal workflows.
+- `.agents/skills/session-management/` is the source-of-truth skill package for isolated parallel agent sessions.
+- `.agents/skills/remote-toolbox/` is the source-of-truth skill package for structured agent-facing remote target/probe/exec/job/sync/service/artifact/cleanup tools.
 - `.agents/skills/remote-code-parity/` is the source-of-truth skill package for remote code parity before remote execution.
 - `.agents/skills/vllm-ascend-serving/` is the source-of-truth skill package for starting, checking, and stopping vLLM Ascend online services on managed containers.
 - `.agents/skills/vllm-ascend-benchmark/` is the source-of-truth skill package for running `vllm bench serve` performance benchmarks on managed containers.
 - `.agents/skills/ascend-memory-profiling/` is the source-of-truth skill package for profiling and attributing HBM memory usage on Ascend NPU for vLLM serving scenarios.
+- `.agents/skills/ascend-profiling-collection/` is the source-of-truth skill package for collecting Ascend torch-profiler traces and verified manifests.
+- `.agents/skills/ascend-profiling-analysis/` is the source-of-truth skill package for analyzing collected profiler roots/manifests and generating reports.
 - `.agents/scripts/workspace_profile.py` is the shared low-level helper for the local workspace machine profile.
 - `.agents/lib/vaws_local_state.py` is the shared library for untracked local runtime state.
+- `.agents/lib/vaws_session_id.py` and `.agents/lib/vaws_session_state.py` are the shared libraries for session identity, state, locks, and leases.
+- `.agents/lib/vaws_remote_toolbox.py` is the shared library for remote target resolution, SSH execution, job observation, artifact streaming, sync adapters, service adapters, and cleanup.
 - `AGENTS.md` carries repository-wide routing rules and mandatory decision gates.
 
 ## Script-first convention
@@ -33,6 +39,30 @@ Current primary helpers:
 - `machine-management/scripts/machine_verify.py`
 - `machine-management/scripts/machine_repair.py`
 - `machine-management/scripts/machine_remove.py`
+- `session-management/scripts/session_create.py`
+- `session-management/scripts/session_list.py`
+- `session-management/scripts/session_status.py`
+- `session-management/scripts/session_remove.py`
+- `session-management/scripts/session_gc.py`
+- `scripts/remote_target_resolve.py`
+- `scripts/remote_probe.py`
+- `scripts/remote_exec.py`
+- `scripts/remote_job_start.py`
+- `scripts/remote_job_status.py`
+- `scripts/remote_job_tail.py`
+- `scripts/remote_job_stop.py`
+- `scripts/remote_job_collect.py`
+- `scripts/remote_sync_plan.py`
+- `scripts/remote_sync_apply.py`
+- `scripts/remote_service_start.py`
+- `scripts/remote_service_status.py`
+- `scripts/remote_service_logs.py`
+- `scripts/remote_service_stop.py`
+- `scripts/remote_artifact_manifest.py`
+- `scripts/remote_artifact_pull.py`
+- `scripts/remote_artifact_push.py`
+- `scripts/remote_cleanup.py`
+- `scripts/remote_toolbox_stress.py`
 - `remote-code-parity/scripts/parity_sync.py`
 - `remote-code-parity/scripts/remote_code_parity.py`
 - `remote-code-parity/scripts/install_consent.py`
@@ -45,6 +75,11 @@ Current primary helpers:
 - `ascend-memory-profiling/scripts/mem_collect.py`
 - `ascend-memory-profiling/scripts/mem_analyze.py`
 - `ascend-memory-profiling/scripts/weight_inspector.py`
+- `ascend-profiling-collection/scripts/collect_torch_profile_case.py`
+- `ascend-profiling-collection/scripts/profile_control.py`
+- `ascend-profiling-collection/scripts/run_remote_analyse.py`
+- `ascend-profiling-analysis/scripts/profile_analyze.py`
+- `ascend-profiling-analysis/scripts/profile_sweep.py`
 - `scripts/workspace_profile.py`
 
 Low-level machine-management helpers remain available for implementation work and debugging:
@@ -63,10 +98,22 @@ Untracked workspace-local state lives under `.vaws-local/`:
 - `.vaws-local/remote-code-parity/install-consents.json`
 - `.vaws-local/remote-code-parity/runtime-state.json`
 - `.vaws-local/serving/<machine-alias>.json`
+- `.vaws-local/remote-toolbox/logs/`
+- `.vaws-local/remote-toolbox/jobs/`
+- `.vaws-local/remote-toolbox/artifacts/`
+- `.vaws-local/sessions/<session-id>/session.json`
+- `.vaws-local/sessions/<session-id>/serving.json`
+- `.vaws-local/sessions/leases.json`
 - `.vaws-local/benchmark/`
 - `.vaws-local/memory-profiling/`
+- `.vaws-local/ascend-profiling-collection/runs/`
+- `.vaws-local/profiling-analysis/runs/`
 
-Remote-code-parity transport is container-only after machine attach: use machine inventory to resolve the target, then push synthetic refs directly into the container-local cache root. Synthetic mirrors should also publish an advertised branch ref for the current snapshot so nested repos can be materialized without brittle submodule fetch behavior. Runtime installs should configure multiple pip indexes (Tsinghua as primary, Aliyun and PyPI as additional), stream progress for long package steps, and keep consent/runtime-state writes atomic.
+Parallel remote work should use `session-management` first. A session owns a local worktree, a dedicated remote container, session-scoped serving/benchmark/profiling state, and resource leases. Existing `--machine` commands remain legacy-compatible for single-tenant workflows.
+
+The remote toolbox is the preferred agent-facing surface once a target exists. It resolves host and container endpoints, probes actual runtime facts, runs bounded remote shell commands with local logs, tracks long jobs, splits source-only/materialize/install sync modes, wraps service lifecycle entrypoints, transfers artifacts with SSH streaming plus hash manifests, and performs dry-run-capable cleanup.
+
+Remote-code-parity transport is container-only after machine attach: use machine inventory to resolve the target, then push synthetic refs directly into the container-local cache root. Synthetic mirrors should also publish an advertised branch ref for the current snapshot so nested repos can be materialized without brittle submodule fetch behavior. Runtime installs should explicitly forward whitelisted `VAWS_*` compile/cache env into the remote shell, configure multiple pip indexes (Tsinghua as primary, Aliyun and PyPI as additional), scope the default Ascend package index to `vllm-ascend` installs, reuse pip / uv / CMake `FetchContent` caches under `/root/.cache`, default paired-image editable installs to `--no-deps`, bound uv bootstrap mirror attempts, stream progress for long package steps, record the effective install env, and keep consent/runtime-state writes atomic.
 
 The legacy repo-root `.machine-inventory.json` is compatibility input only and should not be reintroduced as the primary path.
 
@@ -92,6 +139,24 @@ If you change `machine-management`, update these together:
 - `.agents/skills/machine-management/scripts/`
 - shared helpers when the workflow depends on local profile or inventory state
 
+If you change `session-management`, update these together:
+
+- `.agents/skills/session-management/SKILL.md`
+- `.agents/skills/session-management/references/`
+- `.agents/skills/session-management/scripts/`
+- `.agents/lib/vaws_session_id.py`
+- `.agents/lib/vaws_session_state.py`
+- `AGENTS.md`, `README.md`, and this file when routing or local-state behavior changes
+
+If you change `remote-toolbox`, update these together:
+
+- `.agents/skills/remote-toolbox/SKILL.md`
+- `.agents/skills/remote-toolbox/references/`
+- `.agents/scripts/remote_*.py`
+- `.agents/lib/vaws_remote_toolbox.py`
+- affected wrapper scripts that reuse toolbox primitives
+- `AGENTS.md`, `README.md`, and this file when routing or output contracts change
+
 If you change `vllm-ascend-serving`, update these together:
 
 - `.agents/skills/vllm-ascend-serving/SKILL.md`
@@ -110,6 +175,20 @@ If you change `ascend-memory-profiling`, update these together:
 
 - `.agents/skills/ascend-memory-profiling/SKILL.md`
 - `.agents/skills/ascend-memory-profiling/scripts/`
+- `AGENTS.md` and this file when routing, output contract, or local-state behavior changes
+
+If you change `ascend-profiling-collection`, update these together:
+
+- `.agents/skills/ascend-profiling-collection/SKILL.md`
+- `.agents/skills/ascend-profiling-collection/references/`
+- `.agents/skills/ascend-profiling-collection/scripts/`
+- `AGENTS.md` and this file when routing, output contract, or local-state behavior changes
+
+If you change `ascend-profiling-analysis`, update these together:
+
+- `.agents/skills/ascend-profiling-analysis/SKILL.md`
+- `.agents/skills/ascend-profiling-analysis/references/`
+- `.agents/skills/ascend-profiling-analysis/scripts/`
 - `AGENTS.md` and this file when routing, output contract, or local-state behavior changes
 
 If you change `remote-code-parity`, update these together:

--- a/.agents/lib/vaws_local_state.py
+++ b/.agents/lib/vaws_local_state.py
@@ -21,6 +21,7 @@ STATE_DIRNAME = ".vaws-local"
 PROFILE_FILENAME = "machine-profile.json"
 INVENTORY_FILENAME = "machine-inventory.json"
 LEGACY_INVENTORY_FILENAME = ".machine-inventory.json"
+SESSIONS_DIRNAME = "sessions"
 PROFILE_SCHEMA_VERSION = 1
 CONTAINER_PREFIX = "vaws-"
 USERNAME_PATTERN = re.compile(r"^[a-z0-9]{3,32}$")
@@ -32,6 +33,7 @@ ROOT = Path(__file__).resolve().parents[2]
 STATE_DIR = ROOT / STATE_DIRNAME
 PROFILE_PATH = STATE_DIR / PROFILE_FILENAME
 INVENTORY_PATH = STATE_DIR / INVENTORY_FILENAME
+SESSIONS_DIR = STATE_DIR / SESSIONS_DIRNAME
 LEGACY_INVENTORY_PATH = ROOT / LEGACY_INVENTORY_FILENAME
 
 
@@ -215,6 +217,7 @@ def profile_summary(path: Path = PROFILE_PATH) -> dict[str, Any]:
         "state_dir": str(path.parent),
         "profile_path": str(path),
         "inventory_path": str(INVENTORY_PATH),
+        "sessions_path": str(SESSIONS_DIR),
         "legacy_inventory_path": str(LEGACY_INVENTORY_PATH),
         "exists": path.exists(),
         "choice_required": not path.exists(),

--- a/.agents/lib/vaws_remote_toolbox.py
+++ b/.agents/lib/vaws_remote_toolbox.py
@@ -45,6 +45,13 @@ from vaws_session_state import (  # noqa: E402
     session_record_for_execution,
     session_serving_state_path,
 )
+from vaws_validate import (  # noqa: E402
+    ValidationError,
+    ensure_child_path,
+    require_env_name,
+    require_remote_leaf,
+    require_safe_id,
+)
 
 
 PROGRESS_SENTINEL = "__VAWS_REMOTE_TOOLBOX_PROGRESS__="
@@ -422,9 +429,8 @@ def ssh_exec_bytes(
 def _remote_env_exports(env: dict[str, str]) -> list[str]:
     lines: list[str] = []
     for key, value in sorted(env.items()):
-        if not key.replace("_", "").isalnum() or key[0].isdigit():
-            raise RemoteToolboxError(f"invalid env var name: {key!r}")
-        lines.append(f"export {key}={shlex.quote(str(value))}")
+        name = require_env_name(key)
+        lines.append(f"export {name}={shlex.quote(str(value))}")
     return lines
 
 
@@ -795,16 +801,18 @@ def _parse_env_items(items: Sequence[str] | None) -> dict[str, str]:
         if "=" not in item:
             raise RemoteToolboxError(f"bad env item {item!r}; expected KEY=VALUE")
         key, value = item.split("=", 1)
-        env[key] = value
+        env[require_env_name(key)] = value
     return env
 
 
 def _remote_job_dir(target: RemoteTarget, job_id: str) -> str:
-    return str(PurePosixPath(target.remote_toolbox_root()) / "jobs" / job_id)
+    safe_job_id = require_remote_leaf(job_id, label="job id")
+    return str(PurePosixPath(target.remote_toolbox_root()) / "jobs" / safe_job_id)
 
 
 def _job_record_path(job_id: str) -> Path:
-    return JOB_STATE_DIR / f"{job_id}.json"
+    safe_job_id = require_safe_id(job_id, label="job id")
+    return ensure_child_path(JOB_STATE_DIR, JOB_STATE_DIR / f"{safe_job_id}.json")
 
 
 def _save_job_record(job_id: str, record: dict[str, Any]) -> None:
@@ -831,7 +839,10 @@ def start_remote_job(
 ) -> dict[str, Any]:
     started_at = now_iso()
     start = time.monotonic()
-    job_id = job_id or f"job-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}-{uuid.uuid4().hex[:8]}"
+    job_id = require_safe_id(
+        job_id or f"job-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}-{uuid.uuid4().hex[:8]}",
+        label="job id",
+    )
     remote_dir = _remote_job_dir(target, job_id)
     cwd = cwd or target.runtime_root
     env = env or {}
@@ -923,7 +934,11 @@ printf '{{"pid":%s}}\\n' "$pid"
 
 
 def _resolve_job_target(job_id: str, args: argparse.Namespace | None = None) -> tuple[RemoteTarget, dict[str, Any]]:
+    job_id = require_safe_id(job_id, label="job id")
     record = _load_job_record(job_id)
+    record_job_id = require_safe_id(str(record.get("job_id", "")), label="job id")
+    if record_job_id != job_id:
+        raise RemoteToolboxError(f"job record id mismatch: requested {job_id!r}, record has {record_job_id!r}")
     if args and (getattr(args, "machine", None) or getattr(args, "session_id", None) or getattr(args, "session_file", None)):
         target = resolve_remote_target(
             machine=getattr(args, "machine", None),
@@ -1333,12 +1348,17 @@ def _artifact_pull_tar_batch(
 
 
 def _local_manifest(local_path: Path) -> dict[str, Any]:
-    local_path = local_path.expanduser().resolve()
+    raw_path = local_path.expanduser()
+    if raw_path.is_symlink():
+        raise RemoteToolboxError("symlinks are not allowed by artifact_push")
+    local_path = raw_path.resolve()
     if not local_path.exists():
         raise RemoteToolboxError(f"local path does not exist: {local_path}")
     files: list[dict[str, Any]] = []
     roots = [local_path] if local_path.is_file() else sorted(p for p in local_path.rglob("*") if p.is_file())
     for path in roots:
+        if path.is_symlink():
+            raise RemoteToolboxError(f"symlinks are not allowed by artifact_push: {path}")
         relpath = "." if path == local_path else str(path.relative_to(local_path))
         files.append({
             "relpath": relpath,
@@ -1732,16 +1752,27 @@ def cleanup(
     started_at = now_iso()
     start = time.monotonic()
     actions: list[dict[str, Any]] = []
+    status = "ok"
+    service_release_ok = False
     if service:
         if dry_run:
             actions.append({"action": "service-stop", "dry_run": True})
+            service_release_ok = True
         else:
-            actions.append({"action": "service-stop", "result": call_service("stop", target, ["--force"] if force else [])})
+            service_result = call_service("stop", target, ["--force"] if force else [])
+            actions.append({"action": "service-stop", "result": service_result})
+            service_release_ok = (
+                service_result.get("returncode") == 0
+                and service_result.get("status") in {"stopped", "not_found"}
+            )
     if jobs or remote_temp:
         remote_paths = []
         if jobs:
             if job_ids:
-                remote_paths.extend(str(PurePosixPath(target.remote_toolbox_root()) / "jobs" / job_id) for job_id in job_ids)
+                remote_paths.extend(
+                    str(PurePosixPath(target.remote_toolbox_root()) / "jobs" / require_remote_leaf(job_id, label="job id"))
+                    for job_id in job_ids
+                )
             else:
                 remote_paths.append(str(PurePosixPath(target.remote_toolbox_root()) / "jobs"))
         if remote_temp:
@@ -1767,8 +1798,24 @@ def cleanup(
             rc, payload, stdout, stderr = _run_json_command(cmd, relay_stderr=True)
             actions.append({"action": "session-remove", "returncode": rc, "result": payload, "stdout_tail": tail_text(stdout), "stderr_tail": tail_text(stderr)})
     elif leases and target.session_id:
-        if dry_run:
+        if not service:
+            actions.append({
+                "action": "release-leases",
+                "session_id": target.session_id,
+                "blocked": True,
+                "reason": "lease release requires --service, --session-container, or --all for session targets",
+            })
+            status = "blocked"
+        elif dry_run:
             actions.append({"action": "release-leases", "session_id": target.session_id, "dry_run": True})
+        elif not service_release_ok:
+            actions.append({
+                "action": "release-leases",
+                "session_id": target.session_id,
+                "blocked": True,
+                "reason": "service stop did not prove resources are safe to release",
+            })
+            status = "blocked"
         else:
             release_all_session_leases(repo_root=target.state_repo_root, session_id=target.session_id)
             actions.append({"action": "release-leases", "session_id": target.session_id, "released": True})
@@ -1791,7 +1838,7 @@ def cleanup(
         with contextlib.suppress(Exception):
             proof["leases"] = load_leases(target.state_repo_root)
     return {
-        "status": "ok",
+        "status": status,
         "target": target.to_dict(),
         "started_at": started_at,
         "duration_ms": duration_ms(start),
@@ -1819,7 +1866,7 @@ def target_from_args(args: argparse.Namespace) -> RemoteTarget:
 
 def _cli_error(exc: BaseException, *, started_at: str, start: float) -> int:
     status = "failed"
-    if isinstance(exc, (RemoteToolboxError, WorkspaceStateError, FileNotFoundError)):
+    if isinstance(exc, (RemoteToolboxError, WorkspaceStateError, ValidationError, FileNotFoundError)):
         status = "needs_input"
     if isinstance(exc, subprocess.TimeoutExpired):
         status = "timeout"
@@ -1887,11 +1934,12 @@ def cli_exec(argv: Sequence[str] | None = None) -> int:
             command = " ".join(command_args)
         if not command:
             raise RemoteToolboxError("--command or command after -- is required")
+        env = _parse_env_items(args.env)
         payload = remote_exec(
             target_from_args(args),
             command=command,
             cwd=args.cwd,
-            env=_parse_env_items(args.env),
+            env=env,
             timeout=args.timeout,
             runtime_env=not args.no_runtime_env,
         )
@@ -1919,14 +1967,16 @@ def cli_job_start(argv: Sequence[str] | None = None) -> int:
     started_at = now_iso()
     start = time.monotonic()
     try:
+        env = _parse_env_items(args.env)
+        job_id = require_safe_id(args.job_id, label="job id") if args.job_id else None
         print_json(start_remote_job(
             target_from_args(args),
             command=args.command,
             cwd=args.cwd,
-            env=_parse_env_items(args.env),
+            env=env,
             kind=args.kind,
             timeout_seconds=args.timeout,
-            job_id=args.job_id,
+            job_id=job_id,
             runtime_env=not args.no_runtime_env,
         ))
         return 0
@@ -2162,6 +2212,8 @@ def cli_cleanup(argv: Sequence[str] | None = None) -> int:
     started_at = now_iso()
     start = time.monotonic()
     try:
+        for job_id in args.job_id:
+            require_safe_id(job_id, label="job id")
         if args.job_id:
             args.jobs = True
         if args.all:
@@ -2183,6 +2235,6 @@ def cli_cleanup(argv: Sequence[str] | None = None) -> int:
             force=args.force,
         )
         print_json(payload)
-        return 0
+        return 0 if payload["status"] == "ok" else 1
     except Exception as exc:  # noqa: BLE001
         return _cli_error(exc, started_at=started_at, start=start)

--- a/.agents/lib/vaws_remote_toolbox.py
+++ b/.agents/lib/vaws_remote_toolbox.py
@@ -1,0 +1,2188 @@
+#!/usr/bin/env python3
+"""Agent-facing remote toolbox primitives for VAWS managed containers.
+
+This module is intentionally script-friendly: callers get structured target
+resolution, SSH execution with local logs, job state, artifact streaming, and
+thin adapters around existing parity/serving/session entrypoints.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import fnmatch
+import hashlib
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import tarfile
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, BinaryIO, Iterable, Sequence
+
+from vaws_local_state import (  # noqa: E402
+    INVENTORY_PATH,
+    LEGACY_INVENTORY_PATH,
+    ROOT,
+    WorkspaceStateError,
+    ensure_state_dir,
+    resolve_inventory_read_path,
+    utc_now_iso,
+)
+from vaws_session_state import (  # noqa: E402
+    load_leases,
+    load_session_lookup,
+    release_all_session_leases,
+    session_record_for_execution,
+    session_serving_state_path,
+)
+
+
+PROGRESS_SENTINEL = "__VAWS_REMOTE_TOOLBOX_PROGRESS__="
+STATE_DIR = ROOT / ".vaws-local" / "remote-toolbox"
+LOG_DIR = STATE_DIR / "logs"
+JOB_STATE_DIR = STATE_DIR / "jobs"
+ARTIFACT_STATE_DIR = STATE_DIR / "artifacts"
+DEFAULT_CONTAINER_CACHE_ROOT = "/root/.cache/vaws/remote-code-parity"
+DEFAULT_REMOTE_TOOLBOX_ROOT = ".vaws-runtime/remote-toolbox"
+TAIL_CHARS = 12000
+
+REMOTE_STATUS_VALUES = {
+    "ok",
+    "ready",
+    "needs_input",
+    "blocked",
+    "failed",
+    "timeout",
+    "needs_repair",
+    "cancelled",
+}
+
+VLLM_REINSTALL_PATTERNS = (
+    "requirements*",
+    "pyproject.toml",
+    "setup.*",
+    "CMake*",
+    "cmake/**",
+    "csrc/**",
+    "*.c",
+    "*.cc",
+    "*.cpp",
+    "*.cu",
+    "*.cuh",
+    "*.h",
+    "*.hpp",
+)
+VLLM_ASCEND_REINSTALL_PATTERNS = (
+    *VLLM_REINSTALL_PATTERNS,
+    "vllm_ascend/_cann_ops_custom/**",
+)
+
+
+class RemoteToolboxError(RuntimeError):
+    """Deterministic user-facing remote-toolbox failure."""
+
+
+@dataclass(frozen=True)
+class SshEndpoint:
+    host: str
+    port: int
+    user: str = "root"
+
+    def destination(self) -> str:
+        return f"{self.user}@{self.host}"
+
+    def known_hosts_key(self) -> str:
+        return self.host if self.port == 22 else f"[{self.host}]:{self.port}"
+
+    def to_dict(self, *, plane: str | None = None) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "host": self.host,
+            "port": self.port,
+            "user": self.user,
+            "destination": self.destination(),
+            "known_hosts_key": self.known_hosts_key(),
+        }
+        if plane:
+            payload["plane"] = plane
+        return payload
+
+
+@dataclass(frozen=True)
+class RemoteTarget:
+    mode: str
+    alias: str
+    target_id: str
+    workspace_id: str
+    workspace_root: Path
+    runtime_root: str
+    container_name: str
+    container_image: str
+    container_endpoint: SshEndpoint
+    host_endpoint: SshEndpoint
+    state_repo_root: Path
+    record: dict[str, Any]
+    session_id: str | None = None
+    session_file: Path | None = None
+    session: dict[str, Any] | None = None
+    leased_devices: list[int] | None = None
+
+    def remote_toolbox_root(self) -> str:
+        return str(PurePosixPath(self.runtime_root) / DEFAULT_REMOTE_TOOLBOX_ROOT)
+
+    def to_dict(self) -> dict[str, Any]:
+        state_paths: dict[str, Any] = {
+            "repo_root": str(self.state_repo_root),
+            "remote_toolbox": str(STATE_DIR),
+            "logs": str(LOG_DIR),
+            "jobs": str(JOB_STATE_DIR),
+            "artifacts": str(ARTIFACT_STATE_DIR),
+        }
+        if self.session_id:
+            state_paths["session_file"] = str(self.session_file) if self.session_file else None
+            state_paths["serving_state"] = str(
+                session_serving_state_path(self.session_id, self.state_repo_root)
+            )
+        else:
+            state_paths["serving_state"] = str(
+                self.state_repo_root / ".vaws-local" / "serving" / f"{self.alias}.json"
+            )
+        return {
+            "mode": self.mode,
+            "alias": self.alias,
+            "target_id": self.target_id,
+            "session_id": self.session_id,
+            "session_file": str(self.session_file) if self.session_file else None,
+            "workspace_id": self.workspace_id,
+            "workspace_root": str(self.workspace_root),
+            "runtime_root": self.runtime_root,
+            "remote_toolbox_root": self.remote_toolbox_root(),
+            "leased_devices": self.leased_devices or [],
+            "host": self.host_endpoint.to_dict(plane="host"),
+            "container": {
+                "name": self.container_name,
+                "image_record": self.container_image,
+                **self.container_endpoint.to_dict(plane="container"),
+            },
+            "state_paths": state_paths,
+        }
+
+
+def json_dumps(data: Any) -> str:
+    return json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True)
+
+
+def print_json(data: dict[str, Any]) -> None:
+    print(json_dumps(data))
+
+
+def emit_progress(phase: str, message: str | None = None, **extra: Any) -> None:
+    payload: dict[str, Any] = {
+        "phase": phase,
+        "at": utc_now_iso(),
+    }
+    if message is not None:
+        payload["message"] = message
+    payload.update({key: value for key, value in extra.items() if value is not None})
+    sys.stderr.write(PROGRESS_SENTINEL + json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+    sys.stderr.flush()
+
+
+def now_iso() -> str:
+    return utc_now_iso()
+
+
+def duration_ms(start_monotonic: float) -> int:
+    return int(round((time.monotonic() - start_monotonic) * 1000))
+
+
+def tail_text(value: str, limit: int = TAIL_CHARS) -> str:
+    if len(value) <= limit:
+        return value
+    return value[-limit:]
+
+
+def _write_text(path: Path, value: str) -> None:
+    ensure_state_dir(path.parent)
+    path.write_text(value, encoding="utf-8")
+
+
+def _atomic_write_json(path: Path, data: Any) -> None:
+    ensure_state_dir(path.parent)
+    handle, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as fh:
+            fh.write(json_dumps(data) + "\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(temp_name, path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temp_name)
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _new_log_dir(kind: str, token: str | None = None) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    suffix = token or uuid.uuid4().hex[:8]
+    path = LOG_DIR / kind / f"{stamp}-{suffix}"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def derive_workspace_id(repo_root: Path) -> str:
+    base = "".join(ch if ch.isalnum() or ch in "._-" else "-" for ch in repo_root.name.lower()).strip(".-")
+    digest = hashlib.sha1(str(repo_root.resolve()).encode("utf-8")).hexdigest()[:8]
+    return f"{base or 'workspace'}-{digest}"
+
+
+def _load_inventory(repo_root: Path = ROOT) -> tuple[dict[str, Any], Path]:
+    preferred = repo_root / ".vaws-local" / "machine-inventory.json"
+    path = resolve_inventory_read_path(preferred)
+    if not path.exists():
+        legacy = repo_root / ".machine-inventory.json"
+        if legacy.exists():
+            path = legacy
+        elif INVENTORY_PATH.exists():
+            path = INVENTORY_PATH
+        elif LEGACY_INVENTORY_PATH.exists():
+            path = LEGACY_INVENTORY_PATH
+        else:
+            return {"schema_version": 1, "machines": []}, path
+    return _load_json(path), path
+
+
+def _find_machine_record(identifier: str, repo_root: Path = ROOT) -> tuple[dict[str, Any], Path]:
+    inventory, path = _load_inventory(repo_root)
+    matches: list[dict[str, Any]] = []
+    for record in inventory.get("machines", []):
+        host = record.get("host", {})
+        alias = record.get("alias")
+        ip = host.get("ip") if isinstance(host, dict) else host
+        if identifier in {alias, ip}:
+            matches.append(record)
+    if not matches:
+        raise RemoteToolboxError(f"machine {identifier!r} not found in inventory {path}")
+    if len(matches) > 1:
+        raise RemoteToolboxError(f"machine {identifier!r} matched multiple inventory records")
+    return matches[0], path
+
+
+def _container_endpoint(record: dict[str, Any]) -> SshEndpoint:
+    host = record.get("host", {})
+    container = record.get("container", {})
+    if not isinstance(host, dict) or not isinstance(container, dict):
+        raise RemoteToolboxError("machine record must contain host and container objects")
+    port = container.get("ssh_port")
+    if not isinstance(port, int):
+        raise RemoteToolboxError("machine record is missing container.ssh_port")
+    return SshEndpoint(host=str(host["ip"]), port=port, user=str(container.get("user", "root")))
+
+
+def _host_endpoint(record: dict[str, Any]) -> SshEndpoint:
+    host = record.get("host", {})
+    if not isinstance(host, dict):
+        raise RemoteToolboxError("machine record must contain host object")
+    return SshEndpoint(
+        host=str(host["ip"]),
+        port=int(host.get("port", host.get("ssh_port", 22))),
+        user=str(host.get("user", "root")),
+    )
+
+
+def resolve_remote_target(
+    *,
+    machine: str | None = None,
+    session_id: str | None = None,
+    session_file: str | Path | None = None,
+    repo_root: Path = ROOT,
+) -> RemoteTarget:
+    repo_root = repo_root.expanduser().resolve()
+    if machine and (session_id or session_file):
+        raise RemoteToolboxError("use exactly one target surface: --machine or --session-id/--session-file")
+    if session_id or session_file:
+        lookup = load_session_lookup(
+            session_id=session_id,
+            session_file=session_file,
+            repo_root=repo_root,
+        )
+        session = lookup.session
+        record = session_record_for_execution(session)
+        container = record["container"]
+        session_container = session["remote"]["container"]
+        runtime_root = (
+            session_container.get("runtime_root")
+            or container.get("workdir")
+            or "/vllm-workspace"
+        )
+        workspace_root = Path(session["local"]["worktree_root"]).expanduser().resolve()
+        return RemoteTarget(
+            mode="session",
+            alias=record["alias"],
+            target_id=session["session_id"],
+            workspace_id=str(session.get("workspace_id") or session["session_id"]),
+            workspace_root=workspace_root,
+            runtime_root=runtime_root,
+            container_name=str(container.get("name") or session_container["name"]),
+            container_image=str(container.get("image") or session_container.get("image") or ""),
+            container_endpoint=_container_endpoint(record),
+            host_endpoint=_host_endpoint(record),
+            state_repo_root=lookup.state_repo_root,
+            record=record,
+            session_id=session["session_id"],
+            session_file=lookup.session_file,
+            session=session,
+            leased_devices=[int(item) for item in session.get("leases", {}).get("npu_devices", [])],
+        )
+
+    if not machine:
+        raise RemoteToolboxError("--machine is required unless --session-id or --session-file is used")
+    record, _ = _find_machine_record(machine, repo_root)
+    container = record["container"]
+    runtime_root = container.get("runtime_root") or container.get("workdir") or "/vllm-workspace"
+    alias = str(record.get("alias") or machine)
+    return RemoteTarget(
+        mode="legacy",
+        alias=alias,
+        target_id=alias,
+        workspace_id=derive_workspace_id(repo_root),
+        workspace_root=repo_root,
+        runtime_root=str(runtime_root),
+        container_name=str(container.get("name") or ""),
+        container_image=str(container.get("image") or ""),
+        container_endpoint=_container_endpoint(record),
+        host_endpoint=_host_endpoint(record),
+        state_repo_root=repo_root,
+        record=record,
+        leased_devices=[],
+    )
+
+
+def _ssh_base_cmd(endpoint: SshEndpoint) -> list[str]:
+    return [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-o",
+        "LogLevel=ERROR",
+        "-p",
+        str(endpoint.port),
+        endpoint.destination(),
+    ]
+
+
+def ssh_exec_raw(
+    endpoint: SshEndpoint,
+    script: str,
+    *,
+    timeout: float | None = None,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [*_ssh_base_cmd(endpoint), "bash", "-c", shlex.quote(script)]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, check=False)
+    if check and result.returncode != 0:
+        raise RemoteToolboxError(
+            f"remote command failed (rc={result.returncode}): {tail_text(result.stderr, 2000)}"
+        )
+    return result
+
+
+def ssh_exec_bytes(
+    endpoint: SshEndpoint,
+    remote_command: str,
+    *,
+    stdin: BinaryIO | None = None,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    cmd = [*_ssh_base_cmd(endpoint), "bash", "-c", shlex.quote(remote_command)]
+    return subprocess.run(
+        cmd,
+        stdin=stdin,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _remote_env_exports(env: dict[str, str]) -> list[str]:
+    lines: list[str] = []
+    for key, value in sorted(env.items()):
+        if not key.replace("_", "").isalnum() or key[0].isdigit():
+            raise RemoteToolboxError(f"invalid env var name: {key!r}")
+        lines.append(f"export {key}={shlex.quote(str(value))}")
+    return lines
+
+
+def _runtime_env_lines(enabled: bool) -> list[str]:
+    if not enabled:
+        return []
+    return [
+        "if [ -f /etc/profile.d/vaws-ascend-env.sh ]; then set +u; . /etc/profile.d/vaws-ascend-env.sh; fi",
+    ]
+
+
+def _probe_effective_environment(
+    target: RemoteTarget,
+    *,
+    cwd: str,
+    env: dict[str, str],
+    runtime_env: bool,
+) -> dict[str, Any]:
+    script = "\n".join(
+        [
+            "set +e",
+            *_runtime_env_lines(runtime_env),
+            *_remote_env_exports(env),
+            f"cd {shlex.quote(cwd)} 2>/dev/null || true",
+            "PYTHON=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)",
+            "if [ -z \"$PYTHON\" ]; then printf '%s\\n' '{\"status\":\"ok\",\"python\":{\"available\":false}}'; exit 0; fi",
+            "\"$PYTHON\" - <<'PY'",
+            "import json, os, sys",
+            "print(json.dumps({",
+            "  'status': 'ok',",
+            "  'cwd': os.getcwd(),",
+            "  'python': {'available': True, 'executable': sys.executable, 'version': sys.version.split()[0]},",
+            "  'ascend_home': os.environ.get('ASCEND_HOME_PATH'),",
+            "}, sort_keys=True))",
+            "PY",
+        ]
+    )
+    try:
+        payload = _remote_json(target.container_endpoint, script, timeout=20)
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "failed", "error": str(exc)}
+    return payload
+
+
+def remote_exec(
+    target: RemoteTarget,
+    *,
+    command: str,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+    timeout: float | None = None,
+    runtime_env: bool = True,
+    log_kind: str = "exec",
+) -> dict[str, Any]:
+    started_at = now_iso()
+    start = time.monotonic()
+    log_dir = _new_log_dir(log_kind)
+    cwd = cwd or target.runtime_root
+    env = env or {}
+    script_lines = [
+        "set -o pipefail",
+        *_runtime_env_lines(runtime_env),
+        f"cd {shlex.quote(cwd)}",
+        *_remote_env_exports(env),
+        f"bash -c {shlex.quote(command)}",
+    ]
+    script = "\n".join(script_lines)
+    stdout = ""
+    stderr = ""
+    exit_code: int | None = None
+    status = "failed"
+    timed_out = False
+    try:
+        result = ssh_exec_raw(target.container_endpoint, script, timeout=timeout, check=False)
+        stdout = result.stdout or ""
+        stderr = result.stderr or ""
+        exit_code = result.returncode
+        status = "ok" if result.returncode == 0 else "failed"
+    except subprocess.TimeoutExpired as exc:
+        timed_out = True
+        stdout = _decode_timeout_stream(exc.stdout)
+        stderr = _decode_timeout_stream(exc.stderr)
+        status = "timeout"
+    effective_environment = _probe_effective_environment(
+        target,
+        cwd=cwd,
+        env=env,
+        runtime_env=runtime_env,
+    )
+    stdout_path = log_dir / "stdout.log"
+    stderr_path = log_dir / "stderr.log"
+    meta_path = log_dir / "meta.json"
+    _write_text(stdout_path, stdout)
+    _write_text(stderr_path, stderr)
+    payload = {
+        "status": status,
+        "target": target.to_dict(),
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "exit_code": exit_code,
+        "timed_out": timed_out,
+        "error": "remote command timed out" if timed_out else (f"remote command exited with code {exit_code}" if exit_code not in (0, None) else None),
+        "command": command,
+        "cwd": cwd,
+        "environment": {
+            "runtime_env": runtime_env,
+            "env_keys": sorted(env),
+            "timeout_seconds": timeout,
+            "effective": effective_environment,
+        },
+        "stdout_tail": tail_text(stdout),
+        "stderr_tail": tail_text(stderr),
+        "logs": {
+            "dir": str(log_dir),
+            "stdout": str(stdout_path),
+            "stderr": str(stderr_path),
+            "meta": str(meta_path),
+        },
+    }
+    _atomic_write_json(meta_path, payload)
+    return payload
+
+
+def _decode_timeout_stream(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def known_hosts_status(endpoint: SshEndpoint) -> dict[str, Any]:
+    key = endpoint.known_hosts_key()
+    result = subprocess.run(
+        ["ssh-keygen", "-F", key],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {
+        "key": key,
+        "present": result.returncode == 0 and bool(result.stdout.strip()),
+        "stdout_tail": tail_text(result.stdout or "", 1000),
+        "stderr_tail": tail_text(result.stderr or "", 1000),
+    }
+
+
+def _remote_json(endpoint: SshEndpoint, script: str, *, timeout: float | None = 60) -> dict[str, Any]:
+    try:
+        result = ssh_exec_raw(endpoint, script, timeout=timeout, check=False)
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "status": "timeout",
+            "error": f"remote command timed out after {timeout}s",
+            "stdout_tail": tail_text(_decode_timeout_stream(exc.stdout), 2000),
+            "stderr_tail": tail_text(_decode_timeout_stream(exc.stderr), 2000),
+        }
+    if result.returncode != 0:
+        return {
+            "status": "failed",
+            "exit_code": result.returncode,
+            "stdout_tail": tail_text(result.stdout or "", 2000),
+            "stderr_tail": tail_text(result.stderr or "", 2000),
+        }
+    text = result.stdout.strip()
+    if not text:
+        return {"status": "failed", "error": "remote command returned empty stdout"}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return {
+            "status": "failed",
+            "error": f"remote command returned non-JSON: {exc}",
+            "stdout_tail": tail_text(result.stdout or "", 2000),
+            "stderr_tail": tail_text(result.stderr or "", 2000),
+        }
+    if isinstance(data, dict):
+        return data
+    return {"status": "failed", "error": "remote JSON was not an object", "value": data}
+
+
+def probe_remote(target: RemoteTarget, *, timeout: float | None = 90) -> dict[str, Any]:
+    started_at = now_iso()
+    start = time.monotonic()
+    emit_progress("probe-host", "checking host/container image facts", target=target.target_id)
+    host_script = f"""
+set +e
+if command -v docker >/dev/null 2>&1; then
+  docker inspect {shlex.quote(target.container_name)} 2>/dev/null | python3 -c '
+import json,sys
+try:
+    data=json.load(sys.stdin)[0]
+    print(json.dumps({{
+      "status":"ok",
+      "container": {{
+        "name": data.get("Name","").lstrip("/"),
+        "config_image": data.get("Config",{{}}).get("Image"),
+        "image_id": data.get("Image"),
+        "state": data.get("State",{{}}),
+        "network_settings": {{"ip_address": data.get("NetworkSettings",{{}}).get("IPAddress")}},
+      }}
+    }}))
+except Exception as exc:
+    print(json.dumps({{"status":"failed","error":str(exc)}}))
+'
+else
+  printf '%s\\n' '{{"status":"failed","error":"docker not found on host"}}'
+fi
+"""
+    host_facts = _remote_json(target.host_endpoint, host_script, timeout=timeout)
+
+    emit_progress("probe-container", "checking runtime inside container", target=target.target_id)
+    runtime_path = json.dumps(target.runtime_root)
+    container_script = f"""
+set +e
+if [ -f /etc/profile.d/vaws-ascend-env.sh ]; then set +u; . /etc/profile.d/vaws-ascend-env.sh; set -u; fi
+PYTHON=""
+for candidate in /usr/local/python3.11.15/bin/python3 /usr/local/python3.11.14/bin/python3 /usr/local/python3.10/bin/python3 python3 python; do
+  if command -v "$candidate" >/dev/null 2>&1 || [ -x "$candidate" ]; then PYTHON="$candidate"; break; fi
+done
+if [ -z "$PYTHON" ]; then
+  printf '%s\\n' '{{"status":"failed","python":{{"available":false}},"error":"python not found"}}'
+  exit 0
+fi
+"$PYTHON" - <<'PY'
+import glob
+import importlib
+import json
+import os
+import pathlib
+import platform
+import subprocess
+import sys
+
+runtime_root = {runtime_path}
+
+def run(cmd, timeout=12):
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, check=False)
+        return {{"returncode": p.returncode, "stdout": p.stdout[-4000:], "stderr": p.stderr[-2000:]}}
+    except Exception as exc:
+        return {{"returncode": None, "error": str(exc)}}
+
+def module_info(name):
+    try:
+        mod = importlib.import_module(name)
+        return {{
+            "available": True,
+            "version": str(getattr(mod, "__version__", "unknown")),
+            "file": str(getattr(mod, "__file__", "")),
+        }}
+    except BaseException as exc:
+        return {{"available": False, "error": repr(exc)}}
+
+def read_first(paths):
+    for path in paths:
+        try:
+            p = pathlib.Path(path)
+            if p.is_file():
+                return {{"path": str(p), "content": p.read_text(errors="replace")[:2000]}}
+        except Exception:
+            pass
+    return None
+
+version_paths = []
+version_paths.extend(glob.glob("/usr/local/Ascend/ascend-toolkit/*/version.info"))
+version_paths.extend(glob.glob("/usr/local/Ascend/ascend-toolkit/latest/*version*"))
+version_paths.extend(glob.glob("/usr/local/Ascend/cann-*/*version*"))
+version_paths.extend(glob.glob("/usr/local/Ascend/cann-*/*/version.info"))
+version_paths.extend(glob.glob("/usr/local/Ascend/cann/*/version.info"))
+try:
+    cann_home_real = str(pathlib.Path("/usr/local/Ascend/cann").resolve())
+except Exception:
+    cann_home_real = None
+
+workspace = {{"runtime_root": runtime_root, "exists": pathlib.Path(runtime_root).exists()}}
+for rel in ["", "vllm", "vllm-ascend"]:
+    repo = pathlib.Path(runtime_root) / rel if rel else pathlib.Path(runtime_root)
+    if repo.exists():
+        workspace[rel or "."] = run(["git", "-C", str(repo), "rev-parse", "HEAD"], timeout=5)
+
+payload = {{
+    "status": "ok",
+    "hostname": platform.node(),
+    "python": {{
+        "executable": sys.executable,
+        "version": sys.version.split()[0],
+        "version_full": sys.version,
+    }},
+    "modules": {{
+        name: module_info(name) for name in ["torch", "torch_npu", "vllm", "vllm_ascend"]
+    }},
+    "cann": {{
+        "ascend_home": os.environ.get("ASCEND_HOME_PATH"),
+        "cann_home": cann_home_real,
+        "version_info": read_first(version_paths),
+    }},
+    "npu": {{
+        "npu_smi": run(["npu-smi", "info"], timeout=15),
+    }},
+    "workspace": workspace,
+    "os_release": read_first(["/etc/os-release"]),
+}}
+print(json.dumps(payload, sort_keys=True))
+PY
+"""
+    container_facts = _remote_json(target.container_endpoint, container_script, timeout=timeout)
+    service_facts = probe_service_state(target)
+    return {
+        "status": "ok" if container_facts.get("status") == "ok" else "needs_repair",
+        "target": target.to_dict(),
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "facts": {
+            "image": {
+                "recorded_tag": target.container_image,
+                "host_docker_inspect": host_facts,
+                "note": "recorded tag is untrusted; host_docker_inspect.image_id/config_image are observed from the running container",
+            },
+            "container_runtime": container_facts,
+            "service": service_facts,
+            "known_hosts": {
+                "host": known_hosts_status(target.host_endpoint),
+                "container": known_hosts_status(target.container_endpoint),
+            },
+        },
+        "logs": {},
+    }
+
+
+def _load_serving_state_for_target(target: RemoteTarget) -> tuple[dict[str, Any] | None, Path]:
+    if target.session_id:
+        path = session_serving_state_path(target.session_id, target.state_repo_root)
+    else:
+        path = target.state_repo_root / ".vaws-local" / "serving" / f"{target.alias}.json"
+    if not path.exists():
+        return None, path
+    try:
+        return _load_json(path), path
+    except Exception:
+        return None, path
+
+
+def probe_service_state(target: RemoteTarget) -> dict[str, Any]:
+    state, path = _load_serving_state_for_target(target)
+    payload: dict[str, Any] = {"state_path": str(path), "recorded": state is not None}
+    if not state:
+        return payload
+    payload["state"] = {k: state.get(k) for k in ("status", "pid", "port", "base_url", "model", "runtime_dir", "log_stdout", "log_stderr")}
+    pid = state.get("pid")
+    port = state.get("port")
+    if pid:
+        alive = ssh_exec_raw(target.container_endpoint, f"kill -0 {int(pid)} 2>/dev/null && echo alive || echo dead", check=False)
+        payload["pid_alive"] = (alive.stdout or "").strip() == "alive"
+    if port:
+        health = ssh_exec_raw(
+            target.container_endpoint,
+            f"curl -s -o /dev/null -w '%{{http_code}}' --connect-timeout 2 http://127.0.0.1:{int(port)}/health 2>/dev/null || echo 000",
+            check=False,
+        )
+        payload["health_code"] = (health.stdout or "").strip()
+    return payload
+
+
+def _parse_env_items(items: Sequence[str] | None) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for item in items or []:
+        if "=" not in item:
+            raise RemoteToolboxError(f"bad env item {item!r}; expected KEY=VALUE")
+        key, value = item.split("=", 1)
+        env[key] = value
+    return env
+
+
+def _remote_job_dir(target: RemoteTarget, job_id: str) -> str:
+    return str(PurePosixPath(target.remote_toolbox_root()) / "jobs" / job_id)
+
+
+def _job_record_path(job_id: str) -> Path:
+    return JOB_STATE_DIR / f"{job_id}.json"
+
+
+def _save_job_record(job_id: str, record: dict[str, Any]) -> None:
+    _atomic_write_json(_job_record_path(job_id), record)
+
+
+def _load_job_record(job_id: str) -> dict[str, Any]:
+    path = _job_record_path(job_id)
+    if not path.exists():
+        raise RemoteToolboxError(f"unknown remote job id: {job_id}")
+    return _load_json(path)
+
+
+def start_remote_job(
+    target: RemoteTarget,
+    *,
+    command: str,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+    kind: str = "command",
+    timeout_seconds: int | None = None,
+    job_id: str | None = None,
+    runtime_env: bool = True,
+) -> dict[str, Any]:
+    started_at = now_iso()
+    start = time.monotonic()
+    job_id = job_id or f"job-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}-{uuid.uuid4().hex[:8]}"
+    remote_dir = _remote_job_dir(target, job_id)
+    cwd = cwd or target.runtime_root
+    env = env or {}
+    status_json = json.dumps({"status": "running", "job_id": job_id, "started_at": started_at})
+    meta = {
+        "schema_version": 1,
+        "job_id": job_id,
+        "kind": kind,
+        "target": target.to_dict(),
+        "command": command,
+        "cwd": cwd,
+        "env_keys": sorted(env),
+        "runtime_env": runtime_env,
+        "remote_dir": remote_dir,
+        "started_at": started_at,
+        "timeout_seconds": timeout_seconds,
+    }
+    env_lines = _remote_env_exports(env)
+    timeout_prefix = f"timeout {int(timeout_seconds)} " if timeout_seconds else ""
+    runner = "\n".join(
+        [
+            "#!/usr/bin/env bash",
+            "set +e",
+            f"JOB_DIR={shlex.quote(remote_dir)}",
+            *_runtime_env_lines(runtime_env),
+            f"cd {shlex.quote(cwd)}",
+            *env_lines,
+            f"printf '%s\\n' {shlex.quote(status_json)} > \"$JOB_DIR/status.json\"",
+            "date -u +%Y-%m-%dT%H:%M:%SZ > \"$JOB_DIR/started_at\"",
+            f"{timeout_prefix}bash -c {shlex.quote(command)} > \"$JOB_DIR/stdout.log\" 2> \"$JOB_DIR/stderr.log\"",
+            "rc=$?",
+            "finished=$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "status=failed",
+            "[ \"$rc\" -eq 0 ] && status=succeeded",
+            "if [ \"$rc\" -eq 124 ] || [ \"$rc\" -eq 137 ]; then status=timeout; fi",
+            "cat > \"$JOB_DIR/status.json\" <<EOF",
+            '{"status":"'"$status"'","job_id":"'
+            + job_id
+            + '","exit_code":'"$rc"',"finished_at":"'"$finished"'"}',
+            "EOF",
+            "exit 0",
+        ]
+    )
+    remote_meta = json_dumps(meta)
+    script = f"""
+set -e
+mkdir -p {shlex.quote(remote_dir)}
+cat > {shlex.quote(str(PurePosixPath(remote_dir) / "meta.json"))} <<'VAWS_META'
+{remote_meta}
+VAWS_META
+cat > {shlex.quote(str(PurePosixPath(remote_dir) / "run.sh"))} <<'VAWS_RUN'
+{runner}
+VAWS_RUN
+chmod +x {shlex.quote(str(PurePosixPath(remote_dir) / "run.sh"))}
+nohup bash {shlex.quote(str(PurePosixPath(remote_dir) / "run.sh"))} >/dev/null 2>&1 </dev/null &
+pid=$!
+echo "$pid" > {shlex.quote(str(PurePosixPath(remote_dir) / "pid"))}
+printf '{{"pid":%s}}\\n' "$pid"
+"""
+    result = _remote_json(target.container_endpoint, script, timeout=20)
+    if "pid" not in result:
+        return {
+            "status": "failed",
+            "target": target.to_dict(),
+            "started_at": started_at,
+            "duration_ms": duration_ms(start),
+            "error": "failed to launch remote job",
+            "result": result,
+            "logs": {},
+        }
+    meta["pid"] = result["pid"]
+    _save_job_record(job_id, meta)
+    return {
+        "status": "ok",
+        "target": target.to_dict(),
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "job_id": job_id,
+        "pid": result["pid"],
+        "remote_dir": remote_dir,
+        "logs": {
+            "stdout": str(PurePosixPath(remote_dir) / "stdout.log"),
+            "stderr": str(PurePosixPath(remote_dir) / "stderr.log"),
+            "status": str(PurePosixPath(remote_dir) / "status.json"),
+            "meta": str(PurePosixPath(remote_dir) / "meta.json"),
+            "local_record": str(_job_record_path(job_id)),
+        },
+    }
+
+
+def _resolve_job_target(job_id: str, args: argparse.Namespace | None = None) -> tuple[RemoteTarget, dict[str, Any]]:
+    record = _load_job_record(job_id)
+    if args and (getattr(args, "machine", None) or getattr(args, "session_id", None) or getattr(args, "session_file", None)):
+        target = resolve_remote_target(
+            machine=getattr(args, "machine", None),
+            session_id=getattr(args, "session_id", None),
+            session_file=getattr(args, "session_file", None),
+        )
+    else:
+        t = record.get("target", {})
+        if t.get("session_id"):
+            target = resolve_remote_target(session_id=t["session_id"], session_file=t.get("session_file"))
+        else:
+            target = resolve_remote_target(machine=t.get("alias") or t.get("target_id"))
+    return target, record
+
+
+def remote_job_status(target: RemoteTarget, record: dict[str, Any]) -> dict[str, Any]:
+    started_at = now_iso()
+    start = time.monotonic()
+    remote_dir = record["remote_dir"]
+    script = f"""
+set +e
+status_path={shlex.quote(str(PurePosixPath(remote_dir) / "status.json"))}
+pid_path={shlex.quote(str(PurePosixPath(remote_dir) / "pid"))}
+if [ -f "$status_path" ]; then cat "$status_path"; else printf '{{"status":"unknown"}}\\n'; fi
+if [ -f "$pid_path" ]; then pid=$(cat "$pid_path"); if kill -0 "$pid" 2>/dev/null; then echo '__PID_ALIVE__=1'; else echo '__PID_ALIVE__=0'; fi; fi
+"""
+    result = ssh_exec_raw(target.container_endpoint, script, timeout=20, check=False)
+    lines = (result.stdout or "").splitlines()
+    status_data: dict[str, Any] = {"status": "unknown"}
+    pid_alive = None
+    if lines:
+        with contextlib.suppress(json.JSONDecodeError):
+            status_data = json.loads(lines[0])
+    for line in lines[1:]:
+        if line.startswith("__PID_ALIVE__="):
+            pid_alive = line.endswith("1")
+    if status_data.get("status") == "running" and pid_alive is False:
+        status_data["status"] = "failed"
+        status_data["reason"] = "pid is no longer alive but job status was not finalized"
+    top_status = status_data.get("status", "needs_repair")
+    if top_status == "unknown":
+        top_status = "needs_repair"
+    return {
+        "status": top_status,
+        "target": target.to_dict(),
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "error": status_data.get("reason") if top_status in {"failed", "timeout", "needs_repair", "cancelled"} else None,
+        "job": {**record, "remote_status": status_data, "pid_alive": pid_alive},
+        "logs": {
+            "stdout": str(PurePosixPath(record["remote_dir"]) / "stdout.log"),
+            "stderr": str(PurePosixPath(record["remote_dir"]) / "stderr.log"),
+        },
+    }
+
+
+def remote_job_tail(target: RemoteTarget, record: dict[str, Any], *, lines: int = 80, stream: str = "both") -> dict[str, Any]:
+    started_at = now_iso()
+    start = time.monotonic()
+    remote_dir = PurePosixPath(record["remote_dir"])
+    commands: list[str] = []
+    if stream in {"stdout", "both"}:
+        commands.append(f"echo __STDOUT__; tail -n {int(lines)} {shlex.quote(str(remote_dir / 'stdout.log'))} 2>/dev/null || true")
+    if stream in {"stderr", "both"}:
+        commands.append(f"echo __STDERR__; tail -n {int(lines)} {shlex.quote(str(remote_dir / 'stderr.log'))} 2>/dev/null || true")
+    result = ssh_exec_raw(target.container_endpoint, "\n".join(commands), timeout=20, check=False)
+    return {
+        "status": "ok" if result.returncode == 0 else "failed",
+        "target": target.to_dict(),
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "job_id": record["job_id"],
+        "tail": result.stdout,
+        "stderr_tail": result.stderr,
+        "logs": {
+            "stdout": str(remote_dir / "stdout.log"),
+            "stderr": str(remote_dir / "stderr.log"),
+        },
+    }
+
+
+def remote_job_stop(target: RemoteTarget, record: dict[str, Any], *, force: bool = False) -> dict[str, Any]:
+    started_at = now_iso()
+    start = time.monotonic()
+    remote_dir = PurePosixPath(record["remote_dir"])
+    sig = "-9" if force else "-15"
+    script = f"""
+set +e
+pid_path={shlex.quote(str(remote_dir / "pid"))}
+if [ ! -f "$pid_path" ]; then printf '%s\\n' '{{"status":"failed","error":"pid file missing"}}'; exit 0; fi
+pid=$(cat "$pid_path")
+kill {sig} "$pid" 2>/dev/null || true
+sleep 1
+alive=0
+kill -0 "$pid" 2>/dev/null && alive=1
+if [ "$alive" -eq 0 ]; then
+  cat > {shlex.quote(str(remote_dir / "status.json"))} <<EOF
+{{"status":"cancelled","job_id":"{record["job_id"]}","exit_code":null,"finished_at":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}}
+EOF
+fi
+printf '{{"alive":%s}}\\n' "$alive"
+"""
+    result = _remote_json(target.container_endpoint, script, timeout=20)
+    return {
+        "status": "cancelled" if result.get("alive") == 0 else "failed",
+        "target": target.to_dict(),
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "job_id": record["job_id"],
+        "result": result,
+        "logs": {
+            "stdout": str(remote_dir / "stdout.log"),
+            "stderr": str(remote_dir / "stderr.log"),
+        },
+    }
+
+
+def remote_manifest(target: RemoteTarget, remote_path: str, *, timeout: float | None = 120) -> dict[str, Any]:
+    started_at = now_iso()
+    start = time.monotonic()
+    remote_json_path = json.dumps(remote_path)
+    script = f"""
+python3 - <<'PY'
+import hashlib
+import json
+import os
+import pathlib
+import stat
+root = pathlib.Path({remote_json_path})
+if not root.exists():
+    print(json.dumps({{"status":"needs_input","error":"remote path does not exist","remote_path":str(root)}}))
+    raise SystemExit(0)
+files = []
+def add_file(path):
+    h = hashlib.sha256()
+    size = 0
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+            size += len(chunk)
+    rel = "." if path == root else str(path.relative_to(root))
+    files.append({{"relpath": rel, "path": str(path), "size": size, "sha256": h.hexdigest(), "mode": stat.S_IMODE(path.stat().st_mode)}})
+if root.is_file():
+    add_file(root)
+else:
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames.sort()
+        for name in sorted(filenames):
+            path = pathlib.Path(dirpath) / name
+            if path.is_file():
+                add_file(path)
+print(json.dumps({{"status":"ok","remote_path":str(root),"is_dir":root.is_dir(),"file_count":len(files),"files":files}}, sort_keys=True))
+PY
+"""
+    result = _remote_json(target.container_endpoint, script, timeout=timeout)
+    status = result.get("status", "failed")
+    return {
+        "status": status,
+        "target": target.to_dict(),
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "error": result.get("error"),
+        "artifacts": {
+            "manifest": result,
+        },
+        "logs": {},
+    }
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _remote_join(root: str, relpath: str) -> str:
+    if relpath == ".":
+        return root
+    return str(PurePosixPath(root) / PurePosixPath(relpath))
+
+
+def artifact_pull(
+    target: RemoteTarget,
+    *,
+    remote_path: str,
+    local_dir: Path,
+    timeout: float | None = None,
+) -> dict[str, Any]:
+    started_at = now_iso()
+    start = time.monotonic()
+    manifest_payload = remote_manifest(target, remote_path, timeout=timeout)
+    manifest = manifest_payload.get("artifacts", {}).get("manifest", {})
+    if manifest.get("status") != "ok":
+        return {
+            "status": manifest.get("status", "failed"),
+            "target": target.to_dict(),
+            "started_at": started_at,
+            "duration_ms": duration_ms(start),
+            "error": manifest.get("error"),
+            "artifacts": {"manifest": manifest},
+            "logs": {},
+        }
+    ensure_state_dir(local_dir)
+    pulled: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    pending: list[dict[str, Any]] = []
+    for file_info in manifest.get("files", []):
+        relpath = file_info["relpath"]
+        local_path = local_dir / ("artifact" if relpath == "." else relpath)
+        ensure_state_dir(local_path.parent)
+        if local_path.exists() and _sha256_file(local_path) == file_info["sha256"]:
+            skipped.append({"relpath": relpath, "local_path": str(local_path), "reason": "hash-match"})
+            continue
+        pending.append(file_info)
+    if pending and manifest.get("is_dir") and _remote_tar_available(target, timeout=timeout):
+        batch_result = _artifact_pull_tar_batch(
+            target,
+            remote_path=remote_path,
+            local_dir=local_dir,
+            files=pending,
+            timeout=timeout,
+        )
+        if batch_result["status"] != "ok":
+            return {
+                **batch_result,
+                "target": target.to_dict(),
+                "started_at": started_at,
+                "duration_ms": duration_ms(start),
+            }
+        pulled.extend(batch_result["artifacts"]["pulled"])
+    else:
+        for file_info in pending:
+            single = _artifact_pull_single(target, remote_path=remote_path, local_dir=local_dir, file_info=file_info, timeout=timeout)
+            if single["status"] != "ok":
+                return {
+                    **single,
+                    "target": target.to_dict(),
+                    "started_at": started_at,
+                    "duration_ms": duration_ms(start),
+                    "artifacts": {"manifest": manifest, "pulled": pulled, "skipped": skipped},
+                    "logs": {},
+                }
+            pulled.append(single["artifact"])
+    local_manifest = local_dir / "manifest.json"
+    _atomic_write_json(local_manifest, manifest)
+    return {
+        "status": "ok",
+        "target": target.to_dict(),
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "artifacts": {
+            "remote_path": remote_path,
+            "local_dir": str(local_dir),
+            "local_manifest": str(local_manifest),
+            "manifest": manifest,
+            "pulled": pulled,
+            "skipped": skipped,
+        },
+        "logs": {},
+    }
+
+
+def _remote_tar_available(target: RemoteTarget, *, timeout: float | None = None) -> bool:
+    result = ssh_exec_raw(target.container_endpoint, "command -v tar >/dev/null 2>&1", timeout=timeout, check=False)
+    return result.returncode == 0
+
+
+def _artifact_pull_single(
+    target: RemoteTarget,
+    *,
+    remote_path: str,
+    local_dir: Path,
+    file_info: dict[str, Any],
+    timeout: float | None,
+) -> dict[str, Any]:
+    relpath = file_info["relpath"]
+    local_path = local_dir / ("artifact" if relpath == "." else relpath)
+    ensure_state_dir(local_path.parent)
+    remote_file = _remote_join(remote_path, relpath)
+    tmp = local_path.with_suffix(local_path.suffix + ".tmp")
+    cmd = f"cat {shlex.quote(remote_file)}"
+    result = ssh_exec_bytes(target.container_endpoint, cmd, timeout=timeout)
+    if result.returncode != 0:
+        return {
+            "status": "failed",
+            "error": f"failed to pull {remote_file}",
+            "stderr_tail": tail_text(result.stderr.decode("utf-8", errors="replace")),
+        }
+    tmp.write_bytes(result.stdout)
+    observed = _sha256_file(tmp)
+    if observed != file_info["sha256"]:
+        tmp.unlink(missing_ok=True)
+        return {
+            "status": "failed",
+            "error": f"hash mismatch for {remote_file}",
+            "expected_sha256": file_info["sha256"],
+            "observed_sha256": observed,
+        }
+    os.replace(tmp, local_path)
+    return {
+        "status": "ok",
+        "artifact": {
+            "relpath": relpath,
+            "local_path": str(local_path),
+            "sha256": observed,
+            "size": file_info["size"],
+            "transport": "cat",
+        },
+    }
+
+
+def _artifact_pull_tar_batch(
+    target: RemoteTarget,
+    *,
+    remote_path: str,
+    local_dir: Path,
+    files: list[dict[str, Any]],
+    timeout: float | None,
+) -> dict[str, Any]:
+    relpaths = [str(file_info["relpath"]) for file_info in files if file_info.get("relpath") != "."]
+    if not relpaths:
+        return {
+            "status": "failed",
+            "error": "tar batch pull requires directory-relative file paths",
+            "artifacts": {"pulled": []},
+            "logs": {},
+        }
+    arg_text = "\0".join(f"./{relpath}" for relpath in relpaths) + "\0"
+    remote = (
+        f"cd {shlex.quote(remote_path)} && "
+        "python3 - <<'PY' | tar --null -T - -cf -\n"
+        "import sys\n"
+        f"sys.stdout.buffer.write({arg_text.encode('utf-8')!r})\n"
+        "PY"
+    )
+    result = ssh_exec_bytes(target.container_endpoint, remote, timeout=timeout)
+    if result.returncode != 0:
+        return {
+            "status": "failed",
+            "error": "remote tar stream failed",
+            "stderr_tail": tail_text(result.stderr.decode("utf-8", errors="replace")),
+            "artifacts": {"pulled": []},
+            "logs": {},
+        }
+    expected_by_rel = {str(item["relpath"]): item for item in files}
+    pulled: list[dict[str, Any]] = []
+    try:
+        with tarfile.open(fileobj=io.BytesIO(result.stdout), mode="r:") as tf:
+            for member in tf:
+                if not member.isfile():
+                    continue
+                relpath = member.name[2:] if member.name.startswith("./") else member.name
+                if relpath not in expected_by_rel:
+                    return {
+                        "status": "failed",
+                        "error": f"unexpected file in tar stream: {member.name}",
+                        "artifacts": {"pulled": pulled},
+                        "logs": {},
+                    }
+                extracted = tf.extractfile(member)
+                if extracted is None:
+                    continue
+                local_path = local_dir / relpath
+                ensure_state_dir(local_path.parent)
+                tmp = local_path.with_suffix(local_path.suffix + ".tmp")
+                with tmp.open("wb") as fh:
+                    shutil.copyfileobj(extracted, fh)
+                observed = _sha256_file(tmp)
+                expected = expected_by_rel[relpath]
+                if observed != expected["sha256"]:
+                    tmp.unlink(missing_ok=True)
+                    return {
+                        "status": "failed",
+                        "error": f"hash mismatch for {relpath}",
+                        "expected_sha256": expected["sha256"],
+                        "observed_sha256": observed,
+                        "artifacts": {"pulled": pulled},
+                        "logs": {},
+                    }
+                os.replace(tmp, local_path)
+                pulled.append({
+                    "relpath": relpath,
+                    "local_path": str(local_path),
+                    "sha256": observed,
+                    "size": expected["size"],
+                    "transport": "tar",
+                })
+    except tarfile.TarError as exc:
+        return {
+            "status": "failed",
+            "error": f"failed to read remote tar stream: {exc}",
+            "artifacts": {"pulled": pulled},
+            "logs": {},
+        }
+    missing = sorted(set(expected_by_rel) - {item["relpath"] for item in pulled})
+    if missing:
+        return {
+            "status": "failed",
+            "error": "remote tar stream missed expected files",
+            "missing": missing,
+            "artifacts": {"pulled": pulled},
+            "logs": {},
+        }
+    return {"status": "ok", "artifacts": {"pulled": pulled}, "logs": {}}
+
+
+def _local_manifest(local_path: Path) -> dict[str, Any]:
+    local_path = local_path.expanduser().resolve()
+    if not local_path.exists():
+        raise RemoteToolboxError(f"local path does not exist: {local_path}")
+    files: list[dict[str, Any]] = []
+    roots = [local_path] if local_path.is_file() else sorted(p for p in local_path.rglob("*") if p.is_file())
+    for path in roots:
+        relpath = "." if path == local_path else str(path.relative_to(local_path))
+        files.append({
+            "relpath": relpath,
+            "path": str(path),
+            "size": path.stat().st_size,
+            "sha256": _sha256_file(path),
+        })
+    return {"status": "ok", "local_path": str(local_path), "is_dir": local_path.is_dir(), "file_count": len(files), "files": files}
+
+
+def artifact_push(
+    target: RemoteTarget,
+    *,
+    local_path: Path,
+    remote_path: str,
+    timeout: float | None = None,
+) -> dict[str, Any]:
+    started_at = now_iso()
+    start = time.monotonic()
+    manifest = _local_manifest(local_path)
+    pushed: list[dict[str, Any]] = []
+    for file_info in manifest["files"]:
+        relpath = file_info["relpath"]
+        src = Path(file_info["path"])
+        remote_file = _remote_join(remote_path, relpath)
+        remote_tmp = f"{remote_file}.tmp-{uuid.uuid4().hex[:8]}"
+        mkdir_script = f"mkdir -p {shlex.quote(str(PurePosixPath(remote_file).parent))}"
+        mkdir_result = ssh_exec_raw(target.container_endpoint, mkdir_script, timeout=timeout, check=False)
+        if mkdir_result.returncode != 0:
+            return {
+                "status": "failed",
+                "target": target.to_dict(),
+                "started_at": started_at,
+                "duration_ms": duration_ms(start),
+                "error": f"failed to create remote dir for {remote_file}",
+                "stderr_tail": mkdir_result.stderr,
+                "artifacts": {"manifest": manifest, "pushed": pushed},
+                "logs": {},
+            }
+        with src.open("rb") as fh:
+            upload = ssh_exec_bytes(
+                target.container_endpoint,
+                f"cat > {shlex.quote(remote_tmp)} && sha256sum {shlex.quote(remote_tmp)} | awk '{{print $1}}'",
+                stdin=fh,
+                timeout=timeout,
+            )
+        observed = upload.stdout.decode("utf-8", errors="replace").strip().splitlines()[-1:] or [""]
+        if upload.returncode != 0 or observed[0] != file_info["sha256"]:
+            ssh_exec_raw(target.container_endpoint, f"rm -f {shlex.quote(remote_tmp)}", check=False)
+            return {
+                "status": "failed",
+                "target": target.to_dict(),
+                "started_at": started_at,
+                "duration_ms": duration_ms(start),
+                "error": f"failed to push or verify {src}",
+                "expected_sha256": file_info["sha256"],
+                "observed_sha256": observed[0],
+                "stderr_tail": upload.stderr.decode("utf-8", errors="replace")[-2000:],
+                "artifacts": {"manifest": manifest, "pushed": pushed},
+                "logs": {},
+            }
+        mv = ssh_exec_raw(target.container_endpoint, f"mv -f {shlex.quote(remote_tmp)} {shlex.quote(remote_file)}", timeout=timeout, check=False)
+        if mv.returncode != 0:
+            return {
+                "status": "failed",
+                "target": target.to_dict(),
+                "started_at": started_at,
+                "duration_ms": duration_ms(start),
+                "error": f"failed to finalize {remote_file}",
+                "stderr_tail": mv.stderr,
+                "artifacts": {"manifest": manifest, "pushed": pushed},
+                "logs": {},
+            }
+        pushed.append({"relpath": relpath, "remote_path": remote_file, "sha256": file_info["sha256"], "size": file_info["size"]})
+    return {
+        "status": "ok",
+        "target": target.to_dict(),
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "artifacts": {"remote_path": remote_path, "manifest": manifest, "pushed": pushed},
+        "logs": {},
+    }
+
+
+def _run_json_command(cmd: list[str], *, cwd: Path = ROOT, relay_stderr: bool = True) -> tuple[int, dict[str, Any], str, str]:
+    proc = subprocess.Popen(
+        cmd,
+        cwd=str(cwd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert proc.stderr is not None
+    stderr_parts: list[str] = []
+
+    def read_stderr() -> None:
+        assert proc.stderr is not None
+        for line in proc.stderr:
+            stderr_parts.append(line)
+            if relay_stderr:
+                sys.stderr.write(line)
+                sys.stderr.flush()
+
+    thread = threading.Thread(target=read_stderr, daemon=True)
+    thread.start()
+    assert proc.stdout is not None
+    stdout = proc.stdout.read()
+    rc = proc.wait()
+    thread.join(timeout=1)
+    stderr = "".join(stderr_parts)
+    try:
+        payload = json.loads(stdout) if stdout.strip() else {}
+    except json.JSONDecodeError:
+        payload = {"status": "failed", "error": "subcommand returned non-JSON stdout", "stdout_tail": tail_text(stdout)}
+    return rc, payload, stdout, stderr
+
+
+def parity_derived_args(target: RemoteTarget, *, force_reinstall: bool = False) -> dict[str, Any]:
+    script = ROOT / ".agents" / "skills" / "remote-code-parity" / "scripts" / "parity_sync.py"
+    cmd = [sys.executable, str(script), "--print-derived-args"]
+    if target.session_file:
+        cmd.extend(["--session-file", str(target.session_file)])
+    elif target.session_id:
+        cmd.extend(["--session-id", target.session_id])
+    else:
+        cmd.extend(["--machine", target.alias])
+    if force_reinstall:
+        cmd.append("--force-reinstall")
+    rc, payload, stdout, stderr = _run_json_command(cmd, relay_stderr=True)
+    if rc != 0:
+        raise RemoteToolboxError(f"failed to derive parity args: stdout={tail_text(stdout)} stderr={tail_text(stderr)}")
+    return payload
+
+
+def _parity_plan_manifest(derived: dict[str, Any]) -> dict[str, Any]:
+    script = ROOT / ".agents" / "skills" / "remote-code-parity" / "scripts" / "remote_code_parity.py"
+    cmd = [
+        sys.executable,
+        str(script),
+        "plan",
+        "--workspace-root",
+        derived["workspace_root"],
+        "--workspace-id",
+        derived["workspace_id"],
+        "--server-name",
+        derived["server_name"],
+        "--runtime-root",
+        derived["runtime_root"],
+        "--container-identity",
+        derived["container_identity"],
+        "--container-cache-root",
+        derived["container_cache_root"],
+    ]
+    for preserve in derived.get("preserve_path", []):
+        cmd.extend(["--preserve-path", preserve])
+    rc, payload, stdout, stderr = _run_json_command(cmd, relay_stderr=True)
+    if rc != 0:
+        raise RemoteToolboxError(f"failed to build parity plan: stdout={tail_text(stdout)} stderr={tail_text(stderr)}")
+    return payload
+
+
+def _repo_install_reasons(repo: dict[str, Any]) -> list[str]:
+    relpath = repo.get("relpath", "")
+    patterns = VLLM_ASCEND_REINSTALL_PATTERNS if relpath == "vllm-ascend" else VLLM_REINSTALL_PATTERNS
+    reasons = []
+    for path in repo.get("changed_paths", []):
+        if any(fnmatch.fnmatch(path, pattern) for pattern in patterns):
+            reasons.append(path)
+    return sorted(set(reasons))
+
+
+def _consent_state(derived: dict[str, Any]) -> dict[str, Any]:
+    scripts = ROOT / ".agents" / "skills" / "remote-code-parity" / "scripts"
+    if str(scripts) not in sys.path:
+        sys.path.insert(0, str(scripts))
+    try:
+        from install_consent import load_consent_state, resolve_sync_mode  # type: ignore
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "failed", "error": str(exc)}
+    repo_root = Path(derived["workspace_root"]).expanduser().resolve()
+    state = load_consent_state(repo_root)
+    record = (
+        state.get("consents", {})
+        .get(derived["server_name"], {})
+        .get("containers", {})
+        .get(derived["container_identity"])
+    )
+    return {
+        "status": "ok",
+        "decision": record.get("decision") if isinstance(record, dict) else "unknown",
+        "sync_mode": resolve_sync_mode(state, derived["server_name"], derived["container_identity"]),
+        "record": record,
+    }
+
+
+def sync_plan(target: RemoteTarget, *, mode: str, force_reinstall: bool = False) -> dict[str, Any]:
+    started_at = now_iso()
+    start = time.monotonic()
+    derived = parity_derived_args(target, force_reinstall=force_reinstall)
+    manifest = _parity_plan_manifest(derived)
+    consent = _consent_state(derived)
+    install_reasons: dict[str, list[str]] = {}
+    for repo in manifest.get("repos", []):
+        reasons = _repo_install_reasons(repo)
+        if reasons:
+            install_reasons[repo.get("relpath", ".")] = reasons
+    will_install = mode == "install" and (
+        force_reinstall or bool(install_reasons) or consent.get("decision") != "allow"
+    )
+    if mode == "source-only":
+        action = "publish source snapshot to container cache only"
+        will_materialize = False
+        will_install = False
+    elif mode == "materialize":
+        action = "publish snapshot and materialize runtime source tree without install/rebuild"
+        will_materialize = True
+        will_install = False
+    else:
+        action = "publish snapshot, materialize runtime source tree, and run install/rebuild when required"
+        will_materialize = True
+    return {
+        "status": "ok",
+        "target": target.to_dict(),
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "mode": mode,
+        "action": action,
+        "will_materialize": will_materialize,
+        "will_install": will_install,
+        "install_reasons": {
+            "force_reinstall": force_reinstall,
+            "changed_paths": install_reasons,
+            "consent": consent,
+            "note": "source-only and materialize modes never enter install/rebuild",
+        },
+        "changed_paths": {
+            repo.get("relpath", "."): repo.get("changed_paths", [])
+            for repo in manifest.get("repos", [])
+        },
+        "derived": {
+            key: derived.get(key)
+            for key in (
+                "workspace_root",
+                "workspace_id",
+                "server_name",
+                "runtime_root",
+                "container_identity",
+                "container_cache_root",
+                "container_host",
+                "container_port",
+                "container_user",
+            )
+        },
+        "artifacts": {"manifest": manifest},
+        "logs": {},
+    }
+
+
+def sync_apply(target: RemoteTarget, *, mode: str, force_reinstall: bool = False, dry_run: bool = False) -> dict[str, Any]:
+    started_at = now_iso()
+    start = time.monotonic()
+    script = ROOT / ".agents" / "skills" / "remote-code-parity" / "scripts" / "parity_sync.py"
+    cmd = [sys.executable, str(script)]
+    if target.session_file:
+        cmd.extend(["--session-file", str(target.session_file)])
+    elif target.session_id:
+        cmd.extend(["--session-id", target.session_id])
+    else:
+        cmd.extend(["--machine", target.alias])
+    if force_reinstall:
+        cmd.append("--force-reinstall")
+    if dry_run:
+        cmd.append("--dry-run")
+    cmd.extend(["--apply-mode", mode])
+    rc, payload, stdout, stderr = _run_json_command(cmd, relay_stderr=True)
+    status = payload.get("status", "failed")
+    if rc != 0 and status not in {"blocked", "needs_input", "needs_repair", "timeout", "failed"}:
+        status = "failed"
+    return {
+        "status": status,
+        "target": target.to_dict(),
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "mode": mode,
+        "returncode": rc,
+        "result": payload,
+        "stdout_tail": tail_text(stdout),
+        "stderr_tail": tail_text(stderr),
+        "artifacts": {
+            "manifest_path": payload.get("manifest_path"),
+            "result": payload,
+        },
+        "logs": {},
+    }
+
+
+def call_service(action: str, target: RemoteTarget, extra_args: list[str]) -> dict[str, Any]:
+    started_at = now_iso()
+    start = time.monotonic()
+    scripts = ROOT / ".agents" / "skills" / "vllm-ascend-serving" / "scripts"
+    script_map = {
+        "start": scripts / "serve_start.py",
+        "status": scripts / "serve_status.py",
+        "stop": scripts / "serve_stop.py",
+    }
+    if action not in script_map:
+        raise RemoteToolboxError(f"unsupported service action: {action}")
+    cmd = [sys.executable, str(script_map[action])]
+    if target.session_file:
+        cmd.extend(["--session-file", str(target.session_file)])
+    elif target.session_id:
+        cmd.extend(["--session-id", target.session_id])
+    else:
+        cmd.extend(["--machine", target.alias])
+    cmd.extend(extra_args)
+    rc, payload, stdout, stderr = _run_json_command(cmd, relay_stderr=True)
+    status = payload.get("status", "failed")
+    if rc != 0 and status not in {"needs_input", "blocked", "failed", "timeout", "needs_repair", "cancelled"}:
+        status = "failed"
+    logs: dict[str, Any] = {}
+    for key in ("log_stdout", "log_stderr", "runtime_dir"):
+        if payload.get(key):
+            logs[key] = payload[key]
+    return {
+        "status": status,
+        "target": target.to_dict(),
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "action": action,
+        "returncode": rc,
+        "error": payload.get("error") if status != "ready" else None,
+        "result": payload,
+        "stdout_tail": tail_text(stdout),
+        "stderr_tail": tail_text(stderr),
+        "logs": logs,
+    }
+
+
+def service_logs(target: RemoteTarget, *, lines: int = 120) -> dict[str, Any]:
+    started_at = now_iso()
+    start = time.monotonic()
+    state, path = _load_serving_state_for_target(target)
+    if not state:
+        return {
+            "status": "needs_input",
+            "target": target.to_dict(),
+            "started_at": started_at,
+            "duration_ms": duration_ms(start),
+            "error": "no serving state recorded",
+            "logs": {"state_path": str(path)},
+        }
+    stdout_path = state.get("log_stdout")
+    stderr_path = state.get("log_stderr")
+    chunks: list[str] = []
+    if stdout_path:
+        chunks.append(f"echo __STDOUT__; tail -n {int(lines)} {shlex.quote(stdout_path)} 2>/dev/null || true")
+    if stderr_path:
+        chunks.append(f"echo __STDERR__; tail -n {int(lines)} {shlex.quote(stderr_path)} 2>/dev/null || true")
+    result = ssh_exec_raw(target.container_endpoint, "\n".join(chunks), timeout=30, check=False)
+    return {
+        "status": "ok" if result.returncode == 0 else "failed",
+        "target": target.to_dict(),
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "tail": result.stdout,
+        "stderr_tail": result.stderr,
+        "logs": {
+            "state_path": str(path),
+            "stdout": stdout_path,
+            "stderr": stderr_path,
+            "runtime_dir": state.get("runtime_dir"),
+        },
+    }
+
+
+def cleanup(
+    target: RemoteTarget,
+    *,
+    dry_run: bool,
+    jobs: bool,
+    job_ids: Sequence[str] | None = None,
+    service: bool,
+    session_container: bool,
+    leases: bool,
+    known_hosts: bool,
+    remote_temp: bool,
+    force: bool,
+) -> dict[str, Any]:
+    started_at = now_iso()
+    start = time.monotonic()
+    actions: list[dict[str, Any]] = []
+    if service:
+        if dry_run:
+            actions.append({"action": "service-stop", "dry_run": True})
+        else:
+            actions.append({"action": "service-stop", "result": call_service("stop", target, ["--force"] if force else [])})
+    if jobs or remote_temp:
+        remote_paths = []
+        if jobs:
+            if job_ids:
+                remote_paths.extend(str(PurePosixPath(target.remote_toolbox_root()) / "jobs" / job_id) for job_id in job_ids)
+            else:
+                remote_paths.append(str(PurePosixPath(target.remote_toolbox_root()) / "jobs"))
+        if remote_temp:
+            remote_paths.append(str(PurePosixPath(target.remote_toolbox_root()) / "tmp"))
+        if dry_run:
+            actions.append({"action": "remote-rm", "paths": remote_paths, "dry_run": True})
+        elif remote_paths:
+            script = "rm -rf " + " ".join(shlex.quote(path) for path in remote_paths)
+            result = ssh_exec_raw(target.container_endpoint, script, timeout=60, check=False)
+            actions.append({"action": "remote-rm", "paths": remote_paths, "returncode": result.returncode, "stderr_tail": tail_text(result.stderr)})
+    if session_container:
+        if not target.session_id:
+            actions.append({"action": "session-remove", "skipped": True, "reason": "target is not a session"})
+        elif dry_run:
+            actions.append({"action": "session-remove", "session_id": target.session_id, "dry_run": True})
+        else:
+            script = ROOT / ".agents" / "skills" / "session-management" / "scripts" / "session_remove.py"
+            cmd = [sys.executable, str(script), "--session-file", str(target.session_file), "--remove-container"]
+            if leases:
+                cmd.append("--release-leases")
+            if force:
+                cmd.append("--force")
+            rc, payload, stdout, stderr = _run_json_command(cmd, relay_stderr=True)
+            actions.append({"action": "session-remove", "returncode": rc, "result": payload, "stdout_tail": tail_text(stdout), "stderr_tail": tail_text(stderr)})
+    elif leases and target.session_id:
+        if dry_run:
+            actions.append({"action": "release-leases", "session_id": target.session_id, "dry_run": True})
+        else:
+            release_all_session_leases(repo_root=target.state_repo_root, session_id=target.session_id)
+            actions.append({"action": "release-leases", "session_id": target.session_id, "released": True})
+    if known_hosts:
+        for endpoint in (target.host_endpoint, target.container_endpoint):
+            key = endpoint.known_hosts_key()
+            if dry_run:
+                actions.append({"action": "known-hosts-remove", "key": key, "dry_run": True})
+            else:
+                result = subprocess.run(["ssh-keygen", "-R", key], capture_output=True, text=True, check=False)
+                actions.append({"action": "known-hosts-remove", "key": key, "returncode": result.returncode, "stderr_tail": tail_text(result.stderr)})
+    proof = {
+        "target_after_cleanup": target.to_dict(),
+        "known_hosts": {
+            "host": known_hosts_status(target.host_endpoint),
+            "container": known_hosts_status(target.container_endpoint),
+        },
+    }
+    if target.session_id:
+        with contextlib.suppress(Exception):
+            proof["leases"] = load_leases(target.state_repo_root)
+    return {
+        "status": "ok",
+        "target": target.to_dict(),
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "dry_run": dry_run,
+        "actions": actions,
+        "artifacts": {"proof": proof},
+        "logs": {},
+    }
+
+
+def add_target_args(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_argument_group("target")
+    group.add_argument("--machine", help="machine alias or host IP")
+    group.add_argument("--session-id", help="VAWS session id")
+    group.add_argument("--session-file", help="explicit session.json path")
+
+
+def target_from_args(args: argparse.Namespace) -> RemoteTarget:
+    return resolve_remote_target(
+        machine=getattr(args, "machine", None),
+        session_id=getattr(args, "session_id", None),
+        session_file=getattr(args, "session_file", None),
+    )
+
+
+def _cli_error(exc: BaseException, *, started_at: str, start: float) -> int:
+    status = "failed"
+    if isinstance(exc, (RemoteToolboxError, WorkspaceStateError, FileNotFoundError)):
+        status = "needs_input"
+    if isinstance(exc, subprocess.TimeoutExpired):
+        status = "timeout"
+    print_json({
+        "status": status,
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "error": str(exc),
+        "target": None,
+        "logs": {},
+    })
+    return 2 if status == "failed" else 1
+
+
+def cli_target_resolve(argv: Sequence[str] | None = None) -> int:
+    started_at = now_iso()
+    start = time.monotonic()
+    parser = argparse.ArgumentParser(description="Resolve a VAWS remote target.", allow_abbrev=False)
+    add_target_args(parser)
+    args = parser.parse_args(argv)
+    try:
+        target = target_from_args(args)
+        print_json({"status": "ok", "target": target.to_dict(), "started_at": started_at, "duration_ms": duration_ms(start), "logs": {}})
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_probe(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Probe a VAWS remote target.", allow_abbrev=False)
+    add_target_args(parser)
+    parser.add_argument("--timeout", type=float, default=90)
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        print_json(probe_remote(target_from_args(args), timeout=args.timeout))
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_exec(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Execute a shell command on a VAWS remote target.", allow_abbrev=False)
+    add_target_args(parser)
+    parser.add_argument("--cwd")
+    parser.add_argument("--env", action="append", default=[])
+    parser.add_argument("--timeout", type=float)
+    parser.add_argument(
+        "--no-runtime-env",
+        action="store_true",
+        help="do not source /etc/profile.d/vaws-ascend-env.sh before running the command",
+    )
+    parser.add_argument("--command", help="shell command to execute; alternatively pass after --")
+    parser.add_argument("command_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        command = args.command
+        if not command and args.command_args:
+            command_args = list(args.command_args)
+            if command_args and command_args[0] == "--":
+                command_args = command_args[1:]
+            command = " ".join(command_args)
+        if not command:
+            raise RemoteToolboxError("--command or command after -- is required")
+        payload = remote_exec(
+            target_from_args(args),
+            command=command,
+            cwd=args.cwd,
+            env=_parse_env_items(args.env),
+            timeout=args.timeout,
+            runtime_env=not args.no_runtime_env,
+        )
+        print_json(payload)
+        return 0 if payload["status"] == "ok" else 1
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_job_start(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Start a long-running remote job.", allow_abbrev=False)
+    add_target_args(parser)
+    parser.add_argument("--cwd")
+    parser.add_argument("--env", action="append", default=[])
+    parser.add_argument("--kind", default="command")
+    parser.add_argument("--job-id")
+    parser.add_argument("--timeout", type=int)
+    parser.add_argument(
+        "--no-runtime-env",
+        action="store_true",
+        help="do not source /etc/profile.d/vaws-ascend-env.sh before running the job",
+    )
+    parser.add_argument("--command", required=True)
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        print_json(start_remote_job(
+            target_from_args(args),
+            command=args.command,
+            cwd=args.cwd,
+            env=_parse_env_items(args.env),
+            kind=args.kind,
+            timeout_seconds=args.timeout,
+            job_id=args.job_id,
+            runtime_env=not args.no_runtime_env,
+        ))
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_job_status(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Inspect a remote job.", allow_abbrev=False)
+    add_target_args(parser)
+    parser.add_argument("--job-id", required=True)
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        target, record = _resolve_job_target(args.job_id, args)
+        payload = remote_job_status(target, record)
+        print_json(payload)
+        return 0 if payload["status"] in {"running", "succeeded", "ok"} else 1
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_job_tail(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Tail a remote job log.", allow_abbrev=False)
+    add_target_args(parser)
+    parser.add_argument("--job-id", required=True)
+    parser.add_argument("--lines", type=int, default=80)
+    parser.add_argument("--stream", choices=("stdout", "stderr", "both"), default="both")
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        target, record = _resolve_job_target(args.job_id, args)
+        print_json(remote_job_tail(target, record, lines=args.lines, stream=args.stream))
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_job_stop(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Stop a remote job.", allow_abbrev=False)
+    add_target_args(parser)
+    parser.add_argument("--job-id", required=True)
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        target, record = _resolve_job_target(args.job_id, args)
+        payload = remote_job_stop(target, record, force=args.force)
+        print_json(payload)
+        return 0 if payload["status"] == "cancelled" else 1
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_job_collect(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Collect a remote job directory.", allow_abbrev=False)
+    add_target_args(parser)
+    parser.add_argument("--job-id", required=True)
+    parser.add_argument("--local-dir", type=Path)
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        target, record = _resolve_job_target(args.job_id, args)
+        local_dir = args.local_dir or (ARTIFACT_STATE_DIR / "jobs" / args.job_id)
+        print_json(artifact_pull(target, remote_path=record["remote_dir"], local_dir=local_dir))
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_sync_plan(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Plan remote code sync without mutating runtime.", allow_abbrev=False)
+    add_target_args(parser)
+    parser.add_argument("--mode", choices=("source-only", "materialize", "install"), required=True)
+    parser.add_argument("--force-reinstall", action="store_true")
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        print_json(sync_plan(target_from_args(args), mode=args.mode, force_reinstall=args.force_reinstall))
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_sync_apply(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Apply remote code sync in a selected mode.", allow_abbrev=False)
+    add_target_args(parser)
+    parser.add_argument("--mode", choices=("source-only", "materialize", "install"), required=True)
+    parser.add_argument("--force-reinstall", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        payload = sync_apply(target_from_args(args), mode=args.mode, force_reinstall=args.force_reinstall, dry_run=args.dry_run)
+        print_json(payload)
+        return 0 if payload["status"] in {"ready", "source-only", "materialized", "dry-run", "ok", "skipped"} else 1
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_service_start(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Start vLLM service through the remote toolbox.",
+        epilog="All unrecognized options are passed through to serve_start.py, so both `-- --model /path` and `--model /path` work.",
+        allow_abbrev=False,
+    )
+    add_target_args(parser)
+    args, extra = parser.parse_known_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        extra = list(extra)
+        if extra and extra[0] == "--":
+            extra = extra[1:]
+        payload = call_service("start", target_from_args(args), extra)
+        print_json(payload)
+        return 0 if payload["status"] == "ready" else 1
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_service_status(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check vLLM service status through the remote toolbox.", allow_abbrev=False)
+    add_target_args(parser)
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        payload = call_service("status", target_from_args(args), [])
+        print_json(payload)
+        return 0 if payload["status"] in {"ready", "alive", "alive_healthy", "stopped", "not_found"} else 1
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_service_logs(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Tail vLLM service logs through the remote toolbox.", allow_abbrev=False)
+    add_target_args(parser)
+    parser.add_argument("--lines", type=int, default=120)
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        payload = service_logs(target_from_args(args), lines=args.lines)
+        print_json(payload)
+        return 0 if payload["status"] == "ok" else 1
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_service_stop(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Stop vLLM service through the remote toolbox.", allow_abbrev=False)
+    add_target_args(parser)
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        payload = call_service("stop", target_from_args(args), ["--force"] if args.force else [])
+        print_json(payload)
+        return 0 if payload["status"] in {"stopped", "not_found"} else 1
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_artifact_manifest(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a remote artifact manifest.", allow_abbrev=False)
+    add_target_args(parser)
+    parser.add_argument("--remote-path", required=True)
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        payload = remote_manifest(target_from_args(args), args.remote_path)
+        print_json(payload)
+        return 0 if payload["status"] == "ok" else 1
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_artifact_pull(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Pull remote artifacts through SSH streaming.", allow_abbrev=False)
+    add_target_args(parser)
+    parser.add_argument("--remote-path", required=True)
+    parser.add_argument("--local-dir", type=Path, required=True)
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        payload = artifact_pull(target_from_args(args), remote_path=args.remote_path, local_dir=args.local_dir)
+        print_json(payload)
+        return 0 if payload["status"] == "ok" else 1
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_artifact_push(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Push local artifacts through SSH streaming.", allow_abbrev=False)
+    add_target_args(parser)
+    parser.add_argument("--local-path", type=Path, required=True)
+    parser.add_argument("--remote-path", required=True)
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        payload = artifact_push(target_from_args(args), local_path=args.local_path, remote_path=args.remote_path)
+        print_json(payload)
+        return 0 if payload["status"] == "ok" else 1
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)
+
+
+def cli_cleanup(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Clean remote toolbox/session state.", allow_abbrev=False)
+    add_target_args(parser)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--jobs", action="store_true")
+    parser.add_argument("--job-id", action="append", default=[], help="cleanup only this remote-toolbox job id (repeatable)")
+    parser.add_argument("--service", action="store_true")
+    parser.add_argument("--session-container", action="store_true")
+    parser.add_argument("--leases", action="store_true")
+    parser.add_argument("--known-hosts", action="store_true")
+    parser.add_argument("--remote-temp", action="store_true")
+    parser.add_argument("--all", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args(argv)
+    started_at = now_iso()
+    start = time.monotonic()
+    try:
+        if args.job_id:
+            args.jobs = True
+        if args.all:
+            args.jobs = args.service = args.remote_temp = True
+            args.known_hosts = args.known_hosts or False
+            if getattr(args, "session_id", None) or getattr(args, "session_file", None):
+                args.session_container = True
+                args.leases = True
+        payload = cleanup(
+            target_from_args(args),
+            dry_run=args.dry_run,
+            jobs=args.jobs,
+            job_ids=args.job_id,
+            service=args.service,
+            session_container=args.session_container,
+            leases=args.leases,
+            known_hosts=args.known_hosts,
+            remote_temp=args.remote_temp,
+            force=args.force,
+        )
+        print_json(payload)
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        return _cli_error(exc, started_at=started_at, start=start)

--- a/.agents/lib/vaws_session_id.py
+++ b/.agents/lib/vaws_session_id.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Session-id resolution helpers for VAWS parallel agent sessions."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import secrets
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from vaws_local_state import STATE_DIR, WorkspaceStateError, utc_now_iso
+
+SESSION_ID_PATTERN = re.compile(r"[^a-z0-9._-]+")
+MULTI_DASH_PATTERN = re.compile(r"-+")
+DEFAULT_SESSION_SOURCES_FILENAME = "session-id-sources.json"
+CURRENT_SESSION_FILENAME = "current-session.json"
+
+
+@dataclass(frozen=True)
+class SessionId:
+    value: str
+    source: str
+
+
+def normalize_session_id(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = SESSION_ID_PATTERN.sub("-", value.strip().lower())
+    normalized = MULTI_DASH_PATTERN.sub("-", normalized).strip(".-_")
+    if not normalized:
+        return None
+    if len(normalized) > 64:
+        normalized = normalized[:64].rstrip(".-_")
+    if len(normalized) < 3:
+        return None
+    return normalized
+
+
+def generate_session_id() -> str:
+    stamp = utc_now_iso().replace("-", "").replace(":", "").replace("T", "-").replace("Z", "")
+    token = secrets.token_hex(3)
+    return f"sess-{stamp}-{token}"
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise WorkspaceStateError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise WorkspaceStateError(f"{path} must contain a JSON object")
+    return data
+
+
+def load_session_id_sources(state_dir: Path = STATE_DIR) -> dict[str, Any]:
+    data = _load_json(state_dir / DEFAULT_SESSION_SOURCES_FILENAME)
+    if data is None:
+        return {
+            "schema_version": 1,
+            "env_allowlist": [],
+            "prefix_by_source": {},
+            "allow_unconfigured_generic_env": False,
+        }
+    if data.get("schema_version") != 1:
+        raise WorkspaceStateError(
+            f"unsupported session-id-sources schema_version: {data.get('schema_version')!r}"
+        )
+    allowlist = data.get("env_allowlist", [])
+    prefixes = data.get("prefix_by_source", {})
+    if not isinstance(allowlist, list) or not all(isinstance(item, str) for item in allowlist):
+        raise WorkspaceStateError("session-id-sources.env_allowlist must be a list of strings")
+    if not isinstance(prefixes, dict) or not all(isinstance(k, str) and isinstance(v, str) for k, v in prefixes.items()):
+        raise WorkspaceStateError("session-id-sources.prefix_by_source must be a string map")
+    return data
+
+
+def load_current_session_binding(repo_root: Path) -> dict[str, Any] | None:
+    return _load_json(repo_root / ".vaws-local" / CURRENT_SESSION_FILENAME)
+
+
+def write_current_session_binding(
+    repo_root: Path,
+    *,
+    session_id: str,
+    source: str,
+    session_file: Path | None = None,
+    base_repo_root: Path | None = None,
+) -> Path:
+    normalized = normalize_session_id(session_id)
+    if normalized is None:
+        raise WorkspaceStateError(f"invalid session id: {session_id!r}")
+    state_dir = repo_root / ".vaws-local"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / CURRENT_SESSION_FILENAME
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "session_id": normalized,
+        "source": source,
+        "created_at": utc_now_iso(),
+    }
+    if session_file is not None:
+        payload["session_file"] = str(session_file.expanduser().resolve())
+    if base_repo_root is not None:
+        payload["base_repo_root"] = str(base_repo_root.expanduser().resolve())
+    handle, temp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(state_dir)
+    )
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(temp_name, path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temp_name)
+    return path
+
+
+def git_current_branch(repo_root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "branch", "--show-current"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return None
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def derive_from_branch(branch: str | None) -> str | None:
+    if not branch:
+        return None
+    for prefix in ("session/", "task/"):
+        if branch.startswith(prefix):
+            return normalize_session_id(branch[len(prefix) :])
+    if branch.startswith("pr/"):
+        tail = normalize_session_id(branch[len("pr/") :])
+        return normalize_session_id(f"pr-{tail}") if tail else None
+    return None
+
+
+def _candidate_from_env(name: str, *, prefix: str | None = None) -> tuple[str, str] | None:
+    value = os.environ.get(name)
+    if not value:
+        return None
+    raw = f"{prefix}-{value}" if prefix else value
+    return raw, f"env:{name}"
+
+
+def resolve_session_id(
+    *,
+    explicit: str | None = None,
+    repo_root: Path,
+    persist_generated: bool = True,
+    use_current_binding: bool = True,
+) -> SessionId:
+    candidates: list[tuple[str, str]] = []
+    if explicit:
+        candidates.append((explicit, "cli"))
+
+    for env_name in ("VAWS_SESSION_ID", "VAWS_AGENT_SESSION_ID"):
+        candidate = _candidate_from_env(env_name)
+        if candidate is not None:
+            candidates.append(candidate)
+
+    cfg = load_session_id_sources(repo_root / ".vaws-local")
+    prefixes = cfg.get("prefix_by_source", {})
+    for env_name in cfg.get("env_allowlist", []):
+        if env_name in {"VAWS_SESSION_ID", "VAWS_AGENT_SESSION_ID"}:
+            continue
+        candidate = _candidate_from_env(env_name, prefix=prefixes.get(env_name))
+        if candidate is not None:
+            candidates.append(candidate)
+
+    if use_current_binding:
+        current = load_current_session_binding(repo_root)
+        if current and isinstance(current.get("session_id"), str):
+            candidates.append((current["session_id"], "current-session"))
+
+    derived = derive_from_branch(git_current_branch(repo_root))
+    if derived:
+        candidates.append((derived, "git-branch"))
+
+    for raw, source in candidates:
+        normalized = normalize_session_id(raw)
+        if normalized:
+            return SessionId(value=normalized, source=source)
+
+    generated = generate_session_id()
+    if persist_generated:
+        write_current_session_binding(repo_root, session_id=generated, source="generated")
+    return SessionId(value=generated, source="generated")

--- a/.agents/lib/vaws_session_id.py
+++ b/.agents/lib/vaws_session_id.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import os
 import re
@@ -20,6 +21,8 @@ SESSION_ID_PATTERN = re.compile(r"[^a-z0-9._-]+")
 MULTI_DASH_PATTERN = re.compile(r"-+")
 DEFAULT_SESSION_SOURCES_FILENAME = "session-id-sources.json"
 CURRENT_SESSION_FILENAME = "current-session.json"
+MAX_SESSION_ID_LENGTH = 64
+SESSION_ID_HASH_LENGTH = 8
 
 
 @dataclass(frozen=True)
@@ -35,8 +38,10 @@ def normalize_session_id(value: str | None) -> str | None:
     normalized = MULTI_DASH_PATTERN.sub("-", normalized).strip(".-_")
     if not normalized:
         return None
-    if len(normalized) > 64:
-        normalized = normalized[:64].rstrip(".-_")
+    if len(normalized) > MAX_SESSION_ID_LENGTH:
+        digest = hashlib.sha1(value.encode("utf-8")).hexdigest()[:SESSION_ID_HASH_LENGTH]
+        keep = MAX_SESSION_ID_LENGTH - len(digest) - 1
+        normalized = f"{normalized[:keep].rstrip('.-_')}-{digest}"
     if len(normalized) < 3:
         return None
     return normalized

--- a/.agents/lib/vaws_session_state.py
+++ b/.agents/lib/vaws_session_state.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+"""Session state and lease helpers for VAWS parallel agent sessions."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import socket
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from vaws_local_state import ROOT, STATE_DIR, WorkspaceStateError, ensure_state_dir, utc_now_iso
+from vaws_session_id import load_current_session_binding, normalize_session_id
+
+SESSION_SCHEMA_VERSION = 1
+INDEX_SCHEMA_VERSION = 1
+LEASE_SCHEMA_VERSION = 1
+SESSION_ROOT = STATE_DIR / "sessions"
+SESSION_INDEX_PATH = SESSION_ROOT / "index.json"
+SESSION_LEASES_PATH = SESSION_ROOT / "leases.json"
+SESSION_LOCK_DIR = SESSION_ROOT / "locks"
+DEFAULT_LOCK_TIMEOUT_SECONDS = 30.0
+DEFAULT_LOCK_POLL_SECONDS = 0.1
+DEFAULT_STALE_LOCK_SECONDS = 60 * 60 * 6
+DEFAULT_CONTAINER_SSH_PORT_RANGE = "46000:46999"
+DEFAULT_SERVING_PORT_RANGE = "30000:45999"
+SAFE_TOKEN_PATTERN = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+class SessionStateError(WorkspaceStateError):
+    """Raised for deterministic session-state failures."""
+
+
+@dataclass(frozen=True)
+class SessionLookup:
+    session: dict[str, Any]
+    session_file: Path
+    state_repo_root: Path
+
+
+def _atomic_write_json(path: Path, data: Any) -> None:
+    ensure_state_dir(path.parent)
+    handle, temp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(temp_name, path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temp_name)
+
+
+def _load_json(path: Path, default: Any | None = None) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SessionStateError(f"invalid JSON in {path}: {exc}") from exc
+
+
+@contextlib.contextmanager
+def file_lock(
+    path: Path,
+    *,
+    timeout_seconds: float = DEFAULT_LOCK_TIMEOUT_SECONDS,
+    poll_seconds: float = DEFAULT_LOCK_POLL_SECONDS,
+    stale_after_seconds: float = DEFAULT_STALE_LOCK_SECONDS,
+):
+    ensure_state_dir(path.parent)
+    deadline = time.monotonic() + timeout_seconds
+    owner = {
+        "pid": os.getpid(),
+        "hostname": socket.gethostname(),
+        "created_at": utc_now_iso(),
+    }
+    fd: int | None = None
+    while True:
+        try:
+            fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            os.write(fd, json.dumps(owner, ensure_ascii=False).encode("utf-8"))
+            break
+        except FileExistsError:
+            try:
+                age = time.time() - path.stat().st_mtime
+            except FileNotFoundError:
+                continue
+            if age >= stale_after_seconds:
+                with contextlib.suppress(FileNotFoundError):
+                    path.unlink()
+                continue
+            if time.monotonic() >= deadline:
+                raise SessionStateError(f"timed out waiting for session lock {path}")
+            time.sleep(poll_seconds)
+    try:
+        yield path
+    finally:
+        if fd is not None:
+            os.close(fd)
+        with contextlib.suppress(FileNotFoundError):
+            path.unlink()
+
+
+def sessions_root(repo_root: Path = ROOT) -> Path:
+    return repo_root / ".vaws-local" / "sessions"
+
+
+def session_index_path(repo_root: Path = ROOT) -> Path:
+    return sessions_root(repo_root) / "index.json"
+
+
+def session_leases_path(repo_root: Path = ROOT) -> Path:
+    return sessions_root(repo_root) / "leases.json"
+
+
+def session_lock_dir(repo_root: Path = ROOT) -> Path:
+    return sessions_root(repo_root) / "locks"
+
+
+def session_dir(session_id: str, repo_root: Path = ROOT) -> Path:
+    normalized = require_session_id(session_id)
+    return sessions_root(repo_root) / normalized
+
+
+def session_file_path(session_id: str, repo_root: Path = ROOT) -> Path:
+    return session_dir(session_id, repo_root) / "session.json"
+
+
+def session_serving_state_path(session_id: str, repo_root: Path = ROOT) -> Path:
+    return session_dir(session_id, repo_root) / "serving.json"
+
+
+def session_benchmark_dir(session_id: str, repo_root: Path = ROOT) -> Path:
+    return session_dir(session_id, repo_root) / "benchmark"
+
+
+def require_session_id(value: str) -> str:
+    normalized = normalize_session_id(value)
+    if normalized is None:
+        raise SessionStateError(f"invalid session id: {value!r}")
+    return normalized
+
+
+def safe_token(value: str, *, fallback: str = "item", max_len: int = 63) -> str:
+    token = SAFE_TOKEN_PATTERN.sub("-", value.strip()).strip(".-_")
+    if not token:
+        token = fallback
+    if len(token) <= max_len:
+        return token
+    digest = __import__("hashlib").sha1(token.encode("utf-8")).hexdigest()[:8]
+    keep = max(1, max_len - len(digest) - 1)
+    return f"{token[:keep].rstrip('.-_')}-{digest}"
+
+
+def default_worktree_root(repo_root: Path, session_id: str) -> Path:
+    return repo_root.parent / "vaws-worktrees" / repo_root.name / require_session_id(session_id)
+
+
+def default_branch(session_id: str) -> str:
+    return f"session/{require_session_id(session_id)}"
+
+
+def session_container_name(namespace: str | None, session_id: str) -> str:
+    ns = safe_token(namespace or "agent", fallback="agent", max_len=24)
+    sid = safe_token(require_session_id(session_id), fallback="session", max_len=40)
+    return safe_token(f"vaws-{ns}-{sid}", fallback="vaws-session", max_len=63)
+
+
+def parse_port_range(value: str) -> tuple[int, int]:
+    start_s, sep, end_s = value.partition(":")
+    if not sep:
+        raise SessionStateError(f"port range must be START:END, got {value!r}")
+    start = int(start_s)
+    end = int(end_s)
+    if start <= 0 or end <= 0 or start > end or end > 65535:
+        raise SessionStateError(f"invalid port range: {value!r}")
+    return start, end
+
+
+def _empty_index() -> dict[str, Any]:
+    return {"schema_version": INDEX_SCHEMA_VERSION, "updated_at": utc_now_iso(), "sessions": {}}
+
+
+def _empty_leases() -> dict[str, Any]:
+    return {"schema_version": LEASE_SCHEMA_VERSION, "updated_at": utc_now_iso(), "leases": {}}
+
+
+def load_index(repo_root: Path = ROOT) -> dict[str, Any]:
+    data = _load_json(session_index_path(repo_root), _empty_index())
+    if not isinstance(data, dict) or data.get("schema_version") != INDEX_SCHEMA_VERSION:
+        raise SessionStateError("unsupported sessions index schema")
+    data.setdefault("sessions", {})
+    if not isinstance(data["sessions"], dict):
+        raise SessionStateError("sessions index must contain a sessions object")
+    return data
+
+
+def save_index(index: dict[str, Any], repo_root: Path = ROOT) -> Path:
+    index["schema_version"] = INDEX_SCHEMA_VERSION
+    index["updated_at"] = utc_now_iso()
+    path = session_index_path(repo_root)
+    _atomic_write_json(path, index)
+    return path
+
+
+def load_leases(repo_root: Path = ROOT) -> dict[str, Any]:
+    data = _load_json(session_leases_path(repo_root), _empty_leases())
+    if not isinstance(data, dict) or data.get("schema_version") != LEASE_SCHEMA_VERSION:
+        raise SessionStateError("unsupported sessions lease schema")
+    data.setdefault("leases", {})
+    if not isinstance(data["leases"], dict):
+        raise SessionStateError("sessions leases must contain a leases object")
+    return data
+
+
+def save_leases(leases: dict[str, Any], repo_root: Path = ROOT) -> Path:
+    leases["schema_version"] = LEASE_SCHEMA_VERSION
+    leases["updated_at"] = utc_now_iso()
+    path = session_leases_path(repo_root)
+    _atomic_write_json(path, leases)
+    return path
+
+
+def _machine_lease_bucket(leases: dict[str, Any], machine_alias: str) -> dict[str, Any]:
+    bucket = leases.setdefault("leases", {}).setdefault(machine_alias, {})
+    bucket.setdefault("npu_devices", {})
+    bucket.setdefault("container_ssh_ports", {})
+    bucket.setdefault("service_ports", {})
+    return bucket
+
+
+def _resource_owner(bucket: dict[str, Any], kind: str, value: str) -> str | None:
+    record = bucket.get(kind, {}).get(value)
+    if isinstance(record, dict):
+        owner = record.get("session_id")
+        return str(owner) if owner is not None else None
+    return None
+
+
+def _reserve(bucket: dict[str, Any], kind: str, value: int | str, session_id: str) -> None:
+    key = str(value)
+    owner = _resource_owner(bucket, kind, key)
+    if owner is not None and owner != session_id:
+        raise SessionStateError(f"{kind[:-1]} {key} is already leased by session {owner}")
+    bucket.setdefault(kind, {})[key] = {"session_id": session_id, "updated_at": utc_now_iso()}
+
+
+def _select_port(
+    bucket: dict[str, Any],
+    kind: str,
+    session_id: str,
+    port_range: str,
+    *,
+    preferred: int | None = None,
+    is_available: Callable[[int], bool] | None = None,
+) -> int:
+    start, end = parse_port_range(port_range)
+    candidates: Iterable[int] = [preferred] if preferred is not None else range(start, end + 1)
+    for port in candidates:
+        if port is None:
+            continue
+        if port < start or port > end:
+            raise SessionStateError(f"port {port} is outside allowed range {port_range}")
+        owner = _resource_owner(bucket, kind, str(port))
+        if owner is not None and owner != session_id:
+            if preferred is not None:
+                raise SessionStateError(f"port {port} is already leased by session {owner}")
+            continue
+        if is_available is not None and not is_available(port):
+            if preferred is not None:
+                raise SessionStateError(f"port {port} is not available on the remote host/container")
+            continue
+        _reserve(bucket, kind, port, session_id)
+        return port
+    raise SessionStateError(f"no free port found in range {port_range}")
+
+
+def allocate_session_leases(
+    *,
+    repo_root: Path = ROOT,
+    machine_alias: str,
+    session_id: str,
+    requested_devices: list[int] | None = None,
+    npu_count: int | None = None,
+    container_ssh_port: int | None = None,
+    container_ssh_port_range: str = DEFAULT_CONTAINER_SSH_PORT_RANGE,
+    port_available: Callable[[int], bool] | None = None,
+) -> dict[str, Any]:
+    sid = require_session_id(session_id)
+    with file_lock(session_lock_dir(repo_root) / "leases.lock"):
+        leases = load_leases(repo_root)
+        bucket = _machine_lease_bucket(leases, machine_alias)
+        allocated_devices: list[int] = []
+        if requested_devices is not None:
+            allocated_devices = list(requested_devices)
+        elif npu_count:
+            for dev in range(64):
+                if _resource_owner(bucket, "npu_devices", str(dev)) in {None, sid}:
+                    allocated_devices.append(dev)
+                if len(allocated_devices) >= npu_count:
+                    break
+            if len(allocated_devices) < npu_count:
+                raise SessionStateError(f"not enough locally unleased NPU devices for session {sid}")
+
+        for dev in allocated_devices:
+            _reserve(bucket, "npu_devices", dev, sid)
+        port = _select_port(
+            bucket,
+            "container_ssh_ports",
+            sid,
+            container_ssh_port_range,
+            preferred=container_ssh_port,
+            is_available=port_available,
+        )
+        save_leases(leases, repo_root)
+    return {"npu_devices": allocated_devices, "container_ssh_port": port}
+
+
+def allocate_service_port(
+    *,
+    repo_root: Path = ROOT,
+    machine_alias: str,
+    session_id: str,
+    requested_port: int | None = None,
+    serving_port_range: str = DEFAULT_SERVING_PORT_RANGE,
+    port_available: Callable[[int], bool] | None = None,
+) -> int:
+    sid = require_session_id(session_id)
+    with file_lock(session_lock_dir(repo_root) / "leases.lock"):
+        leases = load_leases(repo_root)
+        bucket = _machine_lease_bucket(leases, machine_alias)
+        port = _select_port(
+            bucket,
+            "service_ports",
+            sid,
+            serving_port_range,
+            preferred=requested_port,
+            is_available=port_available,
+        )
+        save_leases(leases, repo_root)
+    return port
+
+
+def release_service_port(
+    *,
+    repo_root: Path = ROOT,
+    machine_alias: str,
+    session_id: str,
+    port: int | None,
+) -> None:
+    if port is None:
+        return
+    sid = require_session_id(session_id)
+    with file_lock(session_lock_dir(repo_root) / "leases.lock"):
+        leases = load_leases(repo_root)
+        bucket = _machine_lease_bucket(leases, machine_alias)
+        record = bucket.get("service_ports", {}).get(str(port))
+        if isinstance(record, dict) and record.get("session_id") == sid:
+            bucket["service_ports"].pop(str(port), None)
+            save_leases(leases, repo_root)
+
+
+def release_all_session_leases(*, repo_root: Path = ROOT, session_id: str) -> None:
+    sid = require_session_id(session_id)
+    with file_lock(session_lock_dir(repo_root) / "leases.lock"):
+        leases = load_leases(repo_root)
+        for bucket in leases.get("leases", {}).values():
+            for kind in ("npu_devices", "container_ssh_ports", "service_ports"):
+                records = bucket.get(kind, {})
+                for key, record in list(records.items()):
+                    if isinstance(record, dict) and record.get("session_id") == sid:
+                        records.pop(key, None)
+        save_leases(leases, repo_root)
+
+
+def validate_session(session: dict[str, Any], *, where: str = "session") -> dict[str, Any]:
+    if not isinstance(session, dict):
+        raise SessionStateError(f"{where} must be an object")
+    if session.get("schema_version") != SESSION_SCHEMA_VERSION:
+        raise SessionStateError(f"unsupported {where}.schema_version: {session.get('schema_version')!r}")
+    sid = require_session_id(str(session.get("session_id", "")))
+    if not isinstance(session.get("base_machine"), str) or not session["base_machine"]:
+        raise SessionStateError(f"{where}.base_machine must be a non-empty string")
+    if not isinstance(session.get("local"), dict):
+        raise SessionStateError(f"{where}.local must be an object")
+    if not isinstance(session.get("remote"), dict):
+        raise SessionStateError(f"{where}.remote must be an object")
+    normalized = dict(session)
+    normalized["session_id"] = sid
+    return normalized
+
+
+def save_session(session: dict[str, Any], *, repo_root: Path = ROOT) -> Path:
+    normalized = validate_session(session)
+    sid = normalized["session_id"]
+    now = utc_now_iso()
+    normalized.setdefault("created_at", now)
+    normalized["updated_at"] = now
+    path = session_file_path(sid, repo_root)
+    with file_lock(session_lock_dir(repo_root) / f"{sid}.lock"):
+        _atomic_write_json(path, normalized)
+        with file_lock(session_lock_dir(repo_root) / "index.lock"):
+            index = load_index(repo_root)
+            index.setdefault("sessions", {})[sid] = {
+                "session_id": sid,
+                "base_machine": normalized["base_machine"],
+                "status": normalized.get("status", "ready"),
+                "created_at": normalized.get("created_at"),
+                "updated_at": normalized.get("updated_at"),
+                "session_file": str(path.relative_to(repo_root)),
+            }
+            save_index(index, repo_root)
+    return path
+
+
+def _session_file_from_binding(repo_root: Path, session_id: str | None) -> Path | None:
+    binding = load_current_session_binding(repo_root)
+    if not binding:
+        return None
+    bound_id = normalize_session_id(str(binding.get("session_id", "")))
+    if session_id is not None and bound_id != require_session_id(session_id):
+        return None
+    session_file = binding.get("session_file")
+    if isinstance(session_file, str) and session_file:
+        return Path(session_file).expanduser().resolve()
+    base_repo_root = binding.get("base_repo_root")
+    if isinstance(base_repo_root, str) and base_repo_root:
+        return session_file_path(bound_id or require_session_id(session_id or ""), Path(base_repo_root))
+    return None
+
+
+def load_session_lookup(
+    *,
+    session_id: str | None = None,
+    session_file: str | Path | None = None,
+    repo_root: Path = ROOT,
+) -> SessionLookup:
+    sid = require_session_id(session_id) if session_id else None
+    if session_file is not None:
+        path = Path(session_file).expanduser().resolve()
+    else:
+        path = None
+        if sid is not None:
+            index = load_index(repo_root)
+            record = index.get("sessions", {}).get(sid)
+            if isinstance(record, dict) and isinstance(record.get("session_file"), str):
+                candidate = Path(record["session_file"])
+                path = candidate if candidate.is_absolute() else repo_root / candidate
+            else:
+                candidate = session_file_path(sid, repo_root)
+                if candidate.exists():
+                    path = candidate
+        if path is None:
+            path = _session_file_from_binding(repo_root, sid)
+        if path is None and sid is None:
+            binding = load_current_session_binding(repo_root)
+            if binding and isinstance(binding.get("session_id"), str):
+                sid = require_session_id(binding["session_id"])
+                path = _session_file_from_binding(repo_root, sid) or session_file_path(sid, repo_root)
+        if path is None:
+            raise SessionStateError("session id or session file is required")
+    if not path.exists():
+        raise SessionStateError(f"session file does not exist: {path}")
+    session = validate_session(_load_json(path), where=str(path))
+    if sid is not None and session["session_id"] != sid:
+        raise SessionStateError(f"session file {path} contains {session['session_id']!r}, expected {sid!r}")
+    state_root = path.parents[3] if path.parent.parent.name == "sessions" else repo_root
+    return SessionLookup(session=session, session_file=path, state_repo_root=state_root)
+
+
+def load_session(
+    *,
+    session_id: str | None = None,
+    session_file: str | Path | None = None,
+    repo_root: Path = ROOT,
+) -> dict[str, Any]:
+    return load_session_lookup(session_id=session_id, session_file=session_file, repo_root=repo_root).session
+
+
+def mark_session_status(
+    *,
+    repo_root: Path = ROOT,
+    session_id: str,
+    status: str,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    lookup = load_session_lookup(session_id=session_id, repo_root=repo_root)
+    session = dict(lookup.session)
+    session["status"] = status
+    session["updated_at"] = utc_now_iso()
+    if extra:
+        session.update(extra)
+    save_session(session, repo_root=lookup.state_repo_root)
+    return session
+
+
+def session_record_for_execution(session: dict[str, Any]) -> dict[str, Any]:
+    remote = session["remote"]
+    container = remote["container"]
+    return {
+        "alias": session["base_machine"],
+        "namespace": remote.get("namespace"),
+        "host": {
+            "ip": remote["host"],
+            "port": remote.get("host_port", 22),
+            "user": remote.get("host_user", "root"),
+            "machine_type": remote.get("machine_type"),
+            "soc": remote.get("soc"),
+        },
+        "container": {
+            "name": container["name"],
+            "ssh_port": container["ssh_port"],
+            "image": container.get("image", ""),
+            "workdir": container.get("workdir", "/vllm-workspace"),
+            "machine_type": container.get("machine_type") or remote.get("machine_type"),
+        },
+        "bootstrap_method": "ssh",
+        "managed_by_skill": True,
+        "created_by_skill": True,
+    }

--- a/.agents/lib/vaws_session_state.py
+++ b/.agents/lib/vaws_session_state.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Iterable
 
 from vaws_local_state import ROOT, STATE_DIR, WorkspaceStateError, ensure_state_dir, utc_now_iso
 from vaws_session_id import load_current_session_binding, normalize_session_id
+from vaws_validate import parse_device_csv
 
 SESSION_SCHEMA_VERSION = 1
 INDEX_SCHEMA_VERSION = 1
@@ -291,19 +292,35 @@ def allocate_session_leases(
     session_id: str,
     requested_devices: list[int] | None = None,
     npu_count: int | None = None,
+    available_devices: list[int] | None = None,
     container_ssh_port: int | None = None,
     container_ssh_port_range: str = DEFAULT_CONTAINER_SSH_PORT_RANGE,
     port_available: Callable[[int], bool] | None = None,
 ) -> dict[str, Any]:
     sid = require_session_id(session_id)
+    if npu_count is not None and npu_count < 1:
+        raise SessionStateError("--npu-count must be >= 1")
+    if requested_devices is not None:
+        requested_devices = parse_device_csv(",".join(str(item) for item in requested_devices)) or []
+    if requested_devices is not None and npu_count is not None:
+        raise SessionStateError("use only one of --devices or --npu-count")
+    available_set = set(available_devices) if available_devices is not None else None
     with file_lock(session_lock_dir(repo_root) / "leases.lock"):
         leases = load_leases(repo_root)
         bucket = _machine_lease_bucket(leases, machine_alias)
         allocated_devices: list[int] = []
         if requested_devices is not None:
+            if available_set is not None:
+                missing = sorted(set(requested_devices) - available_set)
+                if missing:
+                    raise SessionStateError(
+                        f"requested NPU devices are not visible on host: {missing}; "
+                        f"available={sorted(available_set)}"
+                    )
             allocated_devices = list(requested_devices)
         elif npu_count:
-            for dev in range(64):
+            candidates = sorted(available_set) if available_set is not None else list(range(64))
+            for dev in candidates:
                 if _resource_owner(bucket, "npu_devices", str(dev)) in {None, sid}:
                     allocated_devices.append(dev)
                 if len(allocated_devices) >= npu_count:

--- a/.agents/lib/vaws_validate.py
+++ b/.agents/lib/vaws_validate.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Shared validation helpers for VAWS agent-facing scripts."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path, PurePosixPath
+
+ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{2,63}$")
+
+
+class ValidationError(ValueError):
+    """Raised for deterministic user-input validation failures."""
+
+
+def require_env_name(name: str) -> str:
+    if not isinstance(name, str) or not ENV_NAME_RE.fullmatch(name):
+        raise ValidationError(
+            f"invalid env var name: {name!r}; use ASCII [A-Za-z_][A-Za-z0-9_]*"
+        )
+    return name
+
+
+def require_safe_id(value: str, *, label: str = "id") -> str:
+    if not isinstance(value, str) or not SAFE_ID_RE.fullmatch(value):
+        raise ValidationError(
+            f"invalid {label}: use 3-64 chars from A-Z a-z 0-9 _ . -; "
+            "no slashes, spaces, path traversal, or absolute paths"
+        )
+    return value
+
+
+def require_remote_leaf(value: str, *, label: str = "id") -> str:
+    safe = require_safe_id(value, label=label)
+    path = PurePosixPath(safe)
+    if path.is_absolute() or ".." in path.parts or len(path.parts) != 1:
+        raise ValidationError(f"invalid {label}: must be one remote path segment")
+    return safe
+
+
+def ensure_child_path(root: Path, child: Path) -> Path:
+    root_resolved = root.expanduser().resolve()
+    child_resolved = child.expanduser().resolve()
+    if root_resolved != child_resolved and root_resolved not in child_resolved.parents:
+        raise ValidationError(f"path escapes state dir: {child_resolved}")
+    return child_resolved
+
+
+def parse_device_csv(value: str | None, *, label: str = "devices") -> list[int] | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must be a non-empty comma-separated device list")
+    devices: list[int] = []
+    seen: set[int] = set()
+    for raw in value.split(","):
+        token = raw.strip()
+        if not token:
+            raise ValidationError(f"{label} contains an empty device id")
+        try:
+            device = int(token, 10)
+        except ValueError as exc:
+            raise ValidationError(f"{label} contains a non-integer device id: {token!r}") from exc
+        if device < 0:
+            raise ValidationError(f"{label} contains a negative device id: {device}")
+        if device in seen:
+            raise ValidationError(f"{label} contains a duplicate device id: {device}")
+        seen.add(device)
+        devices.append(device)
+    return sorted(devices)

--- a/.agents/scripts/remote_artifact_manifest.py
+++ b/.agents/scripts/remote_artifact_manifest.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_artifact_manifest  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_artifact_manifest())

--- a/.agents/scripts/remote_artifact_pull.py
+++ b/.agents/scripts/remote_artifact_pull.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_artifact_pull  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_artifact_pull())

--- a/.agents/scripts/remote_artifact_push.py
+++ b/.agents/scripts/remote_artifact_push.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_artifact_push  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_artifact_push())

--- a/.agents/scripts/remote_cleanup.py
+++ b/.agents/scripts/remote_cleanup.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_cleanup  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_cleanup())

--- a/.agents/scripts/remote_exec.py
+++ b/.agents/scripts/remote_exec.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_exec  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_exec())

--- a/.agents/scripts/remote_job_collect.py
+++ b/.agents/scripts/remote_job_collect.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_job_collect  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_job_collect())

--- a/.agents/scripts/remote_job_start.py
+++ b/.agents/scripts/remote_job_start.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_job_start  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_job_start())

--- a/.agents/scripts/remote_job_status.py
+++ b/.agents/scripts/remote_job_status.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_job_status  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_job_status())

--- a/.agents/scripts/remote_job_stop.py
+++ b/.agents/scripts/remote_job_stop.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_job_stop  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_job_stop())

--- a/.agents/scripts/remote_job_tail.py
+++ b/.agents/scripts/remote_job_tail.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_job_tail  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_job_tail())

--- a/.agents/scripts/remote_probe.py
+++ b/.agents/scripts/remote_probe.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_probe  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_probe())

--- a/.agents/scripts/remote_service_logs.py
+++ b/.agents/scripts/remote_service_logs.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_service_logs  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_service_logs())

--- a/.agents/scripts/remote_service_start.py
+++ b/.agents/scripts/remote_service_start.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_service_start  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_service_start())

--- a/.agents/scripts/remote_service_status.py
+++ b/.agents/scripts/remote_service_status.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_service_status  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_service_status())

--- a/.agents/scripts/remote_service_stop.py
+++ b/.agents/scripts/remote_service_stop.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_service_stop  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_service_stop())

--- a/.agents/scripts/remote_sync_apply.py
+++ b/.agents/scripts/remote_sync_apply.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_sync_apply  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_sync_apply())

--- a/.agents/scripts/remote_sync_plan.py
+++ b/.agents/scripts/remote_sync_plan.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_sync_plan  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_sync_plan())

--- a/.agents/scripts/remote_target_resolve.py
+++ b/.agents/scripts/remote_target_resolve.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import cli_target_resolve  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_target_resolve())

--- a/.agents/scripts/remote_toolbox_stress.py
+++ b/.agents/scripts/remote_toolbox_stress.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Run lightweight VAWS remote-toolbox stress checks.
+
+This intentionally avoids NPU-heavy workloads, runtime install/rebuild, and
+benchmarks. It focuses on agent-facing mechanics: concurrent exec, job
+observation, artifact manifest/pull, and cleanup proof.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import shlex
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_remote_toolbox import (  # noqa: E402
+    ARTIFACT_STATE_DIR,
+    RemoteToolboxError,
+    artifact_pull,
+    duration_ms,
+    emit_progress,
+    print_json,
+    remote_exec,
+    remote_job_status,
+    remote_job_tail,
+    resolve_remote_target,
+    start_remote_job,
+    tail_text,
+    utc_now_iso,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    parser.add_argument("--machine", help="machine alias or host IP")
+    parser.add_argument("--session-id", help="VAWS session id")
+    parser.add_argument("--session-file", help="explicit session.json path")
+    parser.add_argument("--parallelism", type=int, default=4)
+    parser.add_argument("--exec-count", type=int, default=8)
+    parser.add_argument("--job-count", type=int, default=4)
+    parser.add_argument("--artifact-files", type=int, default=32)
+    parser.add_argument("--artifact-bytes", type=int, default=1024)
+    parser.add_argument("--timeout", type=float, default=60)
+    parser.add_argument("--skip-exec", action="store_true")
+    parser.add_argument("--skip-jobs", action="store_true")
+    parser.add_argument("--skip-artifacts", action="store_true")
+    parser.add_argument("--cleanup-remote", action=argparse.BooleanOptionalAction, default=True)
+    return parser
+
+
+def _case(status: str, **extra: Any) -> dict[str, Any]:
+    return {"status": status, **extra}
+
+
+def _run_parallel(items: list[Any], worker, *, parallelism: int) -> list[Any]:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, parallelism)) as pool:
+        futures = [pool.submit(worker, item) for item in items]
+        return [future.result() for future in concurrent.futures.as_completed(futures)]
+
+
+def run_stress(args: argparse.Namespace) -> dict[str, Any]:
+    started_at = utc_now_iso()
+    start = time.monotonic()
+    target = resolve_remote_target(
+        machine=args.machine,
+        session_id=args.session_id,
+        session_file=args.session_file,
+    )
+    cases: dict[str, Any] = {}
+
+    if not args.skip_exec:
+        emit_progress("stress-exec", "running concurrent remote_exec checks", count=args.exec_count)
+
+        def exec_worker(i: int) -> dict[str, Any]:
+            result = remote_exec(
+                target,
+                command=f"printf exec-{i}",
+                timeout=args.timeout,
+                log_kind="stress-exec",
+            )
+            return {
+                "index": i,
+                "status": result["status"],
+                "exit_code": result["exit_code"],
+                "duration_ms": result["duration_ms"],
+                "stdout_tail": result["stdout_tail"],
+                "logs": result["logs"],
+            }
+
+        exec_results = _run_parallel(list(range(args.exec_count)), exec_worker, parallelism=args.parallelism)
+        cases["remote_exec"] = _case(
+            "ok" if all(item["status"] == "ok" and item["stdout_tail"].startswith("exec-") for item in exec_results) else "failed",
+            results=sorted(exec_results, key=lambda item: item["index"]),
+        )
+
+    if not args.skip_jobs:
+        emit_progress("stress-jobs", "starting and observing remote jobs", count=args.job_count)
+        job_starts = []
+        for i in range(args.job_count):
+            job_starts.append(
+                start_remote_job(
+                    target,
+                    kind="stress",
+                    command=f"printf job-{i}",
+                    timeout_seconds=int(args.timeout),
+                    job_id=None,
+                )
+            )
+        job_observed = []
+        for item in job_starts:
+            record = {
+                "job_id": item["job_id"],
+                "remote_dir": item["remote_dir"],
+                "target": target.to_dict(),
+                "started_at": item["started_at"],
+                "kind": "stress",
+            }
+            deadline = time.monotonic() + args.timeout
+            status_payload = remote_job_status(target, record)
+            while status_payload["status"] == "running" and time.monotonic() < deadline:
+                time.sleep(0.5)
+                status_payload = remote_job_status(target, record)
+            tail_payload = remote_job_tail(target, record, lines=5)
+            job_observed.append(
+                {
+                    "job_id": item["job_id"],
+                    "start_status": item["status"],
+                    "status": status_payload["status"],
+                    "tail": tail_payload.get("tail", ""),
+                    "logs": item["logs"],
+                }
+            )
+        cases["remote_jobs"] = _case(
+            "ok" if all(item["status"] == "succeeded" and "job-" in item["tail"] for item in job_observed) else "failed",
+            results=job_observed,
+        )
+
+    if not args.skip_artifacts:
+        emit_progress("stress-artifacts", "creating and pulling artifact directory", files=args.artifact_files)
+        remote_dir = f"{target.remote_toolbox_root()}/stress/artifacts-{int(time.time())}"
+        local_dir = ARTIFACT_STATE_DIR / "stress" / target.target_id / Path(remote_dir).name
+        make_script = [
+            f"rm -rf {shlex.quote(remote_dir)}",
+            f"mkdir -p {shlex.quote(remote_dir)}",
+        ]
+        for i in range(args.artifact_files):
+            make_script.append(
+                f"python3 - <<'PY' > {shlex.quote(remote_dir + f'/file-{i:04d}.txt')}\n"
+                f"import sys\nsys.stdout.write('file-{i}-' + 'x' * {max(0, args.artifact_bytes - len(str(i)) - 6)})\n"
+                "PY"
+            )
+        create_result = remote_exec(
+            target,
+            command="\n".join(make_script),
+            timeout=max(args.timeout, 120),
+            log_kind="stress-artifact-create",
+        )
+        pull_result = artifact_pull(
+            target,
+            remote_path=remote_dir,
+            local_dir=local_dir,
+            timeout=max(args.timeout, 120),
+        )
+        cleanup_result = None
+        if args.cleanup_remote:
+            cleanup_result = remote_exec(
+                target,
+                command=f"rm -rf {shlex.quote(remote_dir)}",
+                timeout=args.timeout,
+                log_kind="stress-artifact-cleanup",
+            )
+        cases["artifacts"] = _case(
+            "ok" if create_result["status"] == "ok" and pull_result["status"] == "ok" and pull_result["artifacts"]["manifest"]["file_count"] == args.artifact_files else "failed",
+            remote_dir=remote_dir,
+            local_dir=str(local_dir),
+            create_status=create_result["status"],
+            pull_status=pull_result["status"],
+            file_count=pull_result.get("artifacts", {}).get("manifest", {}).get("file_count"),
+            pulled=len(pull_result.get("artifacts", {}).get("pulled", [])),
+            transports=sorted({item.get("transport") for item in pull_result.get("artifacts", {}).get("pulled", [])}),
+            cleanup_status=cleanup_result["status"] if cleanup_result else "skipped",
+        )
+
+    failed = {name: case for name, case in cases.items() if case.get("status") != "ok"}
+    return {
+        "status": "ok" if not failed else "failed",
+        "target": target.to_dict(),
+        "started_at": started_at,
+        "duration_ms": duration_ms(start),
+        "config": {
+            "parallelism": args.parallelism,
+            "exec_count": args.exec_count,
+            "job_count": args.job_count,
+            "artifact_files": args.artifact_files,
+            "artifact_bytes": args.artifact_bytes,
+        },
+        "cases": cases,
+        "failed_cases": failed,
+        "logs": {},
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    started_at = utc_now_iso()
+    start = time.monotonic()
+    try:
+        payload = run_stress(args)
+        print_json(payload)
+        return 0 if payload["status"] == "ok" else 1
+    except Exception as exc:  # noqa: BLE001
+        print_json({
+            "status": "failed",
+            "started_at": started_at,
+            "duration_ms": duration_ms(start),
+            "error": str(exc),
+            "error_tail": tail_text(str(exc), 2000),
+            "target": None,
+            "logs": {},
+        })
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/workspace_profile.py
+++ b/.agents/scripts/workspace_profile.py
@@ -2,7 +2,8 @@
 """Manage the local workspace machine profile.
 
 The profile is untracked local state used to derive container names and other
-collision-sensitive identifiers for machine-management.
+collision-sensitive identifiers for machine-management. The summary command
+also reports shared local-state roots such as the session namespace.
 """
 
 from __future__ import annotations

--- a/.agents/skills/ascend-memory-profiling/SKILL.md
+++ b/.agents/skills/ascend-memory-profiling/SKILL.md
@@ -56,6 +56,10 @@ All memory attribution is based on measured data — **no estimation or guessing
 
 **Always use the `vllm-ascend-serving` skill for service lifecycle management.** This profiling skill only collects and analyzes data — it attaches to a running service. **msprof wrapping is mandatory** for a complete, traceable memory breakdown.
 
+For parallel agent work, create or reuse a `session-management` session first, then use `--session-id <id>` or `--session-file <session.json>` everywhere below. In session mode, this skill reads serving state from `.vaws-local/sessions/<session-id>/serving.json` and talks only to that session's dedicated container.
+
+Session-scoped memory profiling must use `--attach`. Standalone mode starts its own service and is kept only for legacy single-tenant machine flows; it is blocked when `--session-id` or `--session-file` is used so it cannot bypass session service-port leases or shared state isolation.
+
 ### Step 0: Check msprof availability
 
 Before starting the service, verify that msprof is available on the remote machine:
@@ -63,8 +67,9 @@ Before starting the service, verify that msprof is available on the remote machi
 ```bash
 python3 -c "
 import sys; sys.path.insert(0, '.agents/skills/ascend-memory-profiling/scripts')
-from _common import resolve_machine, endpoint_from_machine, check_msprof_available
-ep = endpoint_from_machine(resolve_machine('<alias>'))
+from _common import check_msprof_available, resolve_execution_target
+target = resolve_execution_target('<alias-or-none>', session_id='<session-id-or-none>')
+ep = target['endpoint']
 print(check_msprof_available(ep))
 "
 ```
@@ -79,18 +84,19 @@ Upload the msprof wrapper, then start the service with `--wrap-script`:
 # Upload msprof wrapper to remote
 python3 -c "
 import sys; sys.path.insert(0, '.agents/skills/ascend-memory-profiling/scripts')
-from _common import resolve_machine, endpoint_from_machine, upload_msprof_wrapper
-ep = endpoint_from_machine(resolve_machine('<alias>'))
+from _common import resolve_execution_target, upload_msprof_wrapper
+target = resolve_execution_target('<alias-or-none>', session_id='<session-id-or-none>')
+ep = target['endpoint']
 print(upload_msprof_wrapper(ep, mem_freq=50))
 "
 # Start service with msprof wrapping
 python3 .agents/skills/vllm-ascend-serving/scripts/serve_start.py \
-  --machine <alias> --model <path> --tp <N> \
+  (--machine <alias> | --session-id <id>) --model <path> --tp <N> \
   --wrap-script /tmp/_vaws_msprof_wrap.sh \
   [-- --speculative-config '...' --compilation-config '...' ...]
 ```
 
-Note: `upload_msprof_wrapper` internally calls `check_msprof_available` as a safety net.
+Note: `upload_msprof_wrapper` internally calls `check_msprof_available` as a safety net and writes a unique wrapper path under `/tmp` for each call.
 
 For baseline npu-smi data, collect `npu-smi info` **before** starting the service.
 
@@ -98,14 +104,16 @@ For baseline npu-smi data, collect `npu-smi info` **before** starting the servic
 
 ```bash
 python3 .agents/skills/ascend-memory-profiling/scripts/mem_collect.py \
-  --machine <alias-or-ip> \
+  --session-id <id> \
   --attach \
   [--baseline-from <previous-run-dir>] \
   [--tag <experiment-name>]
 ```
 
+Use `--machine <alias-or-ip>` for legacy single-tenant workflows, or `--session-file <session.json>` when the session file path is the stable handle.
+
 What happens:
-- Reads `.vaws-local/serving/<alias>.json` to discover port, PID, model path, tp/dp, extra args
+- Reads `.vaws-local/serving/<alias>.json` or `.vaws-local/sessions/<session-id>/serving.json` to discover port, PID, model path, tp/dp, extra args
 - Auto-extracts `--speculative-config`, `--compilation-config`, etc. from the serving state
 - Collects npu-smi snapshot, vLLM logs (from serving's runtime dir), weight manifest
 - Sends inference request to collect activation delta
@@ -114,8 +122,11 @@ What happens:
 ### Step 3: Stop service (via `vllm-ascend-serving`)
 
 ```bash
-python3 .agents/skills/vllm-ascend-serving/scripts/serve_stop.py --machine <alias>
+python3 .agents/skills/vllm-ascend-serving/scripts/serve_stop.py \
+  --session-id <id>
 ```
+
+Use the same target form that was used for `serve_start.py`.
 
 ### Step 4: Collect msprof data
 
@@ -123,7 +134,7 @@ After stop, run `mem_collect --attach` again **with `--resume-run`** pointing to
 
 ```bash
 python3 .agents/skills/ascend-memory-profiling/scripts/mem_collect.py \
-  --machine <alias> --attach \
+  --session-id <id> --attach \
   --resume-run .vaws-local/memory-profiling/<run-dir-from-step-2>/
 ```
 
@@ -155,7 +166,7 @@ When the serving skill is unavailable (e.g. bootstrap scenario), `mem_collect.py
 
 ```bash
 python3 .agents/skills/ascend-memory-profiling/scripts/mem_collect.py \
-  --machine <alias-or-ip> \
+  --session-id <id> \
   --model <remote-weight-path> \
   --tp <N> [--dp <N>] [--tag <name>] \
   [--speculative-config '...'] [--compilation-config '...'] ...
@@ -201,7 +212,8 @@ CANN Runtime                   |      125.3 |      0.122 |   0.4% | msprof npu_m
 
 | Skill | Interaction |
 |-------|-------------|
-| `vllm-ascend-serving` | **Service lifecycle**: Use `serve_start.py` to start (with `--wrap-script` for msprof), `serve_stop.py` to stop. This skill reads serving state from `.vaws-local/serving/<alias>.json`. The serving skill is agnostic to msprof — it only knows about the wrapper script. |
+| `vllm-ascend-serving` | **Service lifecycle**: Use `serve_start.py` to start (with `--wrap-script` for msprof), `serve_stop.py` to stop. This skill reads serving state from `.vaws-local/serving/<alias>.json` or `.vaws-local/sessions/<session-id>/serving.json` in session mode. The serving skill is agnostic to msprof — it only knows about the wrapper script. |
+| `session-management` | **Parallel isolation**: Use `session_create.py` before parallel remote work and pass `--session-id` to serving and memory collection. Session mode stores serving state under `.vaws-local/sessions/<session-id>/serving.json`. |
 | `machine-management` | **SSH endpoint resolution**: Both skills share the machine inventory via `inventory` from `.agents/lib/`. |
 | `remote-code-parity` | **Automatic via serving**: The serving skill calls parity sync before service start. |
 

--- a/.agents/skills/ascend-memory-profiling/scripts/_common.py
+++ b/.agents/skills/ascend-memory-profiling/scripts/_common.py
@@ -9,6 +9,7 @@ import shlex
 import subprocess
 import sys
 import time
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -23,6 +24,11 @@ for _p in (str(LIB_DIR), str(MM_SCRIPTS)):
 
 import inventory as inventory_store  # noqa: E402
 from vaws_local_state import ensure_state_dir  # noqa: E402
+from vaws_session_state import (  # noqa: E402
+    load_session_lookup,
+    session_record_for_execution,
+    session_serving_state_path,
+)
 
 MEMPROF_STATE_DIR = ROOT / ".vaws-local" / "memory-profiling"
 SERVING_STATE_DIR = ROOT / ".vaws-local" / "serving"
@@ -128,8 +134,48 @@ def endpoint_from_machine(machine: dict[str, Any]) -> SshEndpoint:
         user = "root"
 
     ssh_port = container_info.get("ssh_port", host_port)
+    if container_info.get("ssh_port") is not None:
+        user = container_info.get("user", "root")
 
     return SshEndpoint(host=ip, port=ssh_port, user=user)
+
+
+def resolve_execution_target(
+    machine: str | None,
+    *,
+    session_id: str | None = None,
+    session_file: str | None = None,
+) -> dict[str, Any]:
+    if session_id or session_file:
+        lookup = load_session_lookup(
+            session_id=session_id,
+            session_file=session_file,
+            repo_root=ROOT,
+        )
+        record = session_record_for_execution(lookup.session)
+        return {
+            "mode": "session",
+            "record": record,
+            "alias": record["alias"],
+            "endpoint": endpoint_from_machine(record),
+            "session_id": lookup.session["session_id"],
+            "session_file": str(lookup.session_file),
+            "session": lookup.session,
+            "state_repo_root": lookup.state_repo_root,
+        }
+    if not machine:
+        raise ValueError("--machine is required unless --session-id or --session-file is used")
+    record = resolve_machine(machine)
+    return {
+        "mode": "legacy",
+        "record": record,
+        "alias": get_machine_alias(record),
+        "endpoint": endpoint_from_machine(record),
+        "session_id": None,
+        "session_file": None,
+        "session": None,
+        "state_repo_root": ROOT,
+    }
 
 
 def ensure_run_dir(tag: str = "") -> Path:
@@ -143,6 +189,7 @@ def ensure_run_dir(tag: str = "") -> Path:
 def find_python(endpoint: SshEndpoint) -> str:
     """Detect the Python binary with torch_npu on the remote machine."""
     for candidate in [
+        "/usr/local/python3.11.15/bin/python3",
         "/usr/local/python3.11.14/bin/python3",
         "/usr/local/python3.10/bin/python3",
         "python3",
@@ -153,14 +200,23 @@ def find_python(endpoint: SshEndpoint) -> str:
     raise RuntimeError("No Python with torch_npu found on remote machine")
 
 
-def load_serving_state(machine_alias: str) -> dict[str, Any] | None:
+def load_serving_state(
+    machine_alias: str,
+    *,
+    session_id: str | None = None,
+    state_repo_root: Path = ROOT,
+) -> dict[str, Any] | None:
     """Read the serving skill's persisted state for a given machine.
 
     Returns None if no state file exists or it's unparseable.
     The state dict contains: model, pid, port, runtime_dir, log_stdout,
     log_stderr, tp, dp, devices, status, started_at, etc.
     """
-    path = SERVING_STATE_DIR / f"{machine_alias}.json"
+    path = (
+        session_serving_state_path(session_id, state_repo_root)
+        if session_id
+        else SERVING_STATE_DIR / f"{machine_alias}.json"
+    )
     if not path.exists():
         return None
     try:
@@ -228,7 +284,12 @@ _MSPROF_REPORTS_CONFIG = json.dumps({
 }, indent=2)
 
 
-def upload_msprof_wrapper(ep: SshEndpoint, mem_freq: int = 1) -> str:
+def _safe_tmp_token(value: str) -> str:
+    token = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in value)
+    return token.strip("._-") or "run"
+
+
+def upload_msprof_wrapper(ep: SshEndpoint, mem_freq: int = 1, token: str | None = None) -> str:
     """Generate and upload an msprof wrapper script to the remote machine.
 
     The wrapper receives two arguments from the serving skill's --wrap-script:
@@ -253,10 +314,12 @@ exec msprof --output="$MSPROF_OUT" \\
   --ascendcl=off \\
   --application="bash $SERVE_SCRIPT"
 """
-    ssh_write_text(ep, script, MSPROF_WRAPPER_REMOTE_PATH)
-    ssh_exec(ep, f"chmod +x {MSPROF_WRAPPER_REMOTE_PATH}")
+    suffix = _safe_tmp_token(token or f"{os.getpid()}_{uuid.uuid4().hex[:8]}")
+    wrapper_path = f"/tmp/_vaws_msprof_wrap_{suffix}.sh"
+    ssh_write_text(ep, script, wrapper_path)
+    ssh_exec(ep, f"chmod +x {wrapper_path}")
     ssh_write_text(ep, _MSPROF_REPORTS_CONFIG, MSPROF_REPORTS_REMOTE_PATH)
-    return MSPROF_WRAPPER_REMOTE_PATH
+    return wrapper_path
 
 
 def run_msprof_export(

--- a/.agents/skills/ascend-memory-profiling/scripts/mem_collect.py
+++ b/.agents/skills/ascend-memory-profiling/scripts/mem_collect.py
@@ -16,7 +16,8 @@ Two modes of operation:
 **Attach mode** (--attach):
   Attach to a service already managed by the vllm-ascend-serving skill.
   Reads service state (port, PID, log paths, model config) from
-  `.vaws-local/serving/<alias>.json`.  Skips service start/stop.
+  `.vaws-local/serving/<alias>.json` or
+  `.vaws-local/sessions/<session-id>/serving.json`.  Skips service start/stop.
   If the service was launched with --wrap-script pointing to the msprof
   wrapper, attach mode detects this, runs msprof export, and collects CSVs.
   When the service was NOT launched with msprof, a warning is emitted and the
@@ -29,10 +30,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shlex
 import sys
 import time
+import uuid
 from pathlib import Path
 
 from _common import (
@@ -40,19 +43,23 @@ from _common import (
     MSPROF_WRAPPER_REMOTE_PATH,
     SshEndpoint,
     check_msprof_available,
-    endpoint_from_machine,
     ensure_run_dir,
     find_python,
     get_machine_alias,
     load_serving_state,
     progress,
-    resolve_machine,
+    resolve_execution_target,
     run_msprof_export,
     ssh_exec,
     ssh_upload,
     ssh_write_text,
     upload_msprof_wrapper,
 )
+
+
+def unique_remote_tmp(prefix: str, session_id: str | None = None) -> str:
+    sid = re.sub(r"[^A-Za-z0-9_.-]+", "_", session_id or "legacy").strip("._-") or "legacy"
+    return f"/tmp/{prefix}_{sid}_{os.getpid()}_{uuid.uuid4().hex[:8]}"
 
 
 _ENV_ERROR_PATTERNS = [
@@ -67,15 +74,16 @@ _ENV_ERROR_PATTERNS = [
 ]
 
 
-def _emit_env_recovery_hint(log_text: str, machine: str) -> None:
+def _emit_env_recovery_hint(log_text: str, machine: str, session_id: str | None = None) -> None:
     """If log_text contains environment error patterns, emit structured recovery guidance."""
     if not log_text:
         return
     if not any(pat in log_text for pat in _ENV_ERROR_PATTERNS):
         return
+    target_arg = f"--session-id {session_id}" if session_id else f"--machine {machine}"
     recovery_cmd = (
         f"python3 .agents/skills/remote-code-parity/scripts/parity_sync.py "
-        f"--machine {machine} --force-reinstall"
+        f"{target_arg} --force-reinstall"
     )
     progress(
         "ENV_ERROR_DETECTED: Remote Python environment is broken. "
@@ -87,7 +95,9 @@ def _emit_env_recovery_hint(log_text: str, machine: str) -> None:
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Collect Ascend NPU memory profiling data")
-    p.add_argument("--machine", required=True, help="Machine alias or IP")
+    p.add_argument("--machine", help="Machine alias or IP")
+    p.add_argument("--session-id", help="VAWS session id")
+    p.add_argument("--session-file", help="explicit session.json path")
     p.add_argument("--model", default="", help="Remote model weight path (auto-detected in attach mode)")
     p.add_argument("--tp", type=int, default=None, help="Tensor parallel size (auto-detected in attach mode)")
     p.add_argument("--dp", type=int, default=None, help="Data parallel size (auto-detected in attach mode)")
@@ -445,7 +455,11 @@ def _resolve_attach_state(machine: dict, args: argparse.Namespace) -> dict:
     inference).
     """
     alias = get_machine_alias(machine)
-    state = load_serving_state(alias)
+    state = load_serving_state(
+        alias,
+        session_id=args.session_id,
+        state_repo_root=getattr(args, "_state_repo_root", Path(__file__).resolve().parents[4]),
+    )
     if state is None:
         raise SystemExit(
             f"No serving state found for machine '{alias}'. "
@@ -545,12 +559,30 @@ def _collect_serving_logs(ep: SshEndpoint, serving_state: dict, local_path: Path
 
 def main() -> None:
     args = parse_args()
-    machine = resolve_machine(args.machine)
-    ep = endpoint_from_machine(machine)
+    target = resolve_execution_target(
+        args.machine,
+        session_id=args.session_id,
+        session_file=args.session_file,
+    )
+    machine = target["record"]
+    ep = target["endpoint"]
+    args._state_repo_root = target["state_repo_root"]
+    args._session = target.get("session")
+    if target["session_id"]:
+        args.session_id = target["session_id"]
+        args.session_file = target["session_file"]
+    if not args.machine:
+        args.machine = target["alias"]
 
     if args.attach:
         _main_attach(args, machine, ep)
     else:
+        if target["session_id"]:
+            raise SystemExit(
+                "session-scoped memory profiling requires --attach. "
+                "Start the service with vllm-ascend-serving --wrap-script first, "
+                "then run mem_collect.py --session-id <id> --attach."
+            )
         _main_standalone(args, machine, ep)
 
 
@@ -599,7 +631,7 @@ def _main_attach(
         progress(f"Resuming into existing run: {run_dir}")
     else:
         run_dir = ensure_run_dir(tag=args.tag or f"attach_{model_tag}")
-    remote_dir = f"/tmp/vaws_memprof_{int(time.time())}"
+    remote_dir = unique_remote_tmp("vaws_memprof_attach", args.session_id)
 
     progress(f"Output directory: {run_dir}")
     ssh_exec(ep, f"mkdir -p {remote_dir}")
@@ -619,6 +651,8 @@ def _main_attach(
 
     manifest: dict = {
         "mode": "attach",
+        "session_id": args.session_id,
+        "session_file": args.session_file,
         "model": model,
         "tp": tp,
         "dp": dp,
@@ -628,7 +662,10 @@ def _main_attach(
         "msprof_enabled": msprof_used,
         "msprof_output_dir": msprof_data_dir,
         "run_dir": str(run_dir),
-        "serving_state_ref": f".vaws-local/serving/{alias}.json",
+        "serving_state_ref": (
+            f".vaws-local/sessions/{args.session_id}/serving.json"
+            if args.session_id else f".vaws-local/serving/{alias}.json"
+        ),
         "serving_runtime_dir": svc_runtime_dir,
         "speculative_config": args.speculative_config,
         "compilation_config": args.compilation_config,
@@ -654,7 +691,7 @@ def _main_attach(
             wait_for_health(ep, port, timeout=args.health_timeout)
         except TimeoutError:
             log_text = _collect_serving_logs(ep, serving_state, run_dir)
-            _emit_env_recovery_hint(log_text, args.machine)
+            _emit_env_recovery_hint(log_text, args.machine or "", args.session_id)
             raise SystemExit(
                 f"Service on port {port} is not responding to /health after "
                 f"{args.health_timeout}s. Check service status with the serving skill."
@@ -780,10 +817,23 @@ def _main_standalone(
     args.tp = tp
     args.dp = dp
     args.port = port
+    if not args.devices:
+        session = getattr(args, "_session", None)
+        leased_devices = session.get("leases", {}).get("npu_devices", []) if isinstance(session, dict) else []
+        if leased_devices:
+            selected = sorted(int(item) for item in leased_devices)
+            need = tp * dp
+            if len(selected) < need:
+                raise SystemExit(
+                    f"session {args.session_id} leases {len(selected)} NPU devices "
+                    f"but standalone memory profiling needs {need} (tp={tp}, dp={dp})"
+                )
+            args.devices = ",".join(str(item) for item in selected[:need])
+            progress(f"Using leased session devices: {args.devices}")
 
     model_tag = Path(args.model).name.replace("/", "_")
     run_dir = ensure_run_dir(tag=args.tag or model_tag)
-    remote_dir = f"/tmp/vaws_memprof_{int(time.time())}"
+    remote_dir = unique_remote_tmp("vaws_memprof", args.session_id)
 
     progress(f"Output directory: {run_dir}")
     ssh_exec(ep, f"mkdir -p {remote_dir}")
@@ -796,6 +846,8 @@ def _main_standalone(
 
     manifest: dict = {
         "mode": "standalone",
+        "session_id": args.session_id,
+        "session_file": args.session_file,
         "model": args.model,
         "tp": tp,
         "dp": dp,
@@ -824,7 +876,7 @@ def _main_standalone(
         progress(f"ERROR: {e}")
         log_text = collect_vllm_logs(ep, remote_dir, run_dir)
         stop_service(ep)
-        _emit_env_recovery_hint(log_text, args.machine)
+        _emit_env_recovery_hint(log_text, args.machine or "", args.session_id)
         manifest["error"] = str(e)
         print(json.dumps(manifest, indent=2, ensure_ascii=False))
         sys.exit(1)

--- a/.agents/skills/ascend-profiling-analysis/SKILL.md
+++ b/.agents/skills/ascend-profiling-analysis/SKILL.md
@@ -48,7 +48,7 @@ description: Analyze Ascend NPU torch profiler output (kernel_details.csv / trac
 
 ```bash
 python3 .agents/skills/ascend-profiling-analysis/scripts/profile_analyze.py \
-  --machine <alias-or-ip> \
+  (--machine <alias-or-ip> | --session-id <id> | --session-file <session.json>) \
   ( --manifest <local-run-dir>/manifest.json
    | --remote-profile-root <remote-path> ) \
   [--tag <name>] \
@@ -71,7 +71,7 @@ Flag notes:
 
 行为：
 
-1. 解析 machine inventory，得到容器 SSH endpoint。
+1. 解析 machine inventory 或 session state，得到目标容器 SSH endpoint。若 `--manifest` 来自 session-scoped collection 且未显式传 target，则优先使用 manifest 里的 `session_file` / `session_id`，确保分析在采集同一个 session 容器内运行。
 2. 解析输入：
    - `--manifest`：读取 `analysis_status`、`remote_profile_root`、`schema_version`；若不是 `ok` 直接失败。
    - `--remote-profile-root`：直接走原始路径（用于历史 profiling）。

--- a/.agents/skills/ascend-profiling-analysis/references/acceptance.md
+++ b/.agents/skills/ascend-profiling-analysis/references/acceptance.md
@@ -36,8 +36,8 @@
 
 ### Artifact pull
 
-- [ ] By default, only the lightweight pull set is rsynced back (see `behavior.md`).
-- [ ] `--keep-remote-output` rsyncs the entire remote output dir locally.
+- [ ] By default, only the lightweight pull set is transferred back through manifest-verified SSH streaming (see `behavior.md`).
+- [ ] `--keep-remote-output` transfers the entire remote output dir locally through the same artifact path.
 - [ ] `normalized_event_index.csv` and `evidence/bubble_windows.jsonl` are excluded from the lightweight pull.
 
 ### Output JSON

--- a/.agents/skills/ascend-profiling-analysis/references/behavior.md
+++ b/.agents/skills/ascend-profiling-analysis/references/behavior.md
@@ -69,7 +69,7 @@ report/report.xlsx
 report/report.html
 ```
 
-Excluded from the lightweight set (large or only useful for deep debug; pull on demand with `--keep-remote-output` or by explicit `scp`):
+Excluded from the lightweight set (large or only useful for deep debug; pull on demand with `--keep-remote-output` or by explicit `remote_artifact_pull.py` against the remote output dir):
 
 ```
 normalized_event_index.csv
@@ -126,7 +126,7 @@ Hard fail (`status: "failed"` in stdout JSON, non-zero exit code):
 | `parity_sync` | tar-sync of `scripts/ascend_profile/` to remote failed | 3 |
 | `remote_analyze` | remote `analyze.py` exited non-zero or hit `--remote-timeout` | 4 |
 | `artifact_validation` | any required artifact missing, or `segment_manifest.json` reports `hard_errors > 0` / `interior_island_total > 0` | 5 |
-| `artifact_pull` | rsync of artifacts back to the local run dir failed | 6 |
+| `artifact_pull` | artifact manifest / SSH-streaming pull back to the local run dir failed | 6 |
 
 Soft outcomes (still `status: "ok"`):
 

--- a/.agents/skills/ascend-profiling-analysis/references/command-recipes.md
+++ b/.agents/skills/ascend-profiling-analysis/references/command-recipes.md
@@ -11,14 +11,24 @@ Feed that manifest to the analysis skill.
 
 ```bash
 python3 .agents/skills/ascend-profiling-analysis/scripts/profile_analyze.py \
-  --machine 173.131.1.2 \
   --manifest .vaws-local/ascend-profiling-collection/runs/20260507_qwen35_tp4_s3/manifest.json \
   --tag qwen35_tp4_s3
 ```
 
-The skill reads `analysis_status`, `remote_profile_root`, runs the analysis on
-the remote, and pulls `report/` plus the lightweight summaries back to
+The skill reads `analysis_status`, `remote_profile_root`, and any
+`session_file` / `session_id` recorded by collection. Session-scoped manifests
+are analyzed in the same session container by default. It then pulls `report/`
+plus the lightweight summaries back to
 `.vaws-local/profiling-analysis/runs/<timestamp>_qwen35_tp4_s3/`.
+
+To override the target explicitly:
+
+```bash
+python3 .agents/skills/ascend-profiling-analysis/scripts/profile_analyze.py \
+  --session-id scaffold-131-smoke \
+  --manifest .vaws-local/ascend-profiling-collection/runs/20260507_qwen35_tp4_s3/manifest.json \
+  --tag qwen35_tp4_s3
+```
 
 ## Single-root: historical raw root
 

--- a/.agents/skills/ascend-profiling-analysis/scripts/_common.py
+++ b/.agents/skills/ascend-profiling-analysis/scripts/_common.py
@@ -36,6 +36,7 @@ for _p in (str(LIB_DIR), str(MM_SCRIPTS)):
         sys.path.insert(0, _p)
 
 import inventory as inventory_store  # noqa: E402
+from vaws_session_state import load_session_lookup, session_record_for_execution  # noqa: E402
 
 ANALYSIS_STATE_DIR = ROOT / ".vaws-local" / "profiling-analysis" / "runs"
 PROGRESS_SENTINEL = "__VAWS_PROFILE_ANALYSIS_PROGRESS__="
@@ -203,6 +204,42 @@ def get_machine_alias(machine: dict[str, Any]) -> str:
     else:
         host_ip = host or "unknown"
     return machine.get("alias", host_ip)
+
+
+def resolve_execution_target(
+    machine: str | None,
+    *,
+    session_id: str | None = None,
+    session_file: str | Path | None = None,
+) -> dict[str, Any]:
+    if session_id or session_file:
+        lookup = load_session_lookup(
+            session_id=session_id,
+            session_file=session_file,
+            repo_root=ROOT,
+        )
+        record = session_record_for_execution(lookup.session)
+        return {
+            "mode": "session",
+            "record": record,
+            "alias": get_machine_alias(record),
+            "endpoint": endpoint_from_machine(record),
+            "session_id": lookup.session["session_id"],
+            "session_file": str(lookup.session_file),
+            "session": lookup.session,
+        }
+    if not machine:
+        raise ValueError("--machine is required unless --session-id or --session-file is used")
+    record = resolve_machine(machine)
+    return {
+        "mode": "legacy",
+        "record": record,
+        "alias": get_machine_alias(record),
+        "endpoint": endpoint_from_machine(record),
+        "session_id": None,
+        "session_file": None,
+        "session": None,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/README.md
+++ b/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/README.md
@@ -73,12 +73,14 @@ should call `analyze.py` unless it needs to inspect an intermediate artifact.
 
 Do not parse large profiling roots on the local Mac.  Local execution is limited
 to static checks and small schema validation.  Real profiling analysis should
-run inside the remote container that has the profiling data, for example:
+run through the skill entrypoint inside the remote container that has the
+profiling data, for example:
 
 ```bash
-ssh -p 46000 root@173.131.1.2 \
-  'cd /tmp/ascend_profile_framework && \
-   python3 -m ascend_profile.analyze PROFILE_ROOT --output OUT_DIR'
+python3 .agents/skills/ascend-profiling-analysis/scripts/profile_analyze.py \
+  --session-id <session-id> \
+  --remote-profile-root PROFILE_ROOT \
+  --remote-output-dir OUT_DIR
 ```
 
 ## Required Traceability

--- a/.agents/skills/ascend-profiling-analysis/scripts/profile_analyze.py
+++ b/.agents/skills/ascend-profiling-analysis/scripts/profile_analyze.py
@@ -6,7 +6,7 @@ Inputs (one of):
   --remote-profile-root <abs-path>            -- raw remote profiling root (historical)
 
 Behavior:
-  1. Resolve machine + SSH endpoint via inventory.
+  1. Resolve machine/session + SSH endpoint via inventory or session state.
   2. Tar-sync ``scripts/ascend_profile/`` to ``<remote-work-dir>/ascend_profile/``.
   3. Remote: ``python3 -m ascend_profile.analyze <ROOT> --output <OUT> --verbose``.
   4. Validate required artifacts exist on the remote.
@@ -37,7 +37,9 @@ def _build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         allow_abbrev=False,
     )
-    parser.add_argument("--machine", required=True, help="alias or IP from machine inventory")
+    parser.add_argument("--machine", help="alias or IP from machine inventory")
+    parser.add_argument("--session-id", help="VAWS session id")
+    parser.add_argument("--session-file", help="explicit session.json path")
     src = parser.add_mutually_exclusive_group(required=True)
     src.add_argument("--manifest", help="path to ascend-profiling-collection manifest.json")
     src.add_argument("--remote-profile-root", help="absolute remote path to profiling root")
@@ -320,14 +322,33 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     remote_profile_root = input_info["remote_profile_root"]
     manifest = input_info["manifest"]
+    if manifest is not None and not args.session_id and not args.session_file:
+        args.session_id = manifest.get("session_id")
+        args.session_file = manifest.get("session_file")
 
-    machine = common.resolve_machine(args.machine)
-    alias = common.get_machine_alias(machine)
-    endpoint = common.endpoint_from_machine(machine)
+    try:
+        target = common.resolve_execution_target(
+            args.machine,
+            session_id=args.session_id,
+            session_file=args.session_file,
+        )
+    except ValueError as exc:
+        common.print_json(
+            {
+                "status": "failed",
+                "phase": "resolve",
+                "error": str(exc),
+            }
+        )
+        return 2
+    alias = target["alias"]
+    endpoint = target["endpoint"]
     common.progress(
         "resolve",
-        "machine resolved",
+        "target resolved",
         machine=alias,
+        mode=target["mode"],
+        session_id=target["session_id"],
         host=endpoint.host,
         ssh_port=endpoint.port,
     )
@@ -345,6 +366,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "phase": "setup",
                 "error": str(exc),
                 "machine": alias,
+                "session_id": target["session_id"],
             }
         )
         return 2
@@ -523,6 +545,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     output: dict[str, Any] = {
         "status": "ok",
         "machine": alias,
+        "mode": target["mode"],
+        "session_id": target["session_id"],
+        "session_file": target["session_file"],
         "remote_profile_root": remote_profile_root,
         "remote_output_dir": remote_output_dir,
         "local_output_dir": str(run_dir),

--- a/.agents/skills/ascend-profiling-collection/SKILL.md
+++ b/.agents/skills/ascend-profiling-collection/SKILL.md
@@ -43,13 +43,14 @@ This skill is **only** about collection: start a profiled service, bracket a wor
   2. number of `*_ascend_pt` directories does not match `tp * (dp or 1)`
   3. workload was not real — follow-up request failed or benchmark wave fell below `--benchmark-success-threshold`
 - Progress on `stderr` as `__VAWS_PROFILING_COLLECTION_PROGRESS__=<json>`. Final manifest on `stdout` as one JSON object.
-- Local state lives **only** under `.vaws-local/ascend-profiling-collection/runs/`.
+- For parallel agent work, create a session first and pass `--session-id <id>`. Service start/stop and parity then stay scoped to that session.
+- Local state lives under `.vaws-local/ascend-profiling-collection/runs/` for collection manifests; serving/parity state follows the target mode.
 
 ## Public entry point
 
 ```bash
 python3 .agents/skills/ascend-profiling-collection/scripts/collect_torch_profile_case.py \
-  --machine <alias-or-ip> \
+  (--machine <alias-or-ip> | --session-id <id>) \
   --model <remote-weight-path> \
   --served-model-name <name> \
   --tp <N> \
@@ -78,7 +79,7 @@ The script intentionally has no Qwen-specific defaults. The agent must always pa
 
 | Required arg | Why |
 | --- | --- |
-| `--machine` | Target container; resolved through inventory |
+| `--machine` or `--session-id` | Target container; sessions are preferred for parallel work |
 | `--model` / `--served-model-name` | Different cases need different models, no safe default |
 | `--tp` | Hardware shape; never assume it |
 | `--mode` | The profile is meaningless without recording which graph mode produced it |
@@ -97,14 +98,14 @@ The agent can call these directly if it already has a service running and only w
 ```bash
 # Start a profile window on a service that the serving skill already launched
 python3 .agents/skills/ascend-profiling-collection/scripts/profile_control.py \
-  --machine <alias> --action start_profile [--timeout 900]
+  (--machine <alias> | --session-id <id>) --action start_profile [--timeout 900]
 
 # Close it
 python3 .agents/skills/ascend-profiling-collection/scripts/profile_control.py \
-  --machine <alias> --action stop_profile [--timeout 900]
+  (--machine <alias> | --session-id <id>) --action stop_profile [--timeout 900]
 ```
 
-The script reads the service port from `.vaws-local/serving/<alias>.json`. A service must be running.
+The script reads the service port from `.vaws-local/serving/<alias>.json` in legacy mode or `.vaws-local/sessions/<id>/serving.json` in session mode. A service must be running.
 
 ### Re-run `analyse()` on an existing root
 

--- a/.agents/skills/ascend-profiling-collection/references/acceptance.md
+++ b/.agents/skills/ascend-profiling-collection/references/acceptance.md
@@ -22,6 +22,8 @@ A collection run is "good" when **all** of the following hold. The agent should 
 
 If `service_result.status` is anything else (`failed`, `needs_input`, ...) the run did not actually capture anything; the manifest will already be `status=failed` but verify this is the cause before retrying.
 
+In session mode, `service_result.session_id` should match the requested session, and cleanup must call `serve_stop.py` for that same session.
+
 ## 3. Profile window opened and closed cleanly
 
 ```jsonc
@@ -86,7 +88,7 @@ The orchestrator passes `--expected-ranks = tp * (dp or 1)` to `run_remote_analy
 "stop_result": { "status": "stopped", ... }
 ```
 
-If `stop_result.status` is `failed`, an orphan vLLM process may still be holding NPUs. Run `serve_stop.py --machine <alias> --force` and re-check `serve_probe_npus.py` before launching the next collection.
+If `stop_result.status` is `failed`, an orphan vLLM process may still be holding NPUs. Use the same target scope as the collection run (`serve_stop.py --session-id <id> --force` for session runs, or `serve_stop.py --machine <alias> --force` for legacy runs) and re-check `serve_probe_npus.py` before launching the next collection.
 
 ## When you need to re-collect (not re-analyse)
 

--- a/.agents/skills/ascend-profiling-collection/references/behavior.md
+++ b/.agents/skills/ascend-profiling-collection/references/behavior.md
@@ -94,6 +94,8 @@ One directory per invocation. Nothing else is ever written here. The remote prof
 
 Code parity is enforced transitively through `serve_start.py`. The collection skill must not call parity itself. The `.vaws-runtime` preserve carve-out and the `uv pip install --system` fix that profiling needed are owned by the parity skill — see `.agents/skills/remote-code-parity/SKILL.md`.
 
+When `--session-id` is used, `serve_start.py`, `profile_control.py`, and `serve_stop.py` all use the session container and session serving state. This allows two profiling collections on the same base host to run without stopping each other's services.
+
 ## Manifest schema versioning
 
 `schema_version` starts at 1. Bump only when a field is renamed or removed. Adding new fields (e.g. richer profiler config knobs) does not require a bump; the analysis skill should treat unknown fields as advisory.

--- a/.agents/skills/ascend-profiling-collection/references/command-recipes.md
+++ b/.agents/skills/ascend-profiling-collection/references/command-recipes.md
@@ -16,6 +16,20 @@ python3 .agents/skills/ascend-profiling-collection/scripts/collect_torch_profile
   --benchmark-output-tokens 64
 ```
 
+Session-scoped equivalent:
+
+```bash
+python3 .agents/skills/ascend-profiling-collection/scripts/collect_torch_profile_case.py \
+  --session-id pr123 \
+  --model /home/weights/Qwen3-8B \
+  --served-model-name Qwen3-8B \
+  --tp 1 \
+  --tag qwen3_8b_eager_text \
+  --mode enforce_eager \
+  --request-kind text \
+  --benchmark-output-tokens 64
+```
+
 ## Full-decode-only graph mode with MTP=3 speculative decoding
 
 ```bash
@@ -94,7 +108,7 @@ python3 .agents/skills/ascend-profiling-collection/scripts/profile_control.py \
   --machine blue-a --action stop_profile --timeout 900
 ```
 
-The script reads the service port from `.vaws-local/serving/<alias>.json`.
+The script reads the service port from `.vaws-local/serving/<alias>.json`, or from `.vaws-local/sessions/<id>/serving.json` when called with `--session-id`.
 
 ## What NOT to do
 

--- a/.agents/skills/ascend-profiling-collection/scripts/_common.py
+++ b/.agents/skills/ascend-profiling-collection/scripts/_common.py
@@ -18,6 +18,7 @@ import socket
 import subprocess
 import sys
 import textwrap
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -59,6 +60,7 @@ SERVING = _load_serving_common()
 SshEndpoint = SERVING.SshEndpoint
 ssh_exec = SERVING.ssh_exec
 resolve_machine = SERVING.resolve_machine
+resolve_execution_target = SERVING.resolve_execution_target
 container_endpoint = SERVING.container_endpoint
 host_endpoint = SERVING.host_endpoint
 load_serving_state = SERVING.load_serving_state
@@ -190,31 +192,45 @@ def call_json_command(cmd: list[str], *, cwd: Path | None = None) -> dict[str, A
     underlying serving / parity scripts. Raises RuntimeError on non-zero exit
     or non-JSON output, with both streams attached.
     """
-    result = subprocess.run(
+    proc = subprocess.Popen(
         cmd,
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         cwd=str(cwd or ROOT),
     )
-    if result.stderr:
-        sys.stderr.write(result.stderr)
-        sys.stderr.flush()
-    if result.returncode != 0:
+    stderr_lines: list[str] = []
+
+    def relay_stderr() -> None:
+        assert proc.stderr is not None
+        for line in proc.stderr:
+            stderr_lines.append(line)
+            sys.stderr.write(line)
+            sys.stderr.flush()
+
+    thread = threading.Thread(target=relay_stderr, daemon=True)
+    thread.start()
+    assert proc.stdout is not None
+    stdout = proc.stdout.read()
+    returncode = proc.wait()
+    thread.join(timeout=1)
+    stderr = "".join(stderr_lines)
+    if returncode != 0:
         raise RuntimeError(
-            f"command failed (rc={result.returncode}): {' '.join(cmd)}\n"
-            f"stdout={result.stdout[:2000]}\nstderr={result.stderr[:2000]}"
+            f"command failed (rc={returncode}): {' '.join(cmd)}\n"
+            f"stdout={stdout[:2000]}\nstderr={stderr[:2000]}"
         )
-    if not result.stdout.strip():
+    if not stdout.strip():
         raise RuntimeError(
             f"command produced no output: {' '.join(cmd)}\n"
-            f"stderr={result.stderr[:2000]}"
+            f"stderr={stderr[:2000]}"
         )
     try:
-        return json.loads(result.stdout)
+        return json.loads(stdout)
     except json.JSONDecodeError as exc:
         raise RuntimeError(
             f"command returned non-JSON output: {' '.join(cmd)}\n"
-            f"stdout={result.stdout[:2000]}"
+            f"stdout={stdout[:2000]}"
         ) from exc
 
 
@@ -227,8 +243,22 @@ def call_serve_start(extra_args: list[str]) -> dict[str, Any]:
     return call_json_command(cmd)
 
 
-def call_serve_stop(machine: str, *, force: bool = False) -> dict[str, Any]:
-    cmd = [sys.executable, str(SERVING_SCRIPTS / "serve_stop.py"), "--machine", machine]
+def call_serve_stop(
+    machine: str | None,
+    *,
+    session_id: str | None = None,
+    session_file: str | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    cmd = [sys.executable, str(SERVING_SCRIPTS / "serve_stop.py")]
+    if session_file:
+        cmd.extend(["--session-file", session_file])
+    elif session_id:
+        cmd.extend(["--session-id", session_id])
+    else:
+        if not machine:
+            raise RuntimeError("machine is required unless session_id or session_file is provided")
+        cmd.extend(["--machine", machine])
     if force:
         cmd.append("--force")
     return call_json_command(cmd)

--- a/.agents/skills/ascend-profiling-collection/scripts/collect_torch_profile_case.py
+++ b/.agents/skills/ascend-profiling-collection/scripts/collect_torch_profile_case.py
@@ -57,6 +57,7 @@ from _common import (
     now_utc,
     open_local_tunnel,
     print_json,
+    resolve_execution_target,
     resolve_machine,
 )
 from profile_control import post_remote_action
@@ -314,11 +315,16 @@ def _evaluate_workload(
 
 def _build_serve_args(args: argparse.Namespace, profiler_config: dict[str, Any]) -> list[str]:
     serve_args: list[str] = [
-        "--machine", args.machine,
         "--model", args.model,
         "--served-model-name", args.served_model_name,
         "--tp", str(args.tp),
     ]
+    if args.session_file:
+        serve_args[:0] = ["--session-file", args.session_file]
+    elif args.session_id:
+        serve_args[:0] = ["--session-id", args.session_id]
+    else:
+        serve_args[:0] = ["--machine", args.machine]
     if args.dp is not None and args.dp > 1:
         serve_args.extend(["--dp", str(args.dp)])
     serve_args.extend([
@@ -382,8 +388,10 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
 
     # Required: target + workload identity
-    p.add_argument("--machine", required=True,
+    p.add_argument("--machine",
                    help="machine alias or host IP (must be ready in inventory)")
+    p.add_argument("--session-id", help="VAWS session id")
+    p.add_argument("--session-file", help="explicit session.json path")
     p.add_argument("--model", required=True,
                    help="absolute remote path to model weights")
     p.add_argument("--served-model-name", required=True,
@@ -483,6 +491,24 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    if not args.machine and not args.session_id and not args.session_file:
+        print_json({
+            "status": "failed",
+            "error": "--machine is required unless --session-id or --session-file is used",
+        })
+        return 2
+
+    session_target = None
+    if args.session_id or args.session_file:
+        session_target = resolve_execution_target(
+            args.machine,
+            session_id=args.session_id,
+            session_file=args.session_file,
+        )
+        args.session_id = session_target.session_id
+        args.session_file = str(session_target.session_file) if session_target.session_file else args.session_file
+        if not args.machine:
+            args.machine = session_target.alias
 
     ensure_dir(COLLECTION_STATE_DIR)
     run_dir = COLLECTION_STATE_DIR / f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{args.tag}"
@@ -520,6 +546,8 @@ def main(argv: list[str] | None = None) -> int:
         "started_at": now_utc(),
         "tag": args.tag,
         "machine": args.machine,
+        "session_id": args.session_id,
+        "session_file": args.session_file,
         "model": args.model,
         "served_model_name": args.served_model_name,
         "tp": args.tp,
@@ -550,7 +578,7 @@ def main(argv: list[str] | None = None) -> int:
     service_result: dict[str, Any] | None = None
     stop_result: dict[str, Any] | None = None
     try:
-        emit_progress("serve_start", f"starting service on {args.machine}")
+        emit_progress("serve_start", f"starting service on {args.session_id or args.machine}")
         service_result = call_serve_start(serve_args)
         manifest["service_result"] = service_result
         if service_result.get("status") != "ready":
@@ -560,8 +588,17 @@ def main(argv: list[str] | None = None) -> int:
         port = int(service_result["port"])
         profile_root = f"{runtime_dir}/{args.torch_profiler_dir}"
 
-        record = resolve_machine(args.machine)
-        ep = container_endpoint(record)
+        if args.session_id or args.session_file:
+            if session_target is None:
+                session_target = resolve_execution_target(
+                    args.machine,
+                    session_id=args.session_id,
+                    session_file=args.session_file,
+                )
+            ep = session_target.endpoint
+        else:
+            record = resolve_machine(args.machine)
+            ep = container_endpoint(record)
 
         with open_local_tunnel(ep, port) as tunnel:
             manifest["request_tunnel"] = tunnel
@@ -623,7 +660,11 @@ def main(argv: list[str] | None = None) -> int:
         time.sleep(POST_STOP_FLUSH_SECONDS)
 
         emit_progress("serve_stop", "stopping service")
-        stop_result = call_serve_stop(args.machine)
+        stop_result = call_serve_stop(
+            args.machine,
+            session_id=args.session_id,
+            session_file=args.session_file,
+        )
         manifest["stop_result"] = stop_result
 
         expected_ranks = manifest["expected_ranks"]
@@ -678,11 +719,20 @@ def main(argv: list[str] | None = None) -> int:
         manifest["failed_at"] = now_utc()
         if stop_result is None:
             try:
-                stop_result = call_serve_stop(args.machine)
+                stop_result = call_serve_stop(
+                    args.machine,
+                    session_id=args.session_id,
+                    session_file=args.session_file,
+                )
                 manifest["stop_result"] = stop_result
             except Exception:  # noqa: BLE001
                 try:
-                    stop_result = call_serve_stop(args.machine, force=True)
+                    stop_result = call_serve_stop(
+                        args.machine,
+                        session_id=args.session_id,
+                        session_file=args.session_file,
+                        force=True,
+                    )
                     manifest["stop_result"] = stop_result
                 except Exception as stop_exc:  # noqa: BLE001
                     manifest["stop_error"] = str(stop_exc)

--- a/.agents/skills/ascend-profiling-collection/scripts/profile_control.py
+++ b/.agents/skills/ascend-profiling-collection/scripts/profile_control.py
@@ -17,6 +17,7 @@ ordinary inference request, so the timeout is long by default.
 
 Usage:
     python3 profile_control.py --machine <alias> --action start_profile
+    python3 profile_control.py --session-id <id> --action start_profile
     python3 profile_control.py --machine <alias> --action stop_profile [--timeout 900]
 
 Progress on stderr, final JSON on stdout.
@@ -36,11 +37,10 @@ if str(_SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPT_DIR))
 
 from _common import (
-    container_endpoint,
     emit_progress,
     load_serving_state,
     print_json,
-    resolve_machine,
+    resolve_execution_target,
     ssh_exec,
 )
 
@@ -101,7 +101,9 @@ def post_remote_action(ep, port: int, action: str, timeout: int) -> dict[str, An
 
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
-    p.add_argument("--machine", required=True, help="machine alias or host IP")
+    p.add_argument("--machine", help="machine alias or host IP")
+    p.add_argument("--session-id", help="VAWS session id")
+    p.add_argument("--session-file", help="explicit session.json path")
     p.add_argument(
         "--action",
         required=True,
@@ -125,15 +127,24 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
 
     try:
-        record = resolve_machine(args.machine)
-        alias = record["alias"]
-        ep = container_endpoint(record)
+        target = resolve_execution_target(
+            args.machine,
+            session_id=args.session_id,
+            session_file=args.session_file,
+        )
+        alias = target.alias
+        ep = target.endpoint
 
-        state = load_serving_state(alias)
+        state = load_serving_state(
+            alias,
+            session_id=target.session_id,
+            state_repo_root=target.state_repo_root,
+        )
         if state is None:
             print_json({
                 "status": "not_found",
                 "machine": alias,
+                "session_id": target.session_id,
                 "action": args.action,
                 "message": (
                     f"no serving state recorded for {alias}; start the service "
@@ -146,6 +157,7 @@ def main(argv: list[str] | None = None) -> int:
             print_json({
                 "status": "not_found",
                 "machine": alias,
+                "session_id": target.session_id,
                 "action": args.action,
                 "message": "serving state has no port; service may have failed to launch",
             })
@@ -162,6 +174,7 @@ def main(argv: list[str] | None = None) -> int:
         print_json({
             "status": "ok" if ok else "failed",
             "machine": alias,
+            "session_id": target.session_id,
             "action": args.action,
             "port": port,
             "http_status": result.get("status"),
@@ -174,6 +187,7 @@ def main(argv: list[str] | None = None) -> int:
         print_json({
             "status": "failed",
             "machine": getattr(args, "machine", None),
+            "session_id": getattr(args, "session_id", None),
             "action": getattr(args, "action", None),
             "error": str(exc),
         })

--- a/.agents/skills/ascend-profiling-collection/scripts/run_remote_analyse.py
+++ b/.agents/skills/ascend-profiling-collection/scripts/run_remote_analyse.py
@@ -25,7 +25,7 @@ Exit codes:
     2  -- the SSH or analyse() call itself failed
 
 Usage:
-    python3 run_remote_analyse.py --machine <alias> \\
+    python3 run_remote_analyse.py (--machine <alias> | --session-id <id>) \\
         --profile-root <path> [--expected-ranks <N>]
 
 The agent should always pass ``--expected-ranks`` when invoking this from a
@@ -51,10 +51,9 @@ if str(_SCRIPT_DIR) not in sys.path:
 
 from _common import (
     ASCEND_ENV_PREAMBLE,
-    container_endpoint,
     emit_progress,
     print_json,
-    resolve_machine,
+    resolve_execution_target,
     ssh_exec,
 )
 
@@ -203,7 +202,10 @@ def analyse_profile_root(
 
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
-    p.add_argument("--machine", required=True, help="machine alias or host IP")
+    target = p.add_mutually_exclusive_group(required=True)
+    target.add_argument("--machine", help="machine alias or host IP")
+    target.add_argument("--session-id", help="VAWS session id")
+    target.add_argument("--session-file", help="explicit session.json path")
     p.add_argument(
         "--profile-root",
         required=True,
@@ -230,15 +232,22 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
 
     try:
-        record = resolve_machine(args.machine)
-        alias = record["alias"]
-        ep = container_endpoint(record)
+        target = resolve_execution_target(
+            args.machine,
+            session_id=args.session_id,
+            session_file=args.session_file,
+        )
+        alias = target.alias
+        ep = target.endpoint
 
         emit_progress("discover", f"listing *_ascend_pt under {args.profile_root}")
         bundle = analyse_profile_root(
             ep, args.profile_root, expected_ranks=args.expected_ranks
         )
         bundle["machine"] = alias
+        bundle["mode"] = target.mode
+        bundle["session_id"] = target.session_id
+        bundle["session_file"] = str(target.session_file) if target.session_file else None
 
         worst = bundle["analysis_status"]
         if worst == "no_profile_dirs":
@@ -255,6 +264,8 @@ def main(argv: list[str] | None = None) -> int:
         print_json({
             "status": "failed",
             "machine": getattr(args, "machine", None),
+            "session_id": getattr(args, "session_id", None),
+            "session_file": getattr(args, "session_file", None),
             "profile_root": getattr(args, "profile_root", None),
             "error": str(exc),
         })

--- a/.agents/skills/machine-management/SKILL.md
+++ b/.agents/skills/machine-management/SKILL.md
@@ -218,6 +218,7 @@ Do not remove host firewall rules or host-level `authorized_keys` entries.
 - Container bootstrap should leave behind `/etc/vaws/host-info.json`, `/etc/vaws/container-info.json`, and `/etc/profile.d/vaws-ascend-env.sh` so later verify / repair runs can see the recorded machine type, container type, and SoC quickly.
 - Container bootstrap should write `/etc/pip.conf` with multiple pip indexes (Tsinghua as primary, Aliyun and PyPI as additional) so any subsequent `pip install` inside the container does not fail due to missing mirror configuration.
 - Container bootstrap should install `pytest` into the runtime Python if not already present, so that remote test execution works out of the box without ad-hoc environment setup.
+- Session-management may opt into the shared bootstrap helper's prepared image cache for short-lived session containers. Normal `machine_add.py` / `machine_repair.py` managed-base-container flows keep raw selected-image bootstrap behavior unless explicitly wired otherwise.
 - Keep `rc` and `stable` resolution dynamic: resolve the newest official prerelease tag or latest official non-prerelease release tag at execution time instead of using the moving `latest` tag.
 - Keep progress on `stderr` and the final status JSON on `stdout`; do not mix partial human narration into the terminal contract.
 - For smoke tests, do not pin a Python patch version. Discover the highest available `/usr/local/python*/bin/python3`, then fall back to `python3`.

--- a/.agents/skills/machine-management/references/acceptance.md
+++ b/.agents/skills/machine-management/references/acceptance.md
@@ -69,6 +69,8 @@ These should not trigger `machine-management` unless machine readiness is the ob
 - the skill configures a dedicated container `sshd` on a high port without brittle inline edits to `/etc/ssh/sshd_config`
 - the container bootstrap ensures `/run/sshd` exists
 - space-containing remote arguments such as SSH public keys and mesh peer keys survive the SSH hop intact
+- when the shared bootstrap helper's prepared-image cache is not requested, `machine_add.py` and `machine_repair.py` keep raw selected-image bootstrap behavior
+- when a caller explicitly requests the prepared-image cache, the helper reports `prepared_image`, `used_prepared_image_cache`, and `created_prepared_image_cache` in the bootstrap payload
 - `machine_add.py` persists final alias, namespace, host identity, container name, image, and SSH port into inventory without the agent having to call `inventory.py put`
 - the recorded inventory image is the actual selected image after mirror resolution and pull / cache fallback
 - selector-based image resolution is hardware-aware: A2 keeps the base tag, A3 appends `-a3`, and 310P appends `-310p`

--- a/.agents/skills/machine-management/references/behavior.md
+++ b/.agents/skills/machine-management/references/behavior.md
@@ -178,6 +178,8 @@ The managed config must enforce:
 - password auth disabled
 - dedicated PID file
 
+The shared bootstrap helper also supports an opt-in prepared image cache for session-management. When enabled by its caller, it may prefer a local exact image hit for non-moving image policies, derive `vaws-session-prepared:<base-image-id>-ssh-v2`, and use that image to skip repeated `openssh` package installation plus pip / pytest bootstrap for short-lived session containers. The normal managed-base-container add / repair wrappers do not enable this cache by default, preserving conservative raw selected-image behavior.
+
 The container bootstrap must ensure `/run/sshd` exists before starting the dedicated daemon.
 Remote-script arguments that may contain spaces, such as SSH public keys or mesh peer keys, must survive the local -> ssh -> remote-shell hop intact. Do not rely on raw argv joining for those values.
 

--- a/.agents/skills/machine-management/scripts/_workflow_common.py
+++ b/.agents/skills/machine-management/scripts/_workflow_common.py
@@ -520,6 +520,7 @@ def bootstrap_container(
     soc: str | None = None,
     public_key_file: str | None = None,
     replace_container_on_image_change: bool = False,
+    use_prepared_image_cache: bool = False,
 ) -> dict[str, Any]:
     key_path, private_key, public_key, needs_input = ensure_local_public_key(public_key_file)
     if needs_input is not None:
@@ -540,6 +541,7 @@ def bootstrap_container(
             "true" if replace_container_on_image_change else "false",
             machine_type or "",
             soc or "",
+            "true" if use_prepared_image_cache else "false",
         ],
         batch_mode=True,
         timeout_seconds=machine_ops.DEFAULT_BOOTSTRAP_TIMEOUT_SECONDS,

--- a/.agents/skills/machine-management/scripts/manage_machine.py
+++ b/.agents/skills/machine-management/scripts/manage_machine.py
@@ -1227,6 +1227,7 @@ namespace="${6:-}"
 replace_on_image_change="${7:-false}"
 machine_type_input="${8:-}"
 soc_input="${9:-}"
+use_prepared_image_cache="${10:-false}"
 
 emit_json() {
   python3 - "$1" <<'PY'
@@ -1342,6 +1343,20 @@ infer_type_from_image() {
     return 0
   fi
   return 1
+}
+
+prepared_image_tag() {
+  image_ref="$1"
+  image_id="$(docker image inspect -f '{{.Id}}' "$image_ref" 2>/dev/null || true)"
+  if [ -z "$image_id" ]; then
+    return 1
+  fi
+  image_hash="${image_id#sha256:}"
+  image_hash="$(printf '%s' "$image_hash" | tr '[:upper:]' '[:lower:]' | cut -c1-16)"
+  if [ -z "$image_hash" ]; then
+    return 1
+  fi
+  printf 'vaws-session-prepared:%s-ssh-v2\n' "$image_hash"
 }
 
 write_host_state() {
@@ -1536,14 +1551,47 @@ elif command -v yum >/dev/null 2>&1; then
   printf '%s' '{"package_manager":"yum","selected_mirror":null,"candidate_timings_ms":{},"changed_files":[],"changed":false,"install_skipped":false}' > "$state_file"
   echo "yum install openssh-server openssh-clients"
   yum install -y openssh-server openssh-clients
-elif command -v microdnf >/dev/null 2>&1; then
-  printf '%s' '{"package_manager":"microdnf","selected_mirror":null,"candidate_timings_ms":{},"changed_files":[],"changed":false,"install_skipped":false}' > "$state_file"
-  echo "microdnf install openssh-server openssh-clients"
-  microdnf install -y openssh-server openssh-clients
-else
-  echo "no supported package manager found for ssh installation" >&2
-  exit 97
-fi
+  elif command -v microdnf >/dev/null 2>&1; then
+    printf '%s' '{"package_manager":"microdnf","selected_mirror":null,"candidate_timings_ms":{},"changed_files":[],"changed":false,"install_skipped":false}' > "$state_file"
+    echo "microdnf install openssh-server openssh-clients"
+    microdnf install -y openssh-server openssh-clients
+  else
+    echo "no supported package manager found for ssh installation" >&2
+    exit 97
+  fi
+  _vaws_runtime_python=""
+  for _d in $(ls -1d /usr/local/python*/bin 2>/dev/null | sort -V -r); do
+    if [ -x "$_d/python3" ]; then
+      _vaws_runtime_python="$_d/python3"
+      break
+    fi
+  done
+  if [ -z "$_vaws_runtime_python" ] && command -v python3 >/dev/null 2>&1; then
+    _vaws_runtime_python="$(command -v python3)"
+  fi
+  if [ -n "$_vaws_runtime_python" ]; then
+    install -d -m 0755 /etc/pip
+    cat > /etc/pip.conf <<'EOF_PIP'
+[global]
+index-url = https://pypi.tuna.tsinghua.edu.cn/simple
+extra-index-url = https://mirrors.aliyun.com/pypi/simple https://pypi.org/simple
+trusted-host = pypi.tuna.tsinghua.edu.cn mirrors.aliyun.com pypi.org files.pythonhosted.org
+EOF_PIP
+    chmod 0644 /etc/pip.conf
+    echo "[vaws-bootstrap] pip configured: /etc/pip.conf (primary=tsinghua, additional=aliyun,pypi)"
+    if "$_vaws_runtime_python" -c "import pytest" >/dev/null 2>&1; then
+      echo "[vaws-bootstrap] pytest already present"
+    else
+      echo "[vaws-bootstrap] installing pytest..."
+      if "$_vaws_runtime_python" -m pip install pytest -q --disable-pip-version-check 2>/dev/null; then
+        echo "[vaws-bootstrap] pytest installed"
+      else
+        echo "[vaws-bootstrap] pytest install failed (best-effort, continuing)"
+      fi
+    fi
+  else
+    echo "[vaws-bootstrap] runtime python not found, skipping pip/pytest setup"
+  fi
 INNER_PKG
 }
 
@@ -1739,6 +1787,10 @@ pulled=false
 installed_ssh=false
 firewall="none"
 selected_image=""
+run_image=""
+prepared_image=""
+used_prepared_image_cache=false
+created_prepared_image_cache=false
 image_resolution="unknown"
 package_bootstrap='{"package_manager": null, "selected_mirror": null, "candidate_timings_ms": {}, "changed_files": [], "changed": false, "install_skipped": false}'
 host_env_file="/etc/profile.d/vaws-ascend-env.sh"
@@ -1748,6 +1800,7 @@ container_metadata_file="/etc/vaws/container-info.json"
 requested_image="$(image_field requested || true)"
 requested_selector="$(image_field selector || true)"
 image_policy="$(image_field policy || true)"
+docker_pull_policy="${VAWS_DOCKER_PULL_POLICY:-missing}"
 resolved_tag="$(image_field resolved_tag || true)"
 machine_type="${machine_type_input:-$(image_field machine_type || true)}"
 soc="${soc_input:-}"
@@ -1763,10 +1816,14 @@ container_exists=false
 if docker inspect "$container" >/dev/null 2>&1; then
   container_exists=true
   current_image=$(docker inspect -f '{{.Config.Image}}' "$container")
+  current_base_image=$(docker inspect -f '{{ index .Config.Labels "com.vaws.base_image" }}' "$container" 2>/dev/null || true)
+  if [ "$current_base_image" = "<no value>" ]; then
+    current_base_image=""
+  fi
   previous_image="$current_image"
   image_matches=false
   for candidate in "${image_candidates[@]}"; do
-    if [ "$candidate" = "$current_image" ]; then
+    if [ "$candidate" = "$current_image" ] || { [ "$use_prepared_image_cache" = "true" ] && [ "$candidate" = "$current_base_image" ]; }; then
       image_matches=true
       break
     fi
@@ -1807,6 +1864,20 @@ if [ "$container_exists" = "true" ]; then
   emit_progress "container" "running" "reusing an existing managed container" 15
   state=$(docker inspect -f '{{.State.Status}}' "$container")
   selected_image=$(docker inspect -f '{{.Config.Image}}' "$container")
+  run_image="$selected_image"
+  existing_base_image=$(docker inspect -f '{{ index .Config.Labels "com.vaws.base_image" }}' "$container" 2>/dev/null || true)
+  if [ "$existing_base_image" = "<no value>" ]; then
+    existing_base_image=""
+  fi
+  if [ "$use_prepared_image_cache" = "true" ] && [ -n "$existing_base_image" ]; then
+    run_image="$selected_image"
+    selected_image="$existing_base_image"
+    prepared_image="$(docker inspect -f '{{ index .Config.Labels "com.vaws.prepared_image" }}' "$container" 2>/dev/null || true)"
+    if [ "$prepared_image" = "<no value>" ]; then
+      prepared_image=""
+    fi
+    used_prepared_image_cache=true
+  fi
   image_resolution="existing-container"
   if [ "$state" != "running" ]; then
     docker start "$container" >/dev/null
@@ -1819,6 +1890,12 @@ else
   emit_progress "image" "running" "resolved image selector ${requested_image:-unknown} (${image_policy:-unknown})" 30
   for candidate in "${image_candidates[@]}"; do
     emit_progress "image" "running" "trying image candidate $candidate" 600
+    if [ "$docker_pull_policy" != "always" ] && [ "$image_policy" != "main-branch" ] && docker image inspect "$candidate" >/dev/null 2>&1; then
+      selected_image="$candidate"
+      image_resolution="local-cache"
+      actions+=("reused-local-image-cache")
+      break
+    fi
     if run_with_progress "image-pull" "docker pull $candidate" 600 docker pull "$candidate"; then
       selected_image="$candidate"
       image_resolution="pulled"
@@ -1827,12 +1904,6 @@ else
       break
     fi
     emit_progress "image" "running" "pull failed for $candidate; checking local cache" 30
-    if docker image inspect "$candidate" >/dev/null 2>&1; then
-      selected_image="$candidate"
-      image_resolution="local-cache"
-      actions+=("reused-local-image-cache")
-      break
-    fi
   done
   if [ -z "$selected_image" ]; then
     emit_json '{"success": false, "error": "no usable image candidate was found", "phase": "image"}'
@@ -1842,6 +1913,18 @@ else
     machine_type="$(infer_type_from_image "$selected_image" || true)"
   fi
   container_type="$machine_type"
+  run_image="$selected_image"
+  if [ "$use_prepared_image_cache" = "true" ]; then
+    prepared_image="$(prepared_image_tag "$selected_image" || true)"
+    if [ -n "$prepared_image" ] && docker image inspect "$prepared_image" >/dev/null 2>&1; then
+      emit_progress "image-cache" "running" "using prepared session image $prepared_image" 10
+      run_image="$prepared_image"
+      used_prepared_image_cache=true
+      actions+=("reused-prepared-image-cache")
+    elif [ -n "$prepared_image" ]; then
+      emit_progress "image-cache" "running" "prepared session image cache miss; will populate after ssh package install" 10
+    fi
+  fi
 
   mount_args=()
   for optional in /home /tmp /weight /data /mnt; do
@@ -1871,7 +1954,10 @@ else
     -v /usr/local/sbin:/usr/local/sbin \
     -v /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime:ro \
     "${mount_args[@]}" \
-    "$selected_image" >/dev/null
+    --label com.vaws.base_image="$selected_image" \
+    --label com.vaws.run_image="$run_image" \
+    --label com.vaws.prepared_image="$prepared_image" \
+    "$run_image" >/dev/null
 
   created=true
   actions+=("created-container")
@@ -1896,8 +1982,24 @@ if ! docker exec "$container" bash -lc 'command -v sshd >/dev/null 2>&1 && comma
   fi
   installed_ssh=true
   actions+=("installed-openssh")
+  if [ "$use_prepared_image_cache" = "true" ] && [ -n "$prepared_image" ] && ! docker image inspect "$prepared_image" >/dev/null 2>&1; then
+    emit_progress "image-cache" "running" "committing prepared session image $prepared_image" 120
+    if run_with_progress "image-cache-commit" "committing prepared session image" 120 docker commit "$container" "$prepared_image"; then
+      created_prepared_image_cache=true
+      actions+=("created-prepared-image-cache")
+    else
+      emit_progress "image-cache" "running" "prepared session image commit failed; continuing without cache" 30
+    fi
+  fi
 else
   package_bootstrap='{"package_manager": null, "selected_mirror": null, "candidate_timings_ms": {}, "changed_files": [], "changed": false, "install_skipped": true}'
+  if [ "$use_prepared_image_cache" = "true" ] && [ "$run_image" = "$selected_image" ] && [ -n "$prepared_image" ] && ! docker image inspect "$prepared_image" >/dev/null 2>&1; then
+    emit_progress "image-cache" "running" "tagging selected image as prepared session image $prepared_image" 30
+    if docker tag "$selected_image" "$prepared_image" >/dev/null 2>&1; then
+      created_prepared_image_cache=true
+      actions+=("tagged-prepared-image-cache")
+    fi
+  fi
 fi
 
 emit_progress "container-ssh" "running" "configuring dedicated container sshd" 60
@@ -1918,7 +2020,7 @@ elif command -v firewall-cmd >/dev/null 2>&1 && firewall-cmd --state >/dev/null 
   firewall="firewalld"
 fi
 
-payload=$(python3 - <<'PY' "$container" "$port" "$image_request_json" "$selected_image" "$image_resolution" "$workdir" "$namespace" "$created" "$started" "$pulled" "$installed_ssh" "$firewall" "${actions[*]}" "$previous_image" "$replace_on_image_change" "$machine_type" "$container_type" "$soc" "$host_env_file" "$host_metadata_file" "$container_env_file" "$container_metadata_file" "$package_bootstrap"
+payload=$(python3 - <<'PY' "$container" "$port" "$image_request_json" "$selected_image" "$image_resolution" "$workdir" "$namespace" "$created" "$started" "$pulled" "$installed_ssh" "$firewall" "${actions[*]}" "$previous_image" "$replace_on_image_change" "$machine_type" "$container_type" "$soc" "$host_env_file" "$host_metadata_file" "$container_env_file" "$container_metadata_file" "$package_bootstrap" "$run_image" "$prepared_image" "$use_prepared_image_cache" "$used_prepared_image_cache" "$created_prepared_image_cache" "$docker_pull_policy"
 import json
 import sys
 (
@@ -1945,6 +2047,12 @@ import sys
     container_env_file,
     container_metadata_file,
     package_bootstrap,
+    run_image,
+    prepared_image,
+    use_prepared_image_cache,
+    used_prepared_image_cache,
+    created_prepared_image_cache,
+    docker_pull_policy,
 ) = sys.argv[1:]
 image_request = json.loads(image_request_json)
 print(json.dumps({
@@ -1957,7 +2065,13 @@ print(json.dumps({
     "image_policy": image_request.get("policy"),
     "resolved_tag": image_request.get("resolved_tag"),
     "selected_image": selected_image,
+    "run_image": run_image or selected_image,
+    "prepared_image": prepared_image or None,
+    "prepared_image_cache_requested": use_prepared_image_cache == "true",
+    "used_prepared_image_cache": used_prepared_image_cache == "true",
+    "created_prepared_image_cache": created_prepared_image_cache == "true",
     "image_resolution": image_resolution,
+    "docker_pull_policy": docker_pull_policy,
     "image_candidates": list(image_request.get("candidates") or []),
     "image_mirror_order": list(image_request.get("mirror_order") or []),
     "workdir": workdir,

--- a/.agents/skills/remote-code-parity/SKILL.md
+++ b/.agents/skills/remote-code-parity/SKILL.md
@@ -29,15 +29,20 @@ Keep a **ready** remote runtime in exact code parity with the local `vllm-ascend
 - Do **not** use `scp`, `sftp`, `rsync`, `sshpass`, or `expect`.
 - Do **not** require GitHub credentials on the host or in the container.
 - Keep the sync path **container-only** after machine attach: no host storage root, no host mirror, no host lock.
+- For parallel agent work, use `parity_sync.py --session-id <id>`. Session mode derives the workspace root, container endpoint, workspace id, and container identity from `.vaws-local/sessions/<id>/session.json`.
 - Use synthetic snapshot refs so dirty working trees can move through Git transport.
 - Keep container cache / lock / manifest paths isolated by `workspace_id` under a container-local cache root.
 - Preserve runtime-private paths under `/vllm-workspace`, in particular `Mooncake/` (image-provided runtime) and `.vaws-runtime/` (workspace-managed runtime artifacts such as profiler dumps consumed by downstream skills). The exact list lives in `DEFAULT_ROOT_PRESERVE_PATHS` in `scripts/remote_code_parity.py`.
+- Container locks should record owner metadata and recover stale lock directories after the bounded stale interval; failed mirror hydration should best-effort clean any matching legacy `git-receive-pack` process trees and discard that repo's partial mirror before retry.
 - Keep `stdout` reserved for one final JSON summary and stream phase progress on `stderr` as `__VAWS_PARITY_PROGRESS__=<json>`.
 - Runtime install progress should be attributable at the package-step level: uninstall, `vllm`, `vllm-ascend` requirements, `vllm-ascend`, import smoke, and marker write.
-- Publish each synthetic snapshot to both the parity ref and an advertised branch ref inside the container-local mirror.
+- Publish each synthetic snapshot to both the parity ref and an advertised branch ref inside the container-local mirror. Use Git bundles imported inside the container so parentless transport snapshots do not depend on remote receive-pack negotiation or remote base objects.
 - Materialize child repos explicitly; do not rely on `git submodule update` to fetch synthetic child commits.
-- If a child repo snapshot has no tree changes, reuse its original `HEAD` commit instead of inventing a new gitlink-only delta that bubbles into the parent repo.
+- Synthetic commits are deterministic parentless tree snapshots. Keep each repo's real `HEAD` separately as `source_head` for reinstall drift detection instead of using it as the transport parent.
+- If a clean child repo only differs from the parent through the parentless transport commit id, suppress that transport-only child gitlink path from the parent repo's `changed_paths`.
 - Use dynamic Python / pip discovery plus a shell-safe env preamble, and source optional Ascend env scripts under a `set +u` / `set -u` guard instead of relying on shell-specific variables.
+- Runtime dependency installs may opt into a near-cache index with `VAWS_PIP_INDEX_URL`, `VAWS_PIP_EXTRA_INDEX_URL`, and `VAWS_PIP_TRUSTED_HOST`; these whitelisted local env vars are explicitly passed into the remote install shell because SSH does not reliably forward arbitrary local env. When no caller extra index is set, only the `vllm-ascend` requirements/editable steps add the public Ascend PyPI extra index.
+- Runtime editable installs use CI-aligned cache / compile defaults: `PIP_CACHE_DIR`, `UV_CACHE_DIR`, `FETCHCONTENT_BASE_DIR`, `UV_INDEX_STRATEGY=unsafe-best-match`, `MAX_JOBS=4`, and `CMAKE_BUILD_TYPE=Release`, all overrideable by environment. The effective remote install env is recorded in the manifest/runtime state with URL userinfo redacted. Do not default `COMPILE_CUSTOM_KERNELS=0`; that is only available as an explicit `VAWS_COMPILE_CUSTOM_KERNELS=0` unit-test-style override and is not valid for normal serving / benchmark runtime parity.
 - If editable install fails because the image packaging stack is too old, attempt one bounded packaging-stack refresh before failing closed.
 - Before invoking parity, confirm the local working tree represents the **intended deployment state**. If any submodule source files have uncommitted changes made for temporary debugging or hypothesis testing, revert them before syncing — do not sync exploratory patches to the remote.
 - If a previous parity sync in this session led to a failed remote execution and the agent subsequently modified local code, do not re-sync until the root cause of the failure is confirmed from remote logs (not from hypothesis).
@@ -82,8 +87,19 @@ Container commands in this skill assume Linux shells.
 
 Normal agent entrypoint:
 
-- POSIX: `python3 .agents/skills/remote-code-parity/scripts/parity_sync.py --machine <alias-or-ip> ...`
+- POSIX: `python3 .agents/skills/remote-code-parity/scripts/parity_sync.py (--machine <alias-or-ip> | --session-id <id>) ...`
 - Windows: `py -3 .agents/skills/remote-code-parity/scripts/parity_sync.py --machine <alias-or-ip> ...`
+
+Apply-mode split:
+
+- `--apply-mode source-only`: publish source snapshots to the container cache only; no runtime materialization and no install/rebuild.
+- `--apply-mode materialize`: publish snapshots and update the runtime source tree; no install/rebuild.
+- `--apply-mode install`: default full parity behavior with consent, materialization, install/rebuild triggers, and verification.
+
+Agent-facing sync tools:
+
+- `python3 .agents/scripts/remote_sync_plan.py ... --mode source-only|materialize|install`
+- `python3 .agents/scripts/remote_sync_apply.py ... --mode source-only|materialize|install`
 
 Consent helper:
 
@@ -119,7 +135,7 @@ The user can switch sync mode at any time. `--force-reinstall` overrides `image`
 
 ### 2. Resolve the ready target from inventory
 
-For normal agent work, start from `parity_sync.py`.
+For normal agent work, start from `parity_sync.py`. Use `--session-id` when the task was created by `session-management`; use legacy `--machine` only for single-tenant base-container work.
 
 Collect from local machine inventory:
 
@@ -145,8 +161,9 @@ For each repo:
 - stage the full current working tree with `git add -A`
 - reset local-only denylist paths and child-submodule paths from that temporary index
 - replace child submodule gitlinks with the child synthetic snapshot commit ids
-- write a synthetic commit
-- if the resulting tree matches the original `HEAD`, reuse the original commit so clean child repos do not trigger parent reinstall heuristics through gitlink churn
+- write a deterministic parentless synthetic commit for the resulting tree
+- record the repo's original `HEAD` as `source_head`; do not make the synthetic commit a child of that `HEAD`, because an empty container mirror would otherwise receive full vLLM history on first push
+- filter transport-only child gitlink paths out of `changed_paths` when the child `source_head` matches the parent gitlink and the child has no logical changes
 
 Ignored files stay ignored. The snapshot source of truth is tracked + untracked non-ignored.
 
@@ -155,7 +172,8 @@ Ignored files stay ignored. The snapshot source of truth is tracked + untracked 
 For each repo in scope:
 
 - ensure the container-local bare mirror repo exists under the cache root
-- push the synthetic commit to `refs/parity/<workspace_id>/current` and to an advertised branch ref inside that same mirror
+- create a local Git bundle for the synthetic ref, stream it to the container over SSH, and fetch that bundle into the container-local bare mirror
+- update `refs/parity/<workspace_id>/current` and an advertised branch ref inside that same mirror
 - write a compact manifest for this sync attempt under `manifests/`
 - use a **container-local** lock while mutating cache or runtime state
 
@@ -208,7 +226,7 @@ After the first approved replacement, reinstall only when one of the following t
 
 **Trigger 2 — commit drift from last sync:**
 
-Compare each repo's real HEAD commit with `last_head_commits` recorded in `runtime-state.json`. Synthetic snapshot commits change whenever the working tree is dirty, so drift detection must use the underlying HEAD to avoid false positives from pure-Python edits. If a repo's HEAD changed (e.g. the user did `git checkout v0.8.0` inside `vllm/`), trigger reinstall for that repo even when `changed_paths` is empty.
+Compare each repo's real `source_head` commit with `last_head_commits` recorded in `runtime-state.json`. Synthetic snapshot commits are parentless transport commits, so drift detection must use the underlying source HEAD to catch submodule version switches without treating ordinary dirty Python edits as rebuild triggers. If a repo's HEAD changed (e.g. the user did `git checkout v0.8.0` inside `vllm/`), trigger reinstall for that repo even when `changed_paths` is empty.
 
 **Trigger 3 — dependency cascade:**
 
@@ -220,7 +238,7 @@ Only uninstall the packages that will actually be reinstalled. If only `vllm-asc
 
 **Force reinstall:**
 
-Pass `--force-reinstall` to `parity_sync.py` to unconditionally reinstall both `vllm` and `vllm-ascend` regardless of what changed. This overrides all trigger logic above but still runs the full sync flow (snapshot, push, materialize, install, verify).
+Pass `--force-reinstall` to `parity_sync.py` to unconditionally reinstall both `vllm` and `vllm-ascend` regardless of what changed. This overrides all trigger logic above but still runs the full sync flow (snapshot, mirror hydration, materialize, install, verify).
 
 **`--force-reinstall` usage discipline:**
 
@@ -228,9 +246,22 @@ Use `--force-reinstall` only when (a) it is the first sync to a new container, (
 
 **No-change fast path:**
 
-If all snapshot commits match `last_snapshot_commits` and no reinstall is needed (and `--force-reinstall` is not set), the sync verifies container-side commits with a single SSH call and returns `status == ready` immediately, skipping push, materialize, and manifest upload.
+If all snapshot commits match `last_snapshot_commits` and no reinstall is needed (and `--force-reinstall` is not set), the sync verifies container-side commits with a single SSH call and returns `status == ready` immediately, skipping mirror hydration, materialize, and manifest upload.
 
-Use these commands inside the container when required. The normal path first unifies the runtime Python across `python`, `python3`, CMake, and CANN helper tools, sources optional Ascend env scripts under a `set +u` / `set -u` guard, then tries the in-place environment, and finally does one bounded packaging refresh / retry when legacy packaging metadata blocks editable install. Pip resolution should prefer Tsinghua, then Aliyun, then the public PyPI index:
+Use these commands inside the container when required. The normal path first unifies the runtime Python across `python`, `python3`, CMake, and CANN helper tools, sources optional Ascend env scripts under a `set +u` / `set -u` guard, then tries the in-place environment, and finally does one bounded packaging refresh / retry when legacy packaging metadata blocks editable install. Pip/uv resolution can use a caller-provided near-cache index first, then falls back to Tsinghua, Aliyun, and the public PyPI index. The public Ascend package index is added only for `vllm-ascend` dependency/install steps unless the caller explicitly sets `VAWS_PIP_EXTRA_INDEX_URL` or `PIP_EXTRA_INDEX_URL`.
+
+The install environment mirrors the portable parts of `vllm-ascend` CI:
+
+- cache roots default to `/root/.cache/pip`, `/root/.cache/uv`, and `/root/.cache/vaws/fetchcontent` so CMake `FetchContent` survives repo cleanups
+- editable installs default to `--no-deps` against the paired runtime image, and the `vllm-ascend` requirements step is skipped on ordinary paired-image replacement; dependency resolution is re-enabled when dependency files changed, a repo HEAD drifted, verify-deps detects a non-runtime mismatch, or the caller sets `VAWS_INSTALL_DEPS=1`
+- paired-image `torch_npu` is treated as runtime state: accept public-version matches and a successful real import instead of forcing a large wheel reinstall
+- `MAX_JOBS` defaults to `4` like CI and can be overridden with `VAWS_MAX_JOBS` or `MAX_JOBS`
+- `UV_INDEX_STRATEGY` defaults to `unsafe-best-match` because both CI and this workspace use multiple indexes
+- uv bootstrap is progress-wrapped and bounded by `VAWS_UV_BOOTSTRAP_TIMEOUT` seconds per mirror before falling back to the next mirror or pip-only installs; uv package installs are bounded by `VAWS_UV_INSTALL_TIMEOUT`, and `VAWS_DISABLE_UV=1` forces pip-only mode
+- `VAWS_SOC_VERSION` is forwarded as `SOC_VERSION` when the caller needs to pin chip selection instead of relying on `npu-smi`
+- custom kernel compilation remains enabled by default; set `VAWS_COMPILE_CUSTOM_KERNELS=0` only for non-runtime unit-test-style validation
+- `VAWS_USE_CLANG15=1` selects `clang-15` / `clang++-15` only when they are already installed in the image
+- after the editable `vllm` install, `triton` is removed best-effort to match Ascend CI's non-Triton runtime expectation
 
 ### `vllm`
 

--- a/.agents/skills/remote-code-parity/references/acceptance.md
+++ b/.agents/skills/remote-code-parity/references/acceptance.md
@@ -28,17 +28,35 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 - the skill does not use `scp`, `sftp`, `rsync`, `sshpass`, or `expect`
 - the skill does not require GitHub credentials on the host or in the container
 - the skill keeps local runtime state only under `.vaws-local/remote-code-parity/`
+- session mode resolves the source worktree and container endpoint from `.vaws-local/sessions/<session-id>/session.json`
 - normal outcomes are reported as compact JSON with `status` equal to `ready`, `blocked`, `failed`, or `dry-run`
 - phase progress is emitted on `stderr` as `__VAWS_PARITY_PROGRESS__=<json>` while the final summary stays on `stdout`
+- `remote_sync_plan.py --mode source-only` reports that install/rebuild will not run
+- `remote_sync_apply.py --mode source-only` completes without invoking runtime install phases
+- `remote_sync_plan.py --mode install` reports install/rebuild reasons and current consent state
 - long runtime-install waits remain attributable because uninstall, requirements install, editable install, import verification, and marker write each emit their own progress phase
-- runtime install keeps pip mirror fallback in the order Tsinghua -> Aliyun -> PyPI instead of hard-coding only the public index
+- whitelisted local env overrides such as `VAWS_MAX_JOBS`, `VAWS_PIP_INDEX_URL`, and `VAWS_SOC_VERSION` are explicitly exported inside the remote install shell instead of relying on SSH env forwarding
+- runtime install can opt into a caller-provided near-cache index via `VAWS_PIP_INDEX_URL`, then keeps pip mirror fallback in the order Tsinghua -> Aliyun -> PyPI instead of hard-coding only the public index
+- runtime install adds the Ascend PyPI repository as a default extra index only for `vllm-ascend` requirements/editable install steps and allows the caller to override it through `VAWS_PIP_EXTRA_INDEX_URL` or disable the default by exporting an empty `VAWS_ASCEND_PIP_EXTRA_INDEX_URL`
+- runtime install exports persistent pip, uv, and CMake `FetchContent` cache roots outside the synced repos so normal materialization cleanups do not delete dependency caches
+- runtime install wraps uv bootstrap with progress and a per-mirror timeout controlled by `VAWS_UV_BOOTSTRAP_TIMEOUT`, then continues with pip fallback when uv cannot be installed quickly
+- runtime install bounds uv package install attempts with `VAWS_UV_INSTALL_TIMEOUT` and supports `VAWS_DISABLE_UV=1` for pip-only validation when uv resolution stalls
+- runtime editable installs default to `--no-deps` against the paired image and skip ordinary `vllm-ascend` requirements reinstall; dependency resolution is re-enabled for dependency-file changes, HEAD drift, verify-deps repair, or `VAWS_INSTALL_DEPS=1`
+- paired-image `torch_npu` is verified by public-version compatibility and real import smoke instead of forcing a `torch-npu` wheel reinstall during verify-deps repair
+- runtime install defaults to `MAX_JOBS=4` and `CMAKE_BUILD_TYPE=Release`, while allowing `VAWS_MAX_JOBS`, `MAX_JOBS`, and `CMAKE_BUILD_TYPE` to override the compile profile
+- runtime install does not set `COMPILE_CUSTOM_KERNELS=0` unless the caller explicitly exports `VAWS_COMPILE_CUSTOM_KERNELS=0`
+- runtime install records its effective cache/compile/index env in the manifest, final summary, and runtime state with URL userinfo redacted
+- runtime install forwards `VAWS_SOC_VERSION` as `SOC_VERSION` and emits an `npu-smi` probe before building `vllm-ascend` when `npu-smi` is available
 
 ### Repo graph and snapshotting
 
 - the workspace root, `vllm/`, and `vllm-ascend/` all participate in parity
 - synthetic snapshots can represent dirty working trees without forcing a real commit
 - when `vllm` or `vllm-ascend` changed locally, the workspace-root synthetic snapshot also changes because the gitlinks are rewritten to the synthetic child commits
-- when a nested child repo has no tree changes, the parent repo does not report a gitlink-only change just because the child was snapshotted
+- synthetic snapshot commits are parentless, so first mirror hydration transfers the snapshot tree instead of the full upstream history
+- parentless snapshot mirror hydration uses Git bundle import, so it does not depend on remote receive-pack negotiation or remote base history that may not exist
+- repeated snapshots of the same workspace tree produce the same synthetic commit ids, enabling the no-change fast path
+- when a nested child repo has no logical changes, the parent repo does not report a reinstall-relevant `changed_paths` entry just because the child was represented by a parentless transport commit
 - ignored files are not added to the snapshot by default
 - denylisted files such as `.vaws-local/*`, `.env*`, and local cache directories are excluded
 - if a required submodule path exists but is not populated, the skill fails closed with a clear error instead of producing a traceback-heavy Git failure
@@ -46,9 +64,12 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 ### Container-only cache path
 
 - the normal sync path does not require host storage, host lock directories, or `docker inspect`
-- container-local bare mirrors are populated directly through container SSH
+- container-local bare mirrors are populated by SSH-streamed Git bundles, without requiring GitHub credentials or host storage
 - advertised branch refs are published inside the mirror so synthetic child commits are fetchable through ordinary Git paths
+- stale container lock directories are eventually recovered instead of permanently blocking later parity attempts
+- failed or timed-out mirror hydration does not leave matching legacy `git-receive-pack` process trees or partial repo mirrors blocking later retries
 - the normal agent-facing entrypoint can resolve the target from machine inventory through `parity_sync.py`
+- the normal agent-facing entrypoint can also resolve a session target through `parity_sync.py --session-id <id>`
 - the skill does not create or reuse a flat shared host path such as `/home/vaws`
 
 ### Sync mode gate
@@ -101,10 +122,10 @@ These specific mistakes should no longer be part of the normal path:
 - root cleanups inside `/vllm-workspace` should not delete `Mooncake` or `.vaws-runtime`
 - runtime-install should not fail closed just because Ascend env scripts reference shell-specific or otherwise unset variables while being sourced
 - the final heredoc-based import smoke should not fail with a local quoting `SyntaxError`
-- clean nested submodules should not force parent `reinstall_vllm*` decisions through synthetic gitlink churn alone
+- clean nested submodules should not force parent `reinstall_vllm*` decisions through parentless transport gitlink churn alone
 - changing only vllm-ascend files should not uninstall or break the vllm editable install
 - switching vllm to a different commit should trigger both vllm and vllm-ascend reinstall
-- consecutive syncs with no local changes should take the fast path and skip push, materialize, and manifest upload
+- consecutive syncs with no local changes should take the fast path and skip mirror hydration, materialize, and manifest upload
 
 ## Manual regression checklist
 

--- a/.agents/skills/remote-code-parity/references/behavior.md
+++ b/.agents/skills/remote-code-parity/references/behavior.md
@@ -8,10 +8,21 @@ This file defines the durable behavior of `remote-code-parity`.
 - Use Git transport without requiring a real user commit.
 - Keep sync container-only after machine attach.
 - Keep all local parity state under `.vaws-local/remote-code-parity/`.
+- In session mode, derive the source worktree and target container from `.vaws-local/sessions/<session-id>/session.json`.
 - Fail closed when parity cannot be proven.
 - Prove the final container-side commit ids instead of trusting command exit status alone.
 - Stream phase progress on `stderr` as `__VAWS_PARITY_PROGRESS__=<json>` and keep one final JSON payload on `stdout`.
 - Keep runtime-install phases attributable instead of collapsing them into one opaque step: uninstall, `vllm`, `vllm-ascend` requirements, `vllm-ascend`, import verification, and marker write should each surface their own progress event.
+
+## Apply-mode split
+
+The remote toolbox exposes parity through three explicit modes:
+
+- `source-only`: publish source snapshots to the container cache and upload a manifest; do not materialize runtime sources and do not install/rebuild.
+- `materialize`: publish snapshots and update runtime sources; do not install/rebuild.
+- `install`: full parity behavior, including first-install consent and reinstall triggers.
+
+The `source-only` and `materialize` modes must not update runtime install state in a way that lets a later `install` run incorrectly skip first-install or rebuild gates.
 
 ## Sync mode gate
 
@@ -34,6 +45,14 @@ Intended route:
 3. a higher-level serving / benchmark / smoke workflow executes the requested workload.
 
 Normal agent-facing entrypoint: `parity_sync.py`.
+
+Session-aware entrypoint:
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/parity_sync.py --session-id <id>
+```
+
+Session mode sets `workspace_root` to the session worktree, `workspace_id` to the session id by default, and `container_identity` to `<session-container>@<runtime-root>`.
 
 ## Preconditions
 
@@ -88,9 +107,12 @@ Per-workspace layout:
 Required behavior:
 
 - create bare mirror repos inside the container cache root
-- push synthetic refs directly from local -> container SSH
+- stream Git bundles directly from local -> container SSH, then fetch them into the container-local bare mirrors
+- publish deterministic parentless tree snapshot commits so first use of an empty container mirror does not require shipping the full upstream history of large repos such as `vllm`
+- avoid remote receive-pack negotiation for those parentless transport commits so the remote mirror does not need to fix up deltas against absent base history
 - also publish an advertised branch ref inside each mirror so ordinary fetch paths can see the latest synthetic snapshot
-- use a container-local lock while mutating cache or runtime state
+- use a container-local lock while mutating cache or runtime state; locks carry owner metadata and stale lock directories are recovered after the bounded stale interval
+- after failed or timed-out mirror hydration, best-effort terminate any matching legacy `git-receive-pack` process trees for that mirror and discard that repo's partial mirror before surfacing the failure
 - do not create or reuse a shared flat host path such as `/home/vaws`
 
 ## Runtime materialization model
@@ -103,7 +125,7 @@ Materialization requirements:
 - force the root repo and submodules to the synthetic snapshot commits
 - rewrite submodule URLs to container-local mirror paths
 - materialize child repos explicitly instead of relying on `git submodule update` to fetch synthetic child commits
-- when a child repo snapshot has the same tree as its original `HEAD`, reuse that original commit so parent repos do not see a gitlink-only synthetic delta
+- suppress transport-only child gitlink paths from parent `changed_paths` when a clean child repo only differs because it was represented by a parentless snapshot commit
 - preserve runtime-private sibling paths such as `Mooncake` (image-provided runtime) and `.vaws-runtime` (workspace-managed runtime artifacts, e.g. profiler dumps that downstream skills consume after parity refreshes)
 - preserve `.remote-code-parity` so the container-side marker survives root cleanups
 - do not delete the entire runtime root as part of normal sync
@@ -157,7 +179,7 @@ Everything else defaults to parity-only, no reinstall.
 
 ### Trigger 2 — commit drift from last sync
 
-Compare each repo's real HEAD commit with `last_head_commits` in `runtime-state.json`. Synthetic snapshot commits change whenever the working tree is dirty, so drift detection must use the underlying HEAD to avoid false positives from pure-Python edits. If the HEAD differs (e.g. submodule version switch via `git checkout`), trigger reinstall for that repo even when `changed_paths` is empty because the tree matches the new HEAD.
+Compare each repo's real `source_head` commit with `last_head_commits` in `runtime-state.json`. Synthetic snapshot commits are parentless transport commits, so drift detection must use the underlying HEAD to avoid false positives from dirty pure-Python edits while still detecting submodule version switches. If the HEAD differs (e.g. submodule version switch via `git checkout`), trigger reinstall for that repo even when `changed_paths` is empty because the tree matches the new HEAD.
 
 ### Trigger 3 — dependency cascade
 
@@ -175,18 +197,18 @@ On first install the reinstall-branch uninstall step is skipped because `first_i
 
 ### Force reinstall
 
-`--force-reinstall` unconditionally sets `reinstall_vllm` and `reinstall_vllm_ascend` to true, overriding all trigger logic. The full sync flow still runs (snapshot, push, materialize, install, verify). Useful for recovering from a broken editable install or validating the install pipeline without touching source files.
+`--force-reinstall` unconditionally sets `reinstall_vllm` and `reinstall_vllm_ascend` to true, overriding all trigger logic. The full sync flow still runs (snapshot, mirror hydration, materialize, install, verify). Useful for recovering from a broken editable install or validating the install pipeline without touching source files.
 
 ### No-change fast path
 
-When all snapshot commits match `last_snapshot_commits` and no reinstall trigger fires (and `--force-reinstall` is not set), the sync verifies the container-side commits with a single SSH call and returns `status == ready` immediately, skipping push, materialize, and manifest upload.
+When all snapshot commits match `last_snapshot_commits` and no reinstall trigger fires (and `--force-reinstall` is not set), the sync verifies the container-side commits with a single SSH call and returns `status == ready` immediately, skipping mirror hydration, materialize, and manifest upload.
 
 ## Exact proof to collect
 
 A trustworthy parity result records:
 
 - container cache root actually used
-- pushed synthetic commit ids
+- published synthetic commit ids
 - checked-out commit ids in the container
 - whether `vllm` and `vllm-ascend` were reinstalled
 - whether first-time consent was consulted or blocked
@@ -198,9 +220,15 @@ A trustworthy parity result records:
 - unify that interpreter across `python`, `python3`, `HI_PYTHON`, `Python_EXECUTABLE`, `Python3_EXECUTABLE`, and CMake-driven helper processes before editable install
 - preseed the runtime `PATH` and the Ascend driver `LD_LIBRARY_PATH` prefix, then source optional env scripts under a `set +u` / `set -u` guard so shell-specific variables are not required
 - keep the fast path on `pip install -e . --no-build-isolation`
-- route pip installs through mirror-aware fallback in the order Tsinghua -> Aliyun -> PyPI
+- explicitly pass whitelisted local runtime-install env vars into the remote SSH shell; do not assume SSH forwards `VAWS_*` or pip env vars automatically
+- route pip/uv installs through a caller-provided near-cache index when `VAWS_PIP_INDEX_URL` is set, then mirror-aware fallback in the order Tsinghua -> Aliyun -> PyPI; only `vllm-ascend` dependency/install steps add the default public Ascend PyPI repository as an extra index when the caller did not set a broader extra index
+- align runtime editable install environment with portable `vllm-ascend` CI behavior: paired-image editable installs default to `--no-deps`, ordinary paired-image replacement skips the `vllm-ascend` requirements reinstall, persistent pip / uv / CMake `FetchContent` cache roots, bounded/progress-wrapped uv bootstrap/install with pip-only fallback, `UV_INDEX_STRATEGY=unsafe-best-match`, `MAX_JOBS=4`, `CMAKE_BUILD_TYPE=Release`, `VAWS_SOC_VERSION -> SOC_VERSION`, best-effort `triton` removal after `vllm` install, and optional `clang-15` selection when explicitly requested
+- re-enable editable-install dependency resolution and requirements installation when dependency files changed, a repo HEAD drifted, verify-deps detects a mismatch, or the caller explicitly sets `VAWS_INSTALL_DEPS=1`
+- record the effective runtime install env in manifest/runtime-state with URL userinfo redacted so cache/compile differences are auditable
+- keep `COMPILE_CUSTOM_KERNELS` enabled by default for real serving / benchmark runtime parity; only pass `VAWS_COMPILE_CUSTOM_KERNELS=0` for deliberate unit-test-style validation where custom kernels are not required
 - if editable install fails because the image packaging stack is too old for the current `pyproject.toml`, attempt one bounded packaging-stack refresh and one retry before failing closed
+- verify all `vllm-ascend` declared dependencies are version-satisfied (`verify-deps`); if a mismatch is detected (e.g. `numpy<2.0.0` but `numpy 2.x` installed), automatically reinstall `vllm-ascend` requirements and re-verify before failing
+- treat paired-image `torch_npu` as runtime state: accept public-version matches and a successful `import torch_npu` instead of forcing a large `torch-npu` wheel reinstall
 - finish runtime verification with real imports, not `find_spec()` alone, and keep the generated heredoc smoke snippet valid Python after shell quoting
-- after import smoke test, verify all `vllm-ascend` declared dependencies are version-satisfied (`verify-deps`); if a mismatch is detected (e.g. `numpy<2.0.0` but `numpy 2.x` installed), automatically reinstall `vllm-ascend` requirements and re-verify before failing
 - surface a progress transition before each long runtime-install package step so an agent can tell whether the wait is in uninstall, requirements, editable install, or verification
 - keep consent and runtime-state writes atomic so parallel wrapper calls do not clobber local state

--- a/.agents/skills/remote-code-parity/references/command-recipes.md
+++ b/.agents/skills/remote-code-parity/references/command-recipes.md
@@ -1,5 +1,19 @@
 All parity helpers stream phase progress on `stderr` as `__VAWS_PARITY_PROGRESS__=<json>` and keep the final summary JSON on `stdout`.
 
+Remote toolbox sync planning:
+
+```bash
+python3 .agents/scripts/remote_sync_plan.py --session-id <id> --mode source-only
+python3 .agents/scripts/remote_sync_plan.py --session-id <id> --mode install
+```
+
+Remote toolbox sync apply without install/rebuild:
+
+```bash
+python3 .agents/scripts/remote_sync_apply.py --session-id <id> --mode source-only
+python3 .agents/scripts/remote_sync_apply.py --session-id <id> --mode materialize
+```
+
 # Remote-code-parity command recipes
 
 Prefer the helper scripts in `scripts/` when possible.
@@ -97,9 +111,18 @@ python3 .agents/skills/remote-code-parity/scripts/parity_sync.py \
   --machine blue-a
 ```
 
+## Normal sync against an isolated session
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/parity_sync.py \
+  --session-id pr123
+```
+
+This syncs the session worktree to the session container and uses `workspace_id=pr123` unless explicitly overridden.
+
 The runtime-install path sources Ascend env scripts under a `set +u` / `set -u` guard, so first-install parity does not depend on predefining shell-specific variables.
 The final verification path is a heredoc-based Python import smoke, so the generated snippet must remain valid Python after shell quoting.
-Clean child repos reuse their original `HEAD` commit during snapshotting, so a nested submodule like `csrc/third_party/catlass` does not by itself force a parent reinstall.
+Synthetic commits are deterministic parentless tree snapshots. Clean child repos still avoid parent reinstall churn because transport-only child gitlink paths are filtered out of parent `changed_paths`.
 
 ## Force full reinstall without code changes
 
@@ -110,6 +133,28 @@ python3 .agents/skills/remote-code-parity/scripts/parity_sync.py \
 ```
 
 Unconditionally reinstalls both `vllm` and `vllm-ascend` even when no files changed. Useful for recovering from a broken editable install or validating the install pipeline.
+
+## Runtime install cache / compile knobs
+
+The editable install path carries portable defaults from the `vllm-ascend` CI compile jobs:
+
+```bash
+VAWS_MAX_JOBS=8 \
+VAWS_UV_BOOTSTRAP_TIMEOUT=120 \
+VAWS_UV_INSTALL_TIMEOUT=300 \
+VAWS_DISABLE_UV=0 \
+VAWS_INSTALL_DEPS=0 \
+FETCHCONTENT_BASE_DIR=/root/.cache/vaws/fetchcontent \
+VAWS_PIP_INDEX_URL=http://near-cache.example/pypi/simple \
+VAWS_PIP_TRUSTED_HOST=near-cache.example \
+python3 .agents/skills/remote-code-parity/scripts/parity_sync.py \
+  --machine blue-a \
+  --force-reinstall
+```
+
+Defaults are conservative when these variables are unset: `MAX_JOBS=4`, `CMAKE_BUILD_TYPE=Release`, persistent pip / uv / `FetchContent` cache roots under `/root/.cache`, public mirror fallback, and the Ascend PyPI repository as an extra index. `VAWS_COMPILE_CUSTOM_KERNELS=0` is available only for deliberate unit-test-style checks; do not use it for real serving or benchmark validation.
+
+The `VAWS_*` values shown above are exported into the remote install shell by `remote-code-parity`; they do not depend on OpenSSH `SendEnv` / `AcceptEnv`. The default Ascend extra index is scoped to `vllm-ascend` requirements/editable install steps. Set `VAWS_ASCEND_PIP_EXTRA_INDEX_URL=` to disable that default, or set `VAWS_PIP_EXTRA_INDEX_URL` when all package steps should use a custom extra index. Set `VAWS_SOC_VERSION=<soc>` to force `SOC_VERSION` when `npu-smi` auto-detection is not enough. `VAWS_UV_BOOTSTRAP_TIMEOUT` and `VAWS_UV_INSTALL_TIMEOUT` bound uv attempts before continuing with mirror/pip fallback; set `VAWS_DISABLE_UV=1` for pip-only validation. Editable installs default to `--no-deps` against the paired image; set `VAWS_INSTALL_DEPS=1` when validating dependency changes.
 
 ## Dry-run sync without remote mutation
 

--- a/.agents/skills/remote-code-parity/scripts/common.py
+++ b/.agents/skills/remote-code-parity/scripts/common.py
@@ -45,6 +45,7 @@ PROGRESS_SENTINEL = '__VAWS_PARITY_PROGRESS__='
 STATE_LOCK_SUFFIX = '.lock'
 DEFAULT_STATE_LOCK_TIMEOUT_SECONDS = 15.0
 DEFAULT_STATE_LOCK_POLL_SECONDS = 0.05
+DEFAULT_STATE_LOCK_STALE_SECONDS = 60 * 60 * 6
 
 
 @dataclass(frozen=True)
@@ -175,16 +176,30 @@ def state_lock(
     *,
     timeout_seconds: float = DEFAULT_STATE_LOCK_TIMEOUT_SECONDS,
     poll_seconds: float = DEFAULT_STATE_LOCK_POLL_SECONDS,
+    stale_after_seconds: float = DEFAULT_STATE_LOCK_STALE_SECONDS,
 ):
     lock_path = canonical_state_path(repo_root, filename + STATE_LOCK_SUFFIX)
     deadline = time.monotonic() + timeout_seconds
+    owner = {
+        "pid": os.getpid(),
+        "hostname": os.uname().nodename if hasattr(os, "uname") else None,
+        "created_at": now_utc(),
+    }
     fd: int | None = None
     while True:
         try:
             fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-            os.write(fd, f'{os.getpid()}\n'.encode('utf-8'))
+            os.write(fd, (json.dumps(owner, sort_keys=True) + "\n").encode('utf-8'))
             break
         except FileExistsError:
+            try:
+                age = time.time() - lock_path.stat().st_mtime
+            except FileNotFoundError:
+                continue
+            if age >= stale_after_seconds:
+                with contextlib.suppress(FileNotFoundError):
+                    lock_path.unlink()
+                continue
             if time.monotonic() >= deadline:
                 raise RuntimeError(f'timed out waiting for state lock {lock_path}')
             time.sleep(poll_seconds)

--- a/.agents/skills/remote-code-parity/scripts/common.py
+++ b/.agents/skills/remote-code-parity/scripts/common.py
@@ -72,15 +72,25 @@ def run(
     env: dict[str, str] | None = None,
     check: bool = True,
     capture_output: bool = True,
+    timeout: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(
-        cmd,
-        cwd=str(cwd) if cwd else None,
-        env=env,
-        check=False,
-        capture_output=capture_output,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            env=env,
+            check=False,
+            capture_output=capture_output,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"command timed out after {timeout:.0f}s: "
+            f"{' '.join(shlex.quote(part) for part in cmd)}\n"
+            f'stdout:\n{exc.stdout or ""}\n'
+            f'stderr:\n{exc.stderr or ""}'
+        ) from exc
     if check and result.returncode != 0:
         raise RuntimeError(
             f"command failed ({result.returncode}): {' '.join(shlex.quote(part) for part in cmd)}\n"
@@ -90,8 +100,15 @@ def run(
     return result
 
 
-def git(repo: Path, args: list[str], *, env: dict[str, str] | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
-    return run(['git', '-C', str(repo), *args], env=env, check=check)
+def git(
+    repo: Path,
+    args: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return run(['git', '-C', str(repo), *args], env=env, check=check, timeout=timeout)
 
 
 def repo_root_from(path: Path) -> Path:
@@ -352,6 +369,21 @@ def ssh_stream_to_file(endpoint: SshEndpoint, remote_path: str, payload: str) ->
     if result.returncode != 0:
         raise RuntimeError(
             f'failed to stream payload to {remote_path}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}'
+        )
+
+
+def ssh_stream_bytes_to_file(endpoint: SshEndpoint, remote_path: str, payload: bytes) -> None:
+    script = (
+        f'mkdir -p {quoted(str(Path(remote_path).parent))} && '
+        f'head -c {len(payload)} > {quoted(remote_path)}'
+    )
+    cmd = [*_ssh_base_cmd(endpoint), 'bash', '-c', shlex.quote(script)]
+    result = subprocess.run(cmd, input=payload, capture_output=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f'failed to stream binary payload to {remote_path}\n'
+            f'stdout:\n{result.stdout.decode("utf-8", errors="replace")}\n'
+            f'stderr:\n{result.stderr.decode("utf-8", errors="replace")}'
         )
 
 

--- a/.agents/skills/remote-code-parity/scripts/parity_sync.py
+++ b/.agents/skills/remote-code-parity/scripts/parity_sync.py
@@ -14,6 +14,13 @@ from common import WORKSPACE_ID_PATTERN, json_dump, repo_root_from
 from install_consent import load_consent_state, resolve_sync_mode
 from remote_code_parity import DEFAULT_CONTAINER_CACHE_ROOT
 
+ROOT = Path(__file__).resolve().parents[4]
+LIB_DIR = ROOT / '.agents' / 'lib'
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_session_state import load_session_lookup  # noqa: E402
+
 
 DEFAULT_CONTAINER_USER = 'root'
 
@@ -52,6 +59,9 @@ def resolve_machine_record(inventory: dict[str, Any], identifier: str) -> dict[s
 
 
 def build_derived_args(repo_root: Path, args: argparse.Namespace) -> dict[str, Any]:
+    if args.session_id or args.session_file:
+        return build_derived_args_from_session(repo_root, args)
+
     inventory = load_machine_inventory(repo_root)
     record = resolve_machine_record(inventory, args.machine)
     runtime_root = args.runtime_root or record.get('container', {}).get('workdir') or '/vllm-workspace'
@@ -83,6 +93,47 @@ def build_derived_args(repo_root: Path, args: argparse.Namespace) -> dict[str, A
     }
 
 
+def build_derived_args_from_session(repo_root: Path, args: argparse.Namespace) -> dict[str, Any]:
+    lookup = load_session_lookup(
+        session_id=args.session_id,
+        session_file=args.session_file,
+        repo_root=repo_root,
+    )
+    session = lookup.session
+    local = session['local']
+    remote = session['remote']
+    container = remote['container']
+    workspace_root = repo_root_from(Path(local['worktree_root']))
+    runtime_root = args.runtime_root or container.get('runtime_root') or container.get('workdir') or '/vllm-workspace'
+    workspace_id = args.workspace_id or session.get('workspace_id') or session['session_id']
+    container_name = container.get('name')
+    if not container_name:
+        raise RuntimeError(f"session {session['session_id']!r} is missing remote.container.name")
+    container_port = container.get('ssh_port')
+    if not isinstance(container_port, int):
+        raise RuntimeError(f"session {session['session_id']!r} is missing remote.container.ssh_port")
+    container_host = remote.get('host')
+    if not container_host:
+        raise RuntimeError(f"session {session['session_id']!r} is missing remote.host")
+    container_identity = f'{container_name}@{runtime_root}'
+    return {
+        'workspace_root': str(workspace_root),
+        'workspace_id': workspace_id,
+        'server_name': session['base_machine'],
+        'runtime_root': runtime_root,
+        'container_identity': container_identity,
+        'container_cache_root': args.container_cache_root,
+        'container_host': container_host,
+        'container_port': container_port,
+        'container_user': args.container_user,
+        'preserve_path': list(args.preserve_path),
+        'machine_record': None,
+        'session_id': session['session_id'],
+        'session_file': str(lookup.session_file),
+        'inventory_path': str(lookup.session_file),
+    }
+
+
 def build_low_level_command(derived: dict[str, Any], args: argparse.Namespace) -> list[str]:
     script_path = Path(__file__).with_name('remote_code_parity.py')
     cmd = [
@@ -109,12 +160,16 @@ def build_low_level_command(derived: dict[str, Any], args: argparse.Namespace) -
         cmd.append('--force-reinstall')
     if args.dry_run:
         cmd.append('--dry-run')
+    if args.apply_mode:
+        cmd.extend(['--apply-mode', args.apply_mode])
     return cmd
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description='Resolve a managed machine from inventory and run container-only remote-code-parity sync.', allow_abbrev=False)
-    parser.add_argument('--machine', required=True, help='machine alias or host IP from inventory')
+    parser.add_argument('--machine', help='machine alias or host IP from inventory')
+    parser.add_argument('--session-id', help='VAWS session id')
+    parser.add_argument('--session-file', help='explicit session.json path')
     parser.add_argument('--repo-root', default='.')
     parser.add_argument('--workspace-id', default=None)
     parser.add_argument('--runtime-root', default=None)
@@ -125,6 +180,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument('--print-manifest', action='store_true')
     parser.add_argument('--force-reinstall', action='store_true', help='Force reinstall of vllm and vllm-ascend regardless of what changed.')
     parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument(
+        '--apply-mode',
+        choices=('source-only', 'materialize', 'install'),
+        default='install',
+        help='source-only publishes container-cache snapshots only; materialize updates runtime sources without install; install preserves the full parity behavior.',
+    )
     parser.add_argument('--print-derived-args', action='store_true')
     return parser
 
@@ -132,10 +193,13 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     args = build_parser().parse_args()
     repo_root = repo_root_from(Path(args.repo_root))
+    if not args.machine and not args.session_id and not args.session_file:
+        raise RuntimeError('--machine is required unless --session-id or --session-file is used')
     derived = build_derived_args(repo_root, args)
+    state_repo_root = repo_root_from(Path(derived['workspace_root']))
 
     if not args.force_reinstall:
-        consent_state = load_consent_state(repo_root)
+        consent_state = load_consent_state(state_repo_root)
         mode = resolve_sync_mode(consent_state, derived['server_name'], derived['container_identity'])
         if mode == 'image':
             print(json_dump({

--- a/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
+++ b/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
@@ -11,6 +11,7 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from common import (
     DEFAULT_DENYLIST,
@@ -30,6 +31,7 @@ from common import (
     save_state,
     ssh_exec,
     ssh_exec_stream,
+    ssh_stream_bytes_to_file,
     ssh_stream_to_file,
     update_state,
 )
@@ -53,6 +55,13 @@ VLLM_REINSTALL_PATTERNS = (
 
 VLLM_ASCEND_REINSTALL_PATTERNS = VLLM_REINSTALL_PATTERNS + (
     'vllm_ascend/_cann_ops_custom/**',
+)
+
+DEPENDENCY_INSTALL_PATTERNS = (
+    'requirements*',
+    'pyproject.toml',
+    'setup.py',
+    'setup.cfg',
 )
 
 DEFAULT_ENV_PREAMBLE = (
@@ -88,7 +97,25 @@ DEFAULT_ENV_PREAMBLE = (
     'export PIP_DEFAULT_TIMEOUT=60',
     'export PIP_RETRIES=2',
     'export PIP_PROGRESS_BAR=off',
-    'export UV_CACHE_DIR="${UV_CACHE_DIR:-/root/.cache/uv}"',
+    'export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/root/.cache}"',
+    'export PIP_CACHE_DIR="${PIP_CACHE_DIR:-$XDG_CACHE_HOME/pip}"',
+    'export UV_CACHE_DIR="${UV_CACHE_DIR:-$XDG_CACHE_HOME/uv}"',
+    'export UV_SYSTEM_PYTHON="${UV_SYSTEM_PYTHON:-1}"',
+    'export UV_PYTHON="${UV_PYTHON:-$PYTHON}"',
+    'export UV_INDEX_STRATEGY="${UV_INDEX_STRATEGY:-unsafe-best-match}"',
+    'export VAWS_UV_BOOTSTRAP_TIMEOUT="${VAWS_UV_BOOTSTRAP_TIMEOUT:-120}"',
+    'export VAWS_UV_INSTALL_TIMEOUT="${VAWS_UV_INSTALL_TIMEOUT:-300}"',
+    'export VAWS_DISABLE_UV="${VAWS_DISABLE_UV:-0}"',
+    'export VAWS_INSTALL_DEPS="${VAWS_INSTALL_DEPS:-0}"',
+    'export VAWS_ASCEND_PIP_EXTRA_INDEX_URL="${VAWS_ASCEND_PIP_EXTRA_INDEX_URL-https://mirrors.huaweicloud.com/ascend/repos/pypi}"',
+    'export VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL="${VAWS_PIP_EXTRA_INDEX_URL:-${PIP_EXTRA_INDEX_URL:-}}"',
+    'export FETCHCONTENT_BASE_DIR="${FETCHCONTENT_BASE_DIR:-$XDG_CACHE_HOME/vaws/fetchcontent}"',
+    'export CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}"',
+    'export MAX_JOBS="${VAWS_MAX_JOBS:-${MAX_JOBS:-4}}"',
+    'export CMAKE_BUILD_PARALLEL_LEVEL="${CMAKE_BUILD_PARALLEL_LEVEL:-$MAX_JOBS}"',
+    'if [ -n "${VAWS_SOC_VERSION:-}" ]; then export SOC_VERSION="$VAWS_SOC_VERSION"; fi',
+    'if [ -n "${VAWS_COMPILE_CUSTOM_KERNELS:-}" ]; then export COMPILE_CUSTOM_KERNELS="$VAWS_COMPILE_CUSTOM_KERNELS"; fi',
+    'if [ "${VAWS_USE_CLANG15:-0}" = "1" ] && command -v clang-15 >/dev/null 2>&1 && command -v clang++-15 >/dev/null 2>&1; then export C_COMPILER="${C_COMPILER:-$(command -v clang-15)}"; export CXX_COMPILER="${CXX_COMPILER:-$(command -v clang++-15)}"; fi',
     'export VLLM_WORKER_MULTIPROC_METHOD=spawn',
     'export OMP_NUM_THREADS=1',
     'export MKL_NUM_THREADS=1',
@@ -114,12 +141,70 @@ PIP_MIRROR_CANDIDATES = (
 
 DEFAULT_CONTAINER_CACHE_ROOT = '/root/.cache/vaws/remote-code-parity'
 DEFAULT_MARKER_DIRNAME = '.remote-code-parity'
+DEFAULT_GIT_TRANSPORT_TIMEOUT_SECONDS = 900.0
+DEFAULT_CONTAINER_LOCK_STALE_SECONDS = 3600
 # Keep runtime-private state and profiling artifacts that may be needed for
 # post-run analysis across parity refreshes.
 DEFAULT_ROOT_PRESERVE_PATHS = ('Mooncake', '.vaws-runtime')
 STATE_FILENAME = 'runtime-state.json'
 CONSENT_FILENAME = 'install-consents.json'
 PARITY_BRANCH_NAME = 'parity-current'
+
+REMOTE_RUNTIME_ENV_PASSTHROUGH = (
+    'VAWS_PIP_INDEX_URL',
+    'VAWS_PIP_EXTRA_INDEX_URL',
+    'VAWS_PIP_TRUSTED_HOST',
+    'VAWS_ASCEND_PIP_EXTRA_INDEX_URL',
+    'PIP_EXTRA_INDEX_URL',
+    'XDG_CACHE_HOME',
+    'PIP_CACHE_DIR',
+    'UV_CACHE_DIR',
+    'UV_SYSTEM_PYTHON',
+    'UV_INDEX_STRATEGY',
+    'VAWS_UV_BOOTSTRAP_TIMEOUT',
+    'VAWS_UV_INSTALL_TIMEOUT',
+    'VAWS_DISABLE_UV',
+    'VAWS_INSTALL_DEPS',
+    'FETCHCONTENT_BASE_DIR',
+    'VAWS_MAX_JOBS',
+    'MAX_JOBS',
+    'CMAKE_BUILD_PARALLEL_LEVEL',
+    'CMAKE_BUILD_TYPE',
+    'VAWS_SOC_VERSION',
+    'SOC_VERSION',
+    'VAWS_COMPILE_CUSTOM_KERNELS',
+    'COMPILE_CUSTOM_KERNELS',
+    'VAWS_USE_CLANG15',
+    'C_COMPILER',
+    'CXX_COMPILER',
+    'VERBOSE',
+    'ASCEND_HOME_PATH',
+)
+
+RUNTIME_INSTALL_ENV_KEYS = (
+    'MAX_JOBS',
+    'CMAKE_BUILD_PARALLEL_LEVEL',
+    'CMAKE_BUILD_TYPE',
+    'FETCHCONTENT_BASE_DIR',
+    'XDG_CACHE_HOME',
+    'PIP_CACHE_DIR',
+    'UV_CACHE_DIR',
+    'UV_SYSTEM_PYTHON',
+    'UV_INDEX_STRATEGY',
+    'VAWS_UV_BOOTSTRAP_TIMEOUT',
+    'VAWS_UV_INSTALL_TIMEOUT',
+    'VAWS_DISABLE_UV',
+    'VAWS_INSTALL_DEPS',
+    'VAWS_PIP_INDEX_URL',
+    'VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL',
+    'VAWS_ASCEND_PIP_EXTRA_INDEX_URL',
+    'VAWS_VLLM_ASCEND_EFFECTIVE_PIP_EXTRA_INDEX_URL',
+    'SOC_VERSION',
+    'COMPILE_CUSTOM_KERNELS',
+    'C_COMPILER',
+    'CXX_COMPILER',
+    'ASCEND_HOME_PATH',
+)
 
 
 @dataclass
@@ -140,6 +225,7 @@ class RepoNode:
 class SnapshotRecord:
     relpath: str
     repo_id: str
+    source_head: str | None
     parent: str | None
     commit: str
     tree: str
@@ -171,6 +257,41 @@ def validate_absolute_posix_path(value: str, *, label: str) -> str:
     if not value.startswith('/'):
         raise RuntimeError(f'{label} must be an absolute POSIX path, got: {value!r}')
     return PurePosixPath(value).as_posix()
+
+
+def remote_runtime_env_exports() -> list[str]:
+    lines: list[str] = []
+    for key in REMOTE_RUNTIME_ENV_PASSTHROUGH:
+        if key in os.environ:
+            lines.append(f'export {key}={quoted(os.environ[key])}')
+    return lines
+
+
+def redact_url_value(value: str) -> str:
+    parts = value.split()
+    redacted_parts: list[str] = []
+    for part in parts:
+        try:
+            parsed = urlsplit(part)
+        except ValueError:
+            redacted_parts.append(part)
+            continue
+        if parsed.scheme and parsed.netloc and '@' in parsed.netloc:
+            host = parsed.netloc.rsplit('@', 1)[1]
+            redacted_parts.append(urlunsplit((parsed.scheme, f'***@{host}', parsed.path, parsed.query, parsed.fragment)))
+        else:
+            redacted_parts.append(part)
+    return ' '.join(redacted_parts)
+
+
+def redact_runtime_env(env: dict[str, str]) -> dict[str, str]:
+    redacted: dict[str, str] = {}
+    for key, value in env.items():
+        if key.endswith('_URL') or 'INDEX' in key or 'PATH' in key:
+            redacted[key] = redact_url_value(value)
+        else:
+            redacted[key] = value
+    return redacted
 
 
 def resolved_root_preserve_paths(marker_dirname: str, extra_paths: list[str]) -> tuple[str, ...]:
@@ -268,8 +389,27 @@ def synthetic_ref(workspace_id: str, snapshot_id: str, relpath: str) -> str:
     return f'refs/parity/{workspace_id}/{snapshot_id}/{sanitize_repo_id(relpath)}'
 
 
-def commit_message(workspace_id: str, snapshot_id: str, relpath: str) -> str:
-    return f'remote-code-parity snapshot {workspace_id} {snapshot_id} {sanitize_repo_id(relpath)}'
+def commit_message(workspace_id: str, relpath: str) -> str:
+    return f'remote-code-parity tree snapshot {workspace_id} {sanitize_repo_id(relpath)}'
+
+
+def gitlink_for_path(repo: Path, commit: str | None, path: str) -> str | None:
+    if not commit:
+        return None
+    result = git(repo, ['ls-tree', commit, '--', path], check=False)
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    first = result.stdout.splitlines()[0].split(maxsplit=3)
+    if len(first) < 3 or first[0] != '160000':
+        return None
+    return first[2]
+
+
+def filter_transport_only_child_paths(
+    paths: list[str],
+    transport_only_child_paths: set[str],
+) -> list[str]:
+    return [path for path in paths if path not in transport_only_child_paths]
 
 
 def build_synthetic_snapshot(
@@ -281,8 +421,7 @@ def build_synthetic_snapshot(
     child_commits: dict[str, SnapshotRecord],
 ) -> SnapshotRecord:
     repo = node.repo_path
-    parent = git_head(repo)
-    parent_tree = git_tree_for_commit(repo, parent)
+    source_head = git_head(repo)
     ref = synthetic_ref(workspace_id, snapshot_id, node.relpath)
     temp_index = tempfile.NamedTemporaryFile(prefix='parity-index-', delete=False)
     temp_index.close()
@@ -299,17 +438,25 @@ def build_synthetic_snapshot(
     env.setdefault('GIT_COMMITTER_DATE', '1970-01-01T00:00:00Z')
 
     try:
-        if parent:
-            git(repo, ['read-tree', parent], env=env)
+        if source_head:
+            git(repo, ['read-tree', source_head], env=env)
         git(repo, ['add', '-A'], env=env)
         reset_specs = reset_pathspecs(node, denylist)
         if reset_specs:
             git(repo, ['reset', '-q', '--', *reset_specs], env=env)
 
         submodule_records: list[dict[str, str]] = []
+        transport_only_child_paths: set[str] = set()
         for child in node.children:
             child_record = child_commits[child.relpath]
             child_rel_to_repo = child.repo_path.relative_to(repo).as_posix()
+            source_gitlink = gitlink_for_path(repo, source_head, child_rel_to_repo)
+            if (
+                source_gitlink
+                and child_record.source_head == source_gitlink
+                and not child_record.changed_paths
+            ):
+                transport_only_child_paths.add(child_rel_to_repo)
             git(
                 repo,
                 ['update-index', '--add', '--cacheinfo', f'160000,{child_record.commit},{child_rel_to_repo}'],
@@ -325,26 +472,20 @@ def build_synthetic_snapshot(
             )
 
         tree = git(repo, ['write-tree'], env=env).stdout.strip()
-        if parent and parent_tree == tree:
-            commit = parent
-            diff: list[str] = []
+        commit = git(repo, ['commit-tree', tree, '-m', commit_message(workspace_id, node.relpath)], env=env).stdout.strip()
+        if source_head:
+            diff = git(repo, ['diff', '--name-only', f'{source_head}..{commit}']).stdout.splitlines()
         else:
-            commit_args = ['commit-tree', tree]
-            if parent:
-                commit_args.extend(['-p', parent])
-            commit_args.extend(['-m', commit_message(workspace_id, snapshot_id, node.relpath)])
-            commit = git(repo, commit_args, env=env).stdout.strip()
-            if parent:
-                diff = git(repo, ['diff', '--name-only', f'{parent}..{commit}']).stdout.splitlines()
-            else:
-                diff = git(repo, ['show', '--pretty=', '--name-only', commit]).stdout.splitlines()
+            diff = git(repo, ['show', '--pretty=', '--name-only', commit]).stdout.splitlines()
+        diff = filter_transport_only_child_paths(diff, transport_only_child_paths)
 
         git(repo, ['update-ref', ref, commit])
 
         return SnapshotRecord(
             relpath=node.relpath,
             repo_id=sanitize_repo_id(node.relpath),
-            parent=parent,
+            source_head=source_head,
+            parent=source_head,
             commit=commit,
             tree=tree,
             ref=ref,
@@ -396,6 +537,11 @@ def mirror_path_for(container_cache_root: str, workspace_id: str, record: Snapsh
     return str(root / 'nested' / f'{record.repo_id}.git')
 
 
+def bundle_path_for(container_cache_root: str, workspace_id: str, record: SnapshotRecord) -> str:
+    root = Path(cache_workspace_root(container_cache_root, workspace_id)) / 'bundles'
+    return str(root / f'{record.repo_id}-{record.commit}.bundle')
+
+
 def manifest_path_for(container_cache_root: str, workspace_id: str, snapshot_id: str) -> str:
     return str(Path(cache_workspace_root(container_cache_root, workspace_id)) / 'manifests' / f'{snapshot_id}.json')
 
@@ -424,38 +570,120 @@ def ensure_remote_bare_repos(container: SshEndpoint, mirror_paths: list[str], dr
     ssh_exec(container, '\n'.join(lines))
 
 
+def cleanup_failed_mirror_hydration(container: SshEndpoint, mirror_path: str) -> None:
+    script = '\n'.join(
+        [
+            'set +e',
+            f'mirror={quoted(mirror_path)}',
+            'for pid in $(pgrep -x git-receive-pack 2>/dev/null || true); do',
+            '  cmd="$(tr "\\000" " " <"/proc/$pid/cmdline" 2>/dev/null || true)"',
+            '  case "$cmd" in',
+            '    *"$mirror"*)',
+            '      pkill -TERM -P "$pid" >/dev/null 2>&1 || true',
+            '      kill -TERM "$pid" >/dev/null 2>&1 || true',
+            '      ;;',
+            '  esac',
+            'done',
+            'sleep 1',
+            'for pid in $(pgrep -x git-receive-pack 2>/dev/null || true); do',
+            '  cmd="$(tr "\\000" " " <"/proc/$pid/cmdline" 2>/dev/null || true)"',
+            '  case "$cmd" in',
+            '    *"$mirror"*)',
+            '      pkill -KILL -P "$pid" >/dev/null 2>&1 || true',
+            '      kill -KILL "$pid" >/dev/null 2>&1 || true',
+            '      ;;',
+            '  esac',
+            'done',
+            'rm -rf "$mirror"',
+        ]
+    )
+    try:
+        ssh_exec(container, script, check=False)
+    except Exception:
+        pass
+
+
 def push_snapshot_to_mirror(
     repo: Path,
     *,
     container: SshEndpoint,
     mirror_path: str,
+    container_cache_root: str,
     record: SnapshotRecord,
     workspace_id: str,
     dry_run: bool,
 ) -> None:
     if dry_run:
         return
-    remote_url = f'ssh://{container.user}@{container.host}:{container.port}{mirror_path}'
     target_ref = f'refs/parity/{workspace_id}/current'
-    git(
-        repo,
-        [
-            'push',
-            '--force',
-            remote_url,
-            f'{record.commit}:{target_ref}',
-            f'{record.commit}:refs/heads/{PARITY_BRANCH_NAME}',
-        ],
-    )
+    remote_bundle_path = bundle_path_for(container_cache_root, workspace_id, record)
+    local_bundle = tempfile.NamedTemporaryFile(prefix='parity-bundle-', suffix='.bundle', delete=False)
+    local_bundle.close()
+    local_bundle_path = Path(local_bundle.name)
+    try:
+        git(repo, ['bundle', 'create', str(local_bundle_path), record.ref], timeout=DEFAULT_GIT_TRANSPORT_TIMEOUT_SECONDS)
+        ssh_stream_bytes_to_file(container, remote_bundle_path, local_bundle_path.read_bytes())
+        script = '\n'.join(
+            [
+                'set -eo pipefail',
+                f'mkdir -p {quoted(str(Path(mirror_path).parent))}',
+                f'if [ ! -d {quoted(mirror_path)} ]; then git init --bare {quoted(mirror_path)} >/dev/null; fi',
+                (
+                    f'git -C {quoted(mirror_path)} fetch --force {quoted(remote_bundle_path)} '
+                    f'{quoted(record.ref + ":" + target_ref)} '
+                    f'{quoted(record.ref + ":refs/heads/" + PARITY_BRANCH_NAME)} >/dev/null'
+                ),
+                f'rm -f {quoted(remote_bundle_path)}',
+            ]
+        )
+        ssh_exec(container, script)
+    except Exception:
+        cleanup_failed_mirror_hydration(container, mirror_path)
+        raise
+    finally:
+        local_bundle_path.unlink(missing_ok=True)
 
-def acquire_container_lock(container: SshEndpoint, lock_path: str, dry_run: bool) -> None:
+def acquire_container_lock(
+    container: SshEndpoint,
+    lock_path: str,
+    dry_run: bool,
+    *,
+    stale_seconds: int = DEFAULT_CONTAINER_LOCK_STALE_SECONDS,
+) -> None:
     if dry_run:
         return
     script = '\n'.join(
         [
             'set -eo pipefail',
-            f'mkdir -p {quoted(str(Path(lock_path).parent))}',
-            f'mkdir {quoted(lock_path)}',
+            f'lock={quoted(lock_path)}',
+            f'stale_seconds={int(stale_seconds)}',
+            'mkdir -p "$(dirname "$lock")"',
+            'write_owner() {',
+            '  {',
+            '    printf "pid=%s\\n" "$$"',
+            '    printf "host=%s\\n" "$(hostname 2>/dev/null || true)"',
+            '    printf "started_at=%s\\n" "$(date -Is 2>/dev/null || date)"',
+            '  } >"$lock/owner"',
+            '}',
+            'if mkdir "$lock" 2>/dev/null; then',
+            '  write_owner',
+            '  exit 0',
+            'fi',
+            'if [ -d "$lock" ]; then',
+            '  now="$(date +%s)"',
+            '  mtime="$(stat -c %Y "$lock" 2>/dev/null || echo 0)"',
+            '  age="$((now - mtime))"',
+            '  if [ "$age" -ge "$stale_seconds" ]; then',
+            '    rm -rf "$lock"',
+            '    if mkdir "$lock" 2>/dev/null; then',
+            '      write_owner',
+            '      exit 0',
+            '    fi',
+            '  fi',
+            'fi',
+            'echo "lock exists: $lock" >&2',
+            'if [ -f "$lock/owner" ]; then cat "$lock/owner" >&2 || true; fi',
+            'exit 1',
         ]
     )
     result = ssh_exec(container, script, check=False)
@@ -466,7 +694,7 @@ def acquire_container_lock(container: SshEndpoint, lock_path: str, dry_run: bool
 def release_container_lock(container: SshEndpoint, lock_path: str, dry_run: bool) -> None:
     if dry_run:
         return
-    ssh_exec(container, f'rmdir {quoted(lock_path)} >/dev/null 2>&1 || true', check=False)
+    ssh_exec(container, f'rm -rf {quoted(lock_path)} >/dev/null 2>&1 || true', check=False)
 
 
 def upload_manifest(container: SshEndpoint, manifest_path: str, manifest: dict[str, Any], dry_run: bool) -> None:
@@ -483,6 +711,7 @@ def container_repo_path(runtime_root: str, record: SnapshotRecord) -> str:
 
 def first_install_prepare_script(runtime_root: str) -> str:
     lines = ['set -eo pipefail', f'mkdir -p {quoted(runtime_root)}', f'cd {quoted(runtime_root)}']
+    lines.extend(remote_runtime_env_exports())
     lines.extend(DEFAULT_ENV_PREAMBLE)
     lines.extend(
         [
@@ -576,6 +805,10 @@ def reinstall_required_for_repo(record: SnapshotRecord, patterns: tuple[str, ...
     return any(glob_match_any(path, patterns) for path in record.changed_paths)
 
 
+def dependency_install_required_for_repo(record: SnapshotRecord) -> bool:
+    return any(glob_match_any(path, DEPENDENCY_INSTALL_PATTERNS) for path in record.changed_paths)
+
+
 def runtime_install_step_script(
     *,
     runtime_root: str,
@@ -583,10 +816,18 @@ def runtime_install_step_script(
     container_identity: str,
     step: str,
     uninstall_packages: tuple[str, ...] = (),
+    install_deps: bool = False,
 ) -> str:
     lines = ['set -euo pipefail', f'cd {quoted(runtime_root)}']
+    lines.extend(remote_runtime_env_exports())
     lines.extend(DEFAULT_ENV_PREAMBLE)
+    if install_deps:
+        lines.append('export VAWS_INSTALL_DEPS=1')
     if step in {'bootstrap-uv', 'install-vllm', 'install-vllm-ascend', 'install-vllm-ascend-requirements'}:
+        if step in {'install-vllm-ascend', 'install-vllm-ascend-requirements'}:
+            lines.append(
+                'export VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL="${VAWS_PIP_EXTRA_INDEX_URL:-${PIP_EXTRA_INDEX_URL:-$VAWS_ASCEND_PIP_EXTRA_INDEX_URL}}"'
+            )
         lines.extend(
             [
                 'emit_progress() {',
@@ -652,14 +893,20 @@ def runtime_install_step_script(
                 '}',
                 'pip_apply_mirror() {',
                 '  mirror="$1"',
-                '  unset PIP_INDEX_URL PIP_TRUSTED_HOST',
+                '  unset PIP_INDEX_URL PIP_EXTRA_INDEX_URL PIP_TRUSTED_HOST',
                 '  case "$mirror" in',
+                '    custom)',
+                '      if [ -z "${VAWS_PIP_INDEX_URL:-}" ]; then return 1; fi',
+                '      export PIP_INDEX_URL="$VAWS_PIP_INDEX_URL"',
+                '      if [ -n "${VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL:-}" ]; then export PIP_EXTRA_INDEX_URL="$VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL"; fi',
+                '      if [ -n "${VAWS_PIP_TRUSTED_HOST:-}" ]; then export PIP_TRUSTED_HOST="$VAWS_PIP_TRUSTED_HOST"; fi',
+                '      ;;',
             ]
         )
         for mirror in PIP_MIRROR_CANDIDATES:
             lines.extend(
                 [
-                    f'    {mirror["name"]}) export PIP_INDEX_URL={quoted(mirror["index_url"])}; export PIP_TRUSTED_HOST={quoted(mirror["trusted_host"])} ;;',
+                    f'    {mirror["name"]}) export PIP_INDEX_URL={quoted(mirror["index_url"])}; export PIP_TRUSTED_HOST={quoted(mirror["trusted_host"])}; if [ -n "${{VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL:-}}" ]; then export PIP_EXTRA_INDEX_URL="$VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL"; fi ;;',
                 ]
             )
         lines.extend(
@@ -669,15 +916,20 @@ def runtime_install_step_script(
                 '  emit_progress "runtime-pip-mirror" "using pip mirror $mirror" 30',
                 '}',
                 'HAS_UV=0',
-                'if command -v uv >/dev/null 2>&1; then HAS_UV=1; fi',
+                'if [ "${VAWS_DISABLE_UV:-0}" != "1" ] && command -v uv >/dev/null 2>&1; then HAS_UV=1; fi',
                 'ensure_uv() {',
+                '  if [ "${VAWS_DISABLE_UV:-0}" = "1" ]; then return 1; fi',
                 '  if [ "$HAS_UV" -eq 1 ]; then return 0; fi',
                 '  if command -v uv >/dev/null 2>&1; then HAS_UV=1; return 0; fi',
                 '  emit_progress "runtime-bootstrap-uv" "installing uv" 30',
-                '  for mirror in tsinghua aliyun pypi; do',
-                '    pip_apply_mirror "$mirror"',
+                '  for mirror in custom tsinghua aliyun pypi; do',
+                '    pip_apply_mirror "$mirror" || continue',
                 '    set +e',
-                '    "$PYTHON" -m pip install uv -q 2>/dev/null',
+                '    if command -v timeout >/dev/null 2>&1; then',
+                '      run_with_progress "runtime-bootstrap-uv" "installing uv via $mirror" "$VAWS_UV_BOOTSTRAP_TIMEOUT" timeout "$VAWS_UV_BOOTSTRAP_TIMEOUT" "$PYTHON" -m pip install uv -q',
+                '    else',
+                '      run_with_progress "runtime-bootstrap-uv" "installing uv via $mirror" "$VAWS_UV_BOOTSTRAP_TIMEOUT" "$PYTHON" -m pip install uv -q',
+                '    fi',
                 '    status=$?',
                 '    set -e',
                 '    if [ "$status" -eq 0 ]; then',
@@ -687,12 +939,29 @@ def runtime_install_step_script(
                 '  done',
                 '  return 1',
                 '}',
-                'UV_INDEX_ARGS="'
+                'DEFAULT_UV_INDEX_ARGS="'
                 + ' '.join(
                     (f'--index-url {m["index_url"]}' if i == 0 else f'--extra-index-url {m["index_url"]}')
                     for i, m in enumerate(PIP_MIRROR_CANDIDATES)
                 )
                 + '"',
+                'UV_EXTRA_INDEX_ARGS=""',
+                'if [ -n "${VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL:-}" ]; then UV_EXTRA_INDEX_ARGS="$UV_EXTRA_INDEX_ARGS --extra-index-url $VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL"; fi',
+                'UV_INDEX_ARGS="$DEFAULT_UV_INDEX_ARGS$UV_EXTRA_INDEX_ARGS"',
+                'if [ -n "${VAWS_PIP_INDEX_URL:-}" ]; then',
+                '  UV_INDEX_ARGS="--index-url $VAWS_PIP_INDEX_URL"',
+                '  if [ -n "${VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL:-}" ]; then UV_INDEX_ARGS="$UV_INDEX_ARGS --extra-index-url $VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL"; fi',
+                '  UV_INDEX_ARGS="$UV_INDEX_ARGS ${DEFAULT_UV_INDEX_ARGS/--index-url/--extra-index-url}"',
+                'fi',
+                'emit_runtime_install_env() {',
+                '  emit_progress "runtime-install-env" "MAX_JOBS=$MAX_JOBS CMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE INSTALL_DEPS=${VAWS_INSTALL_DEPS:-0} DISABLE_UV=${VAWS_DISABLE_UV:-0} SOC_VERSION=${SOC_VERSION:-auto} FETCHCONTENT_BASE_DIR=$FETCHCONTENT_BASE_DIR UV_CACHE_DIR=$UV_CACHE_DIR PIP_CACHE_DIR=$PIP_CACHE_DIR" 5',
+                '}',
+                'emit_runtime_npu_probe() {',
+                '  if command -v npu-smi >/dev/null 2>&1; then',
+                '    summary="$(npu-smi info 2>/dev/null | head -n 8 | tr "\\n" " " | sed "s/  */ /g" | cut -c1-220 || true)"',
+                '    if [ -n "$summary" ]; then emit_progress "runtime-npu-probe" "$summary" 5; fi',
+                '  fi',
+                '}',
                 'pip_install_with_mirrors() {',
                 '  phase="$1"',
                 '  message="$2"',
@@ -701,16 +970,21 @@ def runtime_install_step_script(
                 '  if [ "$HAS_UV" -eq 1 ]; then',
                 '    uv_args="$*"',
                 '    uv_args="${uv_args#install }"',
+                '    uv_cmd="uv pip install --system $UV_INDEX_ARGS $uv_args"',
                 '    set +e',
-                '    run_with_progress "$phase" "$message via uv" "$expected_seconds" bash -lc "uv pip install --system $UV_INDEX_ARGS $uv_args"',
+                '    if command -v timeout >/dev/null 2>&1; then',
+                '      run_with_progress "$phase" "$message via uv" "$VAWS_UV_INSTALL_TIMEOUT" timeout "$VAWS_UV_INSTALL_TIMEOUT" bash -lc "$uv_cmd"',
+                '    else',
+                '      run_with_progress "$phase" "$message via uv" "$expected_seconds" bash -lc "$uv_cmd"',
+                '    fi',
                 '    status=$?',
                 '    set -e',
                 '    if [ "$status" -eq 0 ]; then return 0; fi',
                 '    emit_progress "$phase" "uv failed (status $status), falling back to pip" 10',
                 '  fi',
                 '  last_status=1',
-                '  for mirror in tsinghua aliyun pypi; do',
-                '    pip_apply_mirror "$mirror"',
+                '  for mirror in custom tsinghua aliyun pypi; do',
+                '    pip_apply_mirror "$mirror" || continue',
                 '    set +e',
                 '    run_with_progress "$phase" "$message via $mirror" "$expected_seconds" "$PYTHON" -m pip "$@"',
                 '    status=$?',
@@ -739,8 +1013,13 @@ def runtime_install_step_script(
                 '  cd "$target_dir"',
                 '  if [ "$HAS_UV" -eq 1 ]; then',
                 '    pip_args="${install_cmd#*pip install }"',
+                '    uv_cmd="uv pip install --system $UV_INDEX_ARGS $pip_args"',
                 '    set +e',
-                '    run_with_log_progress "$phase" "$message via uv" "$expected_seconds" "$log_file" bash -lc "uv pip install --system $UV_INDEX_ARGS $pip_args"',
+                '    if command -v timeout >/dev/null 2>&1; then',
+                '      run_with_log_progress "$phase" "$message via uv" "$VAWS_UV_INSTALL_TIMEOUT" "$log_file" timeout "$VAWS_UV_INSTALL_TIMEOUT" bash -lc "$uv_cmd"',
+                '    else',
+                '      run_with_log_progress "$phase" "$message via uv" "$expected_seconds" "$log_file" bash -lc "$uv_cmd"',
+                '    fi',
                 '    status=$?',
                 '    set -e',
                 '    if [ "$status" -eq 0 ]; then',
@@ -750,8 +1029,8 @@ def runtime_install_step_script(
                 '    emit_progress "$phase" "uv install failed (status $status), falling back to pip" 10',
                 '  fi',
                 '  last_status=1',
-                '  for mirror in tsinghua aliyun pypi; do',
-                '    pip_apply_mirror "$mirror"',
+                '  for mirror in custom tsinghua aliyun pypi; do',
+                '    pip_apply_mirror "$mirror" || continue',
                 '    set +e',
                 '    run_with_log_progress "$phase" "$message via $mirror" "$expected_seconds" "$log_file" bash -lc "$install_cmd"',
                 '    status=$?',
@@ -793,7 +1072,12 @@ def runtime_install_step_script(
         )
 
     if step == 'bootstrap-uv':
-        lines.append('ensure_uv || emit_progress "runtime-bootstrap-uv" "uv not available, will use pip" 5')
+        lines.extend(
+            [
+                'emit_runtime_install_env',
+                'ensure_uv || emit_progress "runtime-bootstrap-uv" "uv not available, will use pip" 5',
+            ]
+        )
     elif step == 'uninstall':
         pkg_args = ' '.join(uninstall_packages) if uninstall_packages else 'vllm vllm-ascend vllm_ascend'
         lines.append(f'$PYTHON -m pip uninstall -y {pkg_args} >/dev/null 2>&1 || true')
@@ -802,13 +1086,19 @@ def runtime_install_step_script(
             [
                 f'cd {quoted(str(Path(runtime_root) / "vllm"))}',
                 'export VLLM_TARGET_DEVICE=empty',
-                'install_with_fallback "runtime-install-vllm" "building editable vllm" . 1800 "$PYTHON -m pip install -e . --no-build-isolation"',
+                'emit_runtime_install_env',
+                'if [ "${VAWS_INSTALL_DEPS:-0}" = "1" ]; then VLLM_EDITABLE_INSTALL_ARGS="-e . --no-build-isolation"; else VLLM_EDITABLE_INSTALL_ARGS="-e . --no-build-isolation --no-deps"; fi',
+                'install_with_fallback "runtime-install-vllm" "building editable vllm" . 1800 "$PYTHON -m pip install $VLLM_EDITABLE_INSTALL_ARGS"',
+                'set +e',
+                '$PYTHON -m pip uninstall -y triton >/dev/null 2>&1',
+                'set -e',
             ]
         )
     elif step == 'install-vllm-ascend-requirements':
         lines.extend(
             [
                 f'cd {quoted(str(Path(runtime_root) / "vllm-ascend"))}',
+                'emit_runtime_install_env',
                 'pip_install_with_mirrors "runtime-install-vllm-ascend-requirements" "installing vllm-ascend requirements" 900 install -r requirements.txt',
             ]
         )
@@ -816,7 +1106,10 @@ def runtime_install_step_script(
         lines.extend(
             [
                 f'cd {quoted(str(Path(runtime_root) / "vllm-ascend"))}',
-                'install_with_fallback "runtime-install-vllm-ascend" "building editable vllm-ascend" . 2400 "$PYTHON -m pip install -v -e . --no-build-isolation"',
+                'emit_runtime_install_env',
+                'emit_runtime_npu_probe',
+                'if [ "${VAWS_INSTALL_DEPS:-0}" = "1" ]; then VLLM_ASCEND_EDITABLE_INSTALL_ARGS="-v -e . --no-build-isolation"; else VLLM_ASCEND_EDITABLE_INSTALL_ARGS="-v -e . --no-build-isolation --no-deps"; fi',
+                'install_with_fallback "runtime-install-vllm-ascend" "building editable vllm-ascend" . 2400 "$PYTHON -m pip install $VLLM_ASCEND_EDITABLE_INSTALL_ARGS"',
             ]
         )
     elif step == 'verify-imports':
@@ -842,6 +1135,34 @@ def runtime_install_step_script(
                 'import sys',
                 'from importlib.metadata import requires, version as pkg_version',
                 'from packaging.requirements import Requirement',
+                'from packaging.utils import canonicalize_name',
+                'from packaging.version import InvalidVersion, Version',
+                '',
+                'def importable(module):',
+                '    try:',
+                '        __import__(module)',
+                '        return True',
+                '    except Exception:',
+                '        return False',
+                '',
+                'def public_version(value):',
+                '    try:',
+                '        return Version(value).public',
+                '    except InvalidVersion:',
+                '        return value.split("+", 1)[0]',
+                '',
+                'def requirement_satisfied(req, installed):',
+                '    if not req.specifier:',
+                '        return True',
+                '    if req.specifier.contains(installed, prereleases=True):',
+                '        return True',
+                '    public = public_version(installed)',
+                '    if public != installed and req.specifier.contains(public, prereleases=True):',
+                '        return True',
+                '    # Paired vLLM Ascend images provide torch_npu as runtime state.',
+                '    if canonicalize_name(req.name) == "torch-npu" and importable("torch_npu"):',
+                '        return True',
+                '    return False',
                 '',
                 'errors = []',
                 'try:',
@@ -853,8 +1174,13 @@ def runtime_install_step_script(
                 '        r = Requirement(raw)',
                 '        if r.marker and not r.marker.evaluate():',
                 '            continue',
-                '        installed = pkg_version(r.name)',
-                '        if r.specifier and not r.specifier.contains(installed):',
+                '        try:',
+                '            installed = pkg_version(r.name)',
+                '        except Exception:',
+                '            if canonicalize_name(r.name) == "torch-npu" and importable("torch_npu"):',
+                '                continue',
+                '            raise',
+                '        if not requirement_satisfied(r, installed):',
                 '            errors.append(f"{r.name}{r.specifier} (installed {installed})")',
                 '    except Exception:',
                 '        pass',
@@ -901,6 +1227,7 @@ def run_runtime_install_step(
     step: str,
     stream_progress: bool = False,
     uninstall_packages: tuple[str, ...] = (),
+    install_deps: bool = False,
 ) -> None:
     script = runtime_install_step_script(
         runtime_root=runtime_root,
@@ -908,6 +1235,7 @@ def run_runtime_install_step(
         container_identity=container_identity,
         step=step,
         uninstall_packages=uninstall_packages,
+        install_deps=install_deps,
     )
     if stream_progress:
         ssh_exec_stream(container, script, stream_progress=True)
@@ -967,6 +1295,38 @@ def verify_runtime_commits(
     return observed
 
 
+def read_runtime_install_env(
+    *,
+    container: SshEndpoint,
+    runtime_root: str,
+    dry_run: bool,
+) -> dict[str, str]:
+    if dry_run:
+        return {}
+    lines = ['set -euo pipefail', f'mkdir -p {quoted(runtime_root)}', f'cd {quoted(runtime_root)}']
+    lines.extend(remote_runtime_env_exports())
+    lines.extend(DEFAULT_ENV_PREAMBLE)
+    lines.extend(
+        [
+            "$PYTHON - <<'PY'",
+            'import json',
+            'import os',
+            f'keys = {json.dumps(RUNTIME_INSTALL_ENV_KEYS)}',
+            'env = {key: os.environ[key] for key in keys if key in os.environ}',
+            'env["VAWS_VLLM_ASCEND_EFFECTIVE_PIP_EXTRA_INDEX_URL"] = (',
+            '    os.environ.get("VAWS_PIP_EXTRA_INDEX_URL")',
+            '    or os.environ.get("PIP_EXTRA_INDEX_URL")',
+            '    or os.environ.get("VAWS_ASCEND_PIP_EXTRA_INDEX_URL", "")',
+            ')',
+            'print(json.dumps(env, sort_keys=True))',
+            'PY',
+        ]
+    )
+    result = ssh_exec(container, '\n'.join(lines))
+    raw = json.loads(result.stdout.strip() or '{}')
+    return redact_runtime_env({str(key): str(value) for key, value in raw.items()})
+
+
 def update_runtime_state(
     *,
     repo_root: Path,
@@ -977,6 +1337,7 @@ def update_runtime_state(
     marker_dirname: str,
     records: list[SnapshotRecord],
     first_reinstall_completed: bool,
+    runtime_install_env: dict[str, str] | None,
 ) -> None:
     def apply_update(state: dict[str, Any]) -> None:
         server_state = state.setdefault('servers', {}).setdefault(server_name, {})
@@ -988,7 +1349,8 @@ def update_runtime_state(
             'last_sync_at': now_utc(),
             'first_reinstall_completed': first_reinstall_completed,
             'last_snapshot_commits': {record.relpath: record.commit for record in records},
-            'last_head_commits': {record.relpath: record.parent for record in records},
+            'last_head_commits': {record.relpath: record.source_head for record in records},
+            'last_runtime_install_env': runtime_install_env or {},
         }
 
     update_state(repo_root, STATE_FILENAME, {'schema_version': 2, 'servers': {}}, apply_update)
@@ -1006,6 +1368,7 @@ def make_manifest(
     marker_dirname: str,
     root_preserve_paths: tuple[str, ...],
     records: list[SnapshotRecord],
+    runtime_install_env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     git_name, git_email = ensure_local_git_identity(workspace_root)
     return {
@@ -1022,6 +1385,7 @@ def make_manifest(
         'root_preserve_paths': list(root_preserve_paths),
         'git_identity': {'name': git_name, 'email': git_email},
         'repos': [asdict(record) for record in records],
+        'runtime_install_env': runtime_install_env or {},
         'local_source_of_truth': 'tracked + staged + unstaged + untracked-nonignored',
     }
 
@@ -1037,6 +1401,7 @@ def summary_payload(
     reinstall_status: str,
     reason: str | None,
     first_install: bool,
+    runtime_install_env: dict[str, str] | None = None,
     observed_runtime_commits: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     return {
@@ -1049,6 +1414,7 @@ def summary_payload(
         'snapshot_commits': {record.relpath: record.commit for record in records},
         'runtime_commits': observed_runtime_commits,
         'reinstall': reinstall_status,
+        'runtime_install_env': runtime_install_env or {},
         'reason': reason,
     }
 
@@ -1126,6 +1492,10 @@ def run_sync(args: argparse.Namespace) -> int:
             record_map = {record.relpath: record for record in records}
             reinstall_vllm = reinstall_required_for_repo(record_map['vllm'], VLLM_REINSTALL_PATTERNS) if 'vllm' in record_map else False
             reinstall_vllm_ascend = reinstall_required_for_repo(record_map['vllm-ascend'], VLLM_ASCEND_REINSTALL_PATTERNS) if 'vllm-ascend' in record_map else False
+            vllm_dependency_changed = dependency_install_required_for_repo(record_map['vllm']) if 'vllm' in record_map else False
+            vllm_ascend_dependency_changed = dependency_install_required_for_repo(record_map['vllm-ascend']) if 'vllm-ascend' in record_map else False
+            vllm_head_drift = False
+            vllm_ascend_head_drift = False
 
             prior_runtime_state = load_runtime_state(workspace_root)
             last_container_state = (
@@ -1137,9 +1507,11 @@ def run_sync(args: argparse.Namespace) -> int:
             )
             last_commits = last_container_state.get('last_snapshot_commits', {})
             last_head_commits = last_container_state.get('last_head_commits', {})
-            if 'vllm' in record_map and last_head_commits.get('vllm') and record_map['vllm'].parent != last_head_commits['vllm']:
+            if 'vllm' in record_map and last_head_commits.get('vllm') and record_map['vllm'].source_head != last_head_commits['vllm']:
+                vllm_head_drift = True
                 reinstall_vllm = True
-            if 'vllm-ascend' in record_map and last_head_commits.get('vllm-ascend') and record_map['vllm-ascend'].parent != last_head_commits['vllm-ascend']:
+            if 'vllm-ascend' in record_map and last_head_commits.get('vllm-ascend') and record_map['vllm-ascend'].source_head != last_head_commits['vllm-ascend']:
+                vllm_ascend_head_drift = True
                 reinstall_vllm_ascend = True
             if reinstall_vllm and 'vllm-ascend' in record_map:
                 reinstall_vllm_ascend = True
@@ -1149,8 +1521,167 @@ def run_sync(args: argparse.Namespace) -> int:
                     reinstall_vllm = True
                 if 'vllm-ascend' in record_map:
                     reinstall_vllm_ascend = True
+            install_vllm_deps = os.environ.get('VAWS_INSTALL_DEPS') == '1' or vllm_dependency_changed or vllm_head_drift
+            install_vllm_ascend_deps = (
+                os.environ.get('VAWS_INSTALL_DEPS') == '1'
+                or vllm_ascend_dependency_changed
+                or vllm_ascend_head_drift
+            )
 
             snapshot_commits = {record.relpath: record.commit for record in records}
+            if args.apply_mode in {'source-only', 'materialize'}:
+                runtime_install_env: dict[str, str] = {}
+                manifest = make_manifest(
+                    workspace_root=workspace_root,
+                    workspace_id=workspace_id,
+                    snapshot_id=snapshot_id,
+                    server_name=args.server_name,
+                    container_identity=args.container_identity,
+                    runtime_root=runtime_root,
+                    container_cache_root=container_cache_root,
+                    marker_dirname=marker_dirname,
+                    root_preserve_paths=root_preserve_paths,
+                    records=records,
+                    runtime_install_env=runtime_install_env,
+                )
+                manifest['apply_mode'] = args.apply_mode
+                if args.print_manifest:
+                    print(json_dump(manifest))
+
+                if args.dry_run:
+                    summary = summary_payload(
+                        status='dry-run',
+                        server_name=args.server_name,
+                        container_identity=args.container_identity,
+                        workspace_id=workspace_id,
+                        container_cache_root=container_cache_root,
+                        records=records,
+                        reinstall_status='skipped-by-apply-mode',
+                        reason=f'apply_mode={args.apply_mode} skips runtime install/rebuild',
+                        first_install=False,
+                        runtime_install_env=runtime_install_env,
+                        observed_runtime_commits=None,
+                    )
+                    summary['apply_mode'] = args.apply_mode
+                    summary['manifest_path'] = manifest_path
+                    print(json_dump(summary))
+                    return 0
+
+                lock_path = lock_path_for(container_cache_root, workspace_id, args.container_identity)
+                current_phase = 'acquire-lock'
+                emit_progress(current_phase, lock_path=lock_path, apply_mode=args.apply_mode)
+                acquire_container_lock(container, lock_path, args.dry_run)
+                try:
+                    current_phase = 'push-mirrors'
+                    emit_progress(current_phase, repo_count=len(records), apply_mode=args.apply_mode)
+                    all_mirror_paths = [mirror_path_for(container_cache_root, workspace_id, r) for r in records]
+                    ensure_remote_bare_repos(container, all_mirror_paths, args.dry_run)
+                    for record in records:
+                        emit_progress('push-mirror', relpath=record.relpath)
+                        push_snapshot_to_mirror(
+                            repo=workspace_root if record.relpath in ('', '.') else workspace_root / record.relpath,
+                            container=container,
+                            mirror_path=mirror_path_for(container_cache_root, workspace_id, record),
+                            container_cache_root=container_cache_root,
+                            record=record,
+                            workspace_id=workspace_id,
+                            dry_run=args.dry_run,
+                        )
+
+                    current_phase = 'upload-manifest'
+                    emit_progress(current_phase, manifest_path=manifest_path, apply_mode=args.apply_mode)
+                    upload_manifest(container, manifest_path, manifest, args.dry_run)
+
+                    observed_runtime_commits = None
+                    status = 'source-only'
+                    if args.apply_mode == 'materialize':
+                        current_phase = 'materialize-runtime'
+                        emit_progress(current_phase, runtime_root=runtime_root, install='skipped')
+                        materialize_runtime(
+                            container=container,
+                            runtime_root=runtime_root,
+                            container_cache_root=container_cache_root,
+                            workspace_id=workspace_id,
+                            marker_dirname=marker_dirname,
+                            root_preserve_paths=root_preserve_paths,
+                            records=records,
+                            dry_run=args.dry_run,
+                        )
+                        current_phase = 'verify-runtime-commits'
+                        emit_progress(current_phase, repo_count=len(records))
+                        observed_runtime_commits = verify_runtime_commits(
+                            container=container,
+                            runtime_root=runtime_root,
+                            records=records,
+                            dry_run=args.dry_run,
+                        )
+                        expected_runtime_commits = {record.relpath: record.commit for record in records}
+                        if observed_runtime_commits != expected_runtime_commits:
+                            upload_manifest(
+                                container,
+                                manifest_path,
+                                final_manifest(
+                                    manifest,
+                                    status='failed',
+                                    reinstall_status='skipped-by-apply-mode',
+                                    runtime_commits=observed_runtime_commits,
+                                ),
+                                False,
+                            )
+                            summary = summary_payload(
+                                status='failed',
+                                server_name=args.server_name,
+                                container_identity=args.container_identity,
+                                workspace_id=workspace_id,
+                                container_cache_root=container_cache_root,
+                                records=records,
+                                reinstall_status='skipped-by-apply-mode',
+                                reason='runtime commit verification mismatch',
+                                first_install=False,
+                                runtime_install_env=runtime_install_env,
+                                observed_runtime_commits=observed_runtime_commits,
+                            )
+                            summary['apply_mode'] = args.apply_mode
+                            summary['manifest_path'] = manifest_path
+                            print(json_dump(summary))
+                            return 1
+                        status = 'materialized'
+
+                    current_phase = 'finalize-manifest'
+                    emit_progress(current_phase, manifest_path=manifest_path, apply_mode=args.apply_mode)
+                    upload_manifest(
+                        container,
+                        manifest_path,
+                        final_manifest(
+                            manifest,
+                            status=status,
+                            reinstall_status='skipped-by-apply-mode',
+                            runtime_commits=observed_runtime_commits,
+                        ),
+                        False,
+                    )
+                    emit_progress('complete', status=status, apply_mode=args.apply_mode)
+                    summary = summary_payload(
+                        status=status,
+                        server_name=args.server_name,
+                        container_identity=args.container_identity,
+                        workspace_id=workspace_id,
+                        container_cache_root=container_cache_root,
+                        records=records,
+                        reinstall_status='skipped-by-apply-mode',
+                        reason=f'apply_mode={args.apply_mode} skipped runtime install/rebuild',
+                        first_install=False,
+                        runtime_install_env=runtime_install_env,
+                        observed_runtime_commits=observed_runtime_commits,
+                    )
+                    summary['apply_mode'] = args.apply_mode
+                    summary['manifest_path'] = manifest_path
+                    print(json_dump(summary))
+                    return 0
+                finally:
+                    emit_progress('release-lock', lock_path=lock_path)
+                    release_container_lock(container, lock_path, args.dry_run)
+
             if (
                 not args.dry_run
                 and not reinstall_vllm
@@ -1178,6 +1709,7 @@ def run_sync(args: argparse.Namespace) -> int:
                         reinstall_status='not-needed',
                         reason=None,
                         first_install=False,
+                        runtime_install_env=last_container_state.get('last_runtime_install_env', {}),
                         observed_runtime_commits=observed,
                     )
                     print(json_dump(summary))
@@ -1214,6 +1746,16 @@ def run_sync(args: argparse.Namespace) -> int:
                 reinstall_vllm = True if 'vllm' in record_map else reinstall_vllm
                 reinstall_vllm_ascend = True if 'vllm-ascend' in record_map else reinstall_vllm_ascend
 
+            runtime_install_env: dict[str, str] = {}
+            if not args.dry_run:
+                current_phase = 'runtime-install-env'
+                emit_progress(current_phase, runtime_root=runtime_root)
+                runtime_install_env = read_runtime_install_env(
+                    container=container,
+                    runtime_root=runtime_root,
+                    dry_run=args.dry_run,
+                )
+
             manifest = make_manifest(
                 workspace_root=workspace_root,
                 workspace_id=workspace_id,
@@ -1225,6 +1767,7 @@ def run_sync(args: argparse.Namespace) -> int:
                 marker_dirname=marker_dirname,
                 root_preserve_paths=root_preserve_paths,
                 records=records,
+                runtime_install_env=runtime_install_env,
             )
             if args.print_manifest:
                 print(json_dump(manifest))
@@ -1241,6 +1784,7 @@ def run_sync(args: argparse.Namespace) -> int:
                     reinstall_status=reinstall_status,
                     reason=None,
                     first_install=first_install,
+                    runtime_install_env=runtime_install_env,
                     observed_runtime_commits=None,
                 )
                 print(json_dump(summary))
@@ -1261,6 +1805,7 @@ def run_sync(args: argparse.Namespace) -> int:
                         repo=workspace_root if record.relpath in ('', '.') else workspace_root / record.relpath,
                         container=container,
                         mirror_path=mirror_path_for(container_cache_root, workspace_id, record),
+                        container_cache_root=container_cache_root,
                         record=record,
                         workspace_id=workspace_id,
                         dry_run=args.dry_run,
@@ -1331,17 +1876,24 @@ def run_sync(args: argparse.Namespace) -> int:
                             container_identity=args.container_identity,
                             step='install-vllm',
                             stream_progress=True,
+                            install_deps=install_vllm_deps,
                         )
                     if reinstall_vllm_ascend:
-                        emit_progress('runtime-install-vllm-ascend-requirements', requirements='requirements.txt')
-                        run_runtime_install_step(
-                            container=container,
-                            runtime_root=runtime_root,
-                            marker_dirname=marker_dirname,
-                            container_identity=args.container_identity,
-                            step='install-vllm-ascend-requirements',
-                            stream_progress=True,
-                        )
+                        if install_vllm_ascend_deps:
+                            emit_progress('runtime-install-vllm-ascend-requirements', requirements='requirements.txt')
+                            run_runtime_install_step(
+                                container=container,
+                                runtime_root=runtime_root,
+                                marker_dirname=marker_dirname,
+                                container_identity=args.container_identity,
+                                step='install-vllm-ascend-requirements',
+                                stream_progress=True,
+                            )
+                        else:
+                            emit_progress(
+                                'runtime-install-vllm-ascend-requirements',
+                                requirements='skipped-paired-image-deps',
+                            )
                         emit_progress('runtime-install-vllm-ascend', package='vllm-ascend')
                         run_runtime_install_step(
                             container=container,
@@ -1350,16 +1902,8 @@ def run_sync(args: argparse.Namespace) -> int:
                             container_identity=args.container_identity,
                             step='install-vllm-ascend',
                             stream_progress=True,
+                            install_deps=install_vllm_ascend_deps,
                         )
-                    emit_progress('runtime-install-verify-imports')
-                    run_runtime_install_step(
-                        container=container,
-                        runtime_root=runtime_root,
-                        marker_dirname=marker_dirname,
-                        container_identity=args.container_identity,
-                        step='verify-imports',
-                        stream_progress=True,
-                    )
                     emit_progress('runtime-install-verify-deps')
                     try:
                         run_runtime_install_step(
@@ -1389,6 +1933,15 @@ def run_sync(args: argparse.Namespace) -> int:
                             step='verify-deps',
                             stream_progress=True,
                         )
+                    emit_progress('runtime-install-verify-imports')
+                    run_runtime_install_step(
+                        container=container,
+                        runtime_root=runtime_root,
+                        marker_dirname=marker_dirname,
+                        container_identity=args.container_identity,
+                        step='verify-imports',
+                        stream_progress=True,
+                    )
                     emit_progress('runtime-install-marker')
                     run_runtime_install_step(
                         container=container,
@@ -1430,6 +1983,7 @@ def run_sync(args: argparse.Namespace) -> int:
                         reinstall_status=reinstall_status,
                         reason='runtime commit verification mismatch',
                         first_install=first_install,
+                        runtime_install_env=runtime_install_env,
                         observed_runtime_commits=observed_runtime_commits,
                     )
                     print(json_dump(summary))
@@ -1448,6 +2002,7 @@ def run_sync(args: argparse.Namespace) -> int:
                     first_reinstall_completed=first_install
                     or last_container_state.get('first_reinstall_completed', False)
                     or reinstall_status == 'performed',
+                    runtime_install_env=runtime_install_env,
                 )
                 current_phase = 'finalize-manifest'
                 emit_progress(current_phase, manifest_path=manifest_path)
@@ -1473,6 +2028,7 @@ def run_sync(args: argparse.Namespace) -> int:
                     reinstall_status=reinstall_status,
                     reason=None,
                     first_install=first_install,
+                    runtime_install_env=runtime_install_env,
                     observed_runtime_commits=observed_runtime_commits,
                 )
                 print(json_dump(summary))
@@ -1512,6 +2068,12 @@ def build_parser() -> argparse.ArgumentParser:
     sync.add_argument('--force-reinstall', action='store_true', help='Force reinstall of vllm and vllm-ascend regardless of what changed.')
     sync.add_argument('--dry-run', action='store_true')
     sync.add_argument('--print-manifest', action='store_true')
+    sync.add_argument(
+        '--apply-mode',
+        choices=('source-only', 'materialize', 'install'),
+        default='install',
+        help='source-only publishes snapshots only; materialize updates runtime sources without install/rebuild; install keeps full parity behavior.',
+    )
 
     return parser
 

--- a/.agents/skills/remote-toolbox/SKILL.md
+++ b/.agents/skills/remote-toolbox/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: remote-toolbox
+description: Resolve, probe, execute, observe jobs, sync, manage service lifecycle, transfer artifacts, and clean VAWS remote Ascend session containers through structured agent-facing CLI entrypoints.
+---
+
+# VAWS Remote Toolbox
+
+Use this skill when an agent needs to operate a managed VAWS machine or session
+container with local-tool-like semantics instead of writing raw SSH, scp, sftp,
+manual tail, or manual ps/kill commands.
+
+## Critical Rules
+
+- Prefer `--session-id` or `--session-file` for parallel work. Use `--machine`
+  only for explicitly single-tenant legacy flows.
+- Entry points stream progress to `stderr` as `__VAWS_REMOTE_TOOLBOX_PROGRESS__=<json>`.
+- Final `stdout` is exactly one JSON object.
+- JSON failures must use one of: `needs_input`, `blocked`, `failed`,
+  `timeout`, `needs_repair`, `cancelled`.
+- Artifact transfer uses SSH streaming plus manifest/hash verification. Do not
+  depend on scp, sftp, or rsync.
+- `remote_sync_plan --mode source-only` and
+  `remote_sync_apply --mode source-only` must not enter install/rebuild.
+- `remote_sync_apply --mode materialize` updates runtime sources but still skips
+  install/rebuild.
+- `remote_sync_apply --mode install` delegates to remote-code-parity full
+  install/rebuild behavior and consent gates.
+
+## Entry Points
+
+Target and diagnostics:
+
+```bash
+python3 .agents/scripts/remote_target_resolve.py (--machine <alias> | --session-id <id> | --session-file <path>)
+python3 .agents/scripts/remote_probe.py (--machine <alias> | --session-id <id> | --session-file <path>)
+python3 .agents/scripts/remote_exec.py --session-id <id> --cwd /vllm-workspace --command 'python3 -V'
+# remote_exec and remote_job_start source /etc/profile.d/vaws-ascend-env.sh by default.
+# Use --no-runtime-env only when intentionally debugging the raw container shell.
+```
+
+Long jobs:
+
+```bash
+python3 .agents/scripts/remote_job_start.py --session-id <id> --kind build --command 'bash build.sh'
+python3 .agents/scripts/remote_job_status.py --job-id <job-id>
+python3 .agents/scripts/remote_job_tail.py --job-id <job-id> --lines 120
+python3 .agents/scripts/remote_job_stop.py --job-id <job-id> --force
+python3 .agents/scripts/remote_job_collect.py --job-id <job-id>
+```
+
+Sync:
+
+```bash
+python3 .agents/scripts/remote_sync_plan.py --session-id <id> --mode source-only
+python3 .agents/scripts/remote_sync_apply.py --session-id <id> --mode source-only
+python3 .agents/scripts/remote_sync_plan.py --session-id <id> --mode install --force-reinstall
+python3 .agents/scripts/remote_sync_apply.py --session-id <id> --mode install
+```
+
+Service:
+
+```bash
+python3 .agents/scripts/remote_service_start.py --session-id <id> -- --model /data/models/Qwen --tp 1
+python3 .agents/scripts/remote_service_status.py --session-id <id>
+python3 .agents/scripts/remote_service_logs.py --session-id <id> --lines 200
+python3 .agents/scripts/remote_service_stop.py --session-id <id> --force
+```
+
+Artifacts and cleanup:
+
+```bash
+python3 .agents/scripts/remote_artifact_manifest.py --session-id <id> --remote-path /vllm-workspace/.vaws-runtime/serving
+python3 .agents/scripts/remote_artifact_pull.py --session-id <id> --remote-path /vllm-workspace/.vaws-runtime/serving --local-dir .vaws-local/remote-toolbox/artifacts/serving
+python3 .agents/scripts/remote_artifact_push.py --session-id <id> --local-path ./local-report --remote-path /tmp/report
+python3 .agents/scripts/remote_cleanup.py --session-id <id> --service --jobs --remote-temp --leases --dry-run
+python3 .agents/scripts/remote_cleanup.py --session-id <id> --job-id <job-id> --dry-run
+```
+
+## State
+
+Local untracked state lives under `.vaws-local/remote-toolbox/`:
+
+- `logs/` for full stdout/stderr from `remote_exec`
+- `jobs/<job-id>.json` for local job registry records
+- `artifacts/` for pulled job/service/profiling artifacts
+
+Remote toolbox state lives under `<runtime-root>/.vaws-runtime/remote-toolbox/`
+inside the target container.
+
+## References
+
+- `.agents/skills/remote-toolbox/references/behavior.md`
+- `.agents/skills/remote-toolbox/references/command-recipes.md`
+- `.agents/skills/remote-toolbox/references/acceptance.md`
+- `.agents/skills/remote-toolbox/references/stress-validation.md`

--- a/.agents/skills/remote-toolbox/references/acceptance.md
+++ b/.agents/skills/remote-toolbox/references/acceptance.md
@@ -1,0 +1,17 @@
+# Remote Toolbox Acceptance
+
+- `python3 -m compileall -q .agents`
+- `git diff --check -- .agents AGENTS.md README.md README.en.md`
+- Every new `remote_*` CLI accepts `--help`.
+- `remote_probe` succeeds on 125 and 131 and reports CANN, Python, torch,
+  torch_npu, NPU facts, and host/container endpoints.
+- Two concurrent 131 sessions have different container names, SSH ports, NPU
+  leases, and state namespaces.
+- `remote_sync_plan --mode source-only` reports `will_install=false`.
+- `remote_sync_plan --mode install` reports install/rebuild reasons and consent.
+- Invalid model service start returns `needs_input`; cleanup leaves no session
+  service state running.
+- Artifact manifest and pull cover at least one service log or profiling/report
+  directory.
+- Final session list, lease state, and service state prove test sessions were
+  cleaned up.

--- a/.agents/skills/remote-toolbox/references/behavior.md
+++ b/.agents/skills/remote-toolbox/references/behavior.md
@@ -1,0 +1,23 @@
+# Remote Toolbox Behavior
+
+The toolbox normalizes a VAWS target before any remote action. Resolution
+accepts `--machine`, `--session-id`, or `--session-file` and returns the host
+SSH endpoint, container SSH endpoint, runtime root, workspace id, session id,
+leased devices, and state paths.
+
+`remote_probe` verifies observed runtime facts from the running container. It
+reports the recorded image tag separately from host `docker inspect` image id
+because tags are not trusted as proof of the active runtime.
+
+`remote_exec` stores complete stdout/stderr locally and returns tails in JSON.
+Long tasks should use `remote_job_start` so agents can call status, tail, stop,
+and collect without manual process management.
+
+`remote_sync_plan` is a planning surface and must not mutate remote state.
+`remote_sync_apply --mode source-only` publishes source snapshots to the
+container cache only. `--mode materialize` checks sources out into the runtime
+root without running pip/build/install steps. `--mode install` keeps the full
+remote-code-parity install behavior.
+
+Artifact push/pull always verifies SHA-256 hashes from a manifest and streams
+over SSH shell commands. It must not rely on scp, sftp, or rsync.

--- a/.agents/skills/remote-toolbox/references/command-recipes.md
+++ b/.agents/skills/remote-toolbox/references/command-recipes.md
@@ -1,0 +1,43 @@
+# Remote Toolbox Command Recipes
+
+Probe both managed base containers:
+
+```bash
+python3 .agents/scripts/remote_probe.py --machine 173.125.1.2
+python3 .agents/scripts/remote_probe.py --machine 173.131.1.2
+```
+
+Create two sessions on one machine, then prove isolation:
+
+```bash
+python3 .agents/skills/session-management/scripts/session_create.py --machine 173.131.1.2 --session-id toolbox-a --npu-count 1 --no-worktree
+python3 .agents/skills/session-management/scripts/session_create.py --machine 173.131.1.2 --session-id toolbox-b --npu-count 1 --no-worktree
+python3 .agents/scripts/remote_target_resolve.py --session-id toolbox-a
+python3 .agents/scripts/remote_target_resolve.py --session-id toolbox-b
+```
+
+Plan sync without install:
+
+```bash
+python3 .agents/scripts/remote_sync_plan.py --session-id toolbox-a --mode source-only
+```
+
+Plan install with explicit reasons and consent state:
+
+```bash
+python3 .agents/scripts/remote_sync_plan.py --session-id toolbox-a --mode install
+```
+
+Validate service failure cleanup:
+
+```bash
+python3 .agents/scripts/remote_service_start.py --session-id toolbox-a -- --model /no/such/model --skip-parity
+python3 .agents/scripts/remote_cleanup.py --session-id toolbox-a --service --force
+```
+
+Pull a service log directory:
+
+```bash
+python3 .agents/scripts/remote_artifact_manifest.py --session-id toolbox-a --remote-path /vllm-workspace/.vaws-runtime/serving
+python3 .agents/scripts/remote_artifact_pull.py --session-id toolbox-a --remote-path /vllm-workspace/.vaws-runtime/serving --local-dir .vaws-local/remote-toolbox/artifacts/toolbox-a-serving
+```

--- a/.agents/skills/remote-toolbox/references/stress-validation.md
+++ b/.agents/skills/remote-toolbox/references/stress-validation.md
@@ -1,0 +1,185 @@
+# VAWS Remote Toolbox Stress Validation Matrix
+
+This matrix is based on recurring vLLM Ascend development tasks in this
+workspace: remote code parity before service/benchmark runs, parallel agent
+sessions on 125/131, negative service launches, profiling/report artifact
+pullback, and cleanup after failed remote work.
+
+## Local Contract Suite
+
+Run before any remote work:
+
+```bash
+python3 -m compileall -q .agents
+git diff --check -- .agents AGENTS.md README.md README.en.md
+for f in .agents/scripts/remote_*.py; do python3 "$f" --help >/dev/null; done
+```
+
+Expected:
+
+- all scripts compile
+- no whitespace errors
+- each CLI exposes `--help`
+- final stdout stays a single JSON object for normal execution paths
+
+## Probe And Target Resolution
+
+Use both managed base machines:
+
+```bash
+python3 .agents/scripts/remote_probe.py --machine 173.125.1.2 --timeout 90
+python3 .agents/scripts/remote_probe.py --machine 173.131.1.2 --timeout 90
+```
+
+Validate:
+
+- host endpoint is `:22`, container endpoint is `:46000` for the base machines
+- image proof includes observed `docker inspect` image id, not only a tag
+- CANN reports `/usr/local/Ascend/cann-9.0.0`
+- Python, torch, torch_npu, NPU facts are present
+- known_hosts facts identify both host and container keys
+
+## Parallel Session Isolation
+
+Create at least two sessions on 131:
+
+```bash
+python3 .agents/skills/session-management/scripts/session_create.py --machine 173.131.1.2 --session-id stress-a --npu-count 1 --no-worktree --verification-mode ssh
+python3 .agents/skills/session-management/scripts/session_create.py --machine 173.131.1.2 --session-id stress-b --npu-count 1 --no-worktree --verification-mode ssh
+python3 .agents/scripts/remote_target_resolve.py --session-id stress-a
+python3 .agents/scripts/remote_target_resolve.py --session-id stress-b
+```
+
+Validate:
+
+- distinct container names
+- distinct container SSH ports
+- distinct NPU leases
+- distinct state files under `.vaws-local/sessions/<id>/`
+- `session_list.py` lease state matches the session files
+
+## Source Sync Mode Split
+
+Plan both no-install and install paths:
+
+```bash
+python3 .agents/scripts/remote_sync_plan.py --session-id stress-a --mode source-only
+python3 .agents/scripts/remote_sync_plan.py --session-id stress-a --mode install --force-reinstall
+```
+
+Validate:
+
+- source-only reports `will_install=false`
+- source-only reports `will_materialize=false`
+- install reports consent state and install/rebuild reasons
+- source-only apply emits no runtime-install progress:
+
+```bash
+python3 .agents/scripts/remote_sync_apply.py --session-id stress-a --mode source-only
+```
+
+## Lightweight Remote Toolbox Pressure
+
+Use `remote_toolbox_stress.py` for repeatable non-NPU pressure:
+
+```bash
+python3 .agents/scripts/remote_toolbox_stress.py \
+  --machine 173.131.1.2 \
+  --parallelism 4 \
+  --exec-count 8 \
+  --job-count 4 \
+  --artifact-files 48 \
+  --artifact-bytes 512
+```
+
+Expected:
+
+- concurrent `remote_exec` cases succeed
+- jobs are observable through start/status/tail
+- artifact pull uses `tar` transport when available and verifies hashes
+- final stdout is one JSON object with `status=ok`
+
+For heavier artifact pressure, increase file count before increasing byte size:
+
+```bash
+python3 .agents/scripts/remote_toolbox_stress.py --machine 173.131.1.2 --artifact-files 512 --artifact-bytes 2048 --skip-jobs --skip-exec
+```
+
+This stresses the profiling/report artifact shape without running msprof or
+benchmark workloads.
+
+## Negative Service Launch Safety
+
+Invalid model paths must fail before stopping existing services:
+
+```bash
+python3 .agents/scripts/remote_service_start.py --machine 173.131.1.2 --model /no/such/model --skip-parity
+```
+
+Expected:
+
+- status is `needs_input`
+- progress reaches `validate`
+- progress does not include `stop-existing`
+
+## Artifact Return Path
+
+For a service log or profiling/report directory:
+
+```bash
+python3 .agents/scripts/remote_artifact_manifest.py --session-id stress-a --remote-path /vllm-workspace/.vaws-runtime/serving
+python3 .agents/scripts/remote_artifact_pull.py --session-id stress-a --remote-path /vllm-workspace/.vaws-runtime/serving --local-dir .vaws-local/remote-toolbox/artifacts/stress-serving
+```
+
+Validate:
+
+- manifest includes file count, size, SHA-256, and relpaths
+- pull skips already matching files on rerun
+- large multi-file directories use one tar stream when possible
+- no scp/sftp/rsync dependency
+
+## Cleanup Proof
+
+Clean test sessions and prove local lease state is empty:
+
+```bash
+python3 .agents/scripts/remote_cleanup.py --session-id stress-a --service --jobs --remote-temp --session-container --leases --force
+python3 .agents/scripts/remote_cleanup.py --session-id stress-b --service --jobs --remote-temp --session-container --leases --force
+python3 .agents/skills/session-management/scripts/session_list.py
+```
+
+Expected:
+
+- session statuses are `removed`
+- `npu_devices`, `container_ssh_ports`, and `service_ports` are empty for the
+  test machine
+- service status returns `not_found`
+
+## Agent-Unfriendly Regression Checks
+
+Track and fix these as failures:
+
+- a validation error stops an existing service before proving the new request is valid
+- a destructive session command falls back to the current-session binding when
+  no explicit `--session-id` or `--session-file` was provided
+- GC mutates lease state unless the caller explicitly requested `--apply`
+- status/list/help commands perform business logic when the caller requested
+  `--help`
+- `remote_exec` or `remote_job_start` runs in the raw shell Python by default
+  instead of the validated Ascend runtime profile
+- cleanup can only delete the entire remote job tree and cannot target one
+  `job_id`
+- long commands hide progress until completion
+- a command requires manual SSH, scp, sftp, tail, ps, or kill for the normal path
+- artifact pull opens one SSH connection per file for large report trees
+- dry-run output does not clearly state whether install/rebuild would happen
+- cleanup cannot prove leases and service state after it runs
+
+Fix expectations:
+
+- `session_remove.py` without an explicit target returns `needs_input`.
+- `session_gc.py` defaults to dry-run and only mutates with `--apply`.
+- `remote_exec.py` and `remote_job_start.py` source
+  `/etc/profile.d/vaws-ascend-env.sh` by default and report the effective
+  Python in their environment summary.
+- `remote_cleanup.py --job-id <job-id>` scopes remote job cleanup.

--- a/.agents/skills/session-management/SKILL.md
+++ b/.agents/skills/session-management/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: session-management
+description: Create, list, inspect, remove, and garbage-collect isolated VAWS agent sessions. Use before remote execution when multiple agent tasks must run in parallel without sharing local worktrees, remote containers, serving state, or resource leases.
+---
+
+# Session Management
+
+Create and maintain isolated VAWS sessions for parallel agent work.
+
+Each session binds:
+
+- one local Git worktree
+- one remote session container
+- one `.vaws-local/sessions/<session-id>/` state namespace
+- local leases for container SSH port, service port, and optional NPU devices
+
+## Use This Skill When
+
+- a user wants multiple agents/tasks to run in parallel
+- a remote execution task should avoid interfering with another service or benchmark
+- a task needs a dedicated worktree plus dedicated remote runtime/container
+- you need to list, inspect, remove, or clean up existing sessions
+
+## Critical Rules
+
+- Prefer `--session-id`, `VAWS_SESSION_ID`, or `VAWS_AGENT_SESSION_ID` when an upstream agent already has a stable id.
+- `session_create.py` creates a fresh generated id when no explicit/env id is provided; it does not reuse `.vaws-local/current-session.json` as a creation default.
+- Existing-session lookup commands may use `.vaws-local/current-session.json` as a convenience fallback.
+- Do not reuse the base machine container for new parallel tasks. New tasks should use `session_create.py`.
+- For NPU work, reserve devices during creation with `--devices` or `--npu-count`; session-aware serving uses that lease by default.
+- For session work, pass `--session-id <id>` or `--session-file <session.json>` to parity, serving, benchmark, profiling-collection, memory-profiling, and profiling-analysis entry points.
+- Never call legacy `serve_stop.py --machine <alias>` from a session-scoped task.
+- Session removal should stop only that session's service and release only that session's leases.
+
+## Entry Points
+
+```bash
+python3 .agents/skills/session-management/scripts/session_create.py \
+  --machine <alias-or-ip> \
+  [--session-id <id>] \
+  [--base-ref main] \
+  [--branch session/<id>] \
+  [--devices 0,1] \
+  [--npu-count 2] \
+  [--verification-mode ssh|full] \
+  [--disable-prepared-image-cache]
+```
+
+```bash
+python3 .agents/skills/session-management/scripts/session_list.py
+python3 .agents/skills/session-management/scripts/session_status.py --session-id <id>
+python3 .agents/skills/session-management/scripts/session_remove.py --session-id <id> --remove-container --remove-worktree --release-leases
+python3 .agents/skills/session-management/scripts/session_gc.py
+```
+
+Progress is emitted on `stderr` as `__VAWS_SESSION_PROGRESS__=<json>`. Final output is JSON on `stdout`.
+
+By default session creation uses a host-local prepared image cache keyed by the selected base image id. The first session for a base image may still install container SSH packages, then commits `vaws-session-prepared:<image-hash>-ssh-v2`; later sessions start from that prepared image and skip the repeated `openssh` package install and cached pip/pytest bootstrap. Use `--disable-prepared-image-cache` only when validating raw base-image bootstrap behavior.
+
+Session creation defaults to `--verification-mode ssh`: it verifies host SSH and direct session-container SSH, then leaves NPU runtime proof to the task that actually uses the session, such as serving, benchmark, or profiling. Use `--verification-mode full` when validating a raw machine/container bootstrap and you need the extra `torch` / `torch_npu` smoke check during creation.
+
+## State
+
+Local untracked state lives under `.vaws-local/sessions/`:
+
+- `index.json`
+- `leases.json`
+- `locks/`
+- `<session-id>/session.json`
+- `<session-id>/serving.json`
+- `<session-id>/benchmark/`
+
+Worktree bindings are written to `<worktree>/.vaws-local/current-session.json` and include the absolute base session file path so scripts run from the worktree can find the base session state.
+
+For explicit `--session-id --no-worktree` timing/debug sessions, `session_create.py` does not overwrite the repo-root `.vaws-local/current-session.json`; agents should pass `--session-id` or `--session-file` explicitly for those shared-root flows. Current-session binding writes are atomic so readers never observe partial JSON.
+
+## References
+
+- `.agents/skills/session-management/references/behavior.md`
+- `.agents/skills/session-management/references/command-recipes.md`
+- `.agents/skills/session-management/references/acceptance.md`

--- a/.agents/skills/session-management/references/acceptance.md
+++ b/.agents/skills/session-management/references/acceptance.md
@@ -1,0 +1,21 @@
+# Acceptance
+
+- Two sessions on the same base machine have different worktree roots, container names, container SSH ports, and serving state paths.
+- For non-moving image policies, session creation checks the host-local image cache before `docker pull`.
+- The first session for a base image can create a `vaws-session-prepared:<image-hash>-ssh-v2` image after installing SSH packages and pip / pytest basics.
+- A later session for the same base image starts from the prepared image and reports `used_prepared_image_cache: true` without reinstalling `openssh` or repeating pip / pytest bootstrap.
+- `session_create.py --disable-prepared-image-cache` keeps the raw base-image bootstrap path available.
+- Default session creation reports `verification_mode: ssh` and `npu_smoke_skipped: true` after host/container SSH checks.
+- `session_create.py --verification-mode full` keeps the full `torch` / `torch_npu` smoke check available.
+- `session_create.py` without `--session-id`, `VAWS_SESSION_ID`, or `VAWS_AGENT_SESSION_ID` generates a fresh session id instead of reusing repo-root `.vaws-local/current-session.json`.
+- Explicit `session_create.py --session-id <id> --no-worktree` does not overwrite the repo-root `.vaws-local/current-session.json`.
+- Session container SSH port allocation does not hold the lease lock while running per-port remote SSH probes.
+- `serve_start.py --session-id s1` stops only `s1`'s previous service.
+- `serve_start.py --session-id s1` defaults to `s1`'s leased NPU devices and rejects explicit devices outside that lease.
+- `serve_stop.py --session-id s1` does not read or mutate `.vaws-local/serving/<machine>.json`.
+- `bench_run.py --session-id s2` stops only `s2`'s service at cleanup time.
+- `parity_sync.py --session-id s1` derives `workspace_id=s1` and `container_identity=<s1-container>@<runtime-root>`.
+- `session_remove.py --remove-container --release-leases` can skip `serve_stop.py` when no session serving state exists and still release leases after the container is removed or the stop result is `not_found`.
+- `session_remove.py` returns `needs_repair` instead of `removed` when requested container or worktree removal fails.
+- `session_gc.py` does not release leases for generic `failed` sessions.
+- Legacy `--machine` commands continue to work against the base machine state.

--- a/.agents/skills/session-management/references/behavior.md
+++ b/.agents/skills/session-management/references/behavior.md
@@ -1,0 +1,67 @@
+# Behavior Reference
+
+## Session Creation
+
+`session_create.py` resolves a session id, allocates local leases, creates or reuses a Git worktree, writes a session spec under `.vaws-local/sessions/<session-id>/session.json`, then bootstraps a dedicated remote container through the existing machine-management bootstrap logic.
+
+The base machine inventory is treated as a resource pool. Creating a session does not replace or mutate the base machine record.
+
+## Worktree Behavior
+
+Default worktree path:
+
+```text
+../vaws-worktrees/<repo-name>/<session-id>
+```
+
+Default branch:
+
+```text
+session/<session-id>
+```
+
+If a worktree already exists and is bound to the same session, it is reused. If it is bound to a different session or has no binding, creation fails closed.
+
+## Container Behavior
+
+Session containers use the base machine image, host mounts, workdir, and Ascend bootstrap logic, but get a distinct container name and SSH port.
+
+The default container name is:
+
+```text
+vaws-<namespace>-<session-id>
+```
+
+Session bootstrap defaults to a host-local prepared image cache. The bootstrapper first prefers a local exact base-image hit over a registry pull for non-moving image policies, then derives `vaws-session-prepared:<base-image-id>-ssh-v2` from that image. On a cache miss, the new session container is created from the base image, installs `openssh-server` / `openssh-client`, configures pip / pytest basics, and commits the prepared image before dynamic SSH configuration. On a cache hit, the session container starts from the prepared image and skips the repeated package-manager and pip / pytest bootstrap work.
+
+The prepared image cache is session-specific behavior; managed base-machine add / repair paths keep their conservative raw-image bootstrap unless they explicitly opt in. `VAWS_DOCKER_PULL_POLICY=always` forces a fresh pull check, and `session_create.py --disable-prepared-image-cache` disables prepared-image usage for raw bootstrap timing or debugging.
+
+After bootstrap, session creation defaults to SSH-only verification. It checks host SSH and direct container SSH, records `npu_smoke_skipped: true`, and marks the session ready when both endpoints are reachable. This avoids serializing every parallel agent behind repeated `torch` / `torch_npu` smoke checks and avoids consuming an NPU during session setup. Use `session_create.py --verification-mode full` when the creation step itself must prove the NPU runtime with the full smoke check.
+
+Explicit `--session-id --no-worktree` sessions are treated as shared-root timing/debug sessions. They write the session record and leases, but do not overwrite the repo-root `.vaws-local/current-session.json`; downstream commands should receive `--session-id` or `--session-file` explicitly.
+
+When no explicit/env session id is provided, `session_create.py` generates a fresh id instead of reusing `.vaws-local/current-session.json`. Current-session lookup remains available for commands that operate on an existing session.
+
+## Lease Behavior
+
+Leases are local to the workspace and live in `.vaws-local/sessions/leases.json`.
+
+The first implementation protects:
+
+- container SSH ports
+- service ports
+- explicitly requested or auto-counted NPU devices
+
+Session-aware serving uses the session NPU lease as its default device set. If a launch requests explicit devices, they must be contained inside the session's leased device list.
+
+Session creation probes host listening ports once before taking the lease lock, then selects a container SSH port from that snapshot. This avoids holding the global lease file lock across one SSH round trip per candidate port.
+
+NPU leases are released by `session_remove.py --release-leases`, not by `serve_stop.py`, because a session may stop serving and continue with another remote task.
+
+When `session_remove.py --remove-container` sees no session serving state file, it skips the serving stop wrapper and relies on container removal to terminate any untracked process. This keeps teardown cheap for sessions that were created only for parity, bootstrap timing, or compile work.
+
+`session_remove.py` marks a session `removed` only when the requested container/worktree removal succeeds. Failed removal leaves the session in `needs_repair`. `session_gc.py` releases leases for `removed` or missing-state sessions; it does not release leases for generic `failed` sessions because those may still protect partially created remote resources.
+
+## Legacy Compatibility
+
+Legacy `--machine` flows continue to use the base machine container and machine-level state. Session-aware flows use `--session-id` or `--session-file` and state under `.vaws-local/sessions/<session-id>/`.

--- a/.agents/skills/session-management/references/command-recipes.md
+++ b/.agents/skills/session-management/references/command-recipes.md
@@ -1,0 +1,100 @@
+# Command Recipes
+
+Create a session on a ready base machine:
+
+```bash
+python3 .agents/skills/session-management/scripts/session_create.py \
+  --machine a2-01 \
+  --session-id pr123 \
+  --devices 0,1
+```
+
+Measure the raw base-image bootstrap path without the prepared image cache:
+
+```bash
+python3 .agents/skills/session-management/scripts/session_create.py \
+  --machine a2-01 \
+  --session-id timing-raw \
+  --no-worktree \
+  --devices 0 \
+  --disable-prepared-image-cache
+```
+
+Normal session creation keeps the prepared image cache enabled. Set `VAWS_DOCKER_PULL_POLICY=always` only when the image tag must be refreshed before session creation.
+
+Default creation uses SSH-only readiness verification so parallel agents do not all run NPU smoke during setup:
+
+```bash
+python3 .agents/skills/session-management/scripts/session_create.py \
+  --machine a2-01 \
+  --session-id pr123 \
+  --devices 0 \
+  --verification-mode ssh
+```
+
+Use full verification only when the create step itself must validate `torch` / `torch_npu`:
+
+```bash
+python3 .agents/skills/session-management/scripts/session_create.py \
+  --machine a2-01 \
+  --session-id timing-full \
+  --no-worktree \
+  --devices 0 \
+  --verification-mode full
+```
+
+Use the session for parity and serving:
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/parity_sync.py --session-id pr123
+python3 .agents/skills/vllm-ascend-serving/scripts/serve_start.py \
+  --session-id pr123 \
+  --model /data/models/Qwen \
+  --tp 2
+```
+
+Run a session-scoped benchmark:
+
+```bash
+python3 .agents/skills/vllm-ascend-benchmark/scripts/bench_run.py \
+  --session-id pr123 \
+  --model /data/models/Qwen \
+  --tp 2
+```
+
+Collect and analyze profiling data in the same session container:
+
+```bash
+python3 .agents/skills/ascend-profiling-collection/scripts/collect_torch_profile_case.py \
+  --session-id pr123 \
+  --model /data/models/Qwen \
+  --served-model-name Qwen \
+  --tp 2 \
+  --tag pr123_smoke \
+  --mode enforce_eager \
+  --request-kind text \
+  --benchmark-output-tokens 32
+
+python3 .agents/skills/ascend-profiling-analysis/scripts/profile_analyze.py \
+  --manifest .vaws-local/ascend-profiling-collection/runs/<timestamp>_pr123_smoke/manifest.json \
+  --tag pr123_smoke
+```
+
+Collect memory data from a session-scoped service:
+
+```bash
+python3 .agents/skills/ascend-memory-profiling/scripts/mem_collect.py \
+  --session-id pr123 \
+  --attach \
+  --tag pr123_memory
+```
+
+Remove a session and its resources:
+
+```bash
+python3 .agents/skills/session-management/scripts/session_remove.py \
+  --session-id pr123 \
+  --remove-container \
+  --remove-worktree \
+  --release-leases
+```

--- a/.agents/skills/session-management/scripts/session_create.py
+++ b/.agents/skills/session-management/scripts/session_create.py
@@ -300,6 +300,9 @@ def ensure_worktree(
     if worktree_root.exists():
         bound = existing_worktree_bound(worktree_root)
         if bound == session_id:
+            emit_progress("worktree", "reusing bound worktree", path=str(worktree_root), branch=branch)
+            emit_progress("worktree", "initializing submodules", path=str(worktree_root))
+            run_git(["submodule", "update", "--init", "--recursive"], cwd=worktree_root)
             return worktree_root, {"action": "reused", "path": str(worktree_root), "branch": branch}
         raise SessionStateError(
             f"worktree path already exists and is not bound to session {session_id}: {worktree_root}"
@@ -314,9 +317,21 @@ def ensure_worktree(
     else:
         run_git(["worktree", "add", "-b", branch, str(worktree_root), base_ref])
         action = "created-branch"
+    staging_binding = write_current_session_binding(
+        worktree_root,
+        session_id=session_id,
+        source="session_create-staging",
+        base_repo_root=ROOT,
+    )
     emit_progress("worktree", "initializing submodules", path=str(worktree_root))
     run_git(["submodule", "update", "--init", "--recursive"], cwd=worktree_root)
-    return worktree_root, {"action": action, "path": str(worktree_root), "branch": branch, "base_ref": base_ref}
+    return worktree_root, {
+        "action": action,
+        "path": str(worktree_root),
+        "branch": branch,
+        "base_ref": base_ref,
+        "staging_binding": str(staging_binding),
+    }
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -421,6 +436,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "action": "skipped",
                 "reason": "explicit --no-worktree session does not overwrite repo-root current-session",
                 "path": str(local_root / ".vaws-local" / "current-session.json"),
+            }
+        elif worktree_payload.get("staging_binding"):
+            binding_payload = {
+                "action": "written",
+                "path": worktree_payload["staging_binding"],
+                "source": "session_create-staging",
             }
         else:
             binding_path = write_current_session_binding(

--- a/.agents/skills/session-management/scripts/session_create.py
+++ b/.agents/skills/session-management/scripts/session_create.py
@@ -40,6 +40,7 @@ from vaws_session_state import (  # noqa: E402
     session_record_for_execution,
 )
 from vaws_local_state import load_profile, utc_now_iso  # noqa: E402
+from vaws_validate import ValidationError, parse_device_csv  # noqa: E402
 
 PROGRESS_SENTINEL = "__VAWS_SESSION_PROGRESS__="
 PORT_TAIL_RE = re.compile(r"[:.]([0-9]+)$")
@@ -54,6 +55,14 @@ def emit_progress(phase: str, message: str, **extra: Any) -> None:
 
 def print_json(data: dict[str, Any]) -> None:
     print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def tail_output(value: str | bytes | None, limit: int = 500) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="replace")
+    return value[-limit:]
 
 
 def run_git(args: list[str], *, cwd: Path = ROOT, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -81,16 +90,47 @@ def load_machine(identifier: str) -> dict[str, Any]:
     return matches[0]
 
 
-def parse_devices(value: str | None) -> list[int] | None:
-    if value is None:
-        return None
-    devices: list[int] = []
-    for item in value.split(","):
-        stripped = item.strip()
-        if not stripped:
-            continue
-        devices.append(int(stripped))
-    return devices
+def parse_host_npu_devices(stdout: str) -> list[int]:
+    devices: set[int] = set()
+    for line in stdout.splitlines():
+        match = re.match(r"\|\s*(\d+)\s+\d*\w+\d+\w*\s+\|", line)
+        if match:
+            devices.add(int(match.group(1)))
+    return sorted(devices)
+
+
+def probe_host_npu_devices(record: dict[str, Any]) -> tuple[list[int] | None, dict[str, Any]]:
+    host = record["host"]
+    target = machine_ops.SshTarget(
+        host=host["ip"],
+        user=host.get("user", "root"),
+        port=host.get("port", 22),
+    )
+    cmd = [
+        *machine_ops.ssh_command(target),
+        "bash",
+        "-c",
+        shlex.quote("npu-smi info 2>/dev/null"),
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=30)
+    except subprocess.TimeoutExpired as exc:
+        return None, {
+            "status": "timeout",
+            "timeout_seconds": 30,
+            "stdout_tail": tail_output(exc.stdout),
+            "stderr_tail": tail_output(exc.stderr),
+        }
+    payload: dict[str, Any] = {
+        "returncode": result.returncode,
+        "stderr_tail": result.stderr[-500:],
+    }
+    if result.returncode != 0:
+        payload["status"] = "unavailable"
+        return None, payload
+    devices = parse_host_npu_devices(result.stdout)
+    payload.update({"status": "ok" if devices else "unparsed", "devices": devices})
+    return devices or None, payload
 
 
 def host_port_available(record: dict[str, Any]) -> Any:
@@ -315,6 +355,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    session_path: Path | None = None
+    binding_payload: dict[str, Any] | None = None
     try:
         resolved = resolve_session_id(
             explicit=args.session_id,
@@ -338,8 +380,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                     }
                 )
                 return 0
-            except Exception:
-                pass
+            except SessionStateError as exc:
+                if "session id or session file is required" not in str(exc) and "session file does not exist" not in str(exc):
+                    print_json({"status": "needs_repair", "session_id": sid, "error": str(exc)})
+                    return 1
 
         emit_progress("resolve-machine", f"loading base machine {args.machine}")
         base_record = load_machine(args.machine)
@@ -354,6 +398,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         runtime_root = args.runtime_root or workdir
         branch = args.branch or default_branch(sid)
         worktree_root = args.worktree_root or default_worktree_root(ROOT, sid)
+        requested_devices = parse_device_csv(args.devices)
+        if requested_devices is not None and args.npu_count is not None:
+            raise SessionStateError("use only one of --devices or --npu-count")
+        if args.npu_count is not None and args.npu_count < 1:
+            raise SessionStateError("--npu-count must be >= 1")
+        available_devices, npu_probe = probe_host_npu_devices(base_record)
+        if available_devices is None:
+            emit_progress("probe-npus", "host NPU device probe unavailable; validating syntax only", **npu_probe)
+        else:
+            emit_progress("probe-npus", "host NPU device probe succeeded", devices=available_devices)
 
         local_root, worktree_payload = ensure_worktree(
             session_id=sid,
@@ -362,14 +416,29 @@ def main(argv: Sequence[str] | None = None) -> int:
             worktree_root=worktree_root,
             no_worktree=args.no_worktree,
         )
+        if args.no_worktree and args.session_id:
+            binding_payload = {
+                "action": "skipped",
+                "reason": "explicit --no-worktree session does not overwrite repo-root current-session",
+                "path": str(local_root / ".vaws-local" / "current-session.json"),
+            }
+        else:
+            binding_path = write_current_session_binding(
+                local_root,
+                session_id=sid,
+                source="session_create-staging",
+                base_repo_root=ROOT,
+            )
+            binding_payload = {"action": "written", "path": str(binding_path)}
 
         emit_progress("lease", "allocating session resources", machine=alias)
         leases = allocate_session_leases(
             repo_root=ROOT,
             machine_alias=alias,
             session_id=sid,
-            requested_devices=parse_devices(args.devices),
+            requested_devices=requested_devices,
             npu_count=args.npu_count,
+            available_devices=available_devices,
             container_ssh_port=args.container_ssh_port,
             container_ssh_port_range=args.container_ssh_port_range,
             port_available=host_port_availability(base_record),
@@ -420,14 +489,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             "created_at": now,
             "updated_at": now,
         }
+        if npu_probe:
+            session["leases"]["npu_probe"] = npu_probe
         session_path = save_session(session, repo_root=ROOT)
-        if args.no_worktree and args.session_id:
-            binding_payload = {
-                "action": "skipped",
-                "reason": "explicit --no-worktree session does not overwrite repo-root current-session",
-                "path": str(local_root / ".vaws-local" / "current-session.json"),
-            }
-        else:
+        if binding_payload and binding_payload.get("action") == "written":
             binding_path = write_current_session_binding(
                 local_root,
                 session_id=sid,
@@ -525,10 +590,22 @@ def main(argv: Sequence[str] | None = None) -> int:
             }
         )
         return 0
+    except ValidationError as exc:
+        if "sid" in locals():
+            with contextlib.suppress(Exception):
+                release_all_session_leases(repo_root=ROOT, session_id=sid)
+        print_json({"status": "needs_input", "error": str(exc)})
+        return 1
     except Exception as exc:
         if "sid" in locals():
             with contextlib.suppress(Exception):
                 release_all_session_leases(repo_root=ROOT, session_id=sid)
+            if session_path is not None:
+                with contextlib.suppress(Exception):
+                    failed_session = load_session_lookup(session_file=session_path, repo_root=ROOT).session
+                    failed_session["status"] = "failed"
+                    failed_session["failure"] = {"error": str(exc)}
+                    save_session(failed_session, repo_root=ROOT)
         print_json({"status": "failed", "error": str(exc)})
         return 2
 

--- a/.agents/skills/session-management/scripts/session_create.py
+++ b/.agents/skills/session-management/scripts/session_create.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""Create or reuse an isolated VAWS agent session."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB_DIR = ROOT / ".agents" / "lib"
+MM_SCRIPTS = ROOT / ".agents" / "skills" / "machine-management" / "scripts"
+for _p in (str(LIB_DIR), str(MM_SCRIPTS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import inventory as inventory_store  # noqa: E402
+import manage_machine as machine_ops  # noqa: E402
+from _workflow_common import bootstrap_container, host_target, verify_machine  # noqa: E402
+from vaws_session_id import resolve_session_id, write_current_session_binding  # noqa: E402
+from vaws_session_state import (  # noqa: E402
+    DEFAULT_CONTAINER_SSH_PORT_RANGE,
+    SessionStateError,
+    allocate_session_leases,
+    default_branch,
+    default_worktree_root,
+    load_session_lookup,
+    release_all_session_leases,
+    require_session_id,
+    save_session,
+    session_container_name,
+    session_file_path,
+    session_record_for_execution,
+)
+from vaws_local_state import load_profile, utc_now_iso  # noqa: E402
+
+PROGRESS_SENTINEL = "__VAWS_SESSION_PROGRESS__="
+PORT_TAIL_RE = re.compile(r"[:.]([0-9]+)$")
+
+
+def emit_progress(phase: str, message: str, **extra: Any) -> None:
+    payload = {"phase": phase, "message": message}
+    payload.update({key: value for key, value in extra.items() if value is not None})
+    sys.stderr.write(PROGRESS_SENTINEL + json.dumps(payload, ensure_ascii=False) + "\n")
+    sys.stderr.flush()
+
+
+def print_json(data: dict[str, Any]) -> None:
+    print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def run_git(args: list[str], *, cwd: Path = ROOT, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if check and proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or f"git {' '.join(args)} failed")
+    return proc
+
+
+def load_machine(identifier: str) -> dict[str, Any]:
+    read_path = inventory_store.read_inventory_path(
+        inventory_store.preferred_inventory_path(inventory_store.DEFAULT_PATH)
+    )
+    inv = inventory_store.load_inventory(read_path)
+    matches = inventory_store._find_matches(inv, identifier=identifier)  # noqa: SLF001
+    if not matches:
+        raise RuntimeError(f"machine {identifier!r} not found in inventory")
+    if len(matches) > 1:
+        raise RuntimeError(f"machine {identifier!r} matched multiple records")
+    return matches[0]
+
+
+def parse_devices(value: str | None) -> list[int] | None:
+    if value is None:
+        return None
+    devices: list[int] = []
+    for item in value.split(","):
+        stripped = item.strip()
+        if not stripped:
+            continue
+        devices.append(int(stripped))
+    return devices
+
+
+def host_port_available(record: dict[str, Any]) -> Any:
+    host = record["host"]
+
+    def check(port: int) -> bool:
+        script = f"! ss -ltnH 2>/dev/null | awk '{{print $4}}' | grep -Eq '[:.]({port})$'"
+        cmd = [
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            "-o",
+            "LogLevel=ERROR",
+            "-p",
+            str(host.get("port", 22)),
+            f"{host.get('user', 'root')}@{host['ip']}",
+            "bash",
+            "-c",
+            shlex.quote(script),
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        return result.returncode == 0
+
+    return check
+
+
+def _parse_listening_ports(stdout: str) -> set[int]:
+    ports: set[int] = set()
+    for line in stdout.splitlines():
+        match = PORT_TAIL_RE.search(line.strip())
+        if match:
+            ports.add(int(match.group(1)))
+    return ports
+
+
+def host_listening_ports(record: dict[str, Any]) -> set[int] | None:
+    host = record["host"]
+    script = """
+if command -v ss >/dev/null 2>&1; then
+  ss -ltnH 2>/dev/null | awk '{print $4}'
+elif command -v netstat >/dev/null 2>&1; then
+  netstat -ltn 2>/dev/null | awk 'NR > 2 {print $4}'
+else
+  exit 42
+fi
+"""
+    cmd = [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-o",
+        "LogLevel=ERROR",
+        "-p",
+        str(host.get("port", 22)),
+        f"{host.get('user', 'root')}@{host['ip']}",
+        "bash",
+        "-c",
+        shlex.quote(script),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        return None
+    return _parse_listening_ports(result.stdout)
+
+
+def host_port_availability(record: dict[str, Any]) -> Any:
+    busy_ports = host_listening_ports(record)
+    if busy_ports is None:
+        return host_port_available(record)
+    return lambda port: port not in busy_ports
+
+
+def verify_session_ssh(
+    base_record: dict[str, Any],
+    *,
+    container_ssh_port: int,
+    public_key_file: str | None,
+) -> dict[str, Any]:
+    """Verify only host/container SSH for a newly bootstrapped session container."""
+    try:
+        identity_file = machine_ops.private_key_for_public_key(machine_ops.find_public_key(public_key_file))
+    except machine_ops.MachineManagementError:
+        identity_file = None
+
+    host = machine_ops.SshTarget(
+        host=base_record["host"]["ip"],
+        user=base_record["host"].get("user", "root"),
+        port=base_record["host"].get("port", 22),
+    )
+    container = machine_ops.SshTarget(
+        host=base_record["host"]["ip"],
+        user="root",
+        port=container_ssh_port,
+    )
+    host_check = machine_ops.check_direct_ssh(host, identity_file=identity_file)
+    container_check = machine_ops.check_direct_ssh(container, identity_file=identity_file)
+    payload: dict[str, Any] = {
+        "verification_mode": "ssh",
+        "identity_file": str(identity_file) if identity_file is not None else None,
+        "host_ssh": host_check,
+        "container_ssh": container_check,
+        "smoke": {
+            "success": None,
+            "skipped": "session creation defaulted to SSH-only verification; use --verification-mode full for torch/torch_npu smoke",
+        },
+        "npu_smoke_skipped": True,
+    }
+    local_tool_errors = []
+    for check in (host_check, container_check):
+        stderr = check.get("stderr")
+        if isinstance(stderr, str) and stderr.startswith("required local command not found:"):
+            local_tool_errors.append(stderr)
+    if local_tool_errors:
+        payload.update(
+            {
+                "success": False,
+                "status": "blocked",
+                "action": "missing-local-tool",
+                "message": "required local SSH tooling is missing",
+                "local_tool_errors": sorted(set(local_tool_errors)),
+                "ready": False,
+            }
+        )
+        return payload
+    ready = bool(host_check.get("ok") and container_check.get("ok"))
+    payload.update(
+        {
+            "success": ready,
+            "status": "ready" if ready else "needs_repair",
+            "action": "ssh-verified" if ready else "ssh-verify-found-drift",
+            "ready": ready,
+        }
+    )
+    if not ready:
+        payload["message"] = "session container SSH is not ready"
+    return payload
+
+
+def existing_worktree_bound(path: Path) -> str | None:
+    binding = path / ".vaws-local" / "current-session.json"
+    if not binding.exists():
+        return None
+    try:
+        data = json.loads(binding.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    sid = data.get("session_id")
+    return str(sid) if sid else None
+
+
+def ensure_worktree(
+    *,
+    session_id: str,
+    branch: str,
+    base_ref: str,
+    worktree_root: Path,
+    no_worktree: bool,
+) -> tuple[Path, dict[str, Any]]:
+    if no_worktree:
+        return ROOT, {"action": "current-repo", "path": str(ROOT)}
+
+    worktree_root = worktree_root.expanduser().resolve()
+    if worktree_root.exists():
+        bound = existing_worktree_bound(worktree_root)
+        if bound == session_id:
+            return worktree_root, {"action": "reused", "path": str(worktree_root), "branch": branch}
+        raise SessionStateError(
+            f"worktree path already exists and is not bound to session {session_id}: {worktree_root}"
+        )
+
+    emit_progress("worktree", f"creating worktree {worktree_root}", branch=branch)
+    branch_exists = run_git(["show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], check=False).returncode == 0
+    worktree_root.parent.mkdir(parents=True, exist_ok=True)
+    if branch_exists:
+        run_git(["worktree", "add", str(worktree_root), branch])
+        action = "added-existing-branch"
+    else:
+        run_git(["worktree", "add", "-b", branch, str(worktree_root), base_ref])
+        action = "created-branch"
+    emit_progress("worktree", "initializing submodules", path=str(worktree_root))
+    run_git(["submodule", "update", "--init", "--recursive"], cwd=worktree_root)
+    return worktree_root, {"action": action, "path": str(worktree_root), "branch": branch, "base_ref": base_ref}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    parser.add_argument("--machine", required=True, help="base machine alias or host IP")
+    parser.add_argument("--session-id", help="explicit session id; otherwise resolver fallback is used")
+    parser.add_argument("--base-ref", default="main")
+    parser.add_argument("--branch", help="worktree branch; defaults to session/<id>")
+    parser.add_argument("--worktree-root", type=Path, help="override local worktree path")
+    parser.add_argument("--no-worktree", action="store_true", help="bind the session to the current repo root")
+    parser.add_argument("--image", help="override the base machine image for this session container")
+    parser.add_argument("--devices", help="comma-separated NPU device ids to lease")
+    parser.add_argument("--npu-count", type=int, help="lease the first N locally unleased devices")
+    parser.add_argument("--container-ssh-port", type=int, help="explicit session container SSH port")
+    parser.add_argument("--container-ssh-port-range", default=DEFAULT_CONTAINER_SSH_PORT_RANGE)
+    parser.add_argument("--runtime-profile", default="vllm-ascend")
+    parser.add_argument("--runtime-root", default=None)
+    parser.add_argument("--workdir", default=None)
+    parser.add_argument("--reuse-existing", action="store_true")
+    parser.add_argument("--skip-container-bootstrap", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--disable-prepared-image-cache",
+        action="store_true",
+        help="do not use the host-local session-ready image cache for this container",
+    )
+    parser.add_argument(
+        "--verification-mode",
+        choices=("ssh", "full"),
+        default="ssh",
+        help="session readiness check after bootstrap; default avoids repeated NPU smoke during parallel session creation",
+    )
+    parser.add_argument("--replace-container-on-image-change", action="store_true")
+    parser.add_argument("--public-key-file")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        resolved = resolve_session_id(
+            explicit=args.session_id,
+            repo_root=ROOT,
+            persist_generated=False,
+            use_current_binding=False,
+        )
+        sid = require_session_id(resolved.value)
+
+        if args.reuse_existing:
+            try:
+                existing = load_session_lookup(session_id=sid, repo_root=ROOT)
+                print_json(
+                    {
+                        "status": existing.session.get("status", "ready"),
+                        "session_id": sid,
+                        "session_file": str(existing.session_file),
+                        "worktree_root": existing.session.get("local", {}).get("worktree_root"),
+                        "container": existing.session.get("remote", {}).get("container"),
+                        "reused": True,
+                    }
+                )
+                return 0
+            except Exception:
+                pass
+
+        emit_progress("resolve-machine", f"loading base machine {args.machine}")
+        base_record = load_machine(args.machine)
+        alias = base_record["alias"]
+        namespace = base_record.get("namespace")
+        if not namespace:
+            profile = load_profile()
+            namespace = profile.get("machine_username") if profile else None
+
+        image = args.image or base_record["container"]["image"]
+        workdir = args.workdir or base_record["container"].get("workdir", "/vllm-workspace")
+        runtime_root = args.runtime_root or workdir
+        branch = args.branch or default_branch(sid)
+        worktree_root = args.worktree_root or default_worktree_root(ROOT, sid)
+
+        local_root, worktree_payload = ensure_worktree(
+            session_id=sid,
+            branch=branch,
+            base_ref=args.base_ref,
+            worktree_root=worktree_root,
+            no_worktree=args.no_worktree,
+        )
+
+        emit_progress("lease", "allocating session resources", machine=alias)
+        leases = allocate_session_leases(
+            repo_root=ROOT,
+            machine_alias=alias,
+            session_id=sid,
+            requested_devices=parse_devices(args.devices),
+            npu_count=args.npu_count,
+            container_ssh_port=args.container_ssh_port,
+            container_ssh_port_range=args.container_ssh_port_range,
+            port_available=host_port_availability(base_record),
+        )
+
+        container_name = session_container_name(namespace, sid)
+        now = utc_now_iso()
+        session = {
+            "schema_version": 1,
+            "session_id": sid,
+            "session_id_source": resolved.source,
+            "base_machine": alias,
+            "workspace_id": sid,
+            "status": "creating",
+            "local": {
+                "worktree_root": str(local_root),
+                "base_repo_root": str(ROOT),
+                "branch": branch,
+                "base_ref": args.base_ref,
+            },
+            "remote": {
+                "host": base_record["host"]["ip"],
+                "host_user": base_record["host"].get("user", "root"),
+                "host_port": base_record["host"].get("port", 22),
+                "namespace": namespace,
+                "machine_type": base_record["host"].get("machine_type") or base_record["container"].get("machine_type"),
+                "soc": base_record["host"].get("soc"),
+                "container": {
+                    "name": container_name,
+                    "ssh_port": leases["container_ssh_port"],
+                    "image": image,
+                    "workdir": workdir,
+                    "runtime_root": runtime_root,
+                    "machine_type": base_record["container"].get("machine_type") or base_record["host"].get("machine_type"),
+                },
+            },
+            "leases": {
+                "npu_devices": leases.get("npu_devices", []),
+                "container_ssh_port": leases["container_ssh_port"],
+                "service_ports": [],
+            },
+            "runtime_profile": {
+                "type": args.runtime_profile,
+                "parity": "local",
+                "serve_adapter": "vllm-ascend-serving",
+                "bench_adapter": "vllm-ascend-benchmark",
+            },
+            "created_at": now,
+            "updated_at": now,
+        }
+        session_path = save_session(session, repo_root=ROOT)
+        if args.no_worktree and args.session_id:
+            binding_payload = {
+                "action": "skipped",
+                "reason": "explicit --no-worktree session does not overwrite repo-root current-session",
+                "path": str(local_root / ".vaws-local" / "current-session.json"),
+            }
+        else:
+            binding_path = write_current_session_binding(
+                local_root,
+                session_id=sid,
+                source="session_create",
+                session_file=session_path,
+                base_repo_root=ROOT,
+            )
+            binding_payload = {"action": "written", "path": str(binding_path)}
+
+        container_payload: dict[str, Any] = {"status": "skipped"} if args.skip_container_bootstrap else {}
+        if not args.skip_container_bootstrap:
+            emit_progress("container", f"bootstrapping session container {container_name}", machine=alias)
+            target = host_target(
+                host=base_record["host"]["ip"],
+                user=base_record["host"].get("user", "root"),
+                port=base_record["host"].get("port", 22),
+            )
+            container_payload = bootstrap_container(
+                target,
+                host=base_record["host"]["ip"],
+                container_name=container_name,
+                container_ssh_port=leases["container_ssh_port"],
+                image=image,
+                workdir=workdir,
+                namespace=namespace,
+                machine_type=base_record["host"].get("machine_type") or base_record["container"].get("machine_type"),
+                soc=base_record["host"].get("soc"),
+                public_key_file=args.public_key_file,
+                replace_container_on_image_change=args.replace_container_on_image_change,
+                use_prepared_image_cache=not args.disable_prepared_image_cache,
+            )
+            if container_payload.get("status") in {"needs_input", "needs_repair", "blocked"}:
+                session["status"] = "failed"
+                session["failure"] = container_payload
+                save_session(session, repo_root=ROOT)
+                print_json(
+                    {
+                        "status": "blocked",
+                        "session_id": sid,
+                        "session_file": str(session_path),
+                        "worktree": worktree_payload,
+                        "container": container_payload,
+                    }
+                )
+                return 1
+            selected_image = container_payload.get("selected_image") or container_payload.get("image")
+            if selected_image:
+                session["remote"]["container"]["image"] = selected_image
+            if container_payload.get("container_type"):
+                session["remote"]["container"]["machine_type"] = container_payload["container_type"]
+            record = session_record_for_execution(session)
+            if args.verification_mode == "full":
+                emit_progress("verify", "running full session verification", session_id=sid)
+                verify = verify_machine(record)
+                verify["verification_mode"] = "full"
+            else:
+                emit_progress("verify", "checking session SSH readiness", session_id=sid)
+                verify = verify_session_ssh(
+                    base_record,
+                    container_ssh_port=leases["container_ssh_port"],
+                    public_key_file=args.public_key_file,
+                )
+            container_payload["verify"] = verify
+            if verify.get("status") != "ready":
+                session["status"] = "blocked" if verify.get("status") == "blocked" else "needs_repair"
+                session["verify"] = verify
+                save_session(session, repo_root=ROOT)
+                print_json(
+                    {
+                        "status": session["status"],
+                        "session_id": sid,
+                        "session_file": str(session_path),
+                        "worktree": worktree_payload,
+                        "current_session_binding": binding_payload,
+                        "container": container_payload,
+                    }
+                )
+                return 1
+            session["status"] = "ready"
+        else:
+            session["status"] = "planned"
+        save_session(session, repo_root=ROOT)
+
+        print_json(
+            {
+                "status": session["status"],
+                "session_id": sid,
+                "session_file": str(session_file_path(sid, ROOT)),
+                "worktree_root": str(local_root),
+                "container": session["remote"]["container"],
+                "leases": session["leases"],
+                "worktree": worktree_payload,
+                "current_session_binding": binding_payload,
+                "container_bootstrap": container_payload,
+            }
+        )
+        return 0
+    except Exception as exc:
+        if "sid" in locals():
+            with contextlib.suppress(Exception):
+                release_all_session_leases(repo_root=ROOT, session_id=sid)
+        print_json({"status": "failed", "error": str(exc)})
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/session-management/scripts/session_gc.py
+++ b/.agents/skills/session-management/scripts/session_gc.py
@@ -14,7 +14,7 @@ LIB_DIR = ROOT / ".agents" / "lib"
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
-from vaws_session_state import load_index, load_session_lookup, release_all_session_leases  # noqa: E402
+from vaws_session_state import load_index, load_leases, load_session_lookup, release_all_session_leases  # noqa: E402
 
 
 def print_json(data: dict[str, Any]) -> None:
@@ -38,19 +38,38 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def lease_owner_session_ids(leases: dict[str, Any]) -> set[str]:
+    owners: set[str] = set()
+    for bucket in leases.get("leases", {}).values():
+        if not isinstance(bucket, dict):
+            continue
+        for kind in ("npu_devices", "container_ssh_ports", "service_ports"):
+            records = bucket.get(kind, {})
+            if not isinstance(records, dict):
+                continue
+            for record in records.values():
+                if isinstance(record, dict) and isinstance(record.get("session_id"), str):
+                    owners.add(record["session_id"])
+    return owners
+
+
 def main() -> int:
     args = build_parser().parse_args()
     dry_run = not args.apply
     try:
         index = load_index(ROOT)
+        leases = load_leases(ROOT)
         released: list[str] = []
         checked: list[dict[str, Any]] = []
-        for sid in sorted(index.get("sessions", {})):
+        active: list[str] = []
+        candidates = set(index.get("sessions", {})) | lease_owner_session_ids(leases)
+        for sid in sorted(candidates):
             try:
                 lookup = load_session_lookup(session_id=sid, repo_root=ROOT)
                 session = lookup.session
             except Exception as exc:  # noqa: BLE001
-                checked.append({"session_id": sid, "status": "missing-state", "error": str(exc)})
+                state = "orphan-lease" if sid not in index.get("sessions", {}) else "missing-state"
+                checked.append({"session_id": sid, "status": state, "error": str(exc)})
                 if not dry_run:
                     release_all_session_leases(repo_root=ROOT, session_id=sid)
                 released.append(sid)
@@ -59,12 +78,15 @@ def main() -> int:
                 if not dry_run:
                     release_all_session_leases(repo_root=lookup.state_repo_root, session_id=sid)
                 released.append(sid)
+            else:
+                active.append(sid)
             checked.append({"session_id": sid, "status": session.get("status")})
         print_json(
             {
                 "status": "ok",
                 "dry_run": dry_run,
                 "checked": checked,
+                "active_session_leases": sorted(set(active) & lease_owner_session_ids(leases)),
                 "released_lease_sessions": [] if dry_run else sorted(set(released)),
                 "would_release_lease_sessions": sorted(set(released)) if dry_run else [],
             }

--- a/.agents/skills/session-management/scripts/session_gc.py
+++ b/.agents/skills/session-management/scripts/session_gc.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Conservative local GC for stale VAWS session metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB_DIR = ROOT / ".agents" / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_session_state import load_index, load_session_lookup, release_all_session_leases  # noqa: E402
+
+
+def print_json(data: dict[str, Any]) -> None:
+    print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="show stale lease releases without mutating state (default)",
+    )
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="actually release leases for removed or missing session metadata",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    dry_run = not args.apply
+    try:
+        index = load_index(ROOT)
+        released: list[str] = []
+        checked: list[dict[str, Any]] = []
+        for sid in sorted(index.get("sessions", {})):
+            try:
+                lookup = load_session_lookup(session_id=sid, repo_root=ROOT)
+                session = lookup.session
+            except Exception as exc:  # noqa: BLE001
+                checked.append({"session_id": sid, "status": "missing-state", "error": str(exc)})
+                if not dry_run:
+                    release_all_session_leases(repo_root=ROOT, session_id=sid)
+                released.append(sid)
+                continue
+            if session.get("status") == "removed":
+                if not dry_run:
+                    release_all_session_leases(repo_root=lookup.state_repo_root, session_id=sid)
+                released.append(sid)
+            checked.append({"session_id": sid, "status": session.get("status")})
+        print_json(
+            {
+                "status": "ok",
+                "dry_run": dry_run,
+                "checked": checked,
+                "released_lease_sessions": [] if dry_run else sorted(set(released)),
+                "would_release_lease_sessions": sorted(set(released)) if dry_run else [],
+            }
+        )
+        return 0
+    except Exception as exc:
+        print_json({"status": "failed", "error": str(exc)})
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/session-management/scripts/session_list.py
+++ b/.agents/skills/session-management/scripts/session_list.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""List VAWS sessions and local resource leases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB_DIR = ROOT / ".agents" / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_session_state import load_index, load_leases, load_session_lookup  # noqa: E402
+
+
+def print_json(data: dict[str, Any]) -> None:
+    print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    parser.add_argument(
+        "--active-only",
+        action="store_true",
+        help="omit removed and stopped sessions from the listing",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        index = load_index(ROOT)
+        sessions: list[dict[str, Any]] = []
+        for sid, record in sorted(index.get("sessions", {}).items()):
+            entry = dict(record)
+            try:
+                lookup = load_session_lookup(session_id=sid, repo_root=ROOT)
+                session = lookup.session
+                entry.update(
+                    {
+                        "status": session.get("status"),
+                        "worktree_root": session.get("local", {}).get("worktree_root"),
+                        "container": session.get("remote", {}).get("container"),
+                        "leases": session.get("leases"),
+                    }
+                )
+            except Exception as exc:  # noqa: BLE001
+                entry["load_error"] = str(exc)
+            if args.active_only and entry.get("status") in {"removed", "stopped"}:
+                continue
+            sessions.append(entry)
+        print_json(
+            {
+                "status": "ok",
+                "count": len(sessions),
+                "sessions": sessions,
+                "leases": load_leases(ROOT),
+            }
+        )
+        return 0
+    except Exception as exc:
+        print_json({"status": "failed", "error": str(exc)})
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/session-management/scripts/session_remove.py
+++ b/.agents/skills/session-management/scripts/session_remove.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Remove a VAWS session's service, container, worktree, and leases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB_DIR = ROOT / ".agents" / "lib"
+MM_SCRIPTS = ROOT / ".agents" / "skills" / "machine-management" / "scripts"
+for _p in (str(LIB_DIR), str(MM_SCRIPTS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from _workflow_common import remove_container  # noqa: E402
+from vaws_session_state import (  # noqa: E402
+    load_session_lookup,
+    mark_session_status,
+    release_all_session_leases,
+    session_record_for_execution,
+    session_serving_state_path,
+)
+
+PROGRESS_SENTINEL = "__VAWS_SESSION_PROGRESS__="
+
+
+def emit_progress(phase: str, message: str, **extra: Any) -> None:
+    payload = {"phase": phase, "message": message}
+    payload.update({key: value for key, value in extra.items() if value is not None})
+    sys.stderr.write(PROGRESS_SENTINEL + json.dumps(payload, ensure_ascii=False) + "\n")
+    sys.stderr.flush()
+
+
+def print_json(data: dict[str, Any]) -> None:
+    print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def run_git(args: list[str], *, check: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(ROOT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def stop_session(session_id: str, *, session_file: Path | None = None, force: bool) -> dict[str, Any]:
+    script = ROOT / ".agents" / "skills" / "vllm-ascend-serving" / "scripts" / "serve_stop.py"
+    cmd = [sys.executable, str(script)]
+    if session_file is not None:
+        cmd.extend(["--session-file", str(session_file)])
+    else:
+        cmd.extend(["--session-id", session_id])
+    if force:
+        cmd.append("--force")
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(ROOT), check=False)
+    if not result.stdout.strip():
+        return {"status": "unknown", "returncode": result.returncode, "stderr_tail": result.stderr[-500:]}
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        payload = {"status": "unknown", "stdout_tail": result.stdout[-500:]}
+    payload["returncode"] = result.returncode
+    return payload
+
+
+def stop_result_allows_lease_release(result: dict[str, Any]) -> bool:
+    return result.get("returncode") == 0 and result.get("status") in {"not_found", "stopped"}
+
+
+def container_result_allows_lease_release(result: dict[str, Any] | None) -> bool:
+    if not result:
+        return False
+    if result.get("success") is False:
+        return False
+    return result.get("status") not in {"blocked", "failed", "needs_input", "needs_repair"}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    parser.add_argument("--session-id")
+    parser.add_argument("--session-file")
+    parser.add_argument("--remove-container", action="store_true")
+    parser.add_argument("--remove-worktree", action="store_true")
+    parser.add_argument("--release-leases", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        if not args.session_id and not args.session_file:
+            print_json(
+                {
+                    "status": "needs_input",
+                    "error": "session_remove requires explicit --session-id or --session-file",
+                    "missing": ["--session-id", "--session-file"],
+                }
+            )
+            return 1
+        lookup = load_session_lookup(
+            session_id=args.session_id,
+            session_file=args.session_file,
+            repo_root=ROOT,
+        )
+        session = lookup.session
+        sid = session["session_id"]
+        results: dict[str, Any] = {}
+
+        serving_state_path = session_serving_state_path(sid, lookup.state_repo_root)
+        if args.remove_container and not serving_state_path.exists():
+            results["stop"] = {
+                "status": "not_found",
+                "returncode": 0,
+                "skipped": True,
+                "session_id": sid,
+                "message": "no session serving state recorded; container removal will stop any untracked process",
+            }
+        else:
+            emit_progress("stop", "stopping session service", session_id=sid)
+            results["stop"] = stop_session(sid, session_file=lookup.session_file, force=args.force)
+
+        if args.remove_container:
+            emit_progress("container", "removing session container", session_id=sid)
+            results["container"] = remove_container(session_record_for_execution(session))
+
+        if args.remove_worktree:
+            worktree_root = Path(session["local"]["worktree_root"])
+            emit_progress("worktree", "removing session worktree", path=str(worktree_root))
+            cmd = ["worktree", "remove"]
+            if args.force:
+                cmd.extend(["--force", "--force"])
+            cmd.append(str(worktree_root))
+            proc = run_git(cmd)
+            results["worktree"] = {
+                "returncode": proc.returncode,
+                "stdout_tail": proc.stdout[-500:],
+                "stderr_tail": proc.stderr[-500:],
+            }
+
+        if args.release_leases:
+            can_release = stop_result_allows_lease_release(results["stop"]) or container_result_allows_lease_release(
+                results.get("container")
+            )
+            if not can_release:
+                results["leases"] = {
+                    "released": False,
+                    "blocked": True,
+                    "reason": (
+                        "service stop did not succeed and the session container was not removed; "
+                        "refusing to release leases that may still protect live resources"
+                    ),
+                }
+                print_json({"status": "failed", "session_id": sid, "results": results})
+                return 1
+            emit_progress("lease", "releasing session leases", session_id=sid)
+            release_all_session_leases(repo_root=lookup.state_repo_root, session_id=sid)
+            results["leases"] = {"released": True}
+
+        if args.remove_container or args.remove_worktree:
+            remove_ok = True
+            if args.remove_container:
+                remove_ok = remove_ok and container_result_allows_lease_release(results.get("container"))
+            if args.remove_worktree:
+                remove_ok = remove_ok and results.get("worktree", {}).get("returncode") == 0
+            next_status = "removed" if remove_ok else "needs_repair"
+        else:
+            next_status = "stopped" if stop_result_allows_lease_release(results["stop"]) else "needs_repair"
+        updated = mark_session_status(
+            repo_root=lookup.state_repo_root,
+            session_id=sid,
+            status=next_status,
+        )
+        print_json({"status": updated["status"], "session_id": sid, "results": results})
+        return 0 if updated["status"] in {"removed", "stopped"} else 1
+    except Exception as exc:
+        print_json({"status": "failed", "error": str(exc)})
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/session-management/scripts/session_status.py
+++ b/.agents/skills/session-management/scripts/session_status.py
@@ -25,6 +25,14 @@ def print_json(data: dict[str, Any]) -> None:
     print(json.dumps(data, indent=2, ensure_ascii=False))
 
 
+def tail_output(value: str | bytes | None, limit: int = 500) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="replace")
+    return value[-limit:]
+
+
 def ssh_check(host: str, port: int, user: str = "root", script: str = "true") -> dict[str, Any]:
     cmd = [
         "ssh",
@@ -41,16 +49,27 @@ def ssh_check(host: str, port: int, user: str = "root", script: str = "true") ->
         "-c",
         shlex.quote(script),
     ]
-    result = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=SSH_CHECK_TIMEOUT_SECONDS,
-    )
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=SSH_CHECK_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "ok": False,
+            "returncode": None,
+            "timed_out": True,
+            "timeout_seconds": SSH_CHECK_TIMEOUT_SECONDS,
+            "stdout_tail": tail_output(exc.stdout),
+            "stderr_tail": tail_output(exc.stderr),
+        }
     return {
         "ok": result.returncode == 0,
         "returncode": result.returncode,
+        "timed_out": False,
         "stdout_tail": result.stdout[-500:],
         "stderr_tail": result.stderr[-500:],
     }

--- a/.agents/skills/session-management/scripts/session_status.py
+++ b/.agents/skills/session-management/scripts/session_status.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Inspect one VAWS session."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB_DIR = ROOT / ".agents" / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_session_state import load_session_lookup, session_serving_state_path  # noqa: E402
+
+SSH_CHECK_TIMEOUT_SECONDS = 60
+
+
+def print_json(data: dict[str, Any]) -> None:
+    print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def ssh_check(host: str, port: int, user: str = "root", script: str = "true") -> dict[str, Any]:
+    cmd = [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-o",
+        "LogLevel=ERROR",
+        "-p",
+        str(port),
+        f"{user}@{host}",
+        "bash",
+        "-c",
+        shlex.quote(script),
+    ]
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=SSH_CHECK_TIMEOUT_SECONDS,
+    )
+    return {
+        "ok": result.returncode == 0,
+        "returncode": result.returncode,
+        "stdout_tail": result.stdout[-500:],
+        "stderr_tail": result.stderr[-500:],
+    }
+
+
+def load_serving(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    parser.add_argument("--session-id")
+    parser.add_argument("--session-file")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        lookup = load_session_lookup(
+            session_id=args.session_id,
+            session_file=args.session_file,
+            repo_root=ROOT,
+        )
+        session = lookup.session
+        sid = session["session_id"]
+        local_root = Path(session["local"]["worktree_root"])
+        remote = session["remote"]
+        container = remote["container"]
+        serving = load_serving(session_serving_state_path(sid, lookup.state_repo_root))
+        container_ssh = ssh_check(
+            remote["host"],
+            int(container["ssh_port"]),
+            "root",
+            "true",
+        )
+        service: dict[str, Any] | None = None
+        if serving and serving.get("pid"):
+            pid = int(serving["pid"])
+            service = ssh_check(
+                remote["host"],
+                int(container["ssh_port"]),
+                "root",
+                f"kill -0 {pid} 2>/dev/null",
+            )
+        status = session.get("status", "unknown")
+        if status == "ready" and not local_root.exists():
+            status = "needs_repair"
+        if status == "ready" and not container_ssh["ok"]:
+            status = "needs_repair"
+        print_json(
+            {
+                "status": status,
+                "session_id": sid,
+                "session_file": str(lookup.session_file),
+                "worktree": {"path": str(local_root), "exists": local_root.exists()},
+                "container": {
+                    "name": container["name"],
+                    "ssh_port": container["ssh_port"],
+                    "ssh": container_ssh,
+                },
+                "serving": serving,
+                "service_alive": service,
+                "session": session,
+            }
+        )
+        return 0 if status in {"ready", "planned", "stopped", "removed"} else 1
+    except Exception as exc:
+        print_json({"status": "failed", "error": str(exc)})
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/vllm-ascend-benchmark/SKILL.md
+++ b/.agents/skills/vllm-ascend-benchmark/SKILL.md
@@ -27,8 +27,10 @@ Run `vllm bench serve` on a **ready** workspace-managed remote container and pro
 - **User intent takes priority** over nightly configs. Nightly YAML files under `vllm-ascend/tests/e2e/nightly/single_node/models/configs/` are a **reference source** for discovering how to configure a given model or feature (MTP, graph mode, TP count, etc.), not an execution template to run verbatim.
 - Nightly configs are used as a **fallback** only when the user specifies a model but provides no other parameters.
 - After benchmarking, the service is automatically stopped. No residual processes should remain.
+- If service startup returns a non-ready result after launching a PID, benchmark cleanup still calls `serve_stop.py --force` for the same target.
+- For parallel agent work, use `session-management` first and call `bench_run.py --session-id <id>`. Cleanup then stops only that session's service.
 - Progress goes to `stderr` as `__VAWS_BENCHMARK_PROGRESS__=<json>`. Final result goes to `stdout` as JSON.
-- Keep local benchmark state only under `.vaws-local/benchmark/`.
+- Keep local benchmark state under `.vaws-local/benchmark/` for legacy mode and `.vaws-local/sessions/<id>/benchmark/` for session-scoped workflows.
 - **Multi-state comparisons** (e.g. baseline vs PR vs modified) are orchestrated by the agent calling `bench_run.py` once per code state, not by a single script. The agent is responsible for switching code states (via worktree, checkout, or manual edit) and running parity between each state.
 
 ## Cross-platform launcher rule
@@ -40,7 +42,7 @@ Run `vllm bench serve` on a **ready** workspace-managed remote container and pro
 
 ```bash
 python3 .agents/skills/vllm-ascend-benchmark/scripts/bench_run.py \
-  --machine <alias-or-ip> \
+  (--machine <alias-or-ip> | --session-id <id>) \
   --model <remote-weight-path> \
   [--tp <N>] [--dp <N>] \
   [--runs <N>] \
@@ -83,6 +85,8 @@ If a service is already running on the target machine, stop it before proceeding
 ### 4. Start the service
 
 Uses `serve_start.py` internally to launch the vLLM service with the assembled configuration. Parity sync is handled automatically by the serving skill.
+
+If startup fails or times out after a remote PID was recorded, `bench_run.py` calls `serve_stop.py --force` before returning failure.
 
 ### 5. Run benchmark iterations
 

--- a/.agents/skills/vllm-ascend-benchmark/references/acceptance.md
+++ b/.agents/skills/vllm-ascend-benchmark/references/acceptance.md
@@ -4,10 +4,13 @@
 
 - [ ] Service is started via `serve_start.py` (not raw SSH).
 - [ ] `vllm bench serve` executes on the remote container and returns a result JSON.
+- [ ] The remote `/tmp/result_bench_*.json` filename includes a target token and random suffix so concurrent same-machine sessions cannot overwrite each other's benchmark result file.
 - [ ] Output JSON has `status: "ok"` with `metrics` containing at least `output_throughput`.
 - [ ] Service is stopped after benchmark completes (no residual processes).
 - [ ] If service fails to start, output has `status: "failed"` with `phase: "serve_start"`.
+- [ ] If service startup returns non-ready after recording a PID, `serve_stop.py --force` is called before failure is returned.
 - [ ] If benchmark fails, service is still stopped (force-kill if needed).
+- [ ] In session mode, `serve_start.py` and `serve_stop.py` are called with the same `--session-id`, and no machine-level serving state is touched.
 - [ ] User-provided `--serve-args` and `--bench-args` appear in the final config.
 - [ ] When `--refer-nightly` is given, nightly values fill in missing args only.
 - [ ] When user args AND nightly are both given, user args win.

--- a/.agents/skills/vllm-ascend-benchmark/references/behavior.md
+++ b/.agents/skills/vllm-ascend-benchmark/references/behavior.md
@@ -2,12 +2,12 @@
 
 ## Lifecycle
 
-1. **Resolve machine** from local inventory (same as serving).
+1. **Resolve target** from local inventory or a VAWS session spec.
 2. **Assemble config** from user args + optional nightly reference.
-3. **Stop existing service** on the target machine if any.
-4. **Start service** via `serve_start.py` (which handles parity sync internally).
+3. **Stop existing service** on the target target if any. In session mode this means only the session service.
+4. **Start service** via `serve_start.py` (which handles parity sync internally). If startup returns non-ready, call `serve_stop.py --force` for the same target before failing.
 5. **Run benchmark iterations** via SSH on the remote container — all against the same warm service.
-6. **Stop service** via `serve_stop.py`.
+6. **Stop service** via `serve_stop.py`, passing through `--session-id` when used.
 7. **Output structured JSON** on stdout.
 
 ## Configuration Priority
@@ -63,7 +63,7 @@ Given baseline throughput `T_b` and patched throughput `T_p`, compute the ratio 
 
 ## Remote Execution
 
-`vllm bench serve` runs inside the container via SSH. The result JSON file is written to `/tmp/` and `cat`-ed back through the SSH session. The script parses the last JSON object from stdout.
+`vllm bench serve` runs inside the container via SSH. The result JSON file is written to `/tmp/` with a target token, local process id, and random suffix in the file name, then `cat`-ed back through the SSH session. The script parses the last JSON object from stdout. The unique file name matters because session containers can share the host `/tmp` mount on the same machine.
 
 ## Defaults
 
@@ -75,4 +75,4 @@ These are conservative defaults suitable for a quick smoke test. For production 
 
 ## State Management
 
-Benchmark results are not persisted locally by default. The structured JSON is returned on stdout for the agent or user to consume. The serving skill handles its own state under `.vaws-local/serving/`.
+Benchmark results are not persisted locally by default. The structured JSON is returned on stdout for the agent or user to consume. The serving skill handles its own state under `.vaws-local/serving/` in legacy mode and `.vaws-local/sessions/<session-id>/serving.json` in session mode.

--- a/.agents/skills/vllm-ascend-benchmark/references/command-recipes.md
+++ b/.agents/skills/vllm-ascend-benchmark/references/command-recipes.md
@@ -9,6 +9,15 @@ python3 .agents/skills/vllm-ascend-benchmark/scripts/bench_run.py \
   --tp 1
 ```
 
+Session-scoped equivalent:
+
+```bash
+python3 .agents/skills/vllm-ascend-benchmark/scripts/bench_run.py \
+  --session-id pr123 \
+  --model /home/weights/Qwen3.5-0.8B \
+  --tp 1
+```
+
 ## Single-run: full-featured (MTP + graph mode)
 
 ```bash

--- a/.agents/skills/vllm-ascend-benchmark/scripts/_common.py
+++ b/.agents/skills/vllm-ascend-benchmark/scripts/_common.py
@@ -7,11 +7,18 @@ import json
 import os
 import subprocess
 import sys
+import threading
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[4]
+LIB_DIR = ROOT / ".agents" / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_session_state import load_session_lookup  # noqa: E402
 
 SERVING_SCRIPTS = ROOT / ".agents" / "skills" / "vllm-ascend-serving" / "scripts"
 NIGHTLY_CONFIGS_DIR = (
@@ -45,6 +52,51 @@ def now_utc() -> str:
         .isoformat()
         .replace("+00:00", "Z")
     )
+
+
+def safe_token(value: str) -> str:
+    token = "".join(ch if ch.isalnum() or ch in "._-" else "-" for ch in value)
+    return token.strip(".-") or "benchmark"
+
+
+def _run_json_command_streaming(
+    cmd: list[str],
+    *,
+    progress_markers: tuple[str, ...] = (),
+) -> tuple[int, dict[str, Any] | None, str, str]:
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(ROOT),
+    )
+    stderr_lines: list[str] = []
+
+    def relay_stderr() -> None:
+        assert proc.stderr is not None
+        for line in proc.stderr:
+            stderr_lines.append(line)
+            if not progress_markers or any(marker in line for marker in progress_markers):
+                sys.stderr.write(line)
+                sys.stderr.flush()
+
+    thread = threading.Thread(target=relay_stderr, daemon=True)
+    thread.start()
+    assert proc.stdout is not None
+    stdout = proc.stdout.read()
+    returncode = proc.wait()
+    thread.join(timeout=1)
+    stderr = "".join(stderr_lines)
+    payload = None
+    if stdout.strip():
+        try:
+            parsed = json.loads(stdout)
+            if isinstance(parsed, dict):
+                payload = parsed
+        except json.JSONDecodeError:
+            payload = None
+    return returncode, payload, stdout, stderr
 
 
 # ---------------------------------------------------------------------------
@@ -131,6 +183,8 @@ def parse_nightly_yaml(yaml_name: str) -> NightlyReference | None:
 class BenchConfig:
     """Assembled benchmark configuration ready for execution."""
     machine: str = ""
+    session_id: str | None = None
+    session_file: str | None = None
     model: str = ""
     tp: int | None = None
     dp: int | None = None
@@ -143,7 +197,13 @@ class BenchConfig:
 
     def to_serve_start_args(self) -> list[str]:
         """Build CLI args for serve_start.py."""
-        args = ["--machine", self.machine, "--model", self.model]
+        args = ["--model", self.model]
+        if self.session_file:
+            args.extend(["--session-file", self.session_file])
+        elif self.session_id:
+            args.extend(["--session-id", self.session_id])
+        else:
+            args.extend(["--machine", self.machine])
         if self.tp is not None:
             args.extend(["--tp", str(self.tp)])
         if self.dp is not None:
@@ -191,6 +251,10 @@ class BenchConfig:
 
     def summary_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {"machine": self.machine, "model": self.model}
+        if self.session_id:
+            d["session_id"] = self.session_id
+        if self.session_file:
+            d["session_file"] = self.session_file
         if self.tp is not None:
             d["tp"] = self.tp
         if self.serve_args:
@@ -204,7 +268,9 @@ class BenchConfig:
 
 def assemble_config(
     *,
-    machine: str,
+    machine: str | None,
+    session_id: str | None = None,
+    session_file: str | None = None,
     model: str,
     tp: int | None = None,
     dp: int | None = None,
@@ -216,12 +282,16 @@ def assemble_config(
     skip_parity: bool = False,
 ) -> BenchConfig:
     """Assemble a BenchConfig with user > nightly priority."""
+    if not machine and not session_id and not session_file:
+        raise RuntimeError("--machine is required unless --session-id or --session-file is used")
     nightly_ref: NightlyReference | None = None
     if refer_nightly:
         nightly_ref = parse_nightly_yaml(refer_nightly)
 
     cfg = BenchConfig(
-        machine=machine,
+        machine=machine or "",
+        session_id=session_id,
+        session_file=session_file,
         model=model,
         skip_parity=skip_parity,
         nightly_ref=nightly_ref,
@@ -300,50 +370,67 @@ def call_serve_start(config: BenchConfig) -> dict[str, Any]:
     cmd = [sys.executable, script] + config.to_serve_start_args()
 
     emit_progress("serve_start", f"starting service: {config.model}")
-    result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(ROOT))
+    returncode, data, stdout, stderr = _run_json_command_streaming(
+        cmd,
+        progress_markers=("__VAWS_SERVING_PROGRESS__=", "__VAWS_PARITY_PROGRESS__="),
+    )
 
-    for line in result.stderr.splitlines():
-        if "__VAWS_SERVING_PROGRESS__=" in line or "__VAWS_PARITY_PROGRESS__=" in line:
-            sys.stderr.write(line + "\n")
-
-    if not result.stdout.strip():
+    if not stdout.strip():
         raise RuntimeError(
-            f"serve_start.py produced no output (rc={result.returncode}):\n"
-            f"{result.stderr[:2000]}"
+            f"serve_start.py produced no output (rc={returncode}):\n"
+            f"{stderr[:2000]}"
         )
-    try:
-        data = json.loads(result.stdout)
-    except json.JSONDecodeError:
+    if data is None:
         raise RuntimeError(
-            f"serve_start.py output is not JSON (rc={result.returncode}):\n"
-            f"stdout: {result.stdout[:1000]}\nstderr: {result.stderr[:1000]}"
+            f"serve_start.py output is not JSON (rc={returncode}):\n"
+            f"stdout: {stdout[:1000]}\nstderr: {stderr[:1000]}"
         )
     return data
 
 
-def call_serve_stop(machine: str, force: bool = False) -> dict[str, Any]:
+def call_serve_stop(config: BenchConfig, force: bool = False) -> dict[str, Any]:
     """Call serve_stop.py and return its JSON output."""
     script = str(SERVING_SCRIPTS / "serve_stop.py")
-    cmd = [sys.executable, script, "--machine", machine]
+    cmd = [sys.executable, script]
+    if config.session_file:
+        cmd.extend(["--session-file", config.session_file])
+    elif config.session_id:
+        cmd.extend(["--session-id", config.session_id])
+    else:
+        cmd.extend(["--machine", config.machine])
     if force:
         cmd.append("--force")
 
     emit_progress("serve_stop", "stopping service")
-    result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(ROOT))
-    if not result.stdout.strip():
+    _returncode, data, stdout, _stderr = _run_json_command_streaming(cmd)
+    if not stdout.strip():
         return {"status": "unknown", "message": "no output from serve_stop"}
-    try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError:
-        return {"status": "unknown", "message": result.stdout[:500]}
+    if data is None:
+        return {"status": "unknown", "message": stdout[:500]}
+    return data
 
 
 # ---------------------------------------------------------------------------
 # Remote benchmark execution
 # ---------------------------------------------------------------------------
 
-def _get_ssh_endpoint(machine: str) -> tuple[str, int]:
+def _get_ssh_endpoint(
+    machine: str | None,
+    *,
+    session_id: str | None = None,
+    session_file: str | None = None,
+) -> tuple[str, int]:
     """Resolve container SSH host and port from inventory."""
+    if session_id or session_file:
+        lookup = load_session_lookup(
+            session_id=session_id,
+            session_file=session_file,
+            repo_root=ROOT,
+        )
+        remote = lookup.session["remote"]
+        container = remote["container"]
+        return remote["host"], int(container["ssh_port"])
+
     lib_dir = str(ROOT / ".agents" / "lib")
     mm_dir = str(ROOT / ".agents" / "skills" / "machine-management" / "scripts")
     for p in (lib_dir, mm_dir):
@@ -386,7 +473,11 @@ def run_bench_on_remote(
     import shlex
 
     bench_cmd_parts = config.to_bench_serve_args(base_url, served_model_name)
-    result_filename = f"result_bench_{now_utc().replace(':', '-')}.json"
+    target_token = safe_token(config.session_id or config.machine or "benchmark")
+    result_filename = (
+        f"result_bench_{target_token}_{now_utc().replace(':', '-')}_"
+        f"{os.getpid()}_{uuid.uuid4().hex[:8]}.json"
+    )
     bench_cmd_parts.extend(["--result-filename", result_filename])
 
     bench_cmd = " ".join(shlex.quote(str(s)) for s in bench_cmd_parts)
@@ -406,7 +497,7 @@ def run_bench_on_remote(
         "bash", "-c", shlex.quote(remote_script),
     ]
 
-    emit_progress("bench_run", f"running vllm bench serve on {config.machine}")
+    emit_progress("bench_run", f"running vllm bench serve on {target_token}")
     proc = subprocess.run(ssh_cmd, capture_output=True, text=True, timeout=1200)
 
     if proc.returncode != 0:
@@ -460,4 +551,3 @@ def extract_metrics(raw_result: dict[str, Any]) -> dict[str, Any]:
             metrics[key] = val
 
     return metrics
-

--- a/.agents/skills/vllm-ascend-benchmark/scripts/_common.py
+++ b/.agents/skills/vllm-ascend-benchmark/scripts/_common.py
@@ -19,6 +19,7 @@ if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
 from vaws_session_state import load_session_lookup  # noqa: E402
+from vaws_validate import require_env_name  # noqa: E402
 
 SERVING_SCRIPTS = ROOT / ".agents" / "skills" / "vllm-ascend-serving" / "scripts"
 NIGHTLY_CONFIGS_DIR = (
@@ -349,12 +350,14 @@ def assemble_config(
     # --- Env: merge nightly base + user overrides ---
     env: dict[str, str] = {}
     if nightly_ref:
-        env.update(nightly_ref.envs)
+        for key, value in nightly_ref.envs.items():
+            env[require_env_name(key)] = value
     if extra_env:
         for item in extra_env:
-            if "=" in item:
-                k, v = item.split("=", 1)
-                env[k] = v
+            if "=" not in item:
+                raise ValueError(f"bad --extra-env {item!r}, expected KEY=VALUE")
+            k, v = item.split("=", 1)
+            env[require_env_name(k)] = v
     cfg.env = env
 
     return cfg

--- a/.agents/skills/vllm-ascend-benchmark/scripts/bench_run.py
+++ b/.agents/skills/vllm-ascend-benchmark/scripts/bench_run.py
@@ -11,6 +11,9 @@ Usage examples:
     # Minimal single run
     python3 bench_run.py --machine 173.131.1.2 --model /home/weights/Qwen3.5-35B
 
+    # Session-scoped single run
+    python3 bench_run.py --session-id pr-123 --model /home/weights/Qwen3.5-35B
+
     # Multi-run with warmup (start service once, run 5 times, discard first)
     python3 bench_run.py --machine 173.131.1.2 --model /home/weights/Qwen3.5-35B \\
         --runs 5 --warmup-runs 1 --tp 4
@@ -58,7 +61,9 @@ def build_parser() -> argparse.ArgumentParser:
         description="Run vllm bench serve benchmarks (single or multi-run).",
         allow_abbrev=False,
     )
-    p.add_argument("--machine", required=True, help="machine alias or IP")
+    p.add_argument("--machine", help="machine alias or IP")
+    p.add_argument("--session-id", help="VAWS session id")
+    p.add_argument("--session-file", help="explicit session.json path")
     p.add_argument("--model", required=True, help="remote model weight path")
     p.add_argument("--tp", "--tensor-parallel-size", type=int, default=None)
     p.add_argument("--dp", "--data-parallel-size", type=int, default=None)
@@ -151,6 +156,8 @@ def main(argv: list[str] | None = None) -> int:
     try:
         config = assemble_config(
             machine=args.machine,
+            session_id=args.session_id,
+            session_file=args.session_file,
             model=args.model,
             tp=args.tp,
             dp=args.dp,
@@ -166,17 +173,23 @@ def main(argv: list[str] | None = None) -> int:
         start_result = call_serve_start(config)
 
         if start_result.get("status") != "ready":
+            cleanup_result = call_serve_stop(config, force=True)
             print_json({
                 "status": "failed",
                 "phase": "serve_start",
                 "error": start_result.get("error", "service did not become ready"),
                 "serve_result": start_result,
+                "cleanup_result": cleanup_result,
             })
             return 1
 
         base_url = start_result["base_url"]
         served_model = start_result.get("served_model_name", Path(args.model).name)
-        container_ip, container_port = _get_ssh_endpoint(args.machine)
+        container_ip, container_port = _get_ssh_endpoint(
+            args.machine,
+            session_id=args.session_id,
+            session_file=args.session_file,
+        )
 
         all_metrics: list[dict[str, Any]] = []
         all_raw: list[dict[str, Any]] = []
@@ -192,7 +205,7 @@ def main(argv: list[str] | None = None) -> int:
                 )
             except Exception as e:
                 emit_progress("bench", f"{run_label}: benchmark failed: {e}")
-                call_serve_stop(args.machine, force=True)
+                call_serve_stop(config, force=True)
                 print_json({
                     "status": "failed",
                     "phase": "bench_run",
@@ -213,11 +226,11 @@ def main(argv: list[str] | None = None) -> int:
             emit_progress("bench", f"{run_label}{tag}: throughput={throughput}")
 
         emit_progress("stop", "stopping service")
-        stop_result = call_serve_stop(args.machine)
+        stop_result = call_serve_stop(config)
         cleanup_warning: str | None = None
         if stop_result.get("status") not in ("stopped", "not_found"):
             emit_progress("stop", "graceful stop failed, retrying with force")
-            stop_result = call_serve_stop(args.machine, force=True)
+            stop_result = call_serve_stop(config, force=True)
             if stop_result.get("status") not in ("stopped", "not_found"):
                 cleanup_warning = f"service may still be running: {stop_result}"
 
@@ -226,6 +239,7 @@ def main(argv: list[str] | None = None) -> int:
             result_json: dict[str, Any] = {
                 "status": "ok",
                 "machine": args.machine,
+                "session_id": args.session_id,
                 "model": args.model,
                 "metrics": all_metrics[0],
                 "config": config.summary_dict(),
@@ -245,6 +259,7 @@ def main(argv: list[str] | None = None) -> int:
             result_json = {
                 "status": "ok",
                 "machine": args.machine,
+                "session_id": args.session_id,
                 "model": args.model,
                 "runs": total_runs,
                 "warmup_runs": warmup_runs,
@@ -263,7 +278,8 @@ def main(argv: list[str] | None = None) -> int:
 
     except Exception as e:
         try:
-            call_serve_stop(args.machine, force=True)
+            if "config" in locals():
+                call_serve_stop(config, force=True)
         except Exception:
             pass
         print_json({

--- a/.agents/skills/vllm-ascend-serving/SKILL.md
+++ b/.agents/skills/vllm-ascend-serving/SKILL.md
@@ -5,7 +5,7 @@ description: Start, check, or stop a single-node vLLM Ascend online service on a
 
 # vLLM Ascend Serving
 
-Manage the lifecycle of a **single-node colocated** `vllm-ascend` online service on a workspace-managed ready remote container.
+Manage the lifecycle of a **single-node colocated** `vllm-ascend` online service on a workspace-managed ready remote container or an isolated VAWS session container.
 
 This skill takes structured parameters, handles all SSH escaping and remote execution internally, and returns machine-readable JSON. The agent never needs to construct raw shell commands for service management.
 
@@ -29,8 +29,12 @@ This skill takes structured parameters, handles all SSH escaping and remote exec
 
 - `start` automatically runs `remote-code-parity` before launching. If parity fails, start is blocked.
 - `status` and `stop` do not require parity.
+- For parallel agent work, use `session-management` first and pass `--session-id <id>`. Session mode reads and writes `.vaws-local/sessions/<id>/serving.json` and never stops another session's service.
+- Session mode serializes `start` / `stop` operations for the same session with a serving lock; different sessions remain independent.
+- Once a remote PID is launched, `serve_start.py` writes `serving.json` with `status=starting` before health probing so `serve_stop.py` can clean up even if readiness later fails.
+- Legacy `--machine` mode remains supported and keeps the previous machine-level singleton behavior.
 - All remote execution goes through the scripts — never construct raw SSH commands for serving.
-- Keep local runtime state only under `.vaws-local/serving/`.
+- Keep local runtime state under `.vaws-local/serving/` for legacy mode and `.vaws-local/sessions/<id>/` for session mode.
 - Progress on `stderr` as `__VAWS_SERVING_PROGRESS__=<json>`, final result on `stdout` as JSON.
 
 ## Cross-platform launcher rule
@@ -44,7 +48,7 @@ This skill takes structured parameters, handles all SSH escaping and remote exec
 
 ```bash
 python3 .agents/skills/vllm-ascend-serving/scripts/serve_start.py \
-  --machine <alias-or-ip> \
+  (--machine <alias-or-ip> | --session-id <id>) \
   --model <remote-weight-path> \
   [--served-model-name <name>] \
   [--tp <N>] [--dp <N>] \
@@ -102,21 +106,24 @@ Returns which NPU devices are free, which are busy (with PID and HBM details), p
 
 ```bash
 python3 .agents/skills/vllm-ascend-serving/scripts/serve_status.py \
-  --machine <alias-or-ip>
+  (--machine <alias-or-ip> | --session-id <id>)
 ```
 
 ### Stop
 
 ```bash
 python3 .agents/skills/vllm-ascend-serving/scripts/serve_stop.py \
-  --machine <alias-or-ip> [--force]
+  (--machine <alias-or-ip> | --session-id <id>) [--force]
 ```
 
 ## Local state
 
 Per-machine launch state is stored under `.vaws-local/serving/<alias>.json`.
+Session launch state is stored under `.vaws-local/sessions/<session-id>/serving.json`.
 
 This file records the last successful launch parameters (model, tp, devices, env, extra args, port, pid, log paths, runtime_dir, wrap_script). It is the basis for `--relaunch` and is read by other skills (e.g. `ascend-memory-profiling`) in attach mode.
+
+During launch the same file may temporarily contain `status=starting`; this is still a valid cleanup target for `serve_stop.py`.
 
 ## Workflow
 
@@ -126,7 +133,7 @@ The `--machine` argument is looked up in the local machine inventory. The machin
 
 ### 2. Stop any existing service
 
-If a previous service is recorded for this machine, it is stopped before launching a new one.
+If a previous service is recorded for this target, it is stopped before launching a new one. In session mode this target is the session, not the base machine, so other sessions on the same host are not touched.
 
 ### 3. Run remote-code-parity (start only)
 

--- a/.agents/skills/vllm-ascend-serving/references/acceptance.md
+++ b/.agents/skills/vllm-ascend-serving/references/acceptance.md
@@ -12,6 +12,17 @@
 - stdout is a JSON object with `status=ready`, `base_url`, `pid`, `log_stdout`, `log_stderr`
 - `.vaws-local/serving/<alias>.json` is written
 
+## A1s. Fresh start — session target
+
+**Given** a ready session `s1`,
+**When** `serve_start.py --session-id s1 --model <path> --tp 2` runs,
+**Then**:
+- parity is executed with `--session-id s1`
+- the SSH endpoint is the session container
+- a session serving lock is held while the lifecycle state is mutated
+- the service state is written to `.vaws-local/sessions/s1/serving.json`
+- `.vaws-local/serving/<alias>.json` is not modified
+
 ## A2. Fresh start — model path not found
 
 **Given** a ready machine,
@@ -97,6 +108,18 @@
 **Given** a running service on the target machine,
 **When** a new `serve_start.py` runs for the same machine,
 **Then** the old service is stopped before the new one launches.
+
+## A14s. Session cleanup scope
+
+**Given** services are running in sessions `s1` and `s2` on the same base machine,
+**When** `serve_start.py --session-id s1 --relaunch` or `serve_stop.py --session-id s1` runs,
+**Then** only `s1`'s recorded PID is stopped and `s2` remains running.
+
+## A14l. Session lifecycle lock and starting state
+
+**Given** `serve_start.py --session-id s1` has launched a remote PID,
+**When** health probing is still in progress or later fails,
+**Then** `.vaws-local/sessions/s1/serving.json` already contains `status=starting`, the PID, port, and runtime dir so `serve_stop.py --session-id s1 --force` can clean it up.
 
 ## A15. NPU probe — devices busy (cross-container via host)
 

--- a/.agents/skills/vllm-ascend-serving/references/behavior.md
+++ b/.agents/skills/vllm-ascend-serving/references/behavior.md
@@ -6,17 +6,31 @@ The core value of this skill is that all SSH escaping is handled inside `serve_s
 
 ## Launch lifecycle
 
-1. **resolve-machine** — look up the machine alias in `.vaws-local/machine-inventory.json`
-2. **stop-existing** — if a previous service is recorded, send SIGINT+SIGTERM
-3. **parity-sync** — call `parity_sync.py` (unless `--skip-parity`)
-4. **probe-npus** — check NPU device availability via `npu-smi info`; validate or auto-select devices
-5. **validate** — check model path exists remotely via `test -d` / `test -f`
-6. **allocate-port** — find a free port in 30000–60000 range by trying `socket.bind` remotely
-7. **launch** — build and execute the launch script via SSH
-8. **probe-health** — poll `GET /health` (HTTP 200)
-9. **probe-models** — poll `GET /v1/models` (non-empty `data` array)
-10. **persist-state** — write `.vaws-local/serving/<alias>.json`
-11. **output** — print JSON to stdout
+1. **resolve-target** — look up either the legacy machine alias or a session spec
+2. **lock** — in session mode, acquire the session serving lock so `start` and `stop` for the same session cannot race
+3. **stop-existing** — if a previous service is recorded for that target, send SIGINT+SIGTERM
+4. **parity-sync** — call `parity_sync.py` (unless `--skip-parity`)
+5. **probe-npus** — check NPU device availability via `npu-smi info`; validate or auto-select devices
+6. **validate** — check model path exists remotely via `test -d` / `test -f`
+7. **allocate-port** — in session mode, snapshot listening ports once, allocate a leased port locally, then recheck the selected port before launch
+8. **launch** — build and execute the launch script via SSH
+9. **persist-starting-state** — after PID capture, write serving state with `status=starting`
+10. **probe-health** — poll `GET /health` (HTTP 200)
+11. **probe-models** — poll `GET /v1/models` (non-empty `data` array)
+12. **persist-final-state** — update serving state to `ready` or `started`
+13. **output** — print JSON to stdout
+
+## Session mode
+
+`serve_start.py`, `serve_status.py`, and `serve_stop.py` accept `--session-id` or `--session-file`. In this mode:
+
+- the SSH endpoint comes from the session container
+- parity is called with `parity_sync.py --session-id <id>`
+- the service port is allocated through `.vaws-local/sessions/leases.json`
+- leased NPU devices from the session are used as the default `ASCEND_RT_VISIBLE_DEVICES`
+- relaunch and stop read only `.vaws-local/sessions/<id>/serving.json`
+- stopping one session never reads or mutates another session's serving state
+- `serve_start.py` and `serve_stop.py` use `.vaws-local/sessions/locks/<id>.serving.lock` to serialize lifecycle changes for the same session
 
 ## NPU device probing
 
@@ -30,6 +44,7 @@ Before launching, the script SSHes to the **bare-metal host** (port 22, via `hos
 Device selection logic:
 
 - If `--devices` is explicitly given, those specific devices are validated. If any are occupied, start returns `needs_input` with conflict details.
+- In session mode, if the session has leased NPU devices and `--devices` is not explicitly given, the launch defaults to the leased devices. If `--devices` is explicitly given, it must be a subset of the session lease.
 - If `--devices` is not given but `--tp` is, the first `tp` free devices are auto-selected. If not enough free devices exist, returns `needs_input`.
 - If neither is given, no device filtering is applied.
 - If `npu-smi` itself fails (e.g. driver not found), the probe is treated as non-fatal and launch proceeds with whatever devices the user specified.
@@ -39,7 +54,7 @@ Device selection logic:
 
 When `--relaunch` is used:
 
-- Previous launch parameters are loaded from `.vaws-local/serving/<alias>.json`
+- Previous launch parameters are loaded from `.vaws-local/serving/<alias>.json` in legacy mode or `.vaws-local/sessions/<session-id>/serving.json` in session mode.
 - Any CLI argument provided this time **overrides** the previous value
 - `--extra-env KEY=VALUE` is **merged** into the previous env map (new keys added, existing keys overwritten)
 - `--unset-env KEY` **removes** a key from the inherited env map

--- a/.agents/skills/vllm-ascend-serving/references/command-recipes.md
+++ b/.agents/skills/vllm-ascend-serving/references/command-recipes.md
@@ -10,6 +10,17 @@ python3 .agents/skills/vllm-ascend-serving/scripts/serve_start.py \
   --devices 0,1,2,3
 ```
 
+## Fresh start in an isolated session
+
+```bash
+python3 .agents/skills/vllm-ascend-serving/scripts/serve_start.py \
+  --session-id pr123 \
+  --model /data/models/Qwen3-32B \
+  --tp 4
+```
+
+Session mode uses the session container and writes state under `.vaws-local/sessions/pr123/serving.json`.
+
 ## Fresh start with extra vllm args
 
 ```bash
@@ -144,11 +155,25 @@ python3 .agents/skills/vllm-ascend-serving/scripts/serve_status.py \
   --machine blue-a
 ```
 
+Session status:
+
+```bash
+python3 .agents/skills/vllm-ascend-serving/scripts/serve_status.py \
+  --session-id pr123
+```
+
 ## Stop gracefully
 
 ```bash
 python3 .agents/skills/vllm-ascend-serving/scripts/serve_stop.py \
   --machine blue-a
+```
+
+Session stop:
+
+```bash
+python3 .agents/skills/vllm-ascend-serving/scripts/serve_stop.py \
+  --session-id pr123
 ```
 
 ## Force stop
@@ -215,11 +240,13 @@ python3 .agents/skills/vllm-ascend-serving/scripts/serve_start.py \
 After `remote-code-parity` syncs tracked files, custom op build artifacts are missing. Rebuild them before launch:
 
 ```bash
-ssh -p <container_ssh_port> root@<host_ip> 'bash -c "
-  set +u; source /etc/profile.d/vaws-ascend-env.sh; set -u
-  cd /vllm-workspace/vllm-ascend
-  bash csrc/build_aclnn.sh /vllm-workspace/vllm-ascend ascend910b
-"'
+python3 .agents/scripts/remote_job_start.py \
+  --session-id <session-id> \
+  --kind build \
+  --cwd /vllm-workspace/vllm-ascend \
+  --command 'bash csrc/build_aclnn.sh /vllm-workspace/vllm-ascend ascend910b'
+python3 .agents/scripts/remote_job_status.py --job-id <job-id>
+python3 .agents/scripts/remote_job_tail.py --job-id <job-id> --lines 120
 ```
 
 Note: if `numpy>=2.0` is installed, first downgrade: `pip3 install "numpy<2.0.0" -i https://pypi.tuna.tsinghua.edu.cn/simple`

--- a/.agents/skills/vllm-ascend-serving/scripts/_common.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/_common.py
@@ -30,6 +30,7 @@ from vaws_remote_toolbox import (  # noqa: E402
     resolve_remote_target,
 )
 from vaws_session_state import session_serving_state_path  # noqa: E402
+from vaws_validate import parse_device_csv  # noqa: E402
 
 SERVING_STATE_DIR = ROOT / ".vaws-local" / "serving"
 PROGRESS_SENTINEL = "__VAWS_SERVING_PROGRESS__="
@@ -314,7 +315,14 @@ def select_devices(
     busy: dict[str, list] = npu_info.get("busy", {})
 
     if requested_devices is not None:
-        requested = [int(d.strip()) for d in requested_devices.split(",")]
+        requested = parse_device_csv(requested_devices) or []
+        visible = set(npu_info.get("devices", []))
+        missing = [d for d in requested if d not in visible]
+        if missing:
+            return None, (
+                f"requested devices {missing} are not visible on host; "
+                f"visible={sorted(visible)}"
+            )
         conflicts = [d for d in requested if str(d) in busy]
         if conflicts:
             details = {
@@ -324,7 +332,7 @@ def select_devices(
                 f"requested devices {conflicts} are busy: {json.dumps(details)}; "
                 f"free devices: {free}"
             )
-        return requested_devices, None
+        return ",".join(str(d) for d in requested), None
 
     if tp is None:
         return None, None

--- a/.agents/skills/vllm-ascend-serving/scripts/_common.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/_common.py
@@ -25,6 +25,11 @@ for _p in (str(LIB_DIR), str(MM_SCRIPTS)):
 
 import inventory as inventory_store  # noqa: E402
 from vaws_local_state import ensure_state_dir  # noqa: E402
+from vaws_remote_toolbox import (  # noqa: E402
+    SshEndpoint,
+    resolve_remote_target,
+)
+from vaws_session_state import session_serving_state_path  # noqa: E402
 
 SERVING_STATE_DIR = ROOT / ".vaws-local" / "serving"
 PROGRESS_SENTINEL = "__VAWS_SERVING_PROGRESS__="
@@ -35,13 +40,17 @@ PROGRESS_SENTINEL = "__VAWS_SERVING_PROGRESS__="
 # ---------------------------------------------------------------------------
 
 @dataclass(frozen=True)
-class SshEndpoint:
-    host: str
-    port: int
-    user: str = "root"
-
-    def destination(self) -> str:
-        return f"{self.user}@{self.host}"
+class ExecutionTarget:
+    mode: str
+    alias: str
+    session_id: str | None
+    endpoint: SshEndpoint
+    host_endpoint: SshEndpoint
+    runtime_base: str
+    record: dict[str, Any]
+    state_repo_root: Path
+    session_file: Path | None = None
+    session: dict[str, Any] | None = None
 
 
 def _ssh_base_cmd(endpoint: SshEndpoint) -> list[str]:
@@ -103,8 +112,34 @@ def host_endpoint(record: dict[str, Any]) -> SshEndpoint:
     """
     return SshEndpoint(
         host=record["host"]["ip"],
-        port=record["host"].get("ssh_port", 22),
+        port=record["host"].get("port", record["host"].get("ssh_port", 22)),
         user=record["host"].get("user", "root"),
+    )
+
+
+def resolve_execution_target(
+    machine: str | None,
+    *,
+    session_id: str | None = None,
+    session_file: str | Path | None = None,
+) -> ExecutionTarget:
+    remote = resolve_remote_target(
+        machine=machine,
+        session_id=session_id,
+        session_file=session_file,
+        repo_root=ROOT,
+    )
+    return ExecutionTarget(
+        mode=remote.mode,
+        alias=remote.alias,
+        session_id=remote.session_id,
+        endpoint=remote.container_endpoint,
+        host_endpoint=remote.host_endpoint,
+        runtime_base=remote.runtime_root,
+        record=remote.record,
+        state_repo_root=remote.state_repo_root,
+        session_file=remote.session_file,
+        session=remote.session,
     )
 
 
@@ -112,8 +147,17 @@ def host_endpoint(record: dict[str, Any]) -> SshEndpoint:
 # Local serving state
 # ---------------------------------------------------------------------------
 
-def load_serving_state(machine_alias: str) -> dict[str, Any] | None:
-    path = SERVING_STATE_DIR / f"{machine_alias}.json"
+def load_serving_state(
+    machine_alias: str,
+    *,
+    session_id: str | None = None,
+    state_repo_root: Path = ROOT,
+) -> dict[str, Any] | None:
+    path = (
+        session_serving_state_path(session_id, state_repo_root)
+        if session_id
+        else SERVING_STATE_DIR / f"{machine_alias}.json"
+    )
     if not path.exists():
         return None
     try:
@@ -122,9 +166,19 @@ def load_serving_state(machine_alias: str) -> dict[str, Any] | None:
         return None
 
 
-def save_serving_state(machine_alias: str, data: dict[str, Any]) -> Path:
-    ensure_state_dir(SERVING_STATE_DIR)
-    path = SERVING_STATE_DIR / f"{machine_alias}.json"
+def save_serving_state(
+    machine_alias: str,
+    data: dict[str, Any],
+    *,
+    session_id: str | None = None,
+    state_repo_root: Path = ROOT,
+) -> Path:
+    path = (
+        session_serving_state_path(session_id, state_repo_root)
+        if session_id
+        else SERVING_STATE_DIR / f"{machine_alias}.json"
+    )
+    ensure_state_dir(path.parent)
     handle, temp_name = tempfile.mkstemp(
         prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
     )

--- a/.agents/skills/vllm-ascend-serving/scripts/serve_start.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/serve_start.py
@@ -56,6 +56,7 @@ from _common import (
     ssh_exec,
 )
 from vaws_session_state import allocate_service_port, file_lock, release_service_port, session_lock_dir
+from vaws_validate import parse_device_csv, require_env_name
 
 RUNTIME_DIR_BASE = ".vaws-runtime/serving"
 DEFAULT_HEALTH_TIMEOUT = 300
@@ -198,12 +199,9 @@ def remote_port_availability(ep: SshEndpoint):
 
 
 def _parse_devices_csv(value: str) -> set[int]:
-    devices: set[int] = set()
-    for token in value.split(","):
-        stripped = token.strip()
-        if stripped:
-            devices.add(int(stripped))
-    return devices
+    if not value or not value.strip():
+        return set()
+    return set(parse_device_csv(value) or [])
 
 
 def _leased_devices_csv(session: dict[str, Any] | None) -> str | None:
@@ -269,7 +267,8 @@ def build_launch_script(
         lines.append(f"export ASCEND_RT_VISIBLE_DEVICES={shlex.quote(devices)}")
 
     for key, value in extra_env.items():
-        lines.append(f"export {key}={shlex.quote(value)}")
+        name = require_env_name(key)
+        lines.append(f"export {name}={shlex.quote(value)}")
 
     # Launch from the runtime dir — NOT from /vllm-workspace, which would
     # shadow the installed vllm package with the source tree.
@@ -640,7 +639,11 @@ def main(argv: list[str] | None = None) -> int:
                 print_json({"status": "failed", "error": f"bad --extra-env {item!r}, expected KEY=VALUE"})
                 return 1
             k, _, v = item.partition("=")
-            extra_env[k.strip()] = v
+            try:
+                extra_env[require_env_name(k.strip())] = v
+            except ValueError as exc:
+                print_json({"status": "needs_input", "error": str(exc)})
+                return 1
 
         # ---- resolve launch params (fresh or relaunch) ----
         if args.relaunch:
@@ -690,7 +693,11 @@ def main(argv: list[str] | None = None) -> int:
 
         leased_devices = _leased_devices_csv(target.session)
         if target.session_id and leased_devices:
-            leased = _parse_devices_csv(leased_devices)
+            try:
+                leased = _parse_devices_csv(leased_devices)
+            except ValueError as exc:
+                print_json({"status": "needs_repair", "error": str(exc), "session_id": target.session_id})
+                return 1
             needed_devices = tp * (dp or 1) if tp is not None else None
             if needed_devices is not None and len(leased) < needed_devices:
                 print_json({
@@ -705,7 +712,11 @@ def main(argv: list[str] | None = None) -> int:
                 })
                 return 1
             if devices:
-                requested = _parse_devices_csv(devices)
+                try:
+                    requested = _parse_devices_csv(devices)
+                except ValueError as exc:
+                    print_json({"status": "needs_input", "error": str(exc)})
+                    return 1
                 if not requested.issubset(leased):
                     print_json({
                         "status": "needs_input",
@@ -837,9 +848,13 @@ def main(argv: list[str] | None = None) -> int:
             emit_progress("probe-npus", f"NPU probe failed (non-fatal): {exc}")
 
         if npu_info is not None:
-            resolved_devices, device_error = select_devices(
-                npu_info, requested_devices=devices, tp=tp, dp=dp,
-            )
+            try:
+                resolved_devices, device_error = select_devices(
+                    npu_info, requested_devices=devices, tp=tp, dp=dp,
+                )
+            except ValueError as exc:
+                print_json({"status": "needs_input", "error": str(exc), "npu_info": npu_info})
+                return 1
             if device_error:
                 print_json({
                     "status": "needs_input",

--- a/.agents/skills/vllm-ascend-serving/scripts/serve_start.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/serve_start.py
@@ -7,6 +7,10 @@ Usage examples:
     python3 serve_start.py --machine blue-a --model /data/models/Qwen3-32B \\
         --tp 4 --devices 0,1,2,3 -- --max-model-len 4096
 
+    # Session-scoped start for parallel agent work
+    python3 serve_start.py --session-id pr-123 --model /data/models/Qwen3-32B \\
+        --tp 4 --devices 0,1,2,3
+
     # Relaunch with same config
     python3 serve_start.py --machine blue-a --relaunch
 
@@ -23,10 +27,13 @@ Final result on stdout as a single JSON object.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
+import re
 import shlex
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -38,49 +45,74 @@ if str(_SCRIPT_DIR) not in sys.path:
 from _common import (
     ROOT,
     SshEndpoint,
-    container_endpoint,
     emit_progress,
-    host_endpoint,
     load_serving_state,
     now_utc,
     print_json,
     probe_npus,
-    resolve_machine,
+    resolve_execution_target,
     save_serving_state,
     select_devices,
     ssh_exec,
 )
+from vaws_session_state import allocate_service_port, file_lock, release_service_port, session_lock_dir
 
 RUNTIME_DIR_BASE = ".vaws-runtime/serving"
 DEFAULT_HEALTH_TIMEOUT = 300
 HEALTH_POLL_INTERVAL = 5
+PORT_TAIL_RE = re.compile(r"[:.]([0-9]+)$")
 
 
 # ---------------------------------------------------------------------------
 # Parity
 # ---------------------------------------------------------------------------
 
-def run_parity(machine: str) -> dict[str, Any]:
+def run_parity(machine: str | None, session_id: str | None, session_file: Path | None = None) -> dict[str, Any]:
     parity_script = ROOT / ".agents" / "skills" / "remote-code-parity" / "scripts" / "parity_sync.py"
-    cmd = [sys.executable, str(parity_script), "--machine", machine]
-    result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(ROOT))
-    for line in (result.stderr or "").splitlines():
-        if line.startswith("__VAWS_PARITY_PROGRESS__="):
-            sys.stderr.write(line + "\n")
-            sys.stderr.flush()
-    if result.returncode != 0:
+    if session_file is not None:
+        cmd = [sys.executable, str(parity_script), "--session-file", str(session_file)]
+    elif session_id:
+        cmd = [sys.executable, str(parity_script), "--session-id", session_id]
+    else:
+        assert machine is not None
+        cmd = [sys.executable, str(parity_script), "--machine", machine]
+    proc = subprocess.Popen(
+        cmd,
+        cwd=str(ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    stderr_lines: list[str] = []
+
+    def relay_stderr() -> None:
+        assert proc.stderr is not None
+        for line in proc.stderr:
+            stderr_lines.append(line)
+            if line.startswith("__VAWS_PARITY_PROGRESS__="):
+                sys.stderr.write(line)
+                sys.stderr.flush()
+
+    thread = threading.Thread(target=relay_stderr, daemon=True)
+    thread.start()
+    assert proc.stdout is not None
+    stdout = proc.stdout.read()
+    returncode = proc.wait()
+    thread.join(timeout=1)
+    stderr = "".join(stderr_lines)
+    if returncode != 0:
         return {
             "status": "failed",
-            "error": f"parity sync failed (rc={result.returncode})",
-            "stderr_tail": (result.stderr or "")[-1000:],
+            "error": f"parity sync failed (rc={returncode})",
+            "stderr_tail": stderr[-1000:],
         }
     try:
-        return json.loads(result.stdout)
+        return json.loads(stdout)
     except json.JSONDecodeError:
         return {
             "status": "failed",
             "error": "parity sync returned non-JSON output",
-            "stdout_tail": (result.stdout or "")[-500:],
+            "stdout_tail": (stdout or "")[-500:],
         }
 
 
@@ -113,6 +145,75 @@ def find_free_port(ep: SshEndpoint) -> int:
     if "error" in data:
         raise RuntimeError(data["error"])
     return data["port"]
+
+
+def remote_port_available(ep: SshEndpoint, port: int) -> bool:
+    script = (
+        "python3 -c "
+        + shlex.quote(
+            "import socket,sys\n"
+            f"port={int(port)}\n"
+            "s=socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+            "try:\n"
+            "    s.bind(('0.0.0.0', port))\n"
+            "except OSError:\n"
+            "    sys.exit(1)\n"
+            "finally:\n"
+            "    s.close()\n"
+        )
+    )
+    return ssh_exec(ep, script, check=False).returncode == 0
+
+
+def _parse_listening_ports(stdout: str) -> set[int]:
+    ports: set[int] = set()
+    for line in stdout.splitlines():
+        match = PORT_TAIL_RE.search(line.strip())
+        if match:
+            ports.add(int(match.group(1)))
+    return ports
+
+
+def remote_listening_ports(ep: SshEndpoint) -> set[int] | None:
+    script = """
+if command -v ss >/dev/null 2>&1; then
+  ss -ltnH 2>/dev/null | awk '{print $4}'
+elif command -v netstat >/dev/null 2>&1; then
+  netstat -ltn 2>/dev/null | awk 'NR > 2 {print $4}'
+else
+  exit 42
+fi
+"""
+    result = ssh_exec(ep, script, check=False)
+    if result.returncode != 0:
+        return None
+    return _parse_listening_ports(result.stdout)
+
+
+def remote_port_availability(ep: SshEndpoint):
+    busy_ports = remote_listening_ports(ep)
+    if busy_ports is None:
+        return lambda candidate: remote_port_available(ep, candidate)
+    return lambda candidate: candidate not in busy_ports
+
+
+def _parse_devices_csv(value: str) -> set[int]:
+    devices: set[int] = set()
+    for token in value.split(","):
+        stripped = token.strip()
+        if stripped:
+            devices.add(int(stripped))
+    return devices
+
+
+def _leased_devices_csv(session: dict[str, Any] | None) -> str | None:
+    if not session:
+        return None
+    raw_devices = session.get("leases", {}).get("npu_devices", [])
+    if not isinstance(raw_devices, list) or not raw_devices:
+        return None
+    devices = [int(item) for item in raw_devices]
+    return ",".join(str(item) for item in sorted(devices))
 
 
 # ---------------------------------------------------------------------------
@@ -256,6 +357,23 @@ def check_models(ep: SshEndpoint, port: int) -> dict[str, Any] | None:
     return None
 
 
+def wait_for_devices_free(host_ep: SshEndpoint, devices: set[int], *, timeout: int = 45) -> bool:
+    if not devices:
+        return True
+    deadline = time.time() + timeout
+    while True:
+        try:
+            npu_info = probe_npus(host_ep)
+            busy = {int(dev) for dev in npu_info.get("busy", {}) if str(dev).isdigit()}
+            if not (devices & busy):
+                return True
+        except Exception:
+            return True
+        if time.time() >= deadline:
+            return False
+        time.sleep(3)
+
+
 def read_remote_tail(ep: SshEndpoint, remote_path: str, lines: int = 30) -> str:
     r = ssh_exec(ep, f"tail -{lines} {shlex.quote(remote_path)} 2>/dev/null || echo '(no log)'", check=False)
     return r.stdout.strip()
@@ -272,13 +390,18 @@ _ENV_ERROR_PATTERNS: list[tuple[str, str]] = [
     ("No module named 'torch_npu'", "missing-torch-npu"),
     ("cannot open shared object file", "missing-so"),
     ("libhccl.so", "missing-so"),
-    ("torch_npu", "torch-npu-error"),
+    ("RuntimeError:.*torch_npu", "torch-npu-error"),
     ("ImportError", "import-error"),
     ("ModuleNotFoundError", "module-not-found"),
 ]
 
 
-def diagnose_env_failure(stderr_tail: str, machine: str) -> dict[str, Any] | None:
+def diagnose_env_failure(
+    stderr_tail: str,
+    machine: str,
+    *,
+    session_id: str | None = None,
+) -> dict[str, Any] | None:
     """Scan stderr for environment-related errors and return structured recovery guidance.
 
     Returns a dict with diagnosis details, or None if the error
@@ -289,18 +412,19 @@ def diagnose_env_failure(stderr_tail: str, machine: str) -> dict[str, Any] | Non
 
     matched_tags: list[str] = []
     for pattern, tag in _ENV_ERROR_PATTERNS:
-        if pattern in stderr_tail:
+        if pattern in stderr_tail or re.search(pattern, stderr_tail):
             matched_tags.append(tag)
 
     if not matched_tags:
         return None
 
+    recovery_target = f"--session-id {session_id}" if session_id else f"--machine {machine}"
     return {
         "error_tags": sorted(set(matched_tags)),
         "cause": "remote Python package version mismatch",
         "recovery_command": (
             f"python3 .agents/skills/remote-code-parity/scripts/parity_sync.py "
-            f"--machine {machine} --force-reinstall"
+            f"{recovery_target} --force-reinstall"
         ),
         "recovery_description": (
             "Re-run parity sync with --force-reinstall to rebuild "
@@ -435,7 +559,9 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         allow_abbrev=False,
     )
-    p.add_argument("--machine", required=True, help="machine alias or host IP")
+    p.add_argument("--machine", help="machine alias or host IP")
+    p.add_argument("--session-id", help="VAWS session id; uses the session container and state namespace")
+    p.add_argument("--session-file", help="explicit session.json path")
     p.add_argument("--model", help="absolute model weight path on the remote container")
     p.add_argument(
         "--served-model-name", "--served-name",
@@ -486,14 +612,26 @@ def main(argv: list[str] | None = None) -> int:
         vllm_extra = argv[idx + 1:]
 
     args = build_parser().parse_args(own_argv)
+    lock_stack = contextlib.ExitStack()
 
     try:
-        # ---- resolve machine ----
-        emit_progress("resolve-machine", f"looking up {args.machine}")
-        record = resolve_machine(args.machine)
-        alias = record["alias"]
-        ep = container_endpoint(record)
-        runtime_base = record["container"].get("workdir", "/vllm-workspace")
+        # ---- resolve target ----
+        target_label = args.session_id or args.session_file or args.machine
+        emit_progress("resolve-target", f"looking up {target_label}")
+        target = resolve_execution_target(
+            args.machine,
+            session_id=args.session_id,
+            session_file=args.session_file,
+        )
+        record = target.record
+        alias = target.alias
+        ep = target.endpoint
+        runtime_base = target.runtime_base
+        if target.session_id:
+            emit_progress("lock", f"acquiring serving lock for session {target.session_id}")
+            lock_stack.enter_context(
+                file_lock(session_lock_dir(target.state_repo_root) / f"{target.session_id}.serving.lock")
+            )
 
         # ---- parse env overrides ----
         extra_env: dict[str, str] = {}
@@ -506,7 +644,11 @@ def main(argv: list[str] | None = None) -> int:
 
         # ---- resolve launch params (fresh or relaunch) ----
         if args.relaunch:
-            previous = load_serving_state(alias)
+            previous = load_serving_state(
+                alias,
+                session_id=target.session_id,
+                state_repo_root=target.state_repo_root,
+            )
             if previous is None:
                 print_json({
                     "status": "failed",
@@ -546,24 +688,134 @@ def main(argv: list[str] | None = None) -> int:
             launch_env = extra_env
             launch_extra_args = vllm_extra
 
+        leased_devices = _leased_devices_csv(target.session)
+        if target.session_id and leased_devices:
+            leased = _parse_devices_csv(leased_devices)
+            needed_devices = tp * (dp or 1) if tp is not None else None
+            if needed_devices is not None and len(leased) < needed_devices:
+                print_json({
+                    "status": "needs_input",
+                    "error": (
+                        f"session {target.session_id} leases {len(leased)} NPU devices "
+                        f"but launch needs {needed_devices} (tp={tp}, dp={dp or 1})"
+                    ),
+                    "machine": alias,
+                    "mode": target.mode,
+                    "session_id": target.session_id,
+                })
+                return 1
+            if devices:
+                requested = _parse_devices_csv(devices)
+                if not requested.issubset(leased):
+                    print_json({
+                        "status": "needs_input",
+                        "error": (
+                            f"requested devices {sorted(requested)} are outside "
+                            f"session {target.session_id} lease {sorted(leased)}"
+                        ),
+                        "machine": alias,
+                        "mode": target.mode,
+                        "session_id": target.session_id,
+                    })
+                    return 1
+            else:
+                selected = sorted(leased)
+                if needed_devices is not None:
+                    selected = selected[:needed_devices]
+                devices = ",".join(str(item) for item in selected)
+                emit_progress("lease", f"using leased session devices: {devices}")
+
+        # Validate the new launch target before touching an existing service.
+        # A mistyped model path should be a needs_input response, not a reason
+        # to stop a currently running service for this machine/session.
+        emit_progress("validate", f"checking model path: {model}")
+        r = ssh_exec(ep, f"test -d {shlex.quote(model)} || test -f {shlex.quote(model)}", check=False)
+        if r.returncode != 0:
+            print_json({
+                "status": "needs_input",
+                "error": f"model path not found on remote container: {model}",
+                "machine": alias,
+                "mode": target.mode,
+                "session_id": target.session_id,
+            })
+            return 1
+
         # ---- stop existing service on this machine ----
-        prev_state = load_serving_state(alias)
+        prev_state = load_serving_state(
+            alias,
+            session_id=target.session_id,
+            state_repo_root=target.state_repo_root,
+        )
         if prev_state and prev_state.get("pid"):
             old_pid = prev_state["pid"]
-            emit_progress("stop-existing", f"stopping previous service (pid={old_pid})")
-            ssh_exec(
-                ep,
-                f"kill -2 {old_pid} 2>/dev/null || true; sleep 2; kill -15 {old_pid} 2>/dev/null || true",
-                check=False,
-            )
-            time.sleep(1)
+            scope = f"session {target.session_id}" if target.session_id else f"machine {alias}"
+            if not check_alive(ep, int(old_pid)):
+                emit_progress("stop-existing", f"previous service for {scope} is already stopped (pid={old_pid})")
+                prev_state["status"] = "stopped"
+                prev_state["stopped_at"] = now_utc()
+                save_serving_state(
+                    alias,
+                    prev_state,
+                    session_id=target.session_id,
+                    state_repo_root=target.state_repo_root,
+                )
+                if target.session_id:
+                    release_service_port(
+                        repo_root=target.state_repo_root,
+                        machine_alias=alias,
+                        session_id=target.session_id,
+                        port=prev_state.get("port"),
+                    )
+            else:
+                emit_progress("stop-existing", f"stopping previous service for {scope} (pid={old_pid})")
+                ssh_exec(
+                    ep,
+                    f"kill -2 {old_pid} 2>/dev/null || true; sleep 2; kill -15 {old_pid} 2>/dev/null || true",
+                    check=False,
+                )
+                deadline = time.time() + 20
+                while check_alive(ep, int(old_pid)) and time.time() < deadline:
+                    time.sleep(1)
+                if check_alive(ep, int(old_pid)):
+                    emit_progress("stop-existing", f"previous service still alive, sending SIGKILL to pid={old_pid}")
+                    ssh_exec(ep, f"kill -9 {old_pid} 2>/dev/null || true", check=False)
+                    time.sleep(2)
+                old_devices = _parse_devices_csv(str(prev_state.get("devices") or ""))
+                if old_devices:
+                    emit_progress("stop-existing", f"waiting for old service devices to free: {sorted(old_devices)}")
+                    wait_for_devices_free(target.host_endpoint, old_devices)
+                if not check_alive(ep, int(old_pid)):
+                    prev_state["status"] = "stopped"
+                    prev_state["stopped_at"] = now_utc()
+                    save_serving_state(
+                        alias,
+                        prev_state,
+                        session_id=target.session_id,
+                        state_repo_root=target.state_repo_root,
+                    )
+                    if target.session_id:
+                        release_service_port(
+                            repo_root=target.state_repo_root,
+                            machine_alias=alias,
+                            session_id=target.session_id,
+                            port=prev_state.get("port"),
+                        )
+                else:
+                    prev_state["status"] = "stopping"
+                    prev_state["status_checked_at"] = now_utc()
+                    save_serving_state(
+                        alias,
+                        prev_state,
+                        session_id=target.session_id,
+                        state_repo_root=target.state_repo_root,
+                    )
 
         # ---- parity gate ----
         if not args.skip_parity:
             emit_progress("parity-sync", "ensuring remote code parity")
-            parity = run_parity(args.machine)
+            parity = run_parity(args.machine, target.session_id, target.session_file)
             parity_status = parity.get("status")
-            if parity_status not in ("ready", "ok", "success"):
+            if parity_status not in ("ready", "ok", "success", "skipped"):
                 print_json({
                     "status": "blocked",
                     "error": "remote-code-parity did not return ready",
@@ -576,7 +828,7 @@ def main(argv: list[str] | None = None) -> int:
             parity = {"status": "skipped"}
 
         # ---- probe NPUs on the HOST for cross-container visibility ----
-        h_ep = host_endpoint(record)
+        h_ep = target.host_endpoint
         emit_progress("probe-npus", "checking NPU device availability (host)")
         try:
             npu_info = probe_npus(h_ep)
@@ -605,19 +857,33 @@ def main(argv: list[str] | None = None) -> int:
                     busy=list(npu_info.get("busy", {}).keys()),
                 )
 
-        # ---- validate model path exists remotely ----
-        emit_progress("validate", f"checking model path: {model}")
-        r = ssh_exec(ep, f"test -d {shlex.quote(model)} || test -f {shlex.quote(model)}", check=False)
-        if r.returncode != 0:
-            print_json({
-                "status": "needs_input",
-                "error": f"model path not found on remote container: {model}",
-                "machine": alias,
-            })
-            return 1
-
         # ---- port ----
-        if args.port:
+        if target.session_id:
+            emit_progress("allocate-port", "allocating session service port")
+            port_available = remote_port_availability(ep)
+            port = allocate_service_port(
+                repo_root=target.state_repo_root,
+                machine_alias=alias,
+                session_id=target.session_id,
+                requested_port=args.port,
+                port_available=port_available,
+            )
+            if not remote_port_available(ep, port):
+                release_service_port(
+                    repo_root=target.state_repo_root,
+                    machine_alias=alias,
+                    session_id=target.session_id,
+                    port=port,
+                )
+                print_json({
+                    "status": "failed",
+                    "error": f"allocated service port {port} became unavailable before launch",
+                    "machine": alias,
+                    "mode": target.mode,
+                    "session_id": target.session_id,
+                })
+                return 1
+        elif args.port:
             port = args.port
         else:
             emit_progress("allocate-port", "finding free port")
@@ -653,6 +919,13 @@ def main(argv: list[str] | None = None) -> int:
                 "stdout_tail": result.stdout[-500:],
                 "machine": alias,
             })
+            if target.session_id:
+                release_service_port(
+                    repo_root=target.state_repo_root,
+                    machine_alias=alias,
+                    session_id=target.session_id,
+                    port=port,
+                )
             return 1
 
         pid_line = result.stdout.strip().splitlines()[-1].strip() if result.stdout.strip() else ""
@@ -664,15 +937,17 @@ def main(argv: list[str] | None = None) -> int:
                 "error": f"cannot parse PID from launch output: {pid_line!r}",
                 "machine": alias,
             })
+            if target.session_id:
+                release_service_port(
+                    repo_root=target.state_repo_root,
+                    machine_alias=alias,
+                    session_id=target.session_id,
+                    port=port,
+                )
             return 1
 
         emit_progress("launch", f"process started pid={pid}", pid=pid)
 
-        # ---- probe readiness ----
-        emit_progress("probe", f"waiting for ready (timeout={args.health_timeout}s)")
-        readiness = wait_for_ready(ep, pid, port, runtime_dir, timeout=args.health_timeout)
-
-        # ---- persist state (always, even if not ready — so stop can clean up) ----
         state = {
             "model": model,
             "served_model_name": served_model_name,
@@ -682,6 +957,8 @@ def main(argv: list[str] | None = None) -> int:
             "env": launch_env,
             "extra_args": launch_extra_args,
             "machine": alias,
+            "mode": target.mode,
+            "session_id": target.session_id,
             "pid": pid,
             "port": port,
             "base_url": f"http://{ep.host}:{port}",
@@ -689,16 +966,38 @@ def main(argv: list[str] | None = None) -> int:
             "log_stdout": f"{runtime_dir}/stdout.log",
             "log_stderr": f"{runtime_dir}/stderr.log",
             "started_at": now_utc(),
-            "status": "ready" if readiness["ready"] else "started",
+            "status": "starting",
         }
         if wrap_script:
             state["wrap_script"] = wrap_script
-        save_serving_state(alias, state)
+        save_serving_state(
+            alias,
+            state,
+            session_id=target.session_id,
+            state_repo_root=target.state_repo_root,
+        )
+
+        # ---- probe readiness ----
+        emit_progress("probe", f"waiting for ready (timeout={args.health_timeout}s)")
+        readiness = wait_for_ready(ep, pid, port, runtime_dir, timeout=args.health_timeout)
+
+        # ---- persist state (always, even if not ready — so stop can clean up) ----
+        state["status"] = "ready" if readiness["ready"] else "started"
+        state["readiness_checked_at"] = now_utc()
+        save_serving_state(
+            alias,
+            state,
+            session_id=target.session_id,
+            state_repo_root=target.state_repo_root,
+        )
 
         # ---- build output ----
         output: dict[str, Any] = {
             "status": "ready" if readiness["ready"] else "failed",
             "machine": alias,
+            "mode": target.mode,
+            "session_id": target.session_id,
+            "session_file": str(target.session_file) if target.session_file else None,
             "base_url": f"http://{ep.host}:{port}",
             "container_ip": ep.host,
             "port": port,
@@ -723,7 +1022,7 @@ def main(argv: list[str] | None = None) -> int:
         if not readiness["ready"]:
             stderr_tail = readiness.get("stderr_tail") or read_remote_tail(ep, f"{runtime_dir}/stderr.log")
             output["stderr_tail"] = stderr_tail
-            diagnosis = diagnose_env_failure(stderr_tail, alias)
+            diagnosis = diagnose_env_failure(stderr_tail, alias, session_id=target.session_id)
             if diagnosis:
                 output["env_diagnosis"] = diagnosis
                 emit_progress("diagnosis", diagnosis["recovery_command"],
@@ -740,11 +1039,13 @@ def main(argv: list[str] | None = None) -> int:
             "error": error_msg,
             "machine": machine_id,
         }
-        diagnosis = diagnose_env_failure(error_msg, machine_id)
+        diagnosis = diagnose_env_failure(error_msg, machine_id, session_id=getattr(args, "session_id", None))
         if diagnosis:
             result["env_diagnosis"] = diagnosis
         print_json(result)
         return 2
+    finally:
+        lock_stack.close()
 
 
 if __name__ == "__main__":

--- a/.agents/skills/vllm-ascend-serving/scripts/serve_status.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/serve_status.py
@@ -3,6 +3,7 @@
 
 Usage:
     python3 serve_status.py --machine <alias>
+    python3 serve_status.py --session-id <id>
 
 Progress on stderr, final JSON on stdout.
 """
@@ -21,13 +22,15 @@ if str(_SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPT_DIR))
 
 from _common import (
-    container_endpoint,
     emit_progress,
     load_serving_state,
+    now_utc,
     print_json,
-    resolve_machine,
+    resolve_execution_target,
+    save_serving_state,
     ssh_exec,
 )
+from vaws_session_state import release_service_port
 
 
 def check_alive(ep, pid: int) -> bool:
@@ -59,7 +62,9 @@ def check_models(ep, port: int) -> dict[str, Any] | None:
 
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
-    p.add_argument("--machine", required=True, help="machine alias or host IP")
+    p.add_argument("--machine", help="machine alias or host IP")
+    p.add_argument("--session-id", help="VAWS session id")
+    p.add_argument("--session-file", help="explicit session.json path")
     return p
 
 
@@ -67,15 +72,25 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
 
     try:
-        record = resolve_machine(args.machine)
-        alias = record["alias"]
-        ep = container_endpoint(record)
+        target = resolve_execution_target(
+            args.machine,
+            session_id=args.session_id,
+            session_file=args.session_file,
+        )
+        alias = target.alias
+        ep = target.endpoint
 
-        state = load_serving_state(alias)
+        state = load_serving_state(
+            alias,
+            session_id=target.session_id,
+            state_repo_root=target.state_repo_root,
+        )
         if state is None:
             print_json({
                 "status": "not_found",
                 "machine": alias,
+                "mode": target.mode,
+                "session_id": target.session_id,
                 "message": "no serving state recorded for this machine",
             })
             return 0
@@ -86,6 +101,8 @@ def main(argv: list[str] | None = None) -> int:
             print_json({
                 "status": "not_found",
                 "machine": alias,
+                "mode": target.mode,
+                "session_id": target.session_id,
                 "message": "serving state is missing pid or port",
                 "state": state,
             })
@@ -106,9 +123,29 @@ def main(argv: list[str] | None = None) -> int:
         else:
             status = "stopped"
 
+        state["status"] = status
+        state["status_checked_at"] = now_utc()
+        if status == "stopped":
+            state["stopped_at"] = state.get("stopped_at") or state["status_checked_at"]
+        save_serving_state(
+            alias,
+            state,
+            session_id=target.session_id,
+            state_repo_root=target.state_repo_root,
+        )
+        if status == "stopped" and target.session_id:
+            release_service_port(
+                repo_root=target.state_repo_root,
+                machine_alias=alias,
+                session_id=target.session_id,
+                port=state.get("port"),
+            )
+
         output: dict[str, Any] = {
             "status": status,
             "machine": alias,
+            "mode": target.mode,
+            "session_id": target.session_id,
             "alive": alive,
             "health": health,
             "models_ok": models is not None,
@@ -141,6 +178,7 @@ def main(argv: list[str] | None = None) -> int:
             "status": "failed",
             "error": str(exc),
             "machine": getattr(args, "machine", None),
+            "session_id": getattr(args, "session_id", None),
         })
         return 2
 

--- a/.agents/skills/vllm-ascend-serving/scripts/serve_stop.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/serve_stop.py
@@ -3,6 +3,7 @@
 
 Usage:
     python3 serve_stop.py --machine <alias>
+    python3 serve_stop.py --session-id <id>
     python3 serve_stop.py --machine <alias> --force
 
 Progress on stderr, final JSON on stdout.
@@ -11,6 +12,7 @@ Progress on stderr, final JSON on stdout.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import sys
 import time
 from pathlib import Path
@@ -21,15 +23,15 @@ if str(_SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPT_DIR))
 
 from _common import (
-    container_endpoint,
     emit_progress,
     load_serving_state,
     now_utc,
     print_json,
-    resolve_machine,
+    resolve_execution_target,
     save_serving_state,
     ssh_exec,
 )
+from vaws_session_state import file_lock, release_service_port, session_lock_dir
 
 
 GRACE_PERIOD_SECONDS = 5
@@ -42,24 +44,42 @@ def check_alive(ep, pid: int) -> bool:
 
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
-    p.add_argument("--machine", required=True, help="machine alias or host IP")
+    p.add_argument("--machine", help="machine alias or host IP")
+    p.add_argument("--session-id", help="VAWS session id")
+    p.add_argument("--session-file", help="explicit session.json path")
     p.add_argument("--force", action="store_true", help="use SIGKILL if graceful stop fails")
     return p
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    lock_stack = contextlib.ExitStack()
 
     try:
-        record = resolve_machine(args.machine)
-        alias = record["alias"]
-        ep = container_endpoint(record)
+        target = resolve_execution_target(
+            args.machine,
+            session_id=args.session_id,
+            session_file=args.session_file,
+        )
+        alias = target.alias
+        ep = target.endpoint
+        if target.session_id:
+            emit_progress("lock", f"acquiring serving lock for session {target.session_id}")
+            lock_stack.enter_context(
+                file_lock(session_lock_dir(target.state_repo_root) / f"{target.session_id}.serving.lock")
+            )
 
-        state = load_serving_state(alias)
+        state = load_serving_state(
+            alias,
+            session_id=target.session_id,
+            state_repo_root=target.state_repo_root,
+        )
         if state is None:
             print_json({
                 "status": "not_found",
                 "machine": alias,
+                "mode": target.mode,
+                "session_id": target.session_id,
                 "message": "no serving state recorded for this machine",
             })
             return 0
@@ -69,6 +89,8 @@ def main(argv: list[str] | None = None) -> int:
             print_json({
                 "status": "not_found",
                 "machine": alias,
+                "mode": target.mode,
+                "session_id": target.session_id,
                 "message": "serving state has no pid",
             })
             return 0
@@ -78,10 +100,24 @@ def main(argv: list[str] | None = None) -> int:
             emit_progress("stop", f"pid={pid} is already gone")
             state["status"] = "stopped"
             state["stopped_at"] = now_utc()
-            save_serving_state(alias, state)
+            save_serving_state(
+                alias,
+                state,
+                session_id=target.session_id,
+                state_repo_root=target.state_repo_root,
+            )
+            if target.session_id:
+                release_service_port(
+                    repo_root=target.state_repo_root,
+                    machine_alias=alias,
+                    session_id=target.session_id,
+                    port=state.get("port"),
+                )
             print_json({
                 "status": "stopped",
                 "machine": alias,
+                "mode": target.mode,
+                "session_id": target.session_id,
                 "pid": pid,
                 "message": "process was already stopped",
             })
@@ -106,6 +142,8 @@ def main(argv: list[str] | None = None) -> int:
                 print_json({
                     "status": "failed",
                     "machine": alias,
+                    "mode": target.mode,
+                    "session_id": target.session_id,
                     "pid": pid,
                     "error": f"process {pid} did not exit after SIGINT+SIGTERM; rerun with --force to SIGKILL",
                 })
@@ -114,11 +152,25 @@ def main(argv: list[str] | None = None) -> int:
         stopped = not check_alive(ep, pid)
         state["status"] = "stopped" if stopped else "alive"
         state["stopped_at"] = now_utc()
-        save_serving_state(alias, state)
+        save_serving_state(
+            alias,
+            state,
+            session_id=target.session_id,
+            state_repo_root=target.state_repo_root,
+        )
+        if stopped and target.session_id:
+            release_service_port(
+                repo_root=target.state_repo_root,
+                machine_alias=alias,
+                session_id=target.session_id,
+                port=state.get("port"),
+            )
 
         output: dict[str, Any] = {
             "status": "stopped" if stopped else "failed",
             "machine": alias,
+            "mode": target.mode,
+            "session_id": target.session_id,
             "pid": pid,
             "stopped": stopped,
         }
@@ -133,8 +185,11 @@ def main(argv: list[str] | None = None) -> int:
             "status": "failed",
             "error": str(exc),
             "machine": getattr(args, "machine", None),
+            "session_id": getattr(args, "session_id", None),
         })
         return 2
+    finally:
+        lock_stack.close()
 
 
 if __name__ == "__main__":

--- a/.agents/tests/test_vaws_scaffold_safety.py
+++ b/.agents/tests/test_vaws_scaffold_safety.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Local safety regression tests for VAWS scaffold helpers."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB_DIR = ROOT / ".agents" / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+import vaws_remote_toolbox as toolbox  # noqa: E402
+from vaws_remote_toolbox import RemoteTarget, SshEndpoint  # noqa: E402
+from vaws_session_id import normalize_session_id  # noqa: E402
+from vaws_session_state import SessionStateError, allocate_session_leases  # noqa: E402
+from vaws_validate import (  # noqa: E402
+    ValidationError,
+    parse_device_csv,
+    require_env_name,
+    require_safe_id,
+)
+
+
+class ValidatorTests(unittest.TestCase):
+    def test_safe_id_rejects_path_shapes(self) -> None:
+        for value in ("../x", "a/b", "/tmp/x", "..", "a b", ""):
+            with self.subTest(value=value):
+                with self.assertRaises(ValidationError):
+                    require_safe_id(value, label="job id")
+
+    def test_env_name_is_ascii_shell_identifier(self) -> None:
+        self.assertEqual(require_env_name("VLLM_USE_V1"), "VLLM_USE_V1")
+        for value in ("A-B", "1ABC", "A;echo", "", "\u53d8\u91cf"):
+            with self.subTest(value=value):
+                with self.assertRaises(ValidationError):
+                    require_env_name(value)
+
+    def test_device_csv_rejects_invalid_inputs(self) -> None:
+        self.assertEqual(parse_device_csv("2,0,1"), [0, 1, 2])
+        for value in ("-1", "0,0", "999,,1", "", "abc"):
+            with self.subTest(value=value):
+                with self.assertRaises(ValidationError):
+                    parse_device_csv(value)
+
+
+class SessionIdTests(unittest.TestCase):
+    def test_long_session_ids_keep_hash_suffix(self) -> None:
+        raw_a = "feature-" + ("a" * 80) + "-111"
+        raw_b = "feature-" + ("a" * 80) + "-222"
+        sid_a = normalize_session_id(raw_a)
+        sid_b = normalize_session_id(raw_b)
+        self.assertIsNotNone(sid_a)
+        self.assertIsNotNone(sid_b)
+        assert sid_a is not None and sid_b is not None
+        self.assertLessEqual(len(sid_a), 64)
+        self.assertLessEqual(len(sid_b), 64)
+        self.assertNotEqual(sid_a, sid_b)
+
+
+class RemoteToolboxSafetyTests(unittest.TestCase):
+    def test_job_record_path_stays_under_job_state_dir(self) -> None:
+        valid = toolbox._job_record_path("job-abc_123")
+        self.assertIn(toolbox.JOB_STATE_DIR.resolve(), valid.parents)
+        with self.assertRaises(ValidationError):
+            toolbox._job_record_path("../sessions/leases")
+
+    def test_env_items_validate_before_shell_export(self) -> None:
+        self.assertEqual(toolbox._parse_env_items(["A_B=1"]), {"A_B": "1"})
+        with self.assertRaises(ValidationError):
+            toolbox._parse_env_items(["A-B=1"])
+
+    def test_cleanup_leases_only_is_blocked_for_session_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = RemoteTarget(
+                mode="session",
+                alias="machine-a",
+                target_id="sess-abc",
+                workspace_id="sess-abc",
+                workspace_root=Path(tmp),
+                runtime_root="/workspace",
+                container_name="vaws-test",
+                container_image="image",
+                container_endpoint=SshEndpoint("127.0.0.1", 46000),
+                host_endpoint=SshEndpoint("127.0.0.1", 22),
+                state_repo_root=Path(tmp),
+                record={},
+                session_id="sess-abc",
+                session_file=Path(tmp) / "session.json",
+                session={"session_id": "sess-abc"},
+                leased_devices=[0],
+            )
+            payload = toolbox.cleanup(
+                target,
+                dry_run=True,
+                jobs=False,
+                job_ids=None,
+                service=False,
+                session_container=False,
+                leases=True,
+                known_hosts=False,
+                remote_temp=False,
+                force=False,
+            )
+            self.assertEqual(payload["status"], "blocked")
+
+    def test_artifact_manifest_rejects_symlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / "target.txt"
+            target.write_text("secret\n", encoding="utf-8")
+            link = root / "link.txt"
+            link.symlink_to(target)
+            with self.assertRaises(toolbox.RemoteToolboxError):
+                toolbox._local_manifest(link)
+
+
+class LeaseValidationTests(unittest.TestCase):
+    def test_session_lease_validates_devices_against_host_probe(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(SessionStateError):
+                allocate_session_leases(
+                    repo_root=root,
+                    machine_alias="machine-a",
+                    session_id="sess-abc",
+                    requested_devices=[999],
+                    available_devices=[0, 1],
+                    port_available=lambda _port: True,
+                )
+            with self.assertRaises(SessionStateError):
+                allocate_session_leases(
+                    repo_root=root,
+                    machine_alias="machine-a",
+                    session_id="sess-abc",
+                    npu_count=0,
+                    port_available=lambda _port: True,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_vaws_scaffold_safety.py
+++ b/.agents/tests/test_vaws_scaffold_safety.py
@@ -3,10 +3,13 @@
 
 from __future__ import annotations
 
+import importlib.util
+import json
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 ROOT = Path(__file__).resolve().parents[2]
 LIB_DIR = ROOT / ".agents" / "lib"
@@ -23,6 +26,15 @@ from vaws_validate import (  # noqa: E402
     require_env_name,
     require_safe_id,
 )
+
+
+def load_session_create_module():
+    path = ROOT / ".agents" / "skills" / "session-management" / "scripts" / "session_create.py"
+    spec = importlib.util.spec_from_file_location("_vaws_session_create_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 class ValidatorTests(unittest.TestCase):
@@ -139,6 +151,76 @@ class LeaseValidationTests(unittest.TestCase):
                     npu_count=0,
                     port_available=lambda _port: True,
                 )
+
+
+class WorktreeCreateTests(unittest.TestCase):
+    def test_staging_binding_is_written_before_submodule_update(self) -> None:
+        module = load_session_create_module()
+        original_run_git = module.run_git
+        original_write_binding = module.write_current_session_binding
+        original_emit_progress = module.emit_progress
+        events: list[str] = []
+        fail_submodule = True
+        with tempfile.TemporaryDirectory() as tmp:
+            worktree_root = Path(tmp) / "worktree"
+
+            def fake_run_git(args, *, cwd=module.ROOT, check=True):
+                if args[:3] == ["show-ref", "--verify", "--quiet"]:
+                    return SimpleNamespace(returncode=1, stdout="", stderr="")
+                if args[:2] == ["worktree", "add"]:
+                    worktree_root.mkdir(parents=True)
+                    events.append("worktree-add")
+                    return SimpleNamespace(returncode=0, stdout="", stderr="")
+                if args == ["submodule", "update", "--init", "--recursive"]:
+                    events.append("submodule-update")
+                    if fail_submodule:
+                        raise RuntimeError("submodule update failed")
+                    return SimpleNamespace(returncode=0, stdout="", stderr="")
+                raise AssertionError(f"unexpected git args: {args!r}")
+
+            def fake_write_binding(repo_root, *, session_id, source, **_kwargs):
+                events.append("binding")
+                path = Path(repo_root) / ".vaws-local" / "current-session.json"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(
+                    json.dumps({"session_id": session_id, "source": source}) + "\n",
+                    encoding="utf-8",
+                )
+                return path
+
+            try:
+                module.run_git = fake_run_git
+                module.write_current_session_binding = fake_write_binding
+                module.emit_progress = lambda *_args, **_kwargs: None
+                with self.assertRaisesRegex(RuntimeError, "submodule update failed"):
+                    module.ensure_worktree(
+                        session_id="sess-abc",
+                        branch="session/sess-abc",
+                        base_ref="main",
+                        worktree_root=worktree_root,
+                        no_worktree=False,
+                    )
+                self.assertEqual(events, ["worktree-add", "binding", "submodule-update"])
+                fail_submodule = False
+                events.clear()
+                reused_root, reused_payload = module.ensure_worktree(
+                    session_id="sess-abc",
+                    branch="session/sess-abc",
+                    base_ref="main",
+                    worktree_root=worktree_root,
+                    no_worktree=False,
+                )
+            finally:
+                module.run_git = original_run_git
+                module.write_current_session_binding = original_write_binding
+                module.emit_progress = original_emit_progress
+
+            self.assertEqual(events, ["submodule-update"])
+            self.assertEqual(reused_root, worktree_root.resolve())
+            self.assertEqual(reused_payload["action"], "reused")
+            binding = json.loads((worktree_root / ".vaws-local" / "current-session.json").read_text())
+            self.assertEqual(binding["session_id"], "sess-abc")
+            self.assertEqual(binding["source"], "session_create-staging")
 
 
 if __name__ == "__main__":

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,14 @@ Repo-local skills live under `.agents/skills/`. Each has its own `SKILL.md` with
 |-------|---------|
 | `repo-init` | Initialize workspace: `gh`, GitHub auth, submodules, fork topology |
 | `machine-management` | Add / verify / repair / remove a remote NPU machine |
+| `session-management` | Create / inspect / remove isolated agent sessions (local worktree + remote container + leases) |
+| `remote-toolbox` | Structured target/probe/exec/job/sync/service/artifact/cleanup tools for managed remote containers |
 | `remote-code-parity` | Sync local working tree to remote container before execution |
 | `vllm-ascend-serving` | Start / check / stop a vLLM Ascend service on a remote container |
 | `vllm-ascend-benchmark` | Run `vllm bench serve` benchmarks (single-run or multi-run with warmup) |
 | `ascend-memory-profiling` | Profile HBM memory usage on Ascend NPU for vLLM serving scenarios |
 | `ascend-profiling-collection` | Collect one Ascend torch-profiler case end-to-end (start service, bracket workload with `/start_profile` + `/stop_profile`, run `analyse()`, verify outputs, write manifest) |
+| `ascend-profiling-analysis` | Analyze collected Ascend torch-profiler roots/manifests and generate reports |
 
 None of these are gates for normal local coding, docs work, or unrelated Git tasks.
 
@@ -25,8 +28,10 @@ None of these are gates for normal local coding, docs work, or unrelated Git tas
 - Keep `.gitmodules` on community upstream URLs.
 - Prefer skill wrapper scripts over raw SSH / shell commands for remote operations.
 - Skill wrappers: progress on `stderr`, final JSON on `stdout`.
+- Use the remote toolbox entrypoints for agent-facing target resolution, probing, shell execution, long jobs, artifact transfer, service adapters, and cleanup before falling back to bare SSH.
+- For parallel remote work, create or reuse a `session-management` session and pass `--session-id` through parity, serving, benchmark, and profiling commands. Legacy `--machine` flows remain available for explicitly single-tenant work.
 - This repo targets Huawei Ascend NPU. Local machines (Mac/PC) cannot run `torch`/`torch_npu`-dependent code. Do not attempt local test execution — go straight to the remote container.
 
 ## Maintenance
 
-When changing a skill, update the whole package together: `SKILL.md`, `scripts/`, `references/`. When the change affects shared state, also update `.agents/scripts/workspace_profile.py` and `.agents/lib/vaws_local_state.py`.
+When changing a skill, update the whole package together: `SKILL.md`, `scripts/`, `references/`. When the change affects shared state, also update `.agents/scripts/workspace_profile.py`, `.agents/lib/vaws_local_state.py`, `.agents/lib/vaws_session_id.py`, `.agents/lib/vaws_session_state.py`, and `.agents/lib/vaws_remote_toolbox.py` as applicable.

--- a/README.en.md
+++ b/README.en.md
@@ -8,7 +8,7 @@ A composable local development scaffold for working on [vLLM](https://github.com
 
 Developing vLLM Ascend typically involves editing code locally, running tests on remote Ascend NPU servers, and tracking upstream vLLM changes — all of which require repetitive Git, SSH, and environment configuration.
 
-`vllm-ascend-workspace` wraps these operations into six AI Agent skills. You can ask an Agent to handle them in natural language, or ignore the skills entirely and use it as a plain multi-repo workspace.
+`vllm-ascend-workspace` wraps these operations into a set of AI Agent skills. You can ask an Agent to handle them in natural language, or ignore the skills entirely and use it as a plain multi-repo workspace.
 
 ## Quick start
 
@@ -34,10 +34,14 @@ The Agent will detect your environment, install required tools, and configure Gi
 | ---------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
 | **repo-init**          | Install GitHub CLI, authenticate, initialize submodules, configure forks and remote topology | After first clone                                          |
 | **machine-management** | Add, verify, repair, or remove a remote Ascend NPU server and its managed container          | When setting up a remote NPU dev machine                   |
+| **session-management** | Create, inspect, and clean isolated sessions: local worktree, remote container, state namespace, and resource leases | For parallel remote work or multiple agents |
+| **remote-toolbox**    | Structured target/probe/exec/job/sync/service/artifact/cleanup tools for remote containers | When agents need local-tool-like control of a remote session container |
 | **remote-code-parity** | Sync the full local workspace state (including uncommitted changes) to a remote container    | Triggered automatically before remote test or service runs |
 | **vllm-ascend-serving** | Launch a vLLM Ascend inference service on a remote container, with NPU probing, auto card selection, and incremental restart | When you need an inference service on a remote machine |
 | **vllm-ascend-benchmark** | Run `vllm bench serve` performance benchmarks on a remote container, with multi-run warmup and statistical aggregation | When you need throughput/latency benchmarks or performance regression checks |
 | **ascend-memory-profiling** | Profile and attribute HBM memory usage on Ascend NPU, with per-component breakdown and evidence chains | When you need to analyze memory consumption of a vLLM serving workload |
+| **ascend-profiling-collection** | Collect Ascend torch-profiler data: start service, bracket profile window, run workload, remote analyse, and write a manifest | When you need kernel_details/trace_view captures |
+| **ascend-profiling-analysis** | Analyze collected profiler roots/manifests and generate step/layer/operator/cross-rank reports | When you need to analyze profiling output |
 
 
 All skills are **optional**. Use any subset, or none at all.
@@ -79,10 +83,14 @@ When talking to an Agent:
 │   ├── skills/
 │   │   ├── repo-init/         # Workspace initialization skill
 │   │   ├── machine-management/    # Remote machine management skill
+│   │   ├── session-management/    # Parallel session isolation skill
+│   │   ├── remote-toolbox/        # Structured remote toolbox
 │   │   ├── remote-code-parity/    # Code synchronization skill
 │   │   ├── vllm-ascend-serving/   # Inference serving skill
 │   │   ├── vllm-ascend-benchmark/ # Performance benchmarking skill
-│   │   └── ascend-memory-profiling/ # Memory profiling skill
+│   │   ├── ascend-memory-profiling/ # Memory profiling skill
+│   │   ├── ascend-profiling-collection/ # Torch profiler collection skill
+│   │   └── ascend-profiling-analysis/ # Profiling analysis/report skill
 │   ├── lib/               # Shared local-state library
 │   └── scripts/           # Shared helper scripts
 ├── .cursor/rules/         # Cursor IDE specific rules
@@ -96,6 +104,8 @@ When talking to an Agent:
 
 - **Nothing is mandatory** — All skills are optional. Developers choose what to use.
 - **Local state stays untracked** — User-specific remotes, auth, and machine config live only in the untracked `.vaws-local/` directory.
+- **Parallel tasks stay isolated** — Remote parallel work should use sessions: each task gets its own local worktree, remote container, state namespace, and resource leases.
+- **Remote operations are structured** — Agents should prefer the remote toolbox for JSON results, observable logs, resumable artifact manifests, and cleanup-capable state.
 - **Submodules point to community** — `.gitmodules` always targets `vllm-project` official repos. Personal forks are a local runtime concern.
 - **Agent-driven, not Agent-dependent** — Everything can be done manually. Agent skills just make it more convenient.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 vLLM Ascend 的开发通常需要在本地编辑代码、在远程昇腾 NPU 服务器上运行测试，同时还要跟踪上游 vLLM 的变化。手动维护这套工作流涉及大量重复的 Git、SSH 和环境配置操作。
 
-`vllm-ascend-workspace` 把这些操作封装成六个 AI Agent 技能，你可以用自然语言让 Agent 代劳，也可以完全忽略这些技能、只把它当作一个普通的多仓库工作区。
+`vllm-ascend-workspace` 把这些操作封装成一组 AI Agent 技能，你可以用自然语言让 Agent 代劳，也可以完全忽略这些技能、只把它当作一个普通的多仓库工作区。
 
 ## 快速开始
 
@@ -34,10 +34,14 @@ Agent 会自动检测你的环境、安装所需工具、配置 Git 远程仓库
 | ------------------------ | ---------------------------------------------- | ------------------ |
 | **repo-init**            | 安装 GitHub CLI、登录 GitHub、初始化子模块、配置 Fork 和远程仓库拓扑 | 首次 clone 后初始化工作区   |
 | **machine-management**   | 添加、验证、修复或移除远程昇腾 NPU 服务器及其托管容器                  | 需要配置远程 NPU 开发机时    |
+| **session-management**   | 创建/检查/清理隔离 session：本地 worktree、远端容器、状态目录和资源 lease | 多 agent 或多任务并行远端执行时 |
+| **remote-toolbox**       | 结构化解析/探测/执行/长任务/同步/服务/产物传输/清理远端容器              | Agent 需要像使用本地工具一样操作远端 session container 时 |
 | **remote-code-parity**   | 将本地工作区的完整状态（含未提交的修改）同步到远程容器                    | 在远程机器上运行测试或服务前自动触发 |
 | **vllm-ascend-serving**  | 在远程容器上一键拉起 vLLM Ascend 推理服务，支持 NPU 探测、自动选卡、增量重启 | 需要在远程机器上起推理服务时     |
 | **vllm-ascend-benchmark** | 在远程容器上运行 `vllm bench serve` 性能基准测试，支持多轮预热和统计聚合     | 需要跑吞吐/延迟基准测试或性能回归对比时 |
 | **ascend-memory-profiling** | 采集并分析昇腾 NPU 的 HBM 显存占用，按组件拆分并溯源 | 需要分析 vLLM 推理服务的显存占用时 |
+| **ascend-profiling-collection** | 采集 Ascend torch profiler：起服务、控制 profile 窗口、运行 workload、远端 analyse 并写 manifest | 需要采集 kernel_details/trace_view 时 |
+| **ascend-profiling-analysis** | 分析已采集的 profiler root/manifest，生成 step/layer/operator/cross-rank 诊断报告 | 需要分析 profiling 结果或生成报告时 |
 
 
 所有技能都是**可选的**。你可以只用其中的一部分，也可以完全不用。
@@ -80,10 +84,14 @@ Agent 会自动检测你的环境、安装所需工具、配置 Git 远程仓库
 │   ├── skills/
 │   │   ├── repo-init/             # 工作区初始化技能
 │   │   ├── machine-management/    # 远程机器管理技能
+│   │   ├── session-management/    # 并行 Session 隔离技能
+│   │   ├── remote-toolbox/        # 远端结构化工具面
 │   │   ├── remote-code-parity/    # 代码同步技能
 │   │   ├── vllm-ascend-serving/   # 服务拉起技能
 │   │   ├── vllm-ascend-benchmark/ # 性能基准测试技能
-│   │   └── ascend-memory-profiling/ # 显存 profiling 技能
+│   │   ├── ascend-memory-profiling/ # 显存 profiling 技能
+│   │   ├── ascend-profiling-collection/ # torch profiler 采集技能
+│   │   └── ascend-profiling-analysis/ # profiling 分析报告技能
 │   ├── lib/               # 共享本地状态库
 │   └── scripts/           # 共享辅助脚本
 ├── .cursor/rules/         # Cursor IDE 专用规则
@@ -97,6 +105,8 @@ Agent 会自动检测你的环境、安装所需工具、配置 Git 远程仓库
 
 - **不强制任何流程** — 所有技能都可选，开发者自由选择使用哪些部分。
 - **本地状态不入库** — 用户特定的远程仓库、认证信息、机器配置等只存在于本地未跟踪的 `.vaws-local/` 目录中。
+- **并行任务隔离** — 远端并行执行优先使用 session：每个任务有独立本地 worktree、远端容器、状态目录和资源 lease。
+- **远端操作结构化** — Agent 面向远端容器优先使用 remote toolbox，产出 JSON、可观测日志、可恢复 artifact manifest 和可清理状态。
 - **子模块指向社区** — `.gitmodules` 始终指向 `vllm-project` 的官方仓库，个人 Fork 是本地运行时配置。
 - **Agent 驱动，但不依赖 Agent** — 所有操作都可以手动完成，Agent 只是让流程更方便。
 


### PR DESCRIPTION
## Summary

- Add session-management as a first-class VAWS scaffold skill for isolated agent sessions, including session state, identity, leases, create/list/status/remove/gc commands, and routing docs.
- Add the remote-toolbox shared library and wrapper entrypoints for target resolution, probing, bounded exec, long jobs, sync, service lifecycle, artifact transfer, and cleanup.
- Wire session-aware behavior through parity, serving, benchmark, memory profiling, torch-profiler collection, and profiling-analysis skill docs/scripts while preserving legacy `--machine` flows.
- Update `AGENTS.md`, `.agents/README.md`, and README routing so the scaffold contract matches the new session-first workflow.

## Impact

This makes parallel agent work session-scoped by default: each task can own its local worktree, remote container, local state namespace, serving state, profiling/benchmark state, and resource leases without colliding with other tasks.

## Validation

- `git diff --cached --check`
- Parsed 48 staged Python files with `ast.parse`
- Ran `--help` successfully for 35 primary session, remote-toolbox, parity, serving, benchmark, and profiling wrapper scripts

Note: existing local dirty state inside the `vllm-ascend` submodule was intentionally left out of this PR.