### PR TITLE
[codex] fix GLM5 MTP profiling segmentation

### DIFF
--- a/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/knowledge/README.md
+++ b/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/knowledge/README.md
@@ -19,6 +19,8 @@ analysis code; treat them as part of the contract.
 | `moe_families.yaml` | MC2 / fused MC2 / dense FFN families. Also explicitly documents that the HC* / MHC* prefix kernels (`HCPreSinkhorn`, `HCPreInvRMS`, `HCPost`, `MhcRmsNorm`) are **structural block-head helpers** that appear before BOTH attention and MoE blocks — they stay under `block_head.mhc_prefix` and must NOT be conflated with `moe.gating`. | `common.categories_and_roles`, `tests/test_moe_families.py` |
 | `model_architectures.yaml` | HF arch → (attention family, FFN family) high-level map. **Static knowledge / documentation only.** This skill's input is `ascend_pt/` profiling output — never HF `config.json` — so the file is *not consumed at runtime* by any analysis stage. The report's "model structure" line (e.g. `27L · mla+moe`) is derived from observed kernel signatures via `html_report.guess_model_structure`, not from this YAML. Use it as a human reference table when reasoning about which kernel signatures *should* be seen for each architecture. | (none — documentation) |
 
+| `known_counterexamples.md` | Concrete profiling patterns that previously broke segmentation / classification. Add a case here before changing Python rules. | `segment.py`, `classify.py`, reviewer audit |
+
 When adding a new knowledge file, register it in the table above and
 reference it from the analysis stage that consumes it.
 
@@ -35,7 +37,6 @@ The maintenance rule is simple:
 ```text
 structure_roles.yaml
 diagnosis_rules.yaml
-known_counterexamples.yaml
 ```
 
 ## Operator Taxonomy (canonical list)

--- a/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/knowledge/index.md
+++ b/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/knowledge/index.md
@@ -26,6 +26,7 @@ which are *reference docs*.
 | `attention_families.yaml` | **Contract** (active reference) | `common.categories_and_roles`, `html_report.detect_attention_subtype`, `tests/test_attention_families.py` | paper-aligned families MLA / DSA / CSA / HCA / GQA / linear / FA, with "must-have / must-not-have" signature combinations; CANN backend names are documented but never used as family labels |
 | `moe_families.yaml` | **Contract** (active reference) | `common.categories_and_roles`, `tests/test_moe_families.py` | MC2 / fused MC2 / dense FFN families. **Note:** the `HC*` / `MHC*` prefix kernels are NOT moe.gating sub-kernels — they prefix both attention and MoE blocks and stay under `block_head.mhc_prefix` |
 | `model_architectures.yaml` | Reference (report-time annotation only) | future diagnostics for `attention_family_mismatch` | HF arch → (attention family, FFN family); NOT used for segmentation |
+| `known_counterexamples.md` | Reference | `segment.py`, `classify.py`, reviewers | concrete profiles that broke segmentation / classification and the invariants future fixes must preserve |
 | `README.md` | Reference | humans | historical notes; roadmap |
 
 ## Adding new knowledge
@@ -82,7 +83,7 @@ remaining "knowledge externalization" items are:
   and the schema test enforces parity.
 - **`segmentation_strategy.yaml`** — anchor priority, boundary markers,
   residual policy, repair-rule enablement; consumed by `segment.py`.
-- **`known_counterexamples.yaml`** — fixture cases the segmenter /
+- **`known_counterexamples.md`** — fixture cases the segmenter /
   classifier must keep passing.
 - **`diagnosis_rules.yaml`** — declarative rule pack for
   `diagnostics.py`, including the `attention_family_mismatch` and

