### PR TITLE
[codex] Fix ATB ABI startup in machine bootstrap

### DIFF
--- a/.agents/skills/machine-management/SKILL.md
+++ b/.agents/skills/machine-management/SKILL.md
@@ -50,6 +50,7 @@ Ready does **not** imply code sync, rebuild, serving, or benchmark readiness.
 - Persist `host.machine_type`, `host.soc`, and `container.machine_type` into inventory, and write matching metadata under `/etc/vaws/` plus `/etc/profile.d/vaws-ascend-env.sh` on the host and inside the managed container.
 - Before running `apt-get update` / `apt-get install` inside the container, rewrite apt sources to the fixed A3-tested NJU mirror (`mirrors.nju.edu.cn`). Do not spend bootstrap time probing alternate mirrors.
 - Prepend `/usr/local/Ascend/driver/lib64/common`, `/usr/local/Ascend/driver/lib64/driver`, and `/usr/local/Ascend/driver/lib64` before calling `npu-smi` or the smoke test; source `/etc/profile.d/vaws-ascend-env.sh` when it exists.
+- Persist and reuse an explicit ATB C++ ABI setting during container bootstrap. Do not let login shells repeatedly call ATB `set_env.sh` without `--cxx_abi`, because that can import `torch` during shell startup and add 10+ seconds to ordinary SSH commands.
 - Long probe / bootstrap / smoke operations must expose bounded phase progress and have an overall timeout budget, not only a connect timeout.
 - On a missing local machine profile, never call `workspace_profile.py ensure` bare. Use either:
   - `--username <letters-or-digits>` after the user chose a name
@@ -216,6 +217,7 @@ Do not remove host firewall rules or host-level `authorized_keys` entries.
 - Ensure `/run/sshd` exists before starting the dedicated `sshd`.
 - Image pulls should follow the selected mirror order and emit heartbeat-style progress so long `docker pull`, `apt-get update`, and `apt-get install` phases remain attributable. Persist the actually selected image in inventory, not only the selector.
 - Container bootstrap should leave behind `/etc/vaws/host-info.json`, `/etc/vaws/container-info.json`, and `/etc/profile.d/vaws-ascend-env.sh` so later verify / repair runs can see the recorded machine type, container type, and SoC quickly.
+- Container bootstrap should determine ATB C++ ABI once from the runtime Python when possible, write `VAWS_ATB_CXX_ABI`, source ATB with `--cxx_abi=<0|1>`, and patch common image startup files such as `/etc/profile` and `/root/.bashrc` when they source ATB without an explicit ABI.
 - Session-management may opt into the shared bootstrap helper's prepared image cache for short-lived session containers. Normal `machine_add.py` / `machine_repair.py` managed-base-container flows keep raw selected-image bootstrap behavior unless explicitly wired otherwise.
 - Container bootstrap should write `/etc/pip.conf` with a single A3-tested pip source: HuaweiCloud (`https://repo.huaweicloud.com/repository/pypi/simple`). Do not configure extra indexes by default.
 - Container bootstrap should not install test packages opportunistically. Keep fresh-container startup limited to SSH, runtime env metadata, apt source configuration, and pip source configuration.

--- a/.agents/skills/machine-management/references/acceptance.md
+++ b/.agents/skills/machine-management/references/acceptance.md
@@ -99,6 +99,7 @@ These should not trigger `machine-management` unless machine readiness is the ob
 - the skill does not recreate or delete a container unless the user explicitly asked for destructive repair
 - the smoke path stays dynamic: no pinned Python patch version, no unconditional vendor `set_env.bash`, no default `devlib` injection
 - verify / smoke prepend `driver/lib64/common`, `driver/lib64/driver`, and `driver/lib64`, and source `/etc/profile.d/vaws-ascend-env.sh` when it exists
+- container bootstrap records `VAWS_ATB_CXX_ABI`, sources ATB with `--cxx_abi=<0|1>`, and patches common image startup files so `bash -lc true` does not spend 10+ seconds importing `torch` for ATB ABI detection
 
 ### Remove
 
@@ -133,5 +134,6 @@ Review these files together after every substantial skill edit:
 - `.agents/skills/machine-management/scripts/manage_machine.py`
 - `.agents/skills/machine-management/scripts/inventory.py`
 - inspect the generated `/etc/vaws/host-info.json`, `/etc/vaws/container-info.json`, and `/etc/profile.d/vaws-ascend-env.sh` on a real machine after any bootstrap logic change
+- after bootstrap changes touching shell startup, time a direct container SSH command and `bash -lc true`; the login-shell path should stay close to ordinary SSH startup and must not regress to ATB dynamic `import torch` latency
 - `.agents/scripts/workspace_profile.py`
 - `.agents/lib/vaws_local_state.py`

--- a/.agents/skills/machine-management/references/behavior.md
+++ b/.agents/skills/machine-management/references/behavior.md
@@ -205,6 +205,15 @@ Container bootstrap writes persistent runtime environment configuration so that 
 - `/etc/profile.d/vaws-ascend-env.sh`: adds the runtime Python directory and Ascend driver libs to `PATH` and `LD_LIBRARY_PATH`.
 - `/etc/pip.conf`: configures pip with a single A3-tested source, HuaweiCloud (`https://repo.huaweicloud.com/repository/pypi/simple`). Do not add extra indexes by default.
 
+ATB environment initialization must be explicit and fast:
+
+- determine `torch.compiled_with_cxx11_abi()` once during container bootstrap when the runtime Python can import `torch`
+- persist the result as `VAWS_ATB_CXX_ABI` in `/etc/profile.d/vaws-ascend-env.sh` and `/etc/vaws/container-info.json`
+- source `/usr/local/Ascend/nnal/atb/set_env.sh` with `--cxx_abi=<0|1>` from generated VAWS env scripts, smoke paths, and common image startup files
+- patch existing image files such as `/etc/profile` and `/root/.bashrc` when they source ATB without an explicit ABI, keeping a `.vaws-atb-abi.bak` backup
+
+Do not rely on ATB's default dynamic ABI detection in shell startup paths. In vLLM-Ascend images, that detection can run `python3 -c "import torch"` after VAWS has prepended the runtime Python to `PATH`, making simple SSH/login-shell commands take 10+ seconds.
+
 The pip config write is best-effort: if the runtime Python cannot be discovered, the bootstrap continues without failing. Do not install `pytest` or other test packages during container bootstrap; fresh startup should stay focused on SSH reachability and durable runtime-source configuration.
 
 ## Mesh contract

--- a/.agents/skills/machine-management/scripts/manage_machine.py
+++ b/.agents/skills/machine-management/scripts/manage_machine.py
@@ -989,18 +989,19 @@ fi
 sourced_scripts=""
 safe_source() {
   file="$1"
+  shift || true
   if [ -f "$file" ]; then
     set +u
-    . "$file" >/dev/null 2>&1 || true
+    . "$file" "$@" >/dev/null 2>&1 || true
     set -u
-    sourced_scripts="${sourced_scripts}${file}
+    sourced_scripts="${sourced_scripts}${file}${*:+ $*}
 "
   fi
 }
 safe_source /etc/profile.d/vaws-ascend-env.sh
 safe_source /usr/local/Ascend/ascend-toolkit/set_env.sh
 safe_source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh
-safe_source /usr/local/Ascend/nnal/atb/set_env.sh
+safe_source /usr/local/Ascend/nnal/atb/set_env.sh "--cxx_abi=${VAWS_ATB_CXX_ABI:-1}"
 
 py=""
 for cand in python3 python; do
@@ -1591,8 +1592,43 @@ if [ -n "$_vaws_python_dir" ]; then
 else
   _path_prefix="/usr/local/bin:/usr/local/sbin"
 fi
+_vaws_atb_cxx_abi="1"
+if [ -n "$_vaws_python_dir" ] && [ -x "$_vaws_python_dir/python3" ]; then
+  _torch_cxx_abi="$("$_vaws_python_dir/python3" - <<'PY' 2>/dev/null || true
+import torch
+print("1" if torch.compiled_with_cxx11_abi() else "0")
+PY
+)"
+  case "$_torch_cxx_abi" in
+    0|1)
+      _vaws_atb_cxx_abi="$_torch_cxx_abi"
+      ;;
+  esac
+fi
+patch_atb_set_env_source() {
+  file="$1"
+  [ -f "$file" ] || return 0
+  if [ ! -f "${file}.vaws-atb-abi.bak" ]; then
+    cp -a "$file" "${file}.vaws-atb-abi.bak" 2>/dev/null || true
+  fi
+  tmp_file="$(mktemp)"
+  if awk -v abi="$_vaws_atb_cxx_abi" '
+    /^[[:space:]]*(source|\.)[[:space:]]+\/usr\/local\/Ascend\/nnal\/atb\/set_env\.sh[[:space:]]*$/ {
+      sub(/[[:space:]]*$/, "")
+      print $0 " --cxx_abi=" abi
+      next
+    }
+    { print }
+  ' "$file" > "$tmp_file"; then
+    cat "$tmp_file" > "$file"
+  fi
+  rm -f "$tmp_file"
+}
+patch_atb_set_env_source /etc/profile
+patch_atb_set_env_source /root/.bashrc
 cat > /etc/profile.d/vaws-ascend-env.sh <<EOF_CONTAINER_ENV
 #!/bin/sh
+export VAWS_ATB_CXX_ABI="\${VAWS_ATB_CXX_ABI:-$_vaws_atb_cxx_abi}"
 if [ -z "\${ASCEND_HOME_PATH:-}" ]; then
   if [ -d /usr/local/Ascend/ascend-toolkit/latest ]; then
     export ASCEND_HOME_PATH=/usr/local/Ascend/ascend-toolkit/latest
@@ -1607,7 +1643,7 @@ if [ -f /usr/local/Ascend/ascend-toolkit/latest/set_env.sh ]; then
   . /usr/local/Ascend/ascend-toolkit/latest/set_env.sh >/dev/null 2>&1 || true
 fi
 if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then
-  . /usr/local/Ascend/nnal/atb/set_env.sh >/dev/null 2>&1 || true
+  . /usr/local/Ascend/nnal/atb/set_env.sh "--cxx_abi=\${VAWS_ATB_CXX_ABI:-1}" >/dev/null 2>&1 || true
 fi
 export LD_LIBRARY_PATH="/usr/local/Ascend/driver/lib64/common:/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/driver/lib64:\${LD_LIBRARY_PATH:-}"
 export PATH="$_path_prefix:\${PATH:-}"
@@ -1626,10 +1662,10 @@ if [ -n "$image" ]; then
 fi
 EOF_CONTAINER_ENV
 chmod 0644 /etc/profile.d/vaws-ascend-env.sh
-python3 - "$machine_type" "$container_type" "$soc" "$image" "$workdir" "$namespace" > /etc/vaws/container-info.json <<'PY'
+python3 - "$machine_type" "$container_type" "$soc" "$image" "$workdir" "$namespace" "$_vaws_atb_cxx_abi" > /etc/vaws/container-info.json <<'PY'
 import json
 import sys
-machine_type, container_type, soc, image, workdir, namespace = sys.argv[1:]
+machine_type, container_type, soc, image, workdir, namespace, atb_cxx_abi = sys.argv[1:]
 print(json.dumps({
     "machine_type": machine_type or None,
     "container_type": container_type or None,
@@ -1637,6 +1673,7 @@ print(json.dumps({
     "image": image or None,
     "workdir": workdir,
     "namespace": namespace or None,
+    "atb_cxx_abi": atb_cxx_abi or None,
     "env_file": "/etc/profile.d/vaws-ascend-env.sh",
 }, ensure_ascii=False, indent=2))
 PY
@@ -2105,18 +2142,19 @@ export MKL_NUM_THREADS=1
 sourced_file_log=""
 safe_source() {
   file="$1"
+  shift || true
   if [ -f "$file" ]; then
     set +u
-    . "$file" >/dev/null 2>&1 || true
+    . "$file" "$@" >/dev/null 2>&1 || true
     set -u
-    sourced_file_log+="$file\n"
+    sourced_file_log+="$file${*:+ $*}\n"
   fi
 }
 
 safe_source /etc/profile.d/vaws-ascend-env.sh
 safe_source /usr/local/Ascend/ascend-toolkit/set_env.sh
 safe_source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh
-safe_source /usr/local/Ascend/nnal/atb/set_env.sh
+safe_source /usr/local/Ascend/nnal/atb/set_env.sh "--cxx_abi=${VAWS_ATB_CXX_ABI:-1}"
 safe_source /vllm-workspace/vllm-ascend/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/bin/set_env.bash
 
 "$PYTHON_BIN" - <<'PY' "$PYTHON_BIN" "$sourced_file_log"


### PR DESCRIPTION
## Summary

This updates the machine-management bootstrap flow to avoid slow ATB dynamic ABI detection during container shell startup.

## Details

- Detects `torch.compiled_with_cxx11_abi()` once during container bootstrap when runtime Python can import `torch`.
- Persists the result as `VAWS_ATB_CXX_ABI` in `/etc/profile.d/vaws-ascend-env.sh` and `/etc/vaws/container-info.json`.
- Sources ATB with an explicit `--cxx_abi=<0|1>` in generated env scripts and smoke paths.
- Patches common image startup files such as `/etc/profile` and `/root/.bashrc` when they source ATB without an explicit ABI.
- Documents the startup-latency issue and adds acceptance checks for the bootstrap behavior.

## Why

On vLLM-Ascend containers, ATB's default `set_env.sh` path may run `python3 -c "import torch"` to infer ABI. After VAWS prepends the runtime Python to `PATH`, that import can make simple login-shell commands take 10+ seconds. Persisting the ABI avoids repeated shell-startup latency.

## Validation

- `PYTHONPYCACHEPREFIX=/tmp/vaws-pr-compileall-pycache python3 -m compileall -q .agents/skills/machine-management`
- `PYTHONPYCACHEPREFIX=/tmp/vaws-pr-compileall-pycache python3 -m unittest discover -s .agents/tests`
- `git diff --check upstream/main..HEAD -- .agents/skills/machine-management`
- Re-ran bootstrap and verify on `141.61.81.152` / `pcp_qcs0627`; `machine_verify` returned `ready`.
- Measured container shell startup after the fix: plain SSH `true` about 0.15s, `bash -lc true` about 0.31s.