### PR TITLE
[codex] Optimize remote skill install path

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -148,7 +148,7 @@ commands with local logs, tracks long jobs, splits source-only/materialize/insta
 sync modes, wraps service lifecycle entrypoints, transfers artifacts with SSH
 streaming plus hash manifests, and performs dry-run-capable cleanup.
 
-Remote-code-parity transport is container-only after machine attach: use machine inventory to resolve the target, then push synthetic refs directly into the container-local cache root. Synthetic mirrors should also publish an advertised branch ref for the current snapshot so nested repos can be materialized without brittle submodule fetch behavior. Runtime installs should explicitly forward whitelisted `VAWS_*` compile/cache env into the remote shell, configure multiple pip indexes (Tsinghua as primary, Aliyun and PyPI as additional), scope the default Ascend package index to `vllm-ascend` installs, reuse pip / uv / CMake `FetchContent` caches under `/root/.cache`, default paired-image editable installs to `--no-deps`, bound uv bootstrap mirror attempts, stream progress for long package steps, record the effective install env, and keep consent/runtime-state writes atomic.
+Remote-code-parity transport is container-only after machine attach: use machine inventory to resolve the target, then push synthetic refs directly into the container-local cache root. Synthetic mirrors should also publish an advertised branch ref for the current snapshot so nested repos can be materialized without brittle submodule fetch behavior. Runtime installs should use the single A3-tested HuaweiCloud pip index, stream progress for long package steps, and keep consent/runtime-state writes atomic.
 
 The legacy repo-root `.machine-inventory.json` is compatibility input only and should not be reintroduced as the primary path.
 

--- a/.agents/skills/ascend-profiling-collection/references/behavior.md
+++ b/.agents/skills/ascend-profiling-collection/references/behavior.md
@@ -99,7 +99,7 @@ One directory per invocation. Nothing else is ever written here. The remote prof
 
 ## Interaction with `remote-code-parity`
 
-Code parity is enforced transitively through `serve_start.py`. The collection skill must not call parity itself. The `.vaws-runtime` preserve carve-out and the `uv pip install --system` fix that profiling needed are owned by the parity skill — see `.agents/skills/remote-code-parity/SKILL.md`.
+Code parity is enforced transitively through `serve_start.py`. The collection skill must not call parity itself. The `.vaws-runtime` preserve carve-out and pip-only HuaweiCloud runtime install path are owned by the parity skill; see `.agents/skills/remote-code-parity/SKILL.md`.
 
 When `--session-id` is used, `serve_start.py`, `profile_control.py`, and `serve_stop.py` all use the session container and session serving state. This allows two profiling collections on the same base host to run without stopping each other's services.
 

--- a/.agents/skills/machine-management/SKILL.md
+++ b/.agents/skills/machine-management/SKILL.md
@@ -48,7 +48,7 @@ Ready does **not** imply code sync, rebuild, serving, or benchmark readiness.
 - Resolve hardware-specific image tags from the detected machine type whenever the user chose `rc`, `main`, or `stable`: A2 uses the base tag, A3 appends `-a3`, and 310P appends `-310p`.
 - Detect the machine type from `npu-smi info` / SoC output when possible; when detection is inconclusive, stop and ask for an explicit machine type override instead of guessing.
 - Persist `host.machine_type`, `host.soc`, and `container.machine_type` into inventory, and write matching metadata under `/etc/vaws/` plus `/etc/profile.d/vaws-ascend-env.sh` on the host and inside the managed container.
-- Before running `apt-get update` / `apt-get install` inside the container, probe a small set of reachable domestic mirrors, switch to the fastest usable one, and keep the original source host only as a fallback.
+- Before running `apt-get update` / `apt-get install` inside the container, rewrite apt sources to the fixed A3-tested NJU mirror (`mirrors.nju.edu.cn`). Do not spend bootstrap time probing alternate mirrors.
 - Prepend `/usr/local/Ascend/driver/lib64/common`, `/usr/local/Ascend/driver/lib64/driver`, and `/usr/local/Ascend/driver/lib64` before calling `npu-smi` or the smoke test; source `/etc/profile.d/vaws-ascend-env.sh` when it exists.
 - Long probe / bootstrap / smoke operations must expose bounded phase progress and have an overall timeout budget, not only a connect timeout.
 - On a missing local machine profile, never call `workspace_profile.py ensure` bare. Use either:
@@ -173,7 +173,7 @@ When password bootstrap is required:
 5. if needed, establish host key auth
 6. probe the host, detect `machine_type` / `soc`, and resolve the hardware-specific image tag
 7. choose or reuse the container name and container SSH port
-8. bootstrap or repair the managed container, including container-side apt mirror selection before package installation when needed
+8. bootstrap or repair the managed container, including fixed container-side apt source configuration before package installation when needed
 9. persist the record into inventory
 10. best-effort mesh the new container with existing managed containers
 11. run final readiness verification
@@ -216,9 +216,9 @@ Do not remove host firewall rules or host-level `authorized_keys` entries.
 - Ensure `/run/sshd` exists before starting the dedicated `sshd`.
 - Image pulls should follow the selected mirror order and emit heartbeat-style progress so long `docker pull`, `apt-get update`, and `apt-get install` phases remain attributable. Persist the actually selected image in inventory, not only the selector.
 - Container bootstrap should leave behind `/etc/vaws/host-info.json`, `/etc/vaws/container-info.json`, and `/etc/profile.d/vaws-ascend-env.sh` so later verify / repair runs can see the recorded machine type, container type, and SoC quickly.
-- Container bootstrap should write `/etc/pip.conf` with multiple pip indexes (Tsinghua as primary, Aliyun and PyPI as additional) so any subsequent `pip install` inside the container does not fail due to missing mirror configuration.
-- Container bootstrap should install `pytest` into the runtime Python if not already present, so that remote test execution works out of the box without ad-hoc environment setup.
 - Session-management may opt into the shared bootstrap helper's prepared image cache for short-lived session containers. Normal `machine_add.py` / `machine_repair.py` managed-base-container flows keep raw selected-image bootstrap behavior unless explicitly wired otherwise.
+- Container bootstrap should write `/etc/pip.conf` with a single A3-tested pip source: HuaweiCloud (`https://repo.huaweicloud.com/repository/pypi/simple`). Do not configure extra indexes by default.
+- Container bootstrap should not install test packages opportunistically. Keep fresh-container startup limited to SSH, runtime env metadata, apt source configuration, and pip source configuration.
 - Keep `rc` and `stable` resolution dynamic: resolve the newest official prerelease tag or latest official non-prerelease release tag at execution time instead of using the moving `latest` tag.
 - Keep progress on `stderr` and the final status JSON on `stdout`; do not mix partial human narration into the terminal contract.
 - For smoke tests, do not pin a Python patch version. Discover the highest available `/usr/local/python*/bin/python3`, then fall back to `python3`.

--- a/.agents/skills/machine-management/references/acceptance.md
+++ b/.agents/skills/machine-management/references/acceptance.md
@@ -77,9 +77,9 @@ These should not trigger `machine-management` unless machine readiness is the ob
 - inventory persists `host.machine_type`, `host.soc`, and `container.machine_type`
 - `rc`, `main`, and `stable` remain first-class selectors, while `auto`, `*:latest`, and bare repositories without a tag are rejected as defaults
 - long-running bootstrap phases keep emitting attributable progress for image pull and package-install steps instead of going silent behind one global timeout
-- container-side apt bootstrap probes a small set of domestic mirrors first and rewrites sources to the fastest reachable mirror before `apt-get update` / `apt-get install`
-- container bootstrap writes `/etc/pip.conf` with multiple pip indexes (Tsinghua as primary, Aliyun and PyPI as additional) so pip installs inside the container work reliably
-- container bootstrap installs `pytest` into the runtime Python (best-effort, does not fail bootstrap if pip is broken)
+- container-side apt bootstrap rewrites sources to the fixed A3-tested NJU mirror (`mirrors.nju.edu.cn`) before `apt-get update` / `apt-get install`
+- container bootstrap writes `/etc/pip.conf` with the single A3-tested HuaweiCloud pip source and no default extra indexes
+- container bootstrap does not install `pytest` or other opportunistic test packages
 - inventory `put` / `remove` writes are atomic and serialized so concurrent wrappers do not clobber the recorded machine set
 
 ### Verify

--- a/.agents/skills/machine-management/references/behavior.md
+++ b/.agents/skills/machine-management/references/behavior.md
@@ -203,10 +203,9 @@ The recorded session showed that adding `devlib` advanced past one missing-libra
 Container bootstrap writes persistent runtime environment configuration so that subsequent SSH sessions (parity, serving, benchmark, ad-hoc scripts) work without per-session setup:
 
 - `/etc/profile.d/vaws-ascend-env.sh`: adds the runtime Python directory and Ascend driver libs to `PATH` and `LD_LIBRARY_PATH`.
-- `/etc/pip.conf`: configures pip with multiple indexes — Tsinghua as `index-url` (primary), Aliyun and PyPI as `extra-index-url` (additional). Note: pip searches all configured indexes and selects the best match; this is multi-source availability, not ordered fallback. This prevents `pip install` failures due to unreachable default mirrors inside the container.
-- `pytest`: installed into the runtime Python during bootstrap. This ensures agents can run remote test verification without ad-hoc dependency installation.
+- `/etc/pip.conf`: configures pip with a single A3-tested source, HuaweiCloud (`https://repo.huaweicloud.com/repository/pypi/simple`). Do not add extra indexes by default.
 
-The pip config and pytest install are best-effort: if the runtime Python cannot be discovered or pip is broken, the bootstrap continues without failing.
+The pip config write is best-effort: if the runtime Python cannot be discovered, the bootstrap continues without failing. Do not install `pytest` or other test packages during container bootstrap; fresh startup should stay focused on SSH reachability and durable runtime-source configuration.
 
 ## Mesh contract
 

--- a/.agents/skills/machine-management/scripts/manage_machine.py
+++ b/.agents/skills/machine-management/scripts/manage_machine.py
@@ -1426,11 +1426,10 @@ import json
 import os
 import pathlib
 import re
-import time
-import urllib.request
 from urllib.parse import urlsplit, urlunsplit
 
 state_file = pathlib.Path(__import__("sys").argv[1])
+fixed_host = "mirrors.nju.edu.cn"
 os_release = {}
 os_release_path = pathlib.Path("/etc/os-release")
 if os_release_path.exists():
@@ -1475,62 +1474,31 @@ for source_file in source_files:
             for suite in suites:
                 entries.append((uri, suite))
 
-entries = list(dict.fromkeys(entries))
-candidate_hosts = [
-    "mirrors.nju.edu.cn",
-    "mirrors.tuna.tsinghua.edu.cn",
-    "mirrors.ustc.edu.cn",
-    "mirrors.aliyun.com",
-    "mirrors.cloud.tencent.com",
-]
-for uri, _ in entries:
-    host = urlsplit(uri).netloc
-    if host and host not in candidate_hosts:
-        candidate_hosts.append(host)
-
-timings = {}
-if entries:
-    for host in candidate_hosts:
-        samples = []
-        ok = True
-        for uri, suite in entries[:4]:
-            original = urlsplit(uri)
-            candidate_uri = urlunsplit((original.scheme, host, original.path, original.query, original.fragment)).rstrip("/")
-            probe_url = f"{candidate_uri}/dists/{suite}/InRelease"
-            request = urllib.request.Request(probe_url, headers={"User-Agent": "vaws-apt-probe/1.0"})
-            started = time.monotonic()
-            try:
-                with urllib.request.urlopen(request, timeout=3) as response:
-                    response.read(256)
-            except Exception:
-                ok = False
-                break
-            samples.append((time.monotonic() - started) * 1000.0)
-        if ok and samples:
-            timings[host] = sum(samples) / len(samples)
-
-selected_host = min(timings, key=timings.get) if timings else None
 changed_files = []
 changed = False
-if selected_host is not None:
-    replacements = {}
-    for uri in uri_set:
-        original = urlsplit(uri)
-        replacements[uri] = urlunsplit((original.scheme, selected_host, original.path, original.query, original.fragment))
-    for source_file in source_files:
-        original_text = source_file.read_text(encoding="utf-8", errors="replace")
-        updated_text = original_text
-        for old_uri, new_uri in replacements.items():
-            updated_text = updated_text.replace(old_uri, new_uri)
-        if updated_text != original_text:
-            source_file.write_text(updated_text, encoding="utf-8")
-            changed = True
-            changed_files.append(str(source_file))
+replacements = {}
+for uri in uri_set:
+    original = urlsplit(uri)
+    if not original.scheme or not original.netloc:
+        continue
+    if original.netloc == fixed_host:
+        continue
+    replacements[uri] = urlunsplit((original.scheme, fixed_host, original.path, original.query, original.fragment))
+for source_file in source_files:
+    original_text = source_file.read_text(encoding="utf-8", errors="replace")
+    updated_text = original_text
+    for old_uri, new_uri in replacements.items():
+        updated_text = updated_text.replace(old_uri, new_uri)
+    if updated_text != original_text:
+        source_file.write_text(updated_text, encoding="utf-8")
+        changed = True
+        changed_files.append(str(source_file))
 
 state = {
     "package_manager": "apt",
-    "selected_mirror": selected_host,
-    "candidate_timings_ms": {host: round(value, 2) for host, value in sorted(timings.items(), key=lambda item: item[1])},
+    "selected_mirror": fixed_host,
+    "source_strategy": "fixed-nju",
+    "candidate_timings_ms": {},
     "changed_files": changed_files,
     "changed": changed,
     "install_skipped": False,
@@ -1573,24 +1541,13 @@ elif command -v yum >/dev/null 2>&1; then
     install -d -m 0755 /etc/pip
     cat > /etc/pip.conf <<'EOF_PIP'
 [global]
-index-url = https://pypi.tuna.tsinghua.edu.cn/simple
-extra-index-url = https://mirrors.aliyun.com/pypi/simple https://pypi.org/simple
-trusted-host = pypi.tuna.tsinghua.edu.cn mirrors.aliyun.com pypi.org files.pythonhosted.org
+index-url = https://repo.huaweicloud.com/repository/pypi/simple
+trusted-host = repo.huaweicloud.com
 EOF_PIP
     chmod 0644 /etc/pip.conf
-    echo "[vaws-bootstrap] pip configured: /etc/pip.conf (primary=tsinghua, additional=aliyun,pypi)"
-    if "$_vaws_runtime_python" -c "import pytest" >/dev/null 2>&1; then
-      echo "[vaws-bootstrap] pytest already present"
-    else
-      echo "[vaws-bootstrap] installing pytest..."
-      if "$_vaws_runtime_python" -m pip install pytest -q --disable-pip-version-check 2>/dev/null; then
-        echo "[vaws-bootstrap] pytest installed"
-      else
-        echo "[vaws-bootstrap] pytest install failed (best-effort, continuing)"
-      fi
-    fi
+    echo "[vaws-bootstrap] pip configured: /etc/pip.conf (index=huaweicloud)"
   else
-    echo "[vaws-bootstrap] runtime python not found, skipping pip/pytest setup"
+    echo "[vaws-bootstrap] runtime python not found, skipping pip setup"
   fi
 INNER_PKG
 }
@@ -1694,24 +1651,13 @@ if [ -n "$_vaws_runtime_python" ]; then
   install -d -m 0755 /etc/pip
   cat > /etc/pip.conf <<'EOF_PIP'
 [global]
-index-url = https://pypi.tuna.tsinghua.edu.cn/simple
-extra-index-url = https://mirrors.aliyun.com/pypi/simple https://pypi.org/simple
-trusted-host = pypi.tuna.tsinghua.edu.cn mirrors.aliyun.com pypi.org files.pythonhosted.org
+index-url = https://repo.huaweicloud.com/repository/pypi/simple
+trusted-host = repo.huaweicloud.com
 EOF_PIP
   chmod 0644 /etc/pip.conf
-  echo "[vaws-bootstrap] pip configured: /etc/pip.conf (primary=tsinghua, additional=aliyun,pypi)"
-  if "$_vaws_runtime_python" -c "import pytest" >/dev/null 2>&1; then
-    echo "[vaws-bootstrap] pytest already present"
-  else
-    echo "[vaws-bootstrap] installing pytest..."
-    if "$_vaws_runtime_python" -m pip install pytest -q --disable-pip-version-check 2>/dev/null; then
-      echo "[vaws-bootstrap] pytest installed"
-    else
-      echo "[vaws-bootstrap] pytest install failed (best-effort, continuing)"
-    fi
-  fi
+  echo "[vaws-bootstrap] pip configured: /etc/pip.conf (index=huaweicloud)"
 else
-  echo "[vaws-bootstrap] runtime python not found, skipping pip/pytest setup"
+  echo "[vaws-bootstrap] runtime python not found, skipping pip setup"
 fi
 ssh-keygen -A >/dev/null 2>&1 || true
 cat > /etc/ssh/sshd_vaws_config <<EOF_SSH

--- a/.agents/skills/remote-code-parity/SKILL.md
+++ b/.agents/skills/remote-code-parity/SKILL.md
@@ -41,14 +41,15 @@ Keep a **ready** remote runtime in exact code parity with the local `vllm-ascend
 - Synthetic commits are deterministic parentless tree snapshots. Keep each repo's real `HEAD` separately as `source_head` for reinstall drift detection instead of using it as the transport parent.
 - If a clean child repo only differs from the parent through the parentless transport commit id, suppress that transport-only child gitlink path from the parent repo's `changed_paths`.
 - Use dynamic Python / pip discovery plus a shell-safe env preamble, and source optional Ascend env scripts under a `set +u` / `set -u` guard instead of relying on shell-specific variables.
-- Runtime dependency installs may opt into a near-cache index with `VAWS_PIP_INDEX_URL`, `VAWS_PIP_EXTRA_INDEX_URL`, and `VAWS_PIP_TRUSTED_HOST`; these whitelisted local env vars are explicitly passed into the remote install shell because SSH does not reliably forward arbitrary local env. When no caller extra index is set, only the `vllm-ascend` requirements/editable steps add the public Ascend PyPI extra index.
-- Runtime editable installs use CI-aligned cache / compile defaults: `PIP_CACHE_DIR`, `UV_CACHE_DIR`, `FETCHCONTENT_BASE_DIR`, `UV_INDEX_STRATEGY=unsafe-best-match`, `MAX_JOBS=4`, and `CMAKE_BUILD_TYPE=Release`, all overrideable by environment. The effective remote install env is recorded in the manifest/runtime state with URL userinfo redacted. Do not default `COMPILE_CUSTOM_KERNELS=0`; that is only available as an explicit `VAWS_COMPILE_CUSTOM_KERNELS=0` unit-test-style override and is not valid for normal serving / benchmark runtime parity.
-- If editable install fails because the image packaging stack is too old, attempt one bounded packaging-stack refresh before failing closed.
+- Runtime dependency installs use the single A3-tested HuaweiCloud pip index. Do not configure default extra indexes, mirror fallback, or caller-provided pip index overrides in parity.
+- Runtime editable installs use `--no-deps`; dependency ownership stays in `vllm-ascend` requirements. Cache / compile env such as `PIP_CACHE_DIR`, `FETCHCONTENT_BASE_DIR`, `VAWS_BUILD_JOBS`, `MAX_JOBS`, and `CMAKE_BUILD_PARALLEL_LEVEL` may be explicitly passed into the remote install shell, and the effective remote install env is recorded in the manifest/runtime state with URL userinfo redacted.
+- If editable install or dependency verification fails, fail closed with the captured log instead of trying alternate package sources, installing `uv`, refreshing the packaging stack, or changing install modes.
 - Before invoking parity, confirm the local working tree represents the **intended deployment state**. If any submodule source files have uncommitted changes made for temporary debugging or hypothesis testing, revert them before syncing — do not sync exploratory patches to the remote.
 - If a previous parity sync in this session led to a failed remote execution and the agent subsequently modified local code, do not re-sync until the root cause of the failure is confirmed from remote logs (not from hypothesis).
 - Fail closed if parity cannot be proven.
 - First replacement of image-provided `vllm` / `vllm-ascend` requires explicit user consent for that logical container identity.
-- `install_consent.py set` and `batch-set` must include `--approved-by-user`.
+- `install_consent.py set`, `batch-set`, and `set-sync-mode` must include `--approved-by-user`.
+- If the user explicitly says to use local `vllm` / `vllm-ascend`, replace image packages, or run current workspace code remotely, record both decisions in one atomic write: `set-sync-mode --sync-mode local --allow-first-install --approved-by-user`. Do not ask a second first-install question for the same container identity.
 - Keep local runtime state only under `.vaws-local/remote-code-parity/`.
 
 ## Preconditions
@@ -105,6 +106,7 @@ Consent helper:
 
 - POSIX: `python3 .agents/skills/remote-code-parity/scripts/install_consent.py resolve ...`
 - POSIX: `python3 .agents/skills/remote-code-parity/scripts/install_consent.py set ... --approved-by-user`
+- POSIX: `python3 .agents/skills/remote-code-parity/scripts/install_consent.py set-sync-mode ... --sync-mode local --allow-first-install --approved-by-user`
 - POSIX: `python3 .agents/skills/remote-code-parity/scripts/install_consent.py batch-set --input FILE.json --approved-by-user`
 
 Low-level helper:
@@ -127,11 +129,12 @@ Reference files:
 
 Before running parity for a container, check the persisted `sync_mode`:
 
-- `unset` (first use): the agent must proactively ask the user whether to sync local code (`local`) or use the container's image-provided vllm + vllm-ascend (`image`). Record the choice via `install_consent.py set-sync-mode --approved-by-user`.
+- `unset` (first use): the agent must proactively ask the user whether to sync local code (`local`) or use the container's image-provided vllm + vllm-ascend (`image`). If the user chooses local replacement, record it via `install_consent.py set-sync-mode --sync-mode local --allow-first-install --approved-by-user`; if the user chooses image packages, record `--sync-mode image --approved-by-user`.
 - `local`: proceed with the full parity flow below.
 - `image`: `parity_sync.py` returns `status: skipped` immediately. The agent skips parity and proceeds with remote execution using image-provided packages.
 
 The user can switch sync mode at any time. `--force-reinstall` overrides `image` mode.
+If the agent forgets to set sync mode, `parity_sync.py` returns `status: blocked` before remote mutation.
 
 ### 2. Resolve the ready target from inventory
 
@@ -193,6 +196,7 @@ If the container identity has never been approved:
 - resolve the consent state from `.vaws-local/remote-code-parity/install-consents.json`
 - if there is no `allow`, stop with `status == blocked`
 - do **not** silently continue with the image-provided packages
+- if the user already approved `local` sync with `--allow-first-install`, this consent is already present; do not ask again
 
 If the user already approved this container identity:
 
@@ -248,33 +252,23 @@ Use `--force-reinstall` only when (a) it is the first sync to a new container, (
 
 If all snapshot commits match `last_snapshot_commits` and no reinstall is needed (and `--force-reinstall` is not set), the sync verifies container-side commits with a single SSH call and returns `status == ready` immediately, skipping mirror hydration, materialize, and manifest upload.
 
-Use these commands inside the container when required. The normal path first unifies the runtime Python across `python`, `python3`, CMake, and CANN helper tools, sources optional Ascend env scripts under a `set +u` / `set -u` guard, then tries the in-place environment, and finally does one bounded packaging refresh / retry when legacy packaging metadata blocks editable install. Pip/uv resolution can use a caller-provided near-cache index first, then falls back to Tsinghua, Aliyun, and the public PyPI index. The public Ascend package index is added only for `vllm-ascend` dependency/install steps unless the caller explicitly sets `VAWS_PIP_EXTRA_INDEX_URL` or `PIP_EXTRA_INDEX_URL`.
-
-The install environment mirrors the portable parts of `vllm-ascend` CI:
-
-- cache roots default to `/root/.cache/pip`, `/root/.cache/uv`, and `/root/.cache/vaws/fetchcontent` so CMake `FetchContent` survives repo cleanups
-- editable installs default to `--no-deps` against the paired runtime image, and the `vllm-ascend` requirements step is skipped on ordinary paired-image replacement; dependency resolution is re-enabled when dependency files changed, a repo HEAD drifted, verify-deps detects a non-runtime mismatch, or the caller sets `VAWS_INSTALL_DEPS=1`
-- paired-image `torch_npu` is treated as runtime state: accept public-version matches and a successful real import instead of forcing a large wheel reinstall
-- `MAX_JOBS` defaults to `4` like CI and can be overridden with `VAWS_MAX_JOBS` or `MAX_JOBS`
-- `UV_INDEX_STRATEGY` defaults to `unsafe-best-match` because both CI and this workspace use multiple indexes
-- uv bootstrap is progress-wrapped and bounded by `VAWS_UV_BOOTSTRAP_TIMEOUT` seconds per mirror before falling back to the next mirror or pip-only installs; uv package installs are bounded by `VAWS_UV_INSTALL_TIMEOUT`, and `VAWS_DISABLE_UV=1` forces pip-only mode
-- `VAWS_SOC_VERSION` is forwarded as `SOC_VERSION` when the caller needs to pin chip selection instead of relying on `npu-smi`
-- custom kernel compilation remains enabled by default; set `VAWS_COMPILE_CUSTOM_KERNELS=0` only for non-runtime unit-test-style validation
-- `VAWS_USE_CLANG15=1` selects `clang-15` / `clang++-15` only when they are already installed in the image
-- after the editable `vllm` install, `triton` is removed best-effort to match Ascend CI's non-Triton runtime expectation
+Use these commands inside the container when required. The normal path first unifies the runtime Python across `python`, `python3`, CMake, and CANN helper tools, sources optional Ascend env scripts under a `set +u` / `set -u` guard, then uses pip with the single A3-tested HuaweiCloud index. Editable installs use `--no-deps`; dependency ownership stays in the `vllm-ascend` requirements step so `vllm` cannot upgrade `numpy` away from the CANN-compatible version. Build parallelism defaults to `min(available CPUs, 128)` through both `MAX_JOBS` and `CMAKE_BUILD_PARALLEL_LEVEL`. Do not bootstrap `uv`, probe mirror candidates, retry across indexes, or retry by dropping `--no-build-isolation`.
 
 ### `vllm`
 
 ```bash
 export VLLM_TARGET_DEVICE=empty
-pip install -e . --no-build-isolation
+export TORCH_DEVICE_BACKEND_AUTOLOAD=0
+pip install --no-deps -e . --no-build-isolation
 ```
 
 ### `vllm-ascend`
 
 ```bash
-pip install -r requirements.txt  # mirror-aware fallback: Tsinghua -> Aliyun -> PyPI
-pip install -v -e . --no-build-isolation
+pip install -r requirements.txt
+export MAX_JOBS="${MAX_JOBS:-128}"
+export CMAKE_BUILD_PARALLEL_LEVEL="${CMAKE_BUILD_PARALLEL_LEVEL:-$MAX_JOBS}"
+pip install --no-deps -v -e . --no-build-isolation
 ```
 
 ### 8. Finish with proof, not assumptions

--- a/.agents/skills/remote-code-parity/references/acceptance.md
+++ b/.agents/skills/remote-code-parity/references/acceptance.md
@@ -35,18 +35,12 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 - `remote_sync_apply.py --mode source-only` completes without invoking runtime install phases
 - `remote_sync_plan.py --mode install` reports install/rebuild reasons and current consent state
 - long runtime-install waits remain attributable because uninstall, requirements install, editable install, import verification, and marker write each emit their own progress phase
-- whitelisted local env overrides such as `VAWS_MAX_JOBS`, `VAWS_PIP_INDEX_URL`, and `VAWS_SOC_VERSION` are explicitly exported inside the remote install shell instead of relying on SSH env forwarding
-- runtime install can opt into a caller-provided near-cache index via `VAWS_PIP_INDEX_URL`, then keeps pip mirror fallback in the order Tsinghua -> Aliyun -> PyPI instead of hard-coding only the public index
-- runtime install adds the Ascend PyPI repository as a default extra index only for `vllm-ascend` requirements/editable install steps and allows the caller to override it through `VAWS_PIP_EXTRA_INDEX_URL` or disable the default by exporting an empty `VAWS_ASCEND_PIP_EXTRA_INDEX_URL`
-- runtime install exports persistent pip, uv, and CMake `FetchContent` cache roots outside the synced repos so normal materialization cleanups do not delete dependency caches
-- runtime install wraps uv bootstrap with progress and a per-mirror timeout controlled by `VAWS_UV_BOOTSTRAP_TIMEOUT`, then continues with pip fallback when uv cannot be installed quickly
-- runtime install bounds uv package install attempts with `VAWS_UV_INSTALL_TIMEOUT` and supports `VAWS_DISABLE_UV=1` for pip-only validation when uv resolution stalls
-- runtime editable installs default to `--no-deps` against the paired image and skip ordinary `vllm-ascend` requirements reinstall; dependency resolution is re-enabled for dependency-file changes, HEAD drift, verify-deps repair, or `VAWS_INSTALL_DEPS=1`
-- paired-image `torch_npu` is verified by public-version compatibility and real import smoke instead of forcing a `torch-npu` wheel reinstall during verify-deps repair
-- runtime install defaults to `MAX_JOBS=4` and `CMAKE_BUILD_TYPE=Release`, while allowing `VAWS_MAX_JOBS`, `MAX_JOBS`, and `CMAKE_BUILD_TYPE` to override the compile profile
-- runtime install does not set `COMPILE_CUSTOM_KERNELS=0` unless the caller explicitly exports `VAWS_COMPILE_CUSTOM_KERNELS=0`
+- runtime install uses the single A3-tested HuaweiCloud pip index and does not configure default extra indexes
+- runtime editable installs use `--no-deps`; only the `vllm-ascend` requirements step is allowed to resolve and change Python dependencies
+- runtime install exports persistent pip and CMake `FetchContent` cache roots outside the synced repos so normal materialization cleanups do not delete dependency caches
+- runtime install sets bounded CMake/build parallelism through `VAWS_BUILD_JOBS`, `MAX_JOBS`, and `CMAKE_BUILD_PARALLEL_LEVEL`
+- runtime install does not run `pip install uv`, call `uv`, probe mirror candidates, or retry across indexes
 - runtime install records its effective cache/compile/index env in the manifest, final summary, and runtime state with URL userinfo redacted
-- runtime install forwards `VAWS_SOC_VERSION` as `SOC_VERSION` and emits an `npu-smi` probe before building `vllm-ascend` when `npu-smi` is available
 
 ### Repo graph and snapshotting
 
@@ -75,8 +69,10 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 ### Sync mode gate
 
 - when `sync_mode` is `unset`, the agent proactively asks the user before running parity
+- when `sync_mode` is still `unset`, `parity_sync.py` returns `status == blocked` before remote mutation
 - when `sync_mode` is `image`, `parity_sync.py` returns `status: skipped` without any remote operations
 - when `sync_mode` is `local`, the full parity flow proceeds normally
+- when the user approves local sync plus image-package replacement, `install_consent.py set-sync-mode --sync-mode local --allow-first-install --approved-by-user` records both sync mode and first-install consent in one atomic update
 - `--force-reinstall` overrides `image` mode and forces a full sync + reinstall
 - the user can switch sync mode at any time
 
@@ -84,6 +80,7 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 
 - first sync on a fresh container without recorded approval ends with `status == blocked`
 - consent writes require explicit `--approved-by-user`
+- writing first-install consent preserves existing sync-mode fields, and writing sync-mode preserves existing first-install decision fields
 - consent and runtime-state writes are atomic / lock-protected so concurrent sync wrappers do not overwrite each other
 - first sync on a fresh container with `allow` recorded proceeds to uninstall image-provided packages best-effort, remove only `vllm` and `vllm-ascend`, and perform editable installs
 - later syncs on the same logical container identity do not ask again unless the marker or identity changed
@@ -107,7 +104,10 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 - `--force-reinstall` unconditionally triggers full reinstall of both vllm and vllm-ascend even when no files changed
 - a successful run ends with `status == ready`
 - runtime install uses dynamic Python discovery plus a shell-safe env preamble and guarded env-script sourcing instead of one hard-coded Python patch path
-- packaging-metadata failures from stale image toolchains trigger one bounded packaging-stack refresh / retry before the skill reports `failed`
+- runtime install sources versioned CANN roots such as `/usr/local/Ascend/cann-9.0.0/set_env.sh` when present, avoiding `libhccl.so` failures on A3 images whose login profile is not loaded by SSH commands
+- runtime install uses pip only, with HuaweiCloud as the single package index
+- runtime install keeps `numpy` on the CANN-compatible version; `vllm` editable install must not upgrade it through dependency resolution
+- packaging or build-isolation failures report `failed` directly; the normal path does not run packaging-stack refreshes or build-isolation fallback installs
 
 ## Regression checklist from this patch
 
@@ -121,11 +121,15 @@ These specific mistakes should no longer be part of the normal path:
 - the main snapshot path should not force ignored files into the synthetic snapshot
 - root cleanups inside `/vllm-workspace` should not delete `Mooncake` or `.vaws-runtime`
 - runtime-install should not fail closed just because Ascend env scripts reference shell-specific or otherwise unset variables while being sourced
+- runtime-install should not miss CANN/HCCL libraries just because the image stores them under a versioned `/usr/local/Ascend/cann-*` directory
+- runtime-install should not spend time installing or invoking uv before installing `vllm` / `vllm-ascend`
+- runtime-install should not loop through Tsinghua, Aliyun, or public PyPI when HuaweiCloud is the selected source
 - the final heredoc-based import smoke should not fail with a local quoting `SyntaxError`
 - clean nested submodules should not force parent `reinstall_vllm*` decisions through parentless transport gitlink churn alone
 - changing only vllm-ascend files should not uninstall or break the vllm editable install
 - switching vllm to a different commit should trigger both vllm and vllm-ascend reinstall
-- consecutive syncs with no local changes should take the fast path and skip mirror hydration, materialize, and manifest upload
+- consecutive syncs with no local changes should take the fast path and skip mirror push/hydration, materialize, and manifest upload
+- setting first-install consent after sync-mode should not erase `sync_mode`, and setting sync-mode after first-install consent should not erase `decision`
 
 ## Manual regression checklist
 

--- a/.agents/skills/remote-code-parity/references/behavior.md
+++ b/.agents/skills/remote-code-parity/references/behavior.md
@@ -32,7 +32,9 @@ Before invoking parity for a container, the agent checks the persisted `sync_mod
 - `local`: proceed with the full parity flow.
 - `image`: `parity_sync.py` returns `status: skipped` immediately; the agent proceeds with remote execution using image-provided packages without syncing or installing.
 
-`--force-reinstall` overrides `image` mode. The user can switch sync mode at any time.
+If the user explicitly chooses local code and replacement of image packages, record both facts in one atomic write with `set-sync-mode --sync-mode local --allow-first-install --approved-by-user`. That prevents the later first-install consent write from clobbering sync-mode state and avoids a second prompt for the same logical container identity.
+
+If `sync_mode` is still unset when `parity_sync.py` is invoked, the wrapper returns `status: blocked` before any remote mutation. `--force-reinstall` overrides `image` mode. The user can switch sync mode at any time.
 
 ## Scope and routing
 
@@ -142,6 +144,7 @@ That step is mutating and potentially slow, so:
 - require `--approved-by-user` before writing consent state
 - fail closed if the user declines or has not approved yet
 - use a container-side marker under `/vllm-workspace/.remote-code-parity/runtime-install.json` to detect whether first install already happened
+- preserve existing per-container consent fields when writing first-install decisions or sync-mode decisions
 
 First-install mutation boundary:
 
@@ -219,16 +222,16 @@ A trustworthy parity result records:
 - discover the runtime Python dynamically from `/usr/local/python*/bin/python3`, then fall back to `python3` or `python`
 - unify that interpreter across `python`, `python3`, `HI_PYTHON`, `Python_EXECUTABLE`, `Python3_EXECUTABLE`, and CMake-driven helper processes before editable install
 - preseed the runtime `PATH` and the Ascend driver `LD_LIBRARY_PATH` prefix, then source optional env scripts under a `set +u` / `set -u` guard so shell-specific variables are not required
-- keep the fast path on `pip install -e . --no-build-isolation`
-- explicitly pass whitelisted local runtime-install env vars into the remote SSH shell; do not assume SSH forwards `VAWS_*` or pip env vars automatically
-- route pip/uv installs through a caller-provided near-cache index when `VAWS_PIP_INDEX_URL` is set, then mirror-aware fallback in the order Tsinghua -> Aliyun -> PyPI; only `vllm-ascend` dependency/install steps add the default public Ascend PyPI repository as an extra index when the caller did not set a broader extra index
-- align runtime editable install environment with portable `vllm-ascend` CI behavior: paired-image editable installs default to `--no-deps`, ordinary paired-image replacement skips the `vllm-ascend` requirements reinstall, persistent pip / uv / CMake `FetchContent` cache roots, bounded/progress-wrapped uv bootstrap/install with pip-only fallback, `UV_INDEX_STRATEGY=unsafe-best-match`, `MAX_JOBS=4`, `CMAKE_BUILD_TYPE=Release`, `VAWS_SOC_VERSION -> SOC_VERSION`, best-effort `triton` removal after `vllm` install, and optional `clang-15` selection when explicitly requested
-- re-enable editable-install dependency resolution and requirements installation when dependency files changed, a repo HEAD drifted, verify-deps detects a mismatch, or the caller explicitly sets `VAWS_INSTALL_DEPS=1`
-- record the effective runtime install env in manifest/runtime-state with URL userinfo redacted so cache/compile differences are auditable
-- keep `COMPILE_CUSTOM_KERNELS` enabled by default for real serving / benchmark runtime parity; only pass `VAWS_COMPILE_CUSTOM_KERNELS=0` for deliberate unit-test-style validation where custom kernels are not required
-- if editable install fails because the image packaging stack is too old for the current `pyproject.toml`, attempt one bounded packaging-stack refresh and one retry before failing closed
-- verify all `vllm-ascend` declared dependencies are version-satisfied (`verify-deps`); if a mismatch is detected (e.g. `numpy<2.0.0` but `numpy 2.x` installed), automatically reinstall `vllm-ascend` requirements and re-verify before failing
-- treat paired-image `torch_npu` as runtime state: accept public-version matches and a successful `import torch_npu` instead of forcing a large `torch-npu` wheel reinstall
+- source `/etc/profile.d/vaws-ascend-env.sh`, versioned CANN roots such as `/usr/local/Ascend/cann-9.0.0/set_env.sh`, ascend-toolkit roots, ATB, and the runtime-root-relative custom op `set_env.bash` when present
+- keep the fast path on `pip install --no-deps -e . --no-build-isolation`; editable installs must not run dependency resolution
+- set `TORCH_DEVICE_BACKEND_AUTOLOAD=0` for the `vllm` editable install because `VLLM_TARGET_DEVICE=empty` does not need `torch_npu` during metadata generation
+- compute `VAWS_BUILD_JOBS=min(available CPUs, 128)` and export it through both `MAX_JOBS` and `CMAKE_BUILD_PARALLEL_LEVEL` so `vllm-ascend` top-level and nested CMake builds get bounded parallelism
+- keep dependency ownership in `pip install -r vllm-ascend/requirements.txt`, which pins the CANN-compatible `numpy` / `triton-ascend` stack
+- route pip installs through the single A3-tested HuaweiCloud index (`https://repo.huaweicloud.com/repository/pypi/simple`)
+- do not bootstrap, install, or invoke `uv` as part of parity
+- do not retry across mirror candidates or retry editable installs by dropping `--no-build-isolation`
+- if editable install fails, report the captured install log and fail closed instead of changing package sources, refreshing the packaging stack, or changing install flags
 - finish runtime verification with real imports, not `find_spec()` alone, and keep the generated heredoc smoke snippet valid Python after shell quoting
+- after import smoke test, verify all `vllm-ascend` declared dependencies are version-satisfied (`verify-deps`); if a mismatch is detected (e.g. `numpy<2.0.0` but `numpy 2.x` installed), report `failed` instead of running a repair install
 - surface a progress transition before each long runtime-install package step so an agent can tell whether the wait is in uninstall, requirements, editable install, or verification
 - keep consent and runtime-state writes atomic so parallel wrapper calls do not clobber local state

--- a/.agents/skills/remote-code-parity/references/command-recipes.md
+++ b/.agents/skills/remote-code-parity/references/command-recipes.md
@@ -46,6 +46,23 @@ python3 .agents/skills/remote-code-parity/scripts/install_consent.py set-sync-mo
   --approved-by-user
 ```
 
+## Set local sync and approve first editable replacement
+
+Use this when the user explicitly says to run the local workspace code, replace
+the image `vllm` / `vllm-ascend`, or "用本地的 vllm 和 vllm-ascend 替换".
+This is the preferred first-use command because it writes sync mode and
+first-install consent atomically.
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/install_consent.py set-sync-mode \
+  --server-name blue-a \
+  --container-identity vaws-blue@/vllm-workspace \
+  --sync-mode local \
+  --allow-first-install \
+  --note "use local workspace packages" \
+  --approved-by-user
+```
+
 ## Inspect the current consent state
 
 ```bash
@@ -121,6 +138,9 @@ python3 .agents/skills/remote-code-parity/scripts/parity_sync.py \
 This syncs the session worktree to the session container and uses `workspace_id=pr123` unless explicitly overridden.
 
 The runtime-install path sources Ascend env scripts under a `set +u` / `set -u` guard, so first-install parity does not depend on predefining shell-specific variables.
+It also scans versioned CANN paths such as `/usr/local/Ascend/cann-9.0.0/set_env.sh`, so A3 images that do not expose only `/usr/local/Ascend/ascend-toolkit/set_env.sh` still get HCCL/CANN libraries.
+Package installation is pip-only and uses the single A3-tested HuaweiCloud index. Do not install or invoke `uv`, probe mirror candidates, or configure default extra indexes in the parity path.
+Editable installs use `--no-deps`; `vllm-ascend/requirements.txt` owns dependency versions so `vllm` cannot upgrade `numpy` beyond the CANN-compatible stack. The runtime preamble also exports bounded build parallelism through `MAX_JOBS` and `CMAKE_BUILD_PARALLEL_LEVEL` (`min(available CPUs, 128)` by default), which keeps `vllm-ascend` nested CMake builds from falling back to serial protobuf compilation.
 The final verification path is a heredoc-based Python import smoke, so the generated snippet must remain valid Python after shell quoting.
 Synthetic commits are deterministic parentless tree snapshots. Clean child repos still avoid parent reinstall churn because transport-only child gitlink paths are filtered out of parent `changed_paths`.
 
@@ -136,25 +156,23 @@ Unconditionally reinstalls both `vllm` and `vllm-ascend` even when no files chan
 
 ## Runtime install cache / compile knobs
 
-The editable install path carries portable defaults from the `vllm-ascend` CI compile jobs:
+The editable install path carries only cache and compile knobs; package source selection stays fixed to HuaweiCloud:
 
 ```bash
-VAWS_MAX_JOBS=8 \
-VAWS_UV_BOOTSTRAP_TIMEOUT=120 \
-VAWS_UV_INSTALL_TIMEOUT=300 \
-VAWS_DISABLE_UV=0 \
-VAWS_INSTALL_DEPS=0 \
+VAWS_BUILD_JOBS=64 \
+MAX_JOBS=64 \
+CMAKE_BUILD_PARALLEL_LEVEL=64 \
+CMAKE_BUILD_TYPE=Release \
+PIP_CACHE_DIR=/root/.cache/pip \
 FETCHCONTENT_BASE_DIR=/root/.cache/vaws/fetchcontent \
-VAWS_PIP_INDEX_URL=http://near-cache.example/pypi/simple \
-VAWS_PIP_TRUSTED_HOST=near-cache.example \
 python3 .agents/skills/remote-code-parity/scripts/parity_sync.py \
   --machine blue-a \
   --force-reinstall
 ```
 
-Defaults are conservative when these variables are unset: `MAX_JOBS=4`, `CMAKE_BUILD_TYPE=Release`, persistent pip / uv / `FetchContent` cache roots under `/root/.cache`, public mirror fallback, and the Ascend PyPI repository as an extra index. `VAWS_COMPILE_CUSTOM_KERNELS=0` is available only for deliberate unit-test-style checks; do not use it for real serving or benchmark validation.
+Defaults when these variables are unset: `VAWS_BUILD_JOBS=min(available CPUs, 128)`, `MAX_JOBS=$VAWS_BUILD_JOBS`, `CMAKE_BUILD_PARALLEL_LEVEL=$VAWS_BUILD_JOBS`, `CMAKE_BUILD_TYPE=Release`, persistent pip and `FetchContent` cache roots under `/root/.cache`, and the single HuaweiCloud pip index. `VAWS_COMPILE_CUSTOM_KERNELS=0` is available only for deliberate unit-test-style checks; do not use it for real serving or benchmark validation.
 
-The `VAWS_*` values shown above are exported into the remote install shell by `remote-code-parity`; they do not depend on OpenSSH `SendEnv` / `AcceptEnv`. The default Ascend extra index is scoped to `vllm-ascend` requirements/editable install steps. Set `VAWS_ASCEND_PIP_EXTRA_INDEX_URL=` to disable that default, or set `VAWS_PIP_EXTRA_INDEX_URL` when all package steps should use a custom extra index. Set `VAWS_SOC_VERSION=<soc>` to force `SOC_VERSION` when `npu-smi` auto-detection is not enough. `VAWS_UV_BOOTSTRAP_TIMEOUT` and `VAWS_UV_INSTALL_TIMEOUT` bound uv attempts before continuing with mirror/pip fallback; set `VAWS_DISABLE_UV=1` for pip-only validation. Editable installs default to `--no-deps` against the paired image; set `VAWS_INSTALL_DEPS=1` when validating dependency changes.
+The cache/compile values shown above are exported into the remote install shell by `remote-code-parity`; they do not depend on OpenSSH `SendEnv` / `AcceptEnv`. Set `VAWS_SOC_VERSION=<soc>` to force `SOC_VERSION` when auto-detection is not enough. Editable installs always use `--no-deps`; dependency changes are handled by the explicit `vllm-ascend/requirements.txt` step, then verified without repair reinstall.
 
 ## Dry-run sync without remote mutation
 

--- a/.agents/skills/remote-code-parity/scripts/install_consent.py
+++ b/.agents/skills/remote-code-parity/scripts/install_consent.py
@@ -31,13 +31,13 @@ def set_decision(
 ) -> None:
     if not approved_by_user:
         raise RuntimeError('explicit --approved-by-user is required before writing first-install consent')
-    containers = state.setdefault('consents', {}).setdefault(server_name, {}).setdefault('containers', {})
-    containers[container_identity] = {
+    container = state.setdefault('consents', {}).setdefault(server_name, {}).setdefault('containers', {}).setdefault(container_identity, {})
+    container.update({
         'decision': decision,
         'updated_at': now_utc(),
         'note': note or '',
         'approved_by_user': True,
-    }
+    })
 
 
 def resolve_sync_mode(state: dict[str, Any], server_name: str, container_identity: str) -> str:
@@ -58,14 +58,26 @@ def set_sync_mode(
     note: str | None,
     *,
     approved_by_user: bool,
+    allow_first_install: bool = False,
 ) -> None:
     if not approved_by_user:
         raise RuntimeError('explicit --approved-by-user is required before writing sync-mode')
+    if allow_first_install and sync_mode != 'local':
+        raise RuntimeError('--allow-first-install is only valid with --sync-mode local')
     container = state.setdefault('consents', {}).setdefault(server_name, {}).setdefault('containers', {}).setdefault(container_identity, {})
     container['sync_mode'] = sync_mode
     container['sync_mode_updated_at'] = now_utc()
     if note:
         container['sync_mode_note'] = note
+    if allow_first_install:
+        set_decision(
+            state,
+            server_name,
+            container_identity,
+            'allow',
+            note or 'approved local sync and first editable install',
+            approved_by_user=approved_by_user,
+        )
 
 
 def run_resolve(args: argparse.Namespace) -> int:
@@ -122,10 +134,16 @@ def run_set_sync_mode(args: argparse.Namespace) -> int:
             args.sync_mode,
             args.note,
             approved_by_user=args.approved_by_user,
+            allow_first_install=args.allow_first_install,
         )
 
     _, path, _ = update_state(repo_root, FILENAME, {'schema_version': 1, 'consents': {}}, apply_update)
-    print(json_dump({'status': 'updated', 'sync_mode': args.sync_mode, 'path': str(path)}))
+    print(json_dump({
+        'status': 'updated',
+        'sync_mode': args.sync_mode,
+        'first_install_decision': 'allow' if args.allow_first_install else None,
+        'path': str(path),
+    }))
     return 0
 
 
@@ -185,6 +203,11 @@ def build_parser() -> argparse.ArgumentParser:
     set_sm.add_argument('--sync-mode', required=True, choices=('local', 'image'))
     set_sm.add_argument('--note', default=None)
     set_sm.add_argument('--approved-by-user', action='store_true')
+    set_sm.add_argument(
+        '--allow-first-install',
+        action='store_true',
+        help='with --sync-mode local, also approve the first editable vllm/vllm-ascend replacement',
+    )
 
     return parser
 

--- a/.agents/skills/remote-code-parity/scripts/parity_sync.py
+++ b/.agents/skills/remote-code-parity/scripts/parity_sync.py
@@ -197,26 +197,40 @@ def main() -> int:
         raise RuntimeError('--machine is required unless --session-id or --session-file is used')
     derived = build_derived_args(repo_root, args)
     state_repo_root = repo_root_from(Path(derived['workspace_root']))
+    low_level_cmd = build_low_level_command(derived, args)
+
+    if args.print_derived_args:
+        payload = dict(derived)
+        payload['command'] = low_level_cmd
+        print(json_dump(payload))
+        return 0
 
     if not args.force_reinstall:
         consent_state = load_consent_state(state_repo_root)
         mode = resolve_sync_mode(consent_state, derived['server_name'], derived['container_identity'])
+        if mode == 'unset':
+            print(json_dump({
+                'status': 'blocked',
+                'reason': 'sync_mode is unset; choose local sync or image-provided packages before parity',
+                'sync_mode': 'unset',
+                'server_name': derived['server_name'],
+                'container_identity': derived['container_identity'],
+                'next_actions': [
+                    'set sync mode to local and approve first install when the user wants local vllm/vllm-ascend',
+                    'set sync mode to image when the user wants container-provided packages',
+                ],
+            }))
+            return 2
         if mode == 'image':
             print(json_dump({
                 'status': 'skipped',
-                'reason': 'sync_mode is image — using container-provided packages',
+                'reason': 'sync_mode is image; using container-provided packages',
                 'sync_mode': 'image',
                 'server_name': derived['server_name'],
                 'container_identity': derived['container_identity'],
             }))
             return 0
 
-    low_level_cmd = build_low_level_command(derived, args)
-    if args.print_derived_args:
-        payload = dict(derived)
-        payload['command'] = low_level_cmd
-        print(json_dump(payload))
-        return 0
     result = subprocess.run(low_level_cmd)
     return result.returncode
 

--- a/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
+++ b/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
@@ -66,7 +66,15 @@ DEPENDENCY_INSTALL_PATTERNS = (
 
 DEFAULT_ENV_PREAMBLE = (
     'export PATH="${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"',
-    'export LD_LIBRARY_PATH="/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/driver/lib64:${LD_LIBRARY_PATH:-}"',
+    'export VAWS_RUNTIME_ROOT="${VAWS_RUNTIME_ROOT:-/vllm-workspace}"',
+    'prepend_ld_path() {',
+    '  dir="$1"',
+    '  if [ -d "$dir" ]; then',
+    '    export LD_LIBRARY_PATH="$dir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"',
+    '  fi',
+    '}',
+    'prepend_ld_path /usr/local/Ascend/driver/lib64',
+    'prepend_ld_path /usr/local/Ascend/driver/lib64/driver',
     'safe_source() {',
     '  file="$1"',
     '  if [ -f "$file" ]; then',
@@ -75,9 +83,23 @@ DEFAULT_ENV_PREAMBLE = (
     '    set -u',
     '  fi',
     '}',
-    'safe_source /usr/local/Ascend/ascend-toolkit/set_env.sh',
-    'safe_source /usr/local/Ascend/nnal/atb/set_env.sh',
-    'safe_source /vllm-workspace/vllm-ascend/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/bin/set_env.bash',
+    'for _ascend_env in '
+    '/etc/profile.d/vaws-ascend-env.sh '
+    '/usr/local/Ascend/cann-*/set_env.sh '
+    '/usr/local/Ascend/ascend-toolkit/latest/set_env.sh '
+    '/usr/local/Ascend/ascend-toolkit/set_env.sh '
+    '/usr/local/Ascend/nnal/atb/set_env.sh '
+    '"$VAWS_RUNTIME_ROOT/vllm-ascend/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/bin/set_env.bash"; do',
+    '  safe_source "$_ascend_env"',
+    'done',
+    'for _ascend_lib in '
+    '/usr/local/Ascend/cann-*/lib64 '
+    '/usr/local/Ascend/cann-*/runtime/lib64 '
+    '/usr/local/Ascend/ascend-toolkit/latest/lib64 '
+    '/usr/local/Ascend/ascend-toolkit/lib64; do',
+    '  prepend_ld_path "$_ascend_lib"',
+    'done',
+    'unset _ascend_env _ascend_lib',
     'PYTHON_CANDIDATE="$(ls -1d /usr/local/python*/bin/python3 2>/dev/null | sort -V | tail -n 1 || true)"',
     'if [ -n "$PYTHON_CANDIDATE" ]; then export PYTHON="$PYTHON_CANDIDATE"; elif command -v python3 >/dev/null 2>&1; then export PYTHON="$(command -v python3)"; elif command -v python >/dev/null 2>&1; then export PYTHON="$(command -v python)"; else echo "python not found" >&2; exit 127; fi',
     'PYTHON_BIN_DIR="$(dirname "$PYTHON")"',
@@ -91,28 +113,34 @@ DEFAULT_ENV_PREAMBLE = (
     'export Python3_EXECUTABLE="$PYTHON"',
     'export Python_EXECUTABLE="$PYTHON"',
     'export CMAKE_ARGS="-DPython3_EXECUTABLE=$PYTHON -DPython_EXECUTABLE=$PYTHON ${CMAKE_ARGS:-}"',
+    'if [ -z "${VAWS_BUILD_JOBS:-}" ]; then',
+    '  VAWS_BUILD_JOBS="$("$PYTHON" - <<\'PY\'',
+    'import os',
+    'try:',
+    '    count = len(os.sched_getaffinity(0))',
+    'except Exception:',
+    '    count = os.cpu_count() or 1',
+    'print(max(1, min(int(count), 128)))',
+    'PY',
+    ')"',
+    'fi',
+    'export VAWS_BUILD_JOBS',
+    'export MAX_JOBS="${MAX_JOBS:-$VAWS_BUILD_JOBS}"',
+    'export CMAKE_BUILD_PARALLEL_LEVEL="${CMAKE_BUILD_PARALLEL_LEVEL:-$VAWS_BUILD_JOBS}"',
     'export PIP="$PYTHON -m pip"',
     'export PIP_DISABLE_PIP_VERSION_CHECK=1',
     'export PIP_NO_INPUT=1',
     'export PIP_DEFAULT_TIMEOUT=60',
-    'export PIP_RETRIES=2',
+    'export PIP_RETRIES=1',
     'export PIP_PROGRESS_BAR=off',
     'export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/root/.cache}"',
     'export PIP_CACHE_DIR="${PIP_CACHE_DIR:-$XDG_CACHE_HOME/pip}"',
-    'export UV_CACHE_DIR="${UV_CACHE_DIR:-$XDG_CACHE_HOME/uv}"',
-    'export UV_SYSTEM_PYTHON="${UV_SYSTEM_PYTHON:-1}"',
-    'export UV_PYTHON="${UV_PYTHON:-$PYTHON}"',
-    'export UV_INDEX_STRATEGY="${UV_INDEX_STRATEGY:-unsafe-best-match}"',
-    'export VAWS_UV_BOOTSTRAP_TIMEOUT="${VAWS_UV_BOOTSTRAP_TIMEOUT:-120}"',
-    'export VAWS_UV_INSTALL_TIMEOUT="${VAWS_UV_INSTALL_TIMEOUT:-300}"',
-    'export VAWS_DISABLE_UV="${VAWS_DISABLE_UV:-0}"',
-    'export VAWS_INSTALL_DEPS="${VAWS_INSTALL_DEPS:-0}"',
-    'export VAWS_ASCEND_PIP_EXTRA_INDEX_URL="${VAWS_ASCEND_PIP_EXTRA_INDEX_URL-https://mirrors.huaweicloud.com/ascend/repos/pypi}"',
-    'export VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL="${VAWS_PIP_EXTRA_INDEX_URL:-${PIP_EXTRA_INDEX_URL:-}}"',
     'export FETCHCONTENT_BASE_DIR="${FETCHCONTENT_BASE_DIR:-$XDG_CACHE_HOME/vaws/fetchcontent}"',
+    'export PIP_CONFIG_FILE=/dev/null',
+    'unset PIP_EXTRA_INDEX_URL',
+    'export PIP_INDEX_URL="https://repo.huaweicloud.com/repository/pypi/simple"',
+    'export PIP_TRUSTED_HOST="repo.huaweicloud.com"',
     'export CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}"',
-    'export MAX_JOBS="${VAWS_MAX_JOBS:-${MAX_JOBS:-4}}"',
-    'export CMAKE_BUILD_PARALLEL_LEVEL="${CMAKE_BUILD_PARALLEL_LEVEL:-$MAX_JOBS}"',
     'if [ -n "${VAWS_SOC_VERSION:-}" ]; then export SOC_VERSION="$VAWS_SOC_VERSION"; fi',
     'if [ -n "${VAWS_COMPILE_CUSTOM_KERNELS:-}" ]; then export COMPILE_CUSTOM_KERNELS="$VAWS_COMPILE_CUSTOM_KERNELS"; fi',
     'if [ "${VAWS_USE_CLANG15:-0}" = "1" ] && command -v clang-15 >/dev/null 2>&1 && command -v clang++-15 >/dev/null 2>&1; then export C_COMPILER="${C_COMPILER:-$(command -v clang-15)}"; export CXX_COMPILER="${CXX_COMPILER:-$(command -v clang++-15)}"; fi',
@@ -121,23 +149,9 @@ DEFAULT_ENV_PREAMBLE = (
     'export MKL_NUM_THREADS=1',
 )
 
-PIP_MIRROR_CANDIDATES = (
-    {
-        'name': 'tsinghua',
-        'index_url': 'https://pypi.tuna.tsinghua.edu.cn/simple',
-        'trusted_host': 'pypi.tuna.tsinghua.edu.cn',
-    },
-    {
-        'name': 'aliyun',
-        'index_url': 'https://mirrors.aliyun.com/pypi/simple',
-        'trusted_host': 'mirrors.aliyun.com',
-    },
-    {
-        'name': 'pypi',
-        'index_url': 'https://pypi.org/simple',
-        'trusted_host': 'pypi.org files.pythonhosted.org',
-    },
-)
+PIP_INDEX_NAME = 'huaweicloud'
+PIP_INDEX_URL = 'https://repo.huaweicloud.com/repository/pypi/simple'
+PIP_TRUSTED_HOST = 'repo.huaweicloud.com'
 
 DEFAULT_CONTAINER_CACHE_ROOT = '/root/.cache/vaws/remote-code-parity'
 DEFAULT_MARKER_DIRNAME = '.remote-code-parity'
@@ -151,22 +165,10 @@ CONSENT_FILENAME = 'install-consents.json'
 PARITY_BRANCH_NAME = 'parity-current'
 
 REMOTE_RUNTIME_ENV_PASSTHROUGH = (
-    'VAWS_PIP_INDEX_URL',
-    'VAWS_PIP_EXTRA_INDEX_URL',
-    'VAWS_PIP_TRUSTED_HOST',
-    'VAWS_ASCEND_PIP_EXTRA_INDEX_URL',
-    'PIP_EXTRA_INDEX_URL',
     'XDG_CACHE_HOME',
     'PIP_CACHE_DIR',
-    'UV_CACHE_DIR',
-    'UV_SYSTEM_PYTHON',
-    'UV_INDEX_STRATEGY',
-    'VAWS_UV_BOOTSTRAP_TIMEOUT',
-    'VAWS_UV_INSTALL_TIMEOUT',
-    'VAWS_DISABLE_UV',
-    'VAWS_INSTALL_DEPS',
     'FETCHCONTENT_BASE_DIR',
-    'VAWS_MAX_JOBS',
+    'VAWS_BUILD_JOBS',
     'MAX_JOBS',
     'CMAKE_BUILD_PARALLEL_LEVEL',
     'CMAKE_BUILD_TYPE',
@@ -188,17 +190,10 @@ RUNTIME_INSTALL_ENV_KEYS = (
     'FETCHCONTENT_BASE_DIR',
     'XDG_CACHE_HOME',
     'PIP_CACHE_DIR',
-    'UV_CACHE_DIR',
-    'UV_SYSTEM_PYTHON',
-    'UV_INDEX_STRATEGY',
-    'VAWS_UV_BOOTSTRAP_TIMEOUT',
-    'VAWS_UV_INSTALL_TIMEOUT',
-    'VAWS_DISABLE_UV',
-    'VAWS_INSTALL_DEPS',
-    'VAWS_PIP_INDEX_URL',
-    'VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL',
-    'VAWS_ASCEND_PIP_EXTRA_INDEX_URL',
-    'VAWS_VLLM_ASCEND_EFFECTIVE_PIP_EXTRA_INDEX_URL',
+    'PIP_CONFIG_FILE',
+    'PIP_INDEX_URL',
+    'PIP_TRUSTED_HOST',
+    'VAWS_BUILD_JOBS',
     'SOC_VERSION',
     'COMPILE_CUSTOM_KERNELS',
     'C_COMPILER',
@@ -816,18 +811,12 @@ def runtime_install_step_script(
     container_identity: str,
     step: str,
     uninstall_packages: tuple[str, ...] = (),
-    install_deps: bool = False,
 ) -> str:
     lines = ['set -euo pipefail', f'cd {quoted(runtime_root)}']
     lines.extend(remote_runtime_env_exports())
+    lines.append(f'export VAWS_RUNTIME_ROOT={quoted(runtime_root)}')
     lines.extend(DEFAULT_ENV_PREAMBLE)
-    if install_deps:
-        lines.append('export VAWS_INSTALL_DEPS=1')
-    if step in {'bootstrap-uv', 'install-vllm', 'install-vllm-ascend', 'install-vllm-ascend-requirements'}:
-        if step in {'install-vllm-ascend', 'install-vllm-ascend-requirements'}:
-            lines.append(
-                'export VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL="${VAWS_PIP_EXTRA_INDEX_URL:-${PIP_EXTRA_INDEX_URL:-$VAWS_ASCEND_PIP_EXTRA_INDEX_URL}}"'
-            )
+    if step in {'install-vllm', 'install-vllm-ascend', 'install-vllm-ascend-requirements'}:
         lines.extend(
             [
                 'emit_progress() {',
@@ -891,119 +880,22 @@ def runtime_install_step_script(
                 '  rm -f "$log_file"',
                 '  return "$status"',
                 '}',
-                'pip_apply_mirror() {',
-                '  mirror="$1"',
-                '  unset PIP_INDEX_URL PIP_EXTRA_INDEX_URL PIP_TRUSTED_HOST',
-                '  case "$mirror" in',
-                '    custom)',
-                '      if [ -z "${VAWS_PIP_INDEX_URL:-}" ]; then return 1; fi',
-                '      export PIP_INDEX_URL="$VAWS_PIP_INDEX_URL"',
-                '      if [ -n "${VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL:-}" ]; then export PIP_EXTRA_INDEX_URL="$VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL"; fi',
-                '      if [ -n "${VAWS_PIP_TRUSTED_HOST:-}" ]; then export PIP_TRUSTED_HOST="$VAWS_PIP_TRUSTED_HOST"; fi',
-                '      ;;',
-            ]
-        )
-        for mirror in PIP_MIRROR_CANDIDATES:
-            lines.extend(
-                [
-                    f'    {mirror["name"]}) export PIP_INDEX_URL={quoted(mirror["index_url"])}; export PIP_TRUSTED_HOST={quoted(mirror["trusted_host"])}; if [ -n "${{VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL:-}}" ]; then export PIP_EXTRA_INDEX_URL="$VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL"; fi ;;',
-                ]
-            )
-        lines.extend(
-            [
-                '    *) return 1 ;;',
-                '  esac',
-                '  emit_progress "runtime-pip-mirror" "using pip mirror $mirror" 30',
+                'configure_pip_index() {',
+                '  unset PIP_EXTRA_INDEX_URL',
+                '  export PIP_CONFIG_FILE=/dev/null',
+                f'  export PIP_INDEX_URL={quoted(PIP_INDEX_URL)}',
+                f'  export PIP_TRUSTED_HOST={quoted(PIP_TRUSTED_HOST)}',
+                f'  emit_progress "runtime-pip-index" "using pip index {PIP_INDEX_NAME}" 30',
                 '}',
-                'HAS_UV=0',
-                'if [ "${VAWS_DISABLE_UV:-0}" != "1" ] && command -v uv >/dev/null 2>&1; then HAS_UV=1; fi',
-                'ensure_uv() {',
-                '  if [ "${VAWS_DISABLE_UV:-0}" = "1" ]; then return 1; fi',
-                '  if [ "$HAS_UV" -eq 1 ]; then return 0; fi',
-                '  if command -v uv >/dev/null 2>&1; then HAS_UV=1; return 0; fi',
-                '  emit_progress "runtime-bootstrap-uv" "installing uv" 30',
-                '  for mirror in custom tsinghua aliyun pypi; do',
-                '    pip_apply_mirror "$mirror" || continue',
-                '    set +e',
-                '    if command -v timeout >/dev/null 2>&1; then',
-                '      run_with_progress "runtime-bootstrap-uv" "installing uv via $mirror" "$VAWS_UV_BOOTSTRAP_TIMEOUT" timeout "$VAWS_UV_BOOTSTRAP_TIMEOUT" "$PYTHON" -m pip install uv -q',
-                '    else',
-                '      run_with_progress "runtime-bootstrap-uv" "installing uv via $mirror" "$VAWS_UV_BOOTSTRAP_TIMEOUT" "$PYTHON" -m pip install uv -q',
-                '    fi',
-                '    status=$?',
-                '    set -e',
-                '    if [ "$status" -eq 0 ]; then',
-                '      hash -r',
-                '      if command -v uv >/dev/null 2>&1; then HAS_UV=1; return 0; fi',
-                '    fi',
-                '  done',
-                '  return 1',
-                '}',
-                'DEFAULT_UV_INDEX_ARGS="'
-                + ' '.join(
-                    (f'--index-url {m["index_url"]}' if i == 0 else f'--extra-index-url {m["index_url"]}')
-                    for i, m in enumerate(PIP_MIRROR_CANDIDATES)
-                )
-                + '"',
-                'UV_EXTRA_INDEX_ARGS=""',
-                'if [ -n "${VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL:-}" ]; then UV_EXTRA_INDEX_ARGS="$UV_EXTRA_INDEX_ARGS --extra-index-url $VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL"; fi',
-                'UV_INDEX_ARGS="$DEFAULT_UV_INDEX_ARGS$UV_EXTRA_INDEX_ARGS"',
-                'if [ -n "${VAWS_PIP_INDEX_URL:-}" ]; then',
-                '  UV_INDEX_ARGS="--index-url $VAWS_PIP_INDEX_URL"',
-                '  if [ -n "${VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL:-}" ]; then UV_INDEX_ARGS="$UV_INDEX_ARGS --extra-index-url $VAWS_EFFECTIVE_PIP_EXTRA_INDEX_URL"; fi',
-                '  UV_INDEX_ARGS="$UV_INDEX_ARGS ${DEFAULT_UV_INDEX_ARGS/--index-url/--extra-index-url}"',
-                'fi',
-                'emit_runtime_install_env() {',
-                '  emit_progress "runtime-install-env" "MAX_JOBS=$MAX_JOBS CMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE INSTALL_DEPS=${VAWS_INSTALL_DEPS:-0} DISABLE_UV=${VAWS_DISABLE_UV:-0} SOC_VERSION=${SOC_VERSION:-auto} FETCHCONTENT_BASE_DIR=$FETCHCONTENT_BASE_DIR UV_CACHE_DIR=$UV_CACHE_DIR PIP_CACHE_DIR=$PIP_CACHE_DIR" 5',
-                '}',
-                'emit_runtime_npu_probe() {',
-                '  if command -v npu-smi >/dev/null 2>&1; then',
-                '    summary="$(npu-smi info 2>/dev/null | head -n 8 | tr "\\n" " " | sed "s/  */ /g" | cut -c1-220 || true)"',
-                '    if [ -n "$summary" ]; then emit_progress "runtime-npu-probe" "$summary" 5; fi',
-                '  fi',
-                '}',
-                'pip_install_with_mirrors() {',
+                'pip_install_fast() {',
                 '  phase="$1"',
                 '  message="$2"',
                 '  expected_seconds="$3"',
                 '  shift 3',
-                '  if [ "$HAS_UV" -eq 1 ]; then',
-                '    uv_args="$*"',
-                '    uv_args="${uv_args#install }"',
-                '    uv_cmd="uv pip install --system $UV_INDEX_ARGS $uv_args"',
-                '    set +e',
-                '    if command -v timeout >/dev/null 2>&1; then',
-                '      run_with_progress "$phase" "$message via uv" "$VAWS_UV_INSTALL_TIMEOUT" timeout "$VAWS_UV_INSTALL_TIMEOUT" bash -lc "$uv_cmd"',
-                '    else',
-                '      run_with_progress "$phase" "$message via uv" "$expected_seconds" bash -lc "$uv_cmd"',
-                '    fi',
-                '    status=$?',
-                '    set -e',
-                '    if [ "$status" -eq 0 ]; then return 0; fi',
-                '    emit_progress "$phase" "uv failed (status $status), falling back to pip" 10',
-                '  fi',
-                '  last_status=1',
-                '  for mirror in custom tsinghua aliyun pypi; do',
-                '    pip_apply_mirror "$mirror" || continue',
-                '    set +e',
-                '    run_with_progress "$phase" "$message via $mirror" "$expected_seconds" "$PYTHON" -m pip "$@"',
-                '    status=$?',
-                '    set -e',
-                '    if [ "$status" -eq 0 ]; then',
-                '      return 0',
-                '    fi',
-                '    last_status="$status"',
-                '  done',
-                '  return "$last_status"',
+                '  configure_pip_index',
+                f'  run_with_progress "$phase" "$message via {PIP_INDEX_NAME}" "$expected_seconds" "$PYTHON" -m pip "$@"',
                 '}',
-                'upgrade_packaging_stack() {',
-                '  set +e',
-                '  pip_install_with_mirrors "runtime-install-packaging" "upgrading packaging toolchain" 300 install --upgrade "pip>=24.0" "setuptools>=77" "wheel>=0.43" "packaging>=24.0"',
-                '  status=$?',
-                '  set -e',
-                '  return "$status"',
-                '}',
-                'install_with_fallback() {',
+                'install_editable_fast() {',
                 '  phase="$1"',
                 '  message="$2"',
                 '  target_dir="$3"',
@@ -1011,74 +903,18 @@ def runtime_install_step_script(
                 '  install_cmd="$5"',
                 '  log_file="$(mktemp -t parity-install.XXXXXX.log)"',
                 '  cd "$target_dir"',
-                '  if [ "$HAS_UV" -eq 1 ]; then',
-                '    pip_args="${install_cmd#*pip install }"',
-                '    uv_cmd="uv pip install --system $UV_INDEX_ARGS $pip_args"',
-                '    set +e',
-                '    if command -v timeout >/dev/null 2>&1; then',
-                '      run_with_log_progress "$phase" "$message via uv" "$VAWS_UV_INSTALL_TIMEOUT" "$log_file" timeout "$VAWS_UV_INSTALL_TIMEOUT" bash -lc "$uv_cmd"',
-                '    else',
-                '      run_with_log_progress "$phase" "$message via uv" "$expected_seconds" "$log_file" bash -lc "$uv_cmd"',
-                '    fi',
-                '    status=$?',
-                '    set -e',
-                '    if [ "$status" -eq 0 ]; then',
-                '      rm -f "$log_file"',
-                '      return 0',
-                '    fi',
-                '    emit_progress "$phase" "uv install failed (status $status), falling back to pip" 10',
-                '  fi',
-                '  last_status=1',
-                '  for mirror in custom tsinghua aliyun pypi; do',
-                '    pip_apply_mirror "$mirror" || continue',
-                '    set +e',
-                '    run_with_log_progress "$phase" "$message via $mirror" "$expected_seconds" "$log_file" bash -lc "$install_cmd"',
-                '    status=$?',
-                '    set -e',
-                '    if [ "$status" -eq 0 ]; then',
-                '      rm -f "$log_file"',
-                '      return 0',
-                '    fi',
-                '    last_status="$status"',
-                '    if grep -Eiq "project\\.license|license[^[:alnum:]]|spdx|pyproject" "$log_file"; then',
-                '      upgrade_packaging_stack || true',
-                '      set +e',
-                '      run_with_log_progress "$phase" "$message via $mirror (packaging retry)" "$expected_seconds" "$log_file" bash -lc "$install_cmd"',
-                '      status=$?',
-                '      set -e',
-                '      if [ "$status" -eq 0 ]; then',
-                '        rm -f "$log_file"',
-                '        return 0',
-                '      fi',
-                '      last_status="$status"',
-                '      alt_cmd="$(printf "%s" "$install_cmd" | sed "s/--no-build-isolation//g" | xargs)"',
-                '      if [ -n "$alt_cmd" ] && [ "$alt_cmd" != "$install_cmd" ]; then',
-                '        set +e',
-                '        run_with_log_progress "$phase" "$message via $mirror (isolation fallback)" "$expected_seconds" "$log_file" bash -lc "$alt_cmd"',
-                '        status=$?',
-                '        set -e',
-                '        if [ "$status" -eq 0 ]; then',
-                '          rm -f "$log_file"',
-                '          return 0',
-                '        fi',
-                '        last_status="$status"',
-                '      fi',
-                '    fi',
-                '  done',
+                '  configure_pip_index',
+                '  set +e',
+                f'  run_with_log_progress "$phase" "$message via {PIP_INDEX_NAME}" "$expected_seconds" "$log_file" bash -lc "$install_cmd"',
+                '  status=$?',
+                '  set -e',
                 '  rm -f "$log_file"',
-                '  return "$last_status"',
+                '  return "$status"',
                 '}',
             ]
         )
 
-    if step == 'bootstrap-uv':
-        lines.extend(
-            [
-                'emit_runtime_install_env',
-                'ensure_uv || emit_progress "runtime-bootstrap-uv" "uv not available, will use pip" 5',
-            ]
-        )
-    elif step == 'uninstall':
+    if step == 'uninstall':
         pkg_args = ' '.join(uninstall_packages) if uninstall_packages else 'vllm vllm-ascend vllm_ascend'
         lines.append(f'$PYTHON -m pip uninstall -y {pkg_args} >/dev/null 2>&1 || true')
     elif step == 'install-vllm':
@@ -1086,30 +922,22 @@ def runtime_install_step_script(
             [
                 f'cd {quoted(str(Path(runtime_root) / "vllm"))}',
                 'export VLLM_TARGET_DEVICE=empty',
-                'emit_runtime_install_env',
-                'if [ "${VAWS_INSTALL_DEPS:-0}" = "1" ]; then VLLM_EDITABLE_INSTALL_ARGS="-e . --no-build-isolation"; else VLLM_EDITABLE_INSTALL_ARGS="-e . --no-build-isolation --no-deps"; fi',
-                'install_with_fallback "runtime-install-vllm" "building editable vllm" . 1800 "$PYTHON -m pip install $VLLM_EDITABLE_INSTALL_ARGS"',
-                'set +e',
-                '$PYTHON -m pip uninstall -y triton >/dev/null 2>&1',
-                'set -e',
+                'export TORCH_DEVICE_BACKEND_AUTOLOAD=0',
+                'install_editable_fast "runtime-install-vllm" "building editable vllm" . 900 "$PYTHON -m pip install --no-deps -e . --no-build-isolation"',
             ]
         )
     elif step == 'install-vllm-ascend-requirements':
         lines.extend(
             [
                 f'cd {quoted(str(Path(runtime_root) / "vllm-ascend"))}',
-                'emit_runtime_install_env',
-                'pip_install_with_mirrors "runtime-install-vllm-ascend-requirements" "installing vllm-ascend requirements" 900 install -r requirements.txt',
+                'pip_install_fast "runtime-install-vllm-ascend-requirements" "installing vllm-ascend requirements" 900 install -r requirements.txt',
             ]
         )
     elif step == 'install-vllm-ascend':
         lines.extend(
             [
                 f'cd {quoted(str(Path(runtime_root) / "vllm-ascend"))}',
-                'emit_runtime_install_env',
-                'emit_runtime_npu_probe',
-                'if [ "${VAWS_INSTALL_DEPS:-0}" = "1" ]; then VLLM_ASCEND_EDITABLE_INSTALL_ARGS="-v -e . --no-build-isolation"; else VLLM_ASCEND_EDITABLE_INSTALL_ARGS="-v -e . --no-build-isolation --no-deps"; fi',
-                'install_with_fallback "runtime-install-vllm-ascend" "building editable vllm-ascend" . 2400 "$PYTHON -m pip install $VLLM_ASCEND_EDITABLE_INSTALL_ARGS"',
+                'install_editable_fast "runtime-install-vllm-ascend" "building editable vllm-ascend custom ops" . 2400 "$PYTHON -m pip install --no-deps -v -e . --no-build-isolation"',
             ]
         )
     elif step == 'verify-imports':
@@ -1227,7 +1055,6 @@ def run_runtime_install_step(
     step: str,
     stream_progress: bool = False,
     uninstall_packages: tuple[str, ...] = (),
-    install_deps: bool = False,
 ) -> None:
     script = runtime_install_step_script(
         runtime_root=runtime_root,
@@ -1235,7 +1062,6 @@ def run_runtime_install_step(
         container_identity=container_identity,
         step=step,
         uninstall_packages=uninstall_packages,
-        install_deps=install_deps,
     )
     if stream_progress:
         ssh_exec_stream(container, script, stream_progress=True)
@@ -1305,6 +1131,7 @@ def read_runtime_install_env(
         return {}
     lines = ['set -euo pipefail', f'mkdir -p {quoted(runtime_root)}', f'cd {quoted(runtime_root)}']
     lines.extend(remote_runtime_env_exports())
+    lines.append(f'export VAWS_RUNTIME_ROOT={quoted(runtime_root)}')
     lines.extend(DEFAULT_ENV_PREAMBLE)
     lines.extend(
         [
@@ -1313,11 +1140,6 @@ def read_runtime_install_env(
             'import os',
             f'keys = {json.dumps(RUNTIME_INSTALL_ENV_KEYS)}',
             'env = {key: os.environ[key] for key in keys if key in os.environ}',
-            'env["VAWS_VLLM_ASCEND_EFFECTIVE_PIP_EXTRA_INDEX_URL"] = (',
-            '    os.environ.get("VAWS_PIP_EXTRA_INDEX_URL")',
-            '    or os.environ.get("PIP_EXTRA_INDEX_URL")',
-            '    or os.environ.get("VAWS_ASCEND_PIP_EXTRA_INDEX_URL", "")',
-            ')',
             'print(json.dumps(env, sort_keys=True))',
             'PY',
         ]
@@ -1521,12 +1343,7 @@ def run_sync(args: argparse.Namespace) -> int:
                     reinstall_vllm = True
                 if 'vllm-ascend' in record_map:
                     reinstall_vllm_ascend = True
-            install_vllm_deps = os.environ.get('VAWS_INSTALL_DEPS') == '1' or vllm_dependency_changed or vllm_head_drift
-            install_vllm_ascend_deps = (
-                os.environ.get('VAWS_INSTALL_DEPS') == '1'
-                or vllm_ascend_dependency_changed
-                or vllm_ascend_head_drift
-            )
+            install_vllm_ascend_deps = vllm_ascend_dependency_changed or vllm_ascend_head_drift
 
             snapshot_commits = {record.relpath: record.commit for record in records}
             if args.apply_mode in {'source-only', 'materialize'}:
@@ -1745,6 +1562,7 @@ def run_sync(args: argparse.Namespace) -> int:
                     return 2
                 reinstall_vllm = True if 'vllm' in record_map else reinstall_vllm
                 reinstall_vllm_ascend = True if 'vllm-ascend' in record_map else reinstall_vllm_ascend
+                install_vllm_ascend_deps = True if 'vllm-ascend' in record_map else install_vllm_ascend_deps
 
             runtime_install_env: dict[str, str] = {}
             if not args.dry_run:
@@ -1858,15 +1676,6 @@ def run_sync(args: argparse.Namespace) -> int:
                             stream_progress=False,
                             uninstall_packages=tuple(uninstall_pkgs),
                         )
-                    emit_progress('runtime-bootstrap-uv')
-                    run_runtime_install_step(
-                        container=container,
-                        runtime_root=runtime_root,
-                        marker_dirname=marker_dirname,
-                        container_identity=args.container_identity,
-                        step='bootstrap-uv',
-                        stream_progress=True,
-                    )
                     if reinstall_vllm:
                         emit_progress('runtime-install-vllm', package='vllm')
                         run_runtime_install_step(
@@ -1876,7 +1685,6 @@ def run_sync(args: argparse.Namespace) -> int:
                             container_identity=args.container_identity,
                             step='install-vllm',
                             stream_progress=True,
-                            install_deps=install_vllm_deps,
                         )
                     if reinstall_vllm_ascend:
                         if install_vllm_ascend_deps:
@@ -1902,36 +1710,6 @@ def run_sync(args: argparse.Namespace) -> int:
                             container_identity=args.container_identity,
                             step='install-vllm-ascend',
                             stream_progress=True,
-                            install_deps=install_vllm_ascend_deps,
-                        )
-                    emit_progress('runtime-install-verify-deps')
-                    try:
-                        run_runtime_install_step(
-                            container=container,
-                            runtime_root=runtime_root,
-                            marker_dirname=marker_dirname,
-                            container_identity=args.container_identity,
-                            step='verify-deps',
-                            stream_progress=True,
-                        )
-                    except Exception:
-                        emit_progress('runtime-install-repair-deps',
-                                      message='dependency mismatch detected, installing missing deps')
-                        run_runtime_install_step(
-                            container=container,
-                            runtime_root=runtime_root,
-                            marker_dirname=marker_dirname,
-                            container_identity=args.container_identity,
-                            step='install-vllm-ascend-requirements',
-                            stream_progress=True,
-                        )
-                        run_runtime_install_step(
-                            container=container,
-                            runtime_root=runtime_root,
-                            marker_dirname=marker_dirname,
-                            container_identity=args.container_identity,
-                            step='verify-deps',
-                            stream_progress=True,
                         )
                     emit_progress('runtime-install-verify-imports')
                     run_runtime_install_step(
@@ -1940,6 +1718,15 @@ def run_sync(args: argparse.Namespace) -> int:
                         marker_dirname=marker_dirname,
                         container_identity=args.container_identity,
                         step='verify-imports',
+                        stream_progress=True,
+                    )
+                    emit_progress('runtime-install-verify-deps')
+                    run_runtime_install_step(
+                        container=container,
+                        runtime_root=runtime_root,
+                        marker_dirname=marker_dirname,
+                        container_identity=args.container_identity,
+                        step='verify-deps',
                         stream_progress=True,
                     )
                     emit_progress('runtime-install-marker')

--- a/.agents/skills/repo-init/SKILL.md
+++ b/.agents/skills/repo-init/SKILL.md
@@ -72,6 +72,10 @@ Topology helper:
 - `python3 .agents/skills/repo-init/scripts/repo_topology.py configure --repo <path> [--origin-url URL] [--upstream-url URL] [--gh-default origin|upstream|none]`
 - `python3 .agents/skills/repo-init/scripts/repo_topology.py ensure-main --repo <path> --remote <origin-or-upstream>`
 
+CI-pinned vLLM resolver:
+
+- `python3 .agents/skills/repo-init/scripts/resolve_vllm_ci_pin.py --vllm-ascend-dir vllm-ascend`
+
 Reference files:
 
 - `.agents/skills/repo-init/references/behavior.md`
@@ -97,7 +101,7 @@ That checkpoint must cover:
    - community-only mode
 3. whether to initialize submodules now
 4. vllm submodule version alignment — **always include this question in the grouped checkpoint when the probe shows submodules are not yet initialized**. Since all questions are asked in a single batch, you cannot wait for the answer to question 3 before deciding whether to include question 4. If the user later chooses not to initialize submodules, simply ignore their version-alignment answer. Options:
-   - **CI-pinned** (default): check out `vllm/` at the commit CI actually tests against — from `vllm_version` matrix in `vllm-ascend/.github/workflows/pr_test_full.yaml`; cross-reference with `main_vllm_commit` in `vllm-ascend/docs/source/conf.py`
+   - **CI-pinned** (default): check out `vllm/` at the commit CI actually tests against — resolve it with `resolve_vllm_ci_pin.py`, which prefers `vllm-ascend/.github/vllm-main-verified.commit` and falls back to older workflow/docs sources
    - **upstream main**: both submodules track their respective upstream `main` HEAD
    - **keep current**: leave `vllm/` at whatever commit it is already on
 
@@ -150,8 +154,8 @@ If the request was just “初始化仓库” or similarly broad, do not silentl
 
 After recursive submodule init completes, if the user chose CI-pinned alignment:
 
-- Extract the CI-pinned vllm commit: check `vllm_version` matrix in `vllm-ascend/.github/workflows/pr_test_full.yaml` (ground truth for PR CI), cross-reference with `main_vllm_commit` in `vllm-ascend/docs/source/conf.py`.
-- If the two sources differ, prefer the `pr_test_full.yaml` matrix value.
+- Extract the CI-pinned vllm ref with `python3 .agents/skills/repo-init/scripts/resolve_vllm_ci_pin.py --vllm-ascend-dir vllm-ascend`.
+- Prefer `.github/vllm-main-verified.commit` when present. Older checkouts may only expose a `vllm_version` workflow matrix or `docs/source/conf.py`; treat those as fallbacks and report which source was used.
 - Check out `vllm/` at that commit.
 - Report the active version combination (vllm commit + vllm-ascend branch) in the finish summary.
 

--- a/.agents/skills/repo-init/references/acceptance.md
+++ b/.agents/skills/repo-init/references/acceptance.md
@@ -68,6 +68,7 @@ A successful run should satisfy all applicable items below.
 ### Submodules and topology
 
 - initializes submodules recursively when the user approved it
+- resolves CI-pinned vLLM alignment with `resolve_vllm_ci_pin.py`, preferring `.github/vllm-main-verified.commit` over older workflow/docs fallbacks
 - completes submodule init before configuring submodule remotes
 - `repo_topology.py configure --repo <submodule>` errors out when the submodule is not initialized (git root mismatch)
 - preserves nonstandard remotes
@@ -87,5 +88,6 @@ Review these files together after every substantial skill edit:
 - `.agents/skills/repo-init/scripts/repo_init_profile.py`
 - `.agents/skills/repo-init/scripts/repo_init_probe.py`
 - `.agents/skills/repo-init/scripts/repo_topology.py`
+- `.agents/skills/repo-init/scripts/resolve_vllm_ci_pin.py`
 - `.agents/scripts/workspace_profile.py`
 - `.agents/lib/vaws_local_state.py`

--- a/.agents/skills/repo-init/references/behavior.md
+++ b/.agents/skills/repo-init/references/behavior.md
@@ -95,6 +95,13 @@ For narrow Git-only tasks, skip this stage.
 
 Always use recursive sync + init for this repo.
 
+When the user chose CI-pinned vLLM alignment, resolve the tested vLLM ref with
+`resolve_vllm_ci_pin.py` after `vllm-ascend/` is populated. The resolver
+prefers `.github/vllm-main-verified.commit`, which is the current upstream
+source of truth, and falls back to older workflow/docs sources for older
+checkouts. Report the resolver source in the summary so later remote install
+or parity work can tell which pairing was deployed.
+
 ### Stage 6: topology
 
 Use `repo_topology.py configure` for remote mutations.

--- a/.agents/skills/repo-init/references/command-recipes.md
+++ b/.agents/skills/repo-init/references/command-recipes.md
@@ -63,6 +63,19 @@ git submodule sync --recursive
 git submodule update --init --recursive
 ```
 
+## Resolve CI-pinned vLLM ref
+
+Use this after `vllm-ascend/` is populated and the user chose CI-pinned
+alignment:
+
+```bash
+python3 .agents/skills/repo-init/scripts/resolve_vllm_ci_pin.py --vllm-ascend-dir vllm-ascend
+```
+
+Then check out `vllm/` at the returned `vllm_ref`. The resolver prefers
+`.github/vllm-main-verified.commit`; older checkouts may fall back to a
+workflow `vllm_version` or docs `main_vllm_commit` value.
+
 ## Quiet main comparison
 
 ```bash

--- a/.agents/skills/repo-init/scripts/resolve_vllm_ci_pin.py
+++ b/.agents/skills/repo-init/scripts/resolve_vllm_ci_pin.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Resolve the vLLM ref that the local vllm-ascend checkout tests against."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+HEX_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+SAFE_REF_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+
+
+def read_clean(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    text = path.read_text(encoding="utf-8").strip()
+    return text or None
+
+
+def classify_ref(value: str) -> str:
+    if HEX_RE.match(value):
+        return "commit"
+    if value.startswith("v") and SAFE_REF_RE.match(value):
+        return "tag"
+    if SAFE_REF_RE.match(value):
+        return "ref"
+    return "unknown"
+
+
+def parse_conf_value(conf_path: Path, key: str) -> str | None:
+    if not conf_path.exists():
+        return None
+    text = conf_path.read_text(encoding="utf-8")
+    patterns = (
+        rf"{re.escape(key)}\s*=\s*['\"]([^'\"]+)['\"]",
+        rf"['\"]{re.escape(key)}['\"]\s*:\s*['\"]([^'\"]+)['\"]",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, text)
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+def parse_workflow_vllm_version(workflows_dir: Path) -> tuple[str, str] | None:
+    if not workflows_dir.exists():
+        return None
+
+    def clean_value(raw: str) -> str | None:
+        value = raw.strip().strip("[]").strip().strip("'\"").strip()
+        if "," in value:
+            value = value.split(",", 1)[0].strip().strip("'\"").strip()
+        if not value or value == "-" or "$" in value or not SAFE_REF_RE.match(value):
+            return None
+        return value
+
+    for path in sorted(workflows_dir.glob("*.y*ml")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if "vllm_version" not in text:
+            continue
+        lines = text.splitlines()
+        for idx, line in enumerate(lines):
+            if "vllm_version" not in line or ":" not in line:
+                continue
+            inline = clean_value(line.split(":", 1)[1])
+            if inline:
+                return inline, str(path)
+            for follow in lines[idx + 1 : idx + 8]:
+                stripped = follow.strip()
+                if not stripped:
+                    continue
+                if not stripped.startswith("-"):
+                    break
+                listed = clean_value(stripped[1:])
+                if listed:
+                    return listed, str(path)
+    return None
+
+
+def resolve(vllm_ascend_dir: Path) -> dict[str, Any]:
+    repo = vllm_ascend_dir.resolve()
+    github_dir = repo / ".github"
+    main_verified = github_dir / "vllm-main-verified.commit"
+    release_tag_file = github_dir / "vllm-release-tag.commit"
+    docs_conf = repo / "docs" / "source" / "conf.py"
+    workflows_dir = github_dir / "workflows"
+
+    cross_checks: dict[str, Any] = {}
+    release_tag = read_clean(release_tag_file)
+    if release_tag:
+        cross_checks["vllm_release_tag"] = {
+            "value": release_tag,
+            "source": str(release_tag_file),
+        }
+
+    docs_main = parse_conf_value(docs_conf, "main_vllm_commit")
+    if docs_main:
+        cross_checks["docs_main_vllm_commit"] = {
+            "value": docs_main,
+            "source": str(docs_conf),
+        }
+
+    docs_version = parse_conf_value(docs_conf, "vllm_version")
+    if docs_version:
+        cross_checks["docs_vllm_version"] = {
+            "value": docs_version,
+            "source": str(docs_conf),
+        }
+
+    workflow_value = parse_workflow_vllm_version(workflows_dir)
+    if workflow_value:
+        value, source = workflow_value
+        cross_checks["workflow_vllm_version"] = {
+            "value": value,
+            "source": source,
+        }
+
+    verified = read_clean(main_verified)
+    if verified:
+        return {
+            "status": "ok",
+            "vllm_ref": verified,
+            "ref_type": classify_ref(verified),
+            "source": str(main_verified),
+            "precedence": "vllm-main-verified.commit",
+            "cross_checks": cross_checks,
+        }
+
+    if workflow_value:
+        value, source = workflow_value
+        return {
+            "status": "ok",
+            "vllm_ref": value,
+            "ref_type": classify_ref(value),
+            "source": source,
+            "precedence": "workflow vllm_version fallback",
+            "cross_checks": cross_checks,
+        }
+
+    fallback = docs_main or docs_version
+    if fallback:
+        return {
+            "status": "ok",
+            "vllm_ref": fallback,
+            "ref_type": classify_ref(fallback),
+            "source": str(docs_conf),
+            "precedence": "docs conf fallback",
+            "cross_checks": cross_checks,
+        }
+
+    return {
+        "status": "failed",
+        "reason": "could not resolve a vLLM CI pin from .github/vllm-main-verified.commit, workflows, or docs/source/conf.py",
+        "vllm_ascend_dir": str(repo),
+        "cross_checks": cross_checks,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Resolve vLLM CI-pinned ref for a vllm-ascend checkout.",
+        allow_abbrev=False,
+    )
+    parser.add_argument("--vllm-ascend-dir", default="vllm-ascend")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    payload = resolve(Path(args.vllm_ascend_dir))
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if payload.get("status") == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/vllm-ascend-serving/references/behavior.md
+++ b/.agents/skills/vllm-ascend-serving/references/behavior.md
@@ -86,7 +86,7 @@ After `remote-code-parity` sync, these build artifacts may be missing because th
 cd /vllm-workspace/vllm-ascend && bash csrc/build_aclnn.sh /vllm-workspace/vllm-ascend ascend910b
 ```
 
-Installation note: `pip install -e . -i https://pypi.tuna.tsinghua.edu.cn/simple` handles `numpy<2.0.0` (CANN hard dependency) automatically. Do not skip it or manually override numpy to >=2.0.
+Installation note: parity installs with the HuaweiCloud pip index and handles `numpy<2.0.0` (CANN hard dependency) automatically. Do not skip it or manually override numpy to >=2.0.
 
 ## Extra args escaping
 

--- a/.agents/skills/vllm-ascend-serving/references/command-recipes.md
+++ b/.agents/skills/vllm-ascend-serving/references/command-recipes.md
@@ -249,4 +249,4 @@ python3 .agents/scripts/remote_job_status.py --job-id <job-id>
 python3 .agents/scripts/remote_job_tail.py --job-id <job-id> --lines 120
 ```
 
-Note: if `numpy>=2.0` is installed, first downgrade: `pip3 install "numpy<2.0.0" -i https://pypi.tuna.tsinghua.edu.cn/simple`
+Note: if `numpy>=2.0` is installed, first downgrade through parity or use the same HuaweiCloud pip index: `pip3 install "numpy<2.0.0" -i https://repo.huaweicloud.com/repository/pypi/simple`

--- a/.agents/skills/vllm-ascend-serving/scripts/serve_start.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/serve_start.py
@@ -434,7 +434,7 @@ def diagnose_env_failure(
             "The container has exact version locks between torch, torch_npu, "
             "vllm, and vllm-ascend. Manual pip install will break the "
             "dependency graph. Parity sync uses the correct install flags "
-            "(--no-build-isolation, VLLM_TARGET_DEVICE=empty, uv acceleration)."
+            "(--no-deps, --no-build-isolation, VLLM_TARGET_DEVICE=empty, HuaweiCloud pip index)."
         ),
     }
 


### PR DESCRIPTION
## Summary

- Rework remote-code-parity runtime installs to use the empirically fastest A3 path: pip-only HuaweiCloud index, no uv bootstrap, no multi-mirror fallback, no build-isolation fallback, and editable installs with `--no-deps`.
- Add bounded build parallelism via `MAX_JOBS` and `CMAKE_BUILD_PARALLEL_LEVEL` (`min(available CPUs, 128)` by default), plus `TORCH_DEVICE_BACKEND_AUTOLOAD=0` for the vLLM empty-target editable install.
- Simplify managed-container bootstrap sources: fixed NJU apt source, single HuaweiCloud pip source, and no opportunistic pytest install.
- Add `resolve_vllm_ci_pin.py` so repo-init prefers `.github/vllm-main-verified.commit` for tested vLLM alignment.

## Why

The previous path spent time in slow or counterproductive fallback behavior. Remote A3 evidence showed:

- HuaweiCloud fetched the key `llguidance` aarch64 wheel in about 1.1s, while Tsinghua returned 403 for that wheel and public PyPI timed out in prior probing.
- NJU was the fastest apt source in the tested container.
- `vllm` editable install without `--no-deps` upgraded `numpy` to 2.x and broke the CANN-compatible stack; `--no-deps` kept `numpy==1.26.4` and reduced vLLM editable install to about 9s.
- `vllm-ascend` hot-cache editable install took about 118s with 128 jobs; 256 jobs was about 120s, so 128 remains the better default.

## Validation

- `python3 -m py_compile` on modified Python scripts.
- `git diff --check` on the staged skill changes.
- Generated runtime install shell snippets passed `bash -n` and contained HuaweiCloud / `--no-deps` / build parallelism while excluding uv and mirror fallback paths.
- `resolve_vllm_ci_pin.py --vllm-ascend-dir vllm-ascend` resolved `967c5c3bc38891f4465d3f4e99917ed837bb3833` from `.github/vllm-main-verified.commit`.
- Remote A3 import smoke after install timing: `numpy=1.26.4`, `torch=2.10.0+cpu`, `vllm` import OK, `vllm_ascend` import OK.