--- a/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/knowledge/known_counterexamples.md
+++ b/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/knowledge/known_counterexamples.md
@@ -1,0 +1,11 @@
+# Known Counterexamples
+
+## GLM5 MLA + sparse attention + MTP
+
+- Capture: `D:\profiling\test\8K-1K-W8A8-TP8-MTP3-1BS`
+- Shape: GLM5, TP8, W8A8, main model has 78 layers, MTP is enabled with `mtp=3`.
+- Symptoms before fix:
+  - `segment.py` treated `MlaPrologV3`, `KvQuantSparseFlashAttention`, and the MLA/SFA V-up projection as three separate `LayerObservation` entries. The report then showed `Layer inventory [3]` and 320 complete step segments per rank, which confused one model layer's internal attention subunits with model layers.
+  - After fixing the MLA anchor frequency, `exact_regime_split` still cut each main window into a 3-layer dense prefix and a 75-layer MoE suffix. That produced fake 3-layer main steps and 75-layer main steps instead of one 78-layer GLM5 main body.
+- Required behavior: when a rank has MLA layer-start anchors (`attention.mla` / `attention.mla.kv_norm_rope_cache`), those anchors define model-layer frequency. Sparse/flash score, lightning indexer, RoPE, and V-up projection events remain evidence inside that same layer window; they must not create additional layer boundaries. A short dense main-layer prefix followed by a MoE suffix with the same attention body is a model-layer family transition, not a step/workload boundary.
+- Regression invariant: for this profile, the segmenter should recover four complete forward windows per rank, each with 78 main layers plus 3 MTP/speculative layers. The rank-level layer inventory should be `[78]`, not `[3]` or `[3, 75]`.

--- a/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/segment.py
+++ b/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/segment.py
@@ -102,6 +102,27 @@ def primary_attention_category(event: NormalizedEvent) -> str | None:
     return sorted(matches)[0] if matches else None
 
 
+MLA_LAYER_START_CATEGORIES = (
+    "attention.mla",
+    "attention.mla.kv_norm_rope_cache",
+)
+
+ATTENTION_COMPANION_ONLY_CATEGORIES = {
+    "attention.lightning_indexer",
+    "attention.mla.v_up_proj",
+    "attention.sparse_attn.v_up_proj",
+    "attention.sparse_sharedkv.metadata",
+    "attention.kv_compressor",
+    "attention.kvcomp.signpack",
+    "attention.kvcomp.cache_write",
+    "attention.kv_cache_io",
+}
+
+
+def is_attention_companion_only(category: str) -> bool:
+    return category in ATTENTION_COMPANION_ONLY_CATEGORIES or category.startswith("attention.rope")
+
+
 def primary_moe_category(event: NormalizedEvent) -> str | None:
     matches = [category for category in event.op_categories if category.startswith("moe.")]
     return sorted(matches)[0] if matches else None
@@ -214,14 +235,38 @@ def dedup_adjacent_events(events: Sequence[NormalizedEvent]) -> tuple[Normalized
 def layer_anchor_events(events: Sequence[NormalizedEvent]) -> tuple[NormalizedEvent, ...]:
     """Pick one deterministic layer-anchor family for this rank.
 
-    Attention is the best layer-frequency signal when present.  Dummy/runner
+    Attention is the best layer-frequency signal when present, but some MLA
+    decode paths expose one logical layer as several attention-labelled
+    subunits: MlaProlog, sparse/flash score, and V-up projection.  In those
+    profiles only the layer-start MLA marker should drive layer frequency; the
+    later attention companions stay inside the same layer window.  Dummy/runner
     ranks can miss attention entirely, so the fallback order is MoE, matmul,
     block-head, then normalization.  This is an evidence priority, not a model
     name rule.
     """
 
+    attention_events = dedup_adjacent_events(
+        tuple(
+            event
+            for event in events
+            if event_role(event, "attention") and primary_attention_category(event) is not None
+        )
+    )
+    if attention_events:
+        for category in MLA_LAYER_START_CATEGORIES:
+            anchors = tuple(event for event in attention_events if category in event.op_categories)
+            if anchors:
+                return anchors
+        anchors = tuple(
+            event
+            for event in attention_events
+            if not is_attention_companion_only(primary_attention_category(event) or "")
+        )
+        if anchors:
+            return anchors
+        return attention_events
+
     role_order = (
-        lambda event: event_role(event, "attention"),
         lambda event: event_role(event, "moe"),
         lambda event: "compute.matmul" in event.op_categories and event_role(event, "compute"),
         lambda event: event_role(event, "block_head"),
@@ -585,19 +630,50 @@ def layers_have_moe(layers: Sequence[LayerObservation]) -> bool:
     return any("moe:" in core_role_key(layer.signature) for layer in layers)
 
 
+def layers_have_dense_compute(layers: Sequence[LayerObservation]) -> bool:
+    return any("ffn_or_dense_compute" in core_role_key(layer.signature) for layer in layers)
+
+
+def layers_have_primary_attention(layers: Sequence[LayerObservation]) -> bool:
+    return any(layer_has_primary_attention(layer) for layer in layers)
+
+
+def regime_cut_is_dense_prefix_moe_suffix(frame: LayerFrame, cut: int) -> bool:
+    left = frame.layers[:cut]
+    right = frame.layers[cut:]
+    if not left or not right:
+        return False
+    if len(left) * 4 > len(right):
+        return False
+    if not layers_have_primary_attention(left) or not layers_have_primary_attention(right):
+        return False
+    if not layers_have_dense_compute(left):
+        return False
+    if layers_have_moe(left) or not layers_have_moe(right):
+        return False
+    return dense_prefix_matches_moe_suffix_attention(
+        LayerFrame(tuple(left), reason=frame.reason),
+        LayerFrame(tuple(right), reason=frame.reason),
+    )
+
+
 def regime_cut_is_prefix_variant(frame: LayerFrame, cut: int) -> bool:
     """Keep model-local prefix variants inside one body.
 
     Some models expose early layers without auxiliary attention kernels such as
     CSA compressor/indexer, while the remaining layers include them.  This is a
-    layer-family variation, not a workload boundary.  Dense VL+LLM boundaries
-    are not suppressed here because they lack the MoE/CSA structural marker.
+    layer-family variation, not a workload boundary.  GLM-style MoE models can
+    likewise expose a short dense prefix before the recurring MoE suffix; when
+    both sides share the same attention body, the cut is a main-layer family
+    transition instead of a step/workload boundary.
     """
 
     left = frame.layers[:cut]
     right = frame.layers[cut:]
     left_core = layer_core_set(left)
     right_core = layer_core_set(right)
+    if regime_cut_is_dense_prefix_moe_suffix(frame, cut):
+        return True
     if not left_core or not right_core:
         return False
     same_core_family = bool(left_core & right_core) or left_core.issubset(right_core) or right_core.issubset(left_core)

--- a/.agents/skills/ascend-profiling-analysis/tests/test_segment_validator.py
+++ b/.agents/skills/ascend-profiling-analysis/tests/test_segment_validator.py
@@ -33,12 +33,16 @@ from ascend_profile import segment as segm  # noqa: E402
 from ascend_profile.segment import (  # noqa: E402
     LayerFrame,
     LayerObservation,
+    build_layers,
     StepPlan,
     classify_interior_substructure_plans,
     classify_residual_plans,
+    compose_step_plans,
+    event_role,
     validate_exact_cover,
     validate_unresolved_composite_bodies,
 )
+from ascend_profile.common import NormalizedEvent  # noqa: E402
 
 
 def _layer(index: int, signature: str, *, row_base: int = 0) -> LayerObservation:
@@ -77,6 +81,163 @@ def _step_plan(
         segment_type=segment_type,
         complete=complete,
     )
+
+
+def _event(
+    row_idx: int,
+    name: str,
+    *,
+    categories: tuple[str, ...] = (),
+    roles: tuple[str, ...] = (),
+) -> NormalizedEvent:
+    return NormalizedEvent(
+        event_id=f"evt_{row_idx}",
+        profile_id="profile_test",
+        rank_id="rank0",
+        source_id="src_test",
+        row_idx=row_idx,
+        name_raw=name,
+        task_type=name.upper(),
+        accelerator_core="AI_CORE",
+        stream_id="0",
+        start_us=float(row_idx),
+        end_us=float(row_idx) + 0.5,
+        duration_us=0.5,
+        wait_us=0.0,
+        op_categories=categories,
+        op_roles=roles,
+    )
+
+
+def _build_test_layers(events: list[NormalizedEvent]) -> list[LayerObservation]:
+    row_numbers = tuple(event.row_idx for event in events)
+    boundary_rows = segm.dedup_adjacent_event_rows(
+        events,
+        lambda event: event_role(event, "block_head") or event_role(event, "normalization"),
+    )
+    anchor_boundary_rows = segm.dedup_adjacent_event_rows(
+        events,
+        lambda event: event_role(event, "block_head"),
+    )
+    return build_layers(events, row_numbers, boundary_rows, anchor_boundary_rows, ())
+
+
+def test_mla_sparse_attention_subunits_stay_in_one_layer() -> None:
+    """GLM5-style MLA decode exposes several attention-labelled subunits.
+
+    Only the layer-start MLA marker should define layer frequency.  The sparse
+    score and V-up projection are internal attention evidence for the same
+    model layer, otherwise one transformer layer is reported as three layers.
+    """
+
+    events = [
+        _event(0, "aclnnAddRmsNorm", categories=("block_head",), roles=("block_head",)),
+        _event(1, "MlaPrologV3", categories=("attention.mla", "attention.mla.preprocess"), roles=("attention",)),
+        _event(2, "KvQuantSparseFlashAttention", categories=("attention.flash_score",), roles=("attention",)),
+        _event(
+            3,
+            "aclnnTransposeBatchMatMul",
+            categories=("attention.mla.v_up_proj", "attention.sparse_attn.v_up_proj", "compute.matmul"),
+            roles=("attention", "compute"),
+        ),
+        _event(4, "MoeDistributeDispatchV3", categories=("moe.dispatch",), roles=("moe",)),
+        _event(5, "MoeDistributeCombineV3", categories=("moe.combine",), roles=("moe",)),
+        _event(6, "aclnnAddRmsNorm", categories=("block_head",), roles=("block_head",)),
+        _event(7, "MlaPrologV3", categories=("attention.mla", "attention.mla.preprocess"), roles=("attention",)),
+        _event(8, "KvQuantSparseFlashAttention", categories=("attention.flash_score",), roles=("attention",)),
+        _event(
+            9,
+            "aclnnTransposeBatchMatMul",
+            categories=("attention.mla.v_up_proj", "attention.sparse_attn.v_up_proj", "compute.matmul"),
+            roles=("attention", "compute"),
+        ),
+    ]
+
+    layers = _build_test_layers(events)
+
+    assert len(layers) == 2
+    assert [tuple(anchor.name_raw for anchor in layer.anchors) for layer in layers] == [
+        ("MlaPrologV3",),
+        ("MlaPrologV3",),
+    ]
+    assert layers[0].row_start == 0
+    assert layers[0].row_end == 5
+    assert "attention.flash_scorex1" in layers[0].signature
+    assert "attention.mla.v_up_projx1" in layers[0].signature
+    assert "moe.dispatchx1" in layers[0].signature
+
+
+def test_flash_attention_still_anchors_when_no_mla_marker() -> None:
+    """Dense attention profiles without MLA markers still use flash score as
+    the layer-frequency anchor.
+    """
+
+    events = [
+        _event(0, "aclnnAddRmsNorm", categories=("block_head",), roles=("block_head",)),
+        _event(1, "FusedInferAttentionScore", categories=("attention.flash_score",), roles=("attention",)),
+        _event(2, "aclnnMatmul", categories=("compute.matmul",), roles=("compute",)),
+        _event(3, "aclnnAddRmsNorm", categories=("block_head",), roles=("block_head",)),
+        _event(4, "FusedInferAttentionScore", categories=("attention.flash_score",), roles=("attention",)),
+        _event(5, "aclnnMatmul", categories=("compute.matmul",), roles=("compute",)),
+    ]
+
+    layers = _build_test_layers(events)
+
+    assert len(layers) == 2
+    assert [tuple(anchor.name_raw for anchor in layer.anchors) for layer in layers] == [
+        ("FusedInferAttentionScore",),
+        ("FusedInferAttentionScore",),
+    ]
+
+
+_GLM_MLA_ATTENTION = (
+    "attention:attention.flash_scorex1+attention.lightning_indexerx1+"
+    "attention.mlax1+attention.mla.preprocessx1+attention.mla.v_up_projx1+"
+    "attention.ropex2+attention.sparse_attn.v_up_projx1"
+)
+_GLM_DENSE_LAYER = f"{_GLM_MLA_ATTENTION}|ffn_or_dense_compute|block_head"
+_GLM_MOE_LAYER = (
+    f"{_GLM_MLA_ATTENTION}|"
+    "moe:moe.combinex1+moe.dispatchx1+moe.expert_matmulx2+moe.gatingx1|block_head"
+)
+
+
+def test_glm_dense_prefix_stays_in_main_body_before_mtp_tail() -> None:
+    """GLM5 has dense early main layers followed by MoE main layers.
+
+    That dense->MoE transition is a model-layer family transition inside the
+    main body.  It must not split the 78-layer body into a fake 3-layer step
+    followed by a 75-layer step with a 3-layer MTP tail.
+    """
+
+    main_layers = tuple(
+        _layer(index, _GLM_DENSE_LAYER if index < 3 else _GLM_MOE_LAYER)
+        for index in range(78)
+    )
+    main_frame = LayerFrame(
+        layers=main_layers,
+        reason="selection_delimited_body",
+        selection_after=(1000,),
+    )
+
+    assert segm.split_frame_by_regime(main_frame) == [main_frame]
+
+    mtp_frames = tuple(
+        LayerFrame(
+            layers=(_layer(78 + offset, _GLM_MOE_LAYER),),
+            reason="selection_delimited_body",
+            selection_before=(1000 + offset,),
+            selection_after=(1001 + offset,),
+        )
+        for offset in range(3)
+    )
+
+    plans = compose_step_plans((main_frame, *mtp_frames))
+
+    assert len(plans) == 1
+    assert len(plans[0].main_layers) == 78
+    assert len(plans[0].all_layers) == 81
+    assert plans[0].reason == "main_body+selection_delimited_speculative_tail"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix the Ascend profiling segmenter for GLM5 profiles with MLA attention and MTP enabled.

## Root Cause

The segmenter used every primary attention-like kernel as layer-frequency evidence. For GLM5 MLA decode this split one logical transformer layer into MLA prolog, sparse/flash attention, and V-up projection subunits. After correcting the anchor frequency, `exact_regime_split` still treated the 3 dense main-layer prefix and 75 MoE main-layer suffix as separate workload steps.

## Changes

- Use MLA layer-start markers as the layer-frequency anchor when present.
- Keep sparse/flash score, lightning indexer, RoPE, and V-up projection as evidence inside the same layer window.
- Preserve short dense-prefix + MoE-suffix GLM5 main bodies when they share the same attention structure.
- Add regression tests for GLM5 MLA/MTP segmentation and document the counterexample.

## Validation

- `py -3 -m pytest .agents/skills/ascend-profiling-analysis/tests/test_segment_validator.py -q` -> 20 passed
- `PYTHONUTF8=1 py -3 -m pytest .agents/skills/ascend-profiling-analysis/tests -q` -> 183 passed, 2 warnings
- Re-ran `D:\profiling\test\8K-1K-W8A8-TP8-MTP3-1BS`: each rank now recovers 4 steps, each with 78 main layers + 3 MTP/speculative layers; hard_error_count=0.