### PR TITLE
feat(knowledge): add standalone evidence-chain tooling

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -34,9 +34,19 @@ compatibility backend for managed sessions, sync, service adapters, and cleanup.
 - `.agents/skills/ascend-memory-profiling/` is the source-of-truth skill package for profiling and attributing HBM memory usage on Ascend NPU for vLLM serving scenarios.
 - `.agents/skills/ascend-profiling-collection/` is the source-of-truth skill package for collecting Ascend torch-profiler traces and verified manifests.
 - `.agents/skills/ascend-profiling-analysis/` is the source-of-truth skill package for analyzing collected profiler roots/manifests and generating reports.
+- `.agents/skills/curate-workspace-knowledge/` is the explicit-only package for reviewing and promoting verified candidates into formal knowledge files.
 - `.agents/scripts/workspace_profile.py` is the shared low-level helper for the local workspace machine profile.
 - `.agents/scripts/workspace_identity.py` manages the persistent local UUID4 and optional unified project/agent/resource alias.
+- `.agents/scripts/run_manifest.py` creates and validates shared Run Manifest v1 files.
+- `.agents/scripts/knowledge_validate.py` validates the versioned shared knowledge documents.
+- `.agents/scripts/knowledge_query.py` retrieves compact matching knowledge summaries and expands one entry only by id.
+- `.agents/scripts/knowledge_capture.py` records or merges one verified, redacted candidate without loading a Skill.
+- `.agents/hooks/knowledge_session_end.py` flushes only candidates explicitly deferred for the ending Codex session; it never reads the transcript.
+- `.agents/knowledge/` stores the empty formal document skeleton and any subsequently reviewed project knowledge.
+- `.agents/schemas/` stores the machine-readable Run Manifest and knowledge contracts.
 - `.agents/lib/vaws_local_state.py` is the shared library for untracked local runtime state.
+- `.agents/lib/vaws_run_manifest.py` is the shared Run Manifest v1 library for workflow correlation and artifact links.
+- `.agents/lib/vaws_knowledge.py` is the shared knowledge validation, capture, and query library.
 - `.agents/lib/vaws_session_id.py` and `.agents/lib/vaws_session_state.py` are the shared libraries for session identity, state, locks, and leases.
 - `.agents/lib/vaws_remote_toolbox.py` is the shared library for remote target resolution, SSH execution, job observation, artifact streaming, sync adapters, service adapters, and cleanup.
 - `.agents/lib/vaws_validate.py` is the shared validation library for agent-facing ids, environment names, path boundaries, and NPU device lists.
@@ -106,6 +116,11 @@ Current primary helpers:
 - `ascend-profiling-collection/scripts/run_remote_analyse.py`
 - `ascend-profiling-analysis/scripts/profile_analyze.py`
 - `ascend-profiling-analysis/scripts/profile_sweep.py`
+- `curate-workspace-knowledge/scripts/knowledge_curate.py`
+- `scripts/run_manifest.py`
+- `scripts/knowledge_validate.py`
+- `scripts/knowledge_query.py`
+- `scripts/knowledge_capture.py`
 - `scripts/workspace_profile.py`
 - `.agents/tests/test_vaws_scaffold_safety.py`
 
@@ -136,6 +151,9 @@ Untracked workspace-local state lives under `.vaws-local/`:
 - `.vaws-local/memory-profiling/`
 - `.vaws-local/ascend-profiling-collection/runs/`
 - `.vaws-local/profiling-analysis/runs/`
+- `.vaws-local/knowledge/candidates/`
+- `.vaws-local/knowledge/pending/<session-key>/`
+- `.vaws-local/knowledge/session-end/`
 
 Parallel remote work should use `session-management` first. A session owns a local worktree, a dedicated remote container, session-scoped serving/benchmark/profiling state, and resource leases. Existing `--machine` commands remain legacy-compatible for single-tenant workflows.
 

--- a/.agents/hooks/knowledge_session_end.py
+++ b/.agents/hooks/knowledge_session_end.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Flush only explicitly deferred knowledge candidates for one Codex session."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_knowledge import (  # noqa: E402
+    MAX_CANDIDATE_BYTES,
+    KnowledgeError,
+    capture_candidate,
+    knowledge_session_key,
+    load_candidate,
+)
+
+MAX_PENDING_PER_SESSION = 32
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _resolve_repo_root(payload: Mapping[str, Any]) -> Path:
+    cwd = payload.get("cwd")
+    if isinstance(cwd, str) and cwd:
+        current = Path(cwd).resolve()
+        for candidate in (current, *current.parents):
+            if (candidate / ".agents" / "lib" / "vaws_knowledge.py").is_file():
+                return candidate
+    return ROOT
+
+
+def process_session_end(
+    payload: Mapping[str, Any], *, repo_root: Path | None = None
+) -> dict[str, Any] | None:
+    if payload.get("hook_event_name") != "SessionEnd":
+        raise KnowledgeError("knowledge hook only accepts SessionEnd events")
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise KnowledgeError("SessionEnd payload requires session_id")
+    root = repo_root or _resolve_repo_root(payload)
+    session_key = knowledge_session_key(session_id)
+    pending_dir = (
+        root / ".vaws-local" / "knowledge" / "pending" / session_key
+    )
+    if not pending_dir.is_dir():
+        return None
+
+    pending_paths = sorted(pending_dir.glob("*.json"))
+    processed: list[dict[str, Any]] = []
+    errors: list[dict[str, str]] = []
+    if len(pending_paths) > MAX_PENDING_PER_SESSION:
+        errors.append(
+            {
+                "file": pending_dir.name,
+                "error": (
+                    f"pending candidate count {len(pending_paths)} exceeds "
+                    f"{MAX_PENDING_PER_SESSION}"
+                ),
+            }
+        )
+        pending_paths = pending_paths[:MAX_PENDING_PER_SESSION]
+
+    candidate_dir = root / ".vaws-local" / "knowledge" / "candidates"
+    knowledge_dir = root / ".agents" / "knowledge"
+    for path in pending_paths:
+        try:
+            if path.is_symlink():
+                raise KnowledgeError("pending candidate must not be a symbolic link")
+            if path.stat().st_size > MAX_CANDIDATE_BYTES:
+                raise KnowledgeError(
+                    f"pending candidate exceeds {MAX_CANDIDATE_BYTES} bytes"
+                )
+            candidate = load_candidate(path)
+            if candidate["source"].get("session_id") != session_id:
+                raise KnowledgeError("pending candidate session does not match hook session")
+            result = capture_candidate(
+                candidate,
+                candidate_dir=candidate_dir,
+                knowledge_dir=knowledge_dir,
+            )
+            if result["status"] not in {"passed", "already-promoted"}:
+                raise KnowledgeError(f"unexpected capture status: {result['status']}")
+            path.unlink()
+            processed.append(
+                {
+                    "candidate_id": candidate["candidate_id"],
+                    "capture_status": result["status"],
+                    "action": result.get("action"),
+                }
+            )
+        except (KnowledgeError, OSError) as exc:
+            errors.append({"file": path.name, "error": str(exc)})
+
+    try:
+        pending_dir.rmdir()
+    except OSError:
+        pass
+    receipt = {
+        "schema_version": 1,
+        "session_key": session_key,
+        "status": "passed" if not errors else "partial",
+        "processed": processed,
+        "errors": errors,
+        "processed_at": utc_now(),
+    }
+    receipt_path = (
+        root
+        / ".vaws-local"
+        / "knowledge"
+        / "session-end"
+        / f"{session_key}.json"
+    )
+    _write_json_atomic(receipt_path, receipt)
+    return receipt
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+        if not isinstance(payload, dict):
+            raise KnowledgeError("hook input root must be an object")
+        process_session_end(payload)
+    except (KnowledgeError, OSError, json.JSONDecodeError):
+        # SessionEnd is advisory. Never block shutdown or emit model-visible output.
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/knowledge/README.md
+++ b/.agents/knowledge/README.md
@@ -1,0 +1,10 @@
+# Workspace knowledge store
+
+This directory contains the versioned document skeleton for formal workspace
+knowledge. The branch intentionally starts with empty `entries` arrays: it
+provides the knowledge-management mechanism without importing knowledge from
+another checkout, developer machine, or untracked candidate queue.
+
+Populate these files only through reviewed project changes. Local candidates
+belong under the ignored `.vaws-local/knowledge/` tree until explicitly
+promoted or merged with stable evidence.

--- a/.agents/knowledge/VALIDATION.md
+++ b/.agents/knowledge/VALIDATION.md
@@ -1,0 +1,51 @@
+# Knowledge evidence-chain validation
+
+Validation date: 2026-08-11
+
+Base revision: `upstream/main` at `35f795c`
+
+## End-to-end lifecycle
+
+`.agents/tests/test_knowledge_flow.py` exercises the public command-line
+surfaces against a temporary simulated repository:
+
+1. capture a verified synthetic candidate into a session-scoped pending queue;
+2. flush it through the bounded `SessionEnd` hook without reading a transcript;
+3. list and inspect the review candidate;
+4. promote it to an `active` formal entry using stable regression-test evidence;
+5. query the compact match and fetch the full entry by id;
+6. recapture the same candidate and observe `already-promoted`;
+7. deprecate the entry while retaining its history;
+8. validate all formal knowledge documents.
+
+The candidate, formal knowledge store, reviewed archive, pending queue, and
+SessionEnd receipt all live under a temporary directory. The test snapshots
+the branch's tracked knowledge YAML files and verifies their bytes are
+unchanged after the flow. The fixture is explicitly synthetic and is never
+promoted into the branch's formal knowledge store.
+
+## Commands and results
+
+```text
+PYTHONDONTWRITEBYTECODE=1 python3 .agents/tests/test_knowledge_flow.py
+1 test passed
+
+PYTHONDONTWRITEBYTECODE=1 python3 .agents/tests/test_run_manifest.py
+7 tests passed
+
+PYTHONDONTWRITEBYTECODE=1 python3 .agents/tests/test_knowledge_memory.py
+13 tests passed
+
+PYTHONDONTWRITEBYTECODE=1 python3 .agents/tests/test_knowledge_hook.py
+8 tests passed
+
+PYTHONDONTWRITEBYTECODE=1 python3 \
+  .agents/skills/curate-workspace-knowledge/tests/test_knowledge_curate.py
+10 tests passed
+
+PYTHONDONTWRITEBYTECODE=1 python3 .agents/scripts/knowledge_validate.py
+status: passed; 6 formal documents validated
+```
+
+Result: **39/39 tests passed**, and the formal branch knowledge documents
+remain valid with empty `entries` arrays.

--- a/.agents/knowledge/backend-constraints.yaml
+++ b/.agents/knowledge/backend-constraints.yaml
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "kind": "backend-constraints",
+  "updated_at": "2026-08-11",
+  "entries": []
+}

--- a/.agents/knowledge/known-failure-signatures.yaml
+++ b/.agents/knowledge/known-failure-signatures.yaml
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "kind": "known-failure-signatures",
+  "updated_at": "2026-08-11",
+  "entries": []
+}

--- a/.agents/knowledge/model-capabilities.yaml
+++ b/.agents/knowledge/model-capabilities.yaml
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "kind": "model-capabilities",
+  "updated_at": "2026-08-11",
+  "entries": []
+}

--- a/.agents/knowledge/parallelism-compatibility.yaml
+++ b/.agents/knowledge/parallelism-compatibility.yaml
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "kind": "parallelism-compatibility",
+  "updated_at": "2026-08-11",
+  "entries": []
+}

--- a/.agents/knowledge/validation-rules.yaml
+++ b/.agents/knowledge/validation-rules.yaml
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "kind": "validation-rules",
+  "updated_at": "2026-08-11",
+  "entries": []
+}

--- a/.agents/knowledge/version-compatibility.yaml
+++ b/.agents/knowledge/version-compatibility.yaml
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "kind": "version-compatibility",
+  "updated_at": "2026-08-11",
+  "entries": []
+}

--- a/.agents/lib/vaws_knowledge.py
+++ b/.agents/lib/vaws_knowledge.py
@@ -1,0 +1,676 @@
+#!/usr/bin/env python3
+"""Validate, capture, and query workspace knowledge without loading a Skill."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, MutableMapping, Sequence
+
+SCHEMA_VERSION = 1
+CANDIDATE_SCHEMA_VERSION = 1
+KNOWLEDGE_FILES = {
+    "version-compatibility.yaml": "version-compatibility",
+    "model-capabilities.yaml": "model-capabilities",
+    "parallelism-compatibility.yaml": "parallelism-compatibility",
+    "backend-constraints.yaml": "backend-constraints",
+    "validation-rules.yaml": "validation-rules",
+    "known-failure-signatures.yaml": "known-failure-signatures",
+}
+KNOWLEDGE_KINDS = frozenset(KNOWLEDGE_FILES.values())
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
+SAFE_ENTRY_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+SAFE_SKILL_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,127}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+ENTRY_STATUSES = frozenset({"active", "deprecated", "experimental"})
+CANDIDATE_CONFIDENCE = frozenset({"low", "medium", "high"})
+VERIFICATION_STATUSES = frozenset({"passed", "inconclusive"})
+SECRET_KEY_RE = re.compile(
+    r"(?:^|_)(?:api_?key|access_?key|auth|credential|pass(?:word)?|secret|token)(?:_|$)",
+    re.IGNORECASE,
+)
+SECRET_VALUE_RES = (
+    re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b"),
+    re.compile(r"\bgh[opsu]_[A-Za-z0-9]{20,}\b"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{16,}", re.IGNORECASE),
+)
+WINDOWS_ABSOLUTE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+TOKEN_RE = re.compile(r"[\w.-]{2,}", re.UNICODE)
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+UUID_RE = re.compile(
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b",
+    re.IGNORECASE,
+)
+HEX_ADDRESS_RE = re.compile(r"\b0x[0-9a-f]{6,}\b", re.IGNORECASE)
+TIMESTAMP_RE = re.compile(
+    r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]+(?:Z|[+-]\d{2}:?\d{2})?\b",
+    re.IGNORECASE,
+)
+PID_RE = re.compile(r"\b(pid|process)\s*[:=#]?\s*\d+\b", re.IGNORECASE)
+KNOWN_WORKSPACE_PATH_RE = re.compile(
+    r"(?:/home/[^/\s]+/[^/\s]+/|/vllm-workspace/|[A-Za-z]:[\\/]Users[\\/][^\\/\s]+[\\/][^\\/\s]+[\\/])"
+)
+URI_SCHEME_RE = re.compile(r"^([A-Za-z][A-Za-z0-9+.-]*):")
+ALLOWED_EVIDENCE_SCHEMES = frozenset({"https", "http", "run", "commit", "git"})
+MAX_CANDIDATE_BYTES = 64 * 1024
+MAX_NARRATIVE_LENGTH = 4000
+MAX_FINGERPRINT_LENGTH = 1000
+
+
+class KnowledgeError(ValueError):
+    """Raised when a knowledge file violates the v1 contract."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def knowledge_session_key(session_id: str) -> str:
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise KnowledgeError("session id must be a non-empty string")
+    return hashlib.sha256(session_id.strip().encode("utf-8")).hexdigest()[:20]
+
+
+def _require_non_empty_string(value: Any, path: str, errors: list[str]) -> str:
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{path} must be a non-empty string")
+        return ""
+    return value.strip()
+
+
+def _require_string_array(
+    value: Any, path: str, errors: list[str], *, non_empty: bool = False
+) -> list[str]:
+    if not isinstance(value, list) or any(
+        not isinstance(item, str) or not item.strip() for item in value
+    ):
+        errors.append(f"{path} must be an array of non-empty strings")
+        return []
+    if non_empty and not value:
+        errors.append(f"{path} must contain at least one item")
+    return [item.strip() for item in value]
+
+
+def _scan_sensitive(value: Any, path: str, errors: list[str]) -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if not isinstance(key, str):
+                errors.append(f"{path} contains a non-string key")
+                continue
+            if SECRET_KEY_RE.search(key):
+                errors.append(f"{path}.{key} uses a secret-like key")
+            _scan_sensitive(child, f"{path}.{key}", errors)
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _scan_sensitive(child, f"{path}[{index}]", errors)
+    elif isinstance(value, str):
+        for pattern in SECRET_VALUE_RES:
+            if pattern.search(value):
+                errors.append(f"{path} contains a secret-like value")
+                break
+
+
+def _validate_evidence_uri(uri: str, path: str, errors: list[str]) -> None:
+    if uri.startswith("file://") or Path(uri).is_absolute() or WINDOWS_ABSOLUTE_RE.match(uri):
+        errors.append(f"{path} must be a repository-relative path or stable external URI")
+        return
+    scheme = URI_SCHEME_RE.match(uri)
+    if scheme:
+        if scheme.group(1).lower() not in ALLOWED_EVIDENCE_SCHEMES:
+            errors.append(f"{path} uses an unsupported URI scheme")
+        return
+    if ".." in Path(uri).parts:
+        errors.append(f"{path} must not traverse outside the repository")
+
+
+def normalize_fingerprint(value: str) -> str:
+    normalized = ANSI_RE.sub("", value)
+    normalized = UUID_RE.sub("<uuid>", normalized)
+    normalized = HEX_ADDRESS_RE.sub("<address>", normalized)
+    normalized = TIMESTAMP_RE.sub("<timestamp>", normalized)
+    normalized = PID_RE.sub(lambda match: f"{match.group(1).lower()}=<pid>", normalized)
+    normalized = KNOWN_WORKSPACE_PATH_RE.sub("<workspace>/", normalized)
+    return " ".join(normalized.lower().split())
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def load_knowledge_file(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise KnowledgeError(
+            f"{path} must use JSON-compatible YAML so stdlib validation works: {exc}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise KnowledgeError(f"{path}: document root must be an object")
+    return payload
+
+
+def validate_knowledge_document(
+    payload: Mapping[str, Any], *, expected_kind: str, path: str
+) -> None:
+    errors: list[str] = []
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    if payload.get("kind") != expected_kind:
+        errors.append(f"kind must be {expected_kind!r}")
+    updated_at = payload.get("updated_at")
+    if not isinstance(updated_at, str) or not DATE_RE.fullmatch(updated_at):
+        errors.append("updated_at must use YYYY-MM-DD")
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        errors.append("entries must be an array")
+        entries = []
+
+    seen_ids: set[str] = set()
+    for index, entry in enumerate(entries):
+        prefix = f"entries[{index}]"
+        if not isinstance(entry, Mapping):
+            errors.append(f"{prefix} must be an object")
+            continue
+        entry_id = entry.get("id")
+        if not isinstance(entry_id, str) or not SAFE_ENTRY_ID_RE.fullmatch(entry_id):
+            errors.append(f"{prefix}.id must be a lowercase safe identifier")
+        elif entry_id in seen_ids:
+            errors.append(f"{prefix}.id is duplicated: {entry_id}")
+        else:
+            seen_ids.add(entry_id)
+        for field in ("source", "applicable_versions", "updated_at"):
+            if not isinstance(entry.get(field), str) or not entry[field].strip():
+                errors.append(f"{prefix}.{field} must be a non-empty string")
+        entry_date = entry.get("updated_at")
+        if isinstance(entry_date, str) and not DATE_RE.fullmatch(entry_date):
+            errors.append(f"{prefix}.updated_at must use YYYY-MM-DD")
+        if entry.get("status") not in ENTRY_STATUSES:
+            errors.append(
+                f"{prefix}.status must be one of: {', '.join(sorted(ENTRY_STATUSES))}"
+            )
+        if "rule" not in entry or not isinstance(entry["rule"], Mapping):
+            errors.append(f"{prefix}.rule must be an object")
+
+    allowed = {"schema_version", "kind", "updated_at", "entries"}
+    unknown = sorted(set(payload) - allowed)
+    if unknown:
+        errors.append(f"unknown top-level fields: {', '.join(unknown)}")
+    if errors:
+        raise KnowledgeError(f"{path}: " + "; ".join(errors))
+
+
+def validate_knowledge_dir(root: Path) -> list[str]:
+    validated: list[str] = []
+    errors: list[str] = []
+    for filename, kind in KNOWLEDGE_FILES.items():
+        path = root / filename
+        if not path.is_file():
+            errors.append(f"missing knowledge file: {path}")
+            continue
+        try:
+            payload = load_knowledge_file(path)
+            validate_knowledge_document(payload, expected_kind=kind, path=str(path))
+        except KnowledgeError as exc:
+            errors.append(str(exc))
+        else:
+            validated.append(filename)
+    unknown = sorted(
+        path.name for path in root.glob("*.yaml") if path.name not in KNOWLEDGE_FILES
+    )
+    if unknown:
+        errors.append(f"unknown knowledge files: {', '.join(unknown)}")
+    if errors:
+        raise KnowledgeError("\n".join(errors))
+    return validated
+
+
+def generate_candidate_id(payload: Mapping[str, Any]) -> str:
+    owner = str(payload.get("owner_skill", "knowledge")).lower()
+    owner = re.sub(r"[^a-z0-9-]+", "-", owner).strip("-") or "knowledge"
+    summary = str(payload.get("summary", "candidate")).lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", summary).strip("-")[:48] or "candidate"
+    semantic = {
+        "kind": payload.get("kind"),
+        "owner_skill": payload.get("owner_skill"),
+        "scope": payload.get("scope", {}),
+        "fingerprints": sorted(
+            normalize_fingerprint(str(item))
+            for item in payload.get("fingerprints", [])
+        ),
+        "symptom": normalize_fingerprint(str(payload.get("symptom", ""))),
+        "root_cause": normalize_fingerprint(str(payload.get("root_cause", ""))),
+        "applicable_versions": str(payload.get("applicable_versions", "")).strip().lower(),
+    }
+    digest = hashlib.sha256(
+        json.dumps(semantic, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    ).hexdigest()[:10]
+    return f"{owner[:32]}-{slug}-{digest}"[:128].rstrip("-")
+
+
+def normalize_candidate(
+    payload: Mapping[str, Any], *, now: str | None = None
+) -> dict[str, Any]:
+    timestamp = now or utc_now()
+    normalized = deepcopy(dict(payload))
+    if isinstance(normalized.get("fingerprints"), list):
+        normalized["fingerprints"] = list(
+            dict.fromkeys(
+                normalize_fingerprint(item)
+                for item in normalized["fingerprints"]
+                if isinstance(item, str)
+            )
+        )
+    normalized.setdefault("schema_version", CANDIDATE_SCHEMA_VERSION)
+    normalized.setdefault("candidate_id", generate_candidate_id(normalized))
+    normalized.setdefault("avoidance", "")
+    normalized.setdefault("status", "candidate")
+    normalized.setdefault("occurrence_count", 1)
+    normalized.setdefault("source", {})
+    normalized.setdefault("first_seen_at", timestamp)
+    normalized.setdefault("last_seen_at", timestamp)
+    normalized.setdefault("created_at", timestamp)
+    normalized.setdefault("updated_at", timestamp)
+    validate_candidate(normalized)
+    return normalized
+
+
+def validate_candidate(payload: Mapping[str, Any], *, path: str = "candidate") -> None:
+    errors: list[str] = []
+    try:
+        serialized_size = len(
+            json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        )
+    except (TypeError, ValueError):
+        serialized_size = MAX_CANDIDATE_BYTES + 1
+    if serialized_size > MAX_CANDIDATE_BYTES:
+        errors.append(f"candidate must not exceed {MAX_CANDIDATE_BYTES} bytes")
+    if payload.get("schema_version") != CANDIDATE_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {CANDIDATE_SCHEMA_VERSION}")
+    candidate_id = payload.get("candidate_id")
+    if not isinstance(candidate_id, str) or not SAFE_ENTRY_ID_RE.fullmatch(candidate_id):
+        errors.append("candidate_id must be a lowercase safe identifier")
+    if payload.get("kind") not in KNOWLEDGE_KINDS:
+        errors.append(f"kind must be one of: {', '.join(sorted(KNOWLEDGE_KINDS))}")
+    for field in (
+        "summary",
+        "symptom",
+        "root_cause",
+        "resolution",
+        "applicable_versions",
+    ):
+        text = _require_non_empty_string(payload.get(field), field, errors)
+        if len(text) > MAX_NARRATIVE_LENGTH:
+            errors.append(f"{field} must not exceed {MAX_NARRATIVE_LENGTH} characters")
+    avoidance = payload.get("avoidance")
+    if not isinstance(avoidance, str):
+        errors.append("avoidance must be a string")
+    owner_skill = payload.get("owner_skill")
+    if not isinstance(owner_skill, str) or not SAFE_SKILL_RE.fullmatch(owner_skill):
+        errors.append("owner_skill must be a lowercase skill-style identifier")
+    if not isinstance(payload.get("scope"), Mapping):
+        errors.append("scope must be an object")
+    fingerprints = _require_string_array(
+        payload.get("fingerprints"), "fingerprints", errors, non_empty=True
+    )
+    for index, fingerprint in enumerate(fingerprints):
+        if len(fingerprint) > MAX_FINGERPRINT_LENGTH:
+            errors.append(
+                f"fingerprints[{index}] must not exceed {MAX_FINGERPRINT_LENGTH} characters"
+            )
+
+    verification = payload.get("verification")
+    if not isinstance(verification, Mapping):
+        errors.append("verification must be an object")
+    else:
+        unknown = sorted(set(verification) - {"status", "checks"})
+        if unknown:
+            errors.append(f"verification has unknown fields: {', '.join(unknown)}")
+        if verification.get("status") not in VERIFICATION_STATUSES:
+            errors.append(
+                "verification.status must be one of: "
+                + ", ".join(sorted(VERIFICATION_STATUSES))
+            )
+        _require_string_array(
+            verification.get("checks"), "verification.checks", errors, non_empty=True
+        )
+
+    evidence = payload.get("evidence")
+    if not isinstance(evidence, list) or not evidence:
+        errors.append("evidence must contain at least one item")
+        evidence = []
+    for index, item in enumerate(evidence):
+        item_path = f"evidence[{index}]"
+        if not isinstance(item, Mapping):
+            errors.append(f"{item_path} must be an object")
+            continue
+        unknown = sorted(set(item) - {"kind", "uri", "stable", "sha256"})
+        if unknown:
+            errors.append(f"{item_path} has unknown fields: {', '.join(unknown)}")
+        _require_non_empty_string(item.get("kind"), f"{item_path}.kind", errors)
+        uri = _require_non_empty_string(item.get("uri"), f"{item_path}.uri", errors)
+        if uri:
+            _validate_evidence_uri(uri, f"{item_path}.uri", errors)
+        if not isinstance(item.get("stable"), bool):
+            errors.append(f"{item_path}.stable must be a boolean")
+        sha256 = item.get("sha256")
+        if sha256 is not None and (
+            not isinstance(sha256, str) or not SHA256_RE.fullmatch(sha256)
+        ):
+            errors.append(f"{item_path}.sha256 must be 64 lowercase hex characters")
+
+    if payload.get("confidence") not in CANDIDATE_CONFIDENCE:
+        errors.append(
+            "confidence must be one of: " + ", ".join(sorted(CANDIDATE_CONFIDENCE))
+        )
+    if payload.get("status") != "candidate":
+        errors.append("status must be 'candidate'")
+    occurrence_count = payload.get("occurrence_count")
+    if not isinstance(occurrence_count, int) or isinstance(occurrence_count, bool) or occurrence_count < 1:
+        errors.append("occurrence_count must be an integer greater than zero")
+
+    source = payload.get("source")
+    if not isinstance(source, Mapping):
+        errors.append("source must be an object")
+    else:
+        unknown = sorted(set(source) - {"session_id", "run_ids", "commits"})
+        if unknown:
+            errors.append(f"source has unknown fields: {', '.join(unknown)}")
+        session_id = source.get("session_id")
+        if session_id is not None and not isinstance(session_id, str):
+            errors.append("source.session_id must be a string")
+        for field in ("run_ids", "commits"):
+            if field in source:
+                _require_string_array(source[field], f"source.{field}", errors)
+
+    for field in ("first_seen_at", "last_seen_at", "created_at", "updated_at"):
+        value = payload.get(field)
+        if not isinstance(value, str) or not RFC3339_UTC_RE.fullmatch(value):
+            errors.append(f"{field} must be an RFC3339 UTC timestamp ending in Z")
+
+    allowed = {
+        "schema_version",
+        "candidate_id",
+        "kind",
+        "summary",
+        "owner_skill",
+        "scope",
+        "fingerprints",
+        "symptom",
+        "root_cause",
+        "resolution",
+        "avoidance",
+        "applicable_versions",
+        "verification",
+        "evidence",
+        "confidence",
+        "status",
+        "occurrence_count",
+        "source",
+        "first_seen_at",
+        "last_seen_at",
+        "created_at",
+        "updated_at",
+    }
+    unknown = sorted(set(payload) - allowed)
+    if unknown:
+        errors.append(f"unknown top-level fields: {', '.join(unknown)}")
+    missing = sorted(allowed - set(payload))
+    if missing:
+        errors.append(f"missing top-level fields: {', '.join(missing)}")
+    _scan_sensitive(payload, path, errors)
+    if errors:
+        raise KnowledgeError(f"{path}: " + "; ".join(errors))
+
+
+def load_candidate(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise KnowledgeError(f"cannot read candidate {path}: {exc}") from exc
+    if not isinstance(payload, MutableMapping):
+        raise KnowledgeError(f"{path}: candidate root must be an object")
+    validate_candidate(payload, path=str(path))
+    return dict(payload)
+
+
+def _merge_unique(
+    left: Sequence[Any], right: Sequence[Any]
+) -> list[Any]:
+    merged: list[Any] = []
+    seen: set[str] = set()
+    for item in [*left, *right]:
+        key = json.dumps(item, ensure_ascii=False, sort_keys=True)
+        if key not in seen:
+            seen.add(key)
+            merged.append(deepcopy(item))
+    return merged
+
+
+def _formal_candidate_ids(knowledge_dir: Path) -> set[str]:
+    candidate_ids: set[str] = set()
+    for filename in KNOWLEDGE_FILES:
+        document = load_knowledge_file(knowledge_dir / filename)
+        for entry in document.get("entries", []):
+            rule = entry.get("rule", {})
+            if isinstance(rule, Mapping) and isinstance(rule.get("candidate_id"), str):
+                candidate_ids.add(rule["candidate_id"])
+            if isinstance(rule, Mapping) and isinstance(rule.get("candidate_ids"), list):
+                candidate_ids.update(
+                    value for value in rule["candidate_ids"] if isinstance(value, str)
+                )
+    return candidate_ids
+
+
+def capture_candidate(
+    payload: Mapping[str, Any],
+    *,
+    candidate_dir: Path,
+    knowledge_dir: Path,
+    now: str | None = None,
+) -> dict[str, Any]:
+    timestamp = now or utc_now()
+    candidate = normalize_candidate(payload, now=timestamp)
+    candidate_id = candidate["candidate_id"]
+    if candidate_id in _formal_candidate_ids(knowledge_dir):
+        return {
+            "status": "already-promoted",
+            "candidate_id": candidate_id,
+            "path": None,
+        }
+
+    path = candidate_dir / f"{candidate_id}.json"
+    action = "created"
+    if path.exists():
+        existing = load_candidate(path)
+        merged = deepcopy(existing)
+        semantic_changed = False
+        for field in (
+            "summary",
+            "scope",
+            "symptom",
+            "root_cause",
+            "resolution",
+            "avoidance",
+            "applicable_versions",
+            "verification",
+        ):
+            if existing[field] != candidate[field]:
+                semantic_changed = True
+            merged[field] = deepcopy(candidate[field])
+        merged_fingerprints = _merge_unique(
+            existing["fingerprints"], candidate["fingerprints"]
+        )
+        merged_evidence = _merge_unique(existing["evidence"], candidate["evidence"])
+        if merged_fingerprints != existing["fingerprints"]:
+            semantic_changed = True
+        if merged_evidence != existing["evidence"]:
+            semantic_changed = True
+        merged["fingerprints"] = merged_fingerprints
+        merged["evidence"] = merged_evidence
+        new_occurrence = len(merged_evidence) > len(existing["evidence"])
+        for field in ("run_ids", "commits"):
+            merged_values = _merge_unique(
+                existing["source"].get(field, []), candidate["source"].get(field, [])
+            )
+            if len(merged_values) > len(existing["source"].get(field, [])):
+                new_occurrence = True
+                semantic_changed = True
+            merged["source"][field] = merged_values
+        if candidate["source"].get("session_id"):
+            if candidate["source"]["session_id"] != existing["source"].get("session_id"):
+                new_occurrence = True
+                semantic_changed = True
+            merged["source"]["session_id"] = candidate["source"]["session_id"]
+        confidence_order = {"low": 0, "medium": 1, "high": 2}
+        if confidence_order[candidate["confidence"]] > confidence_order[existing["confidence"]]:
+            merged["confidence"] = candidate["confidence"]
+            semantic_changed = True
+        if new_occurrence:
+            merged["occurrence_count"] = existing["occurrence_count"] + 1
+            merged["last_seen_at"] = timestamp
+        if semantic_changed:
+            merged["updated_at"] = timestamp
+        candidate = merged
+        action = "updated" if semantic_changed else "unchanged"
+    validate_candidate(candidate)
+    _write_json_atomic(path, candidate)
+    return {
+        "status": "passed",
+        "action": action,
+        "candidate_id": candidate_id,
+        "path": str(path),
+        "occurrence_count": candidate["occurrence_count"],
+    }
+
+
+def _iter_strings(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, Mapping):
+        for child in value.values():
+            yield from _iter_strings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _iter_strings(child)
+
+
+def _tokens(value: str) -> set[str]:
+    return set(TOKEN_RE.findall(value.lower()))
+
+
+def _entry_score(query: str, entry: Mapping[str, Any]) -> int:
+    query_normalized = normalize_fingerprint(query)
+    query_tokens = _tokens(query)
+    if not query_tokens:
+        return 0
+    rule = entry.get("rule", {})
+    fingerprint_text = normalize_fingerprint(
+        " ".join(str(item) for item in rule.get("fingerprints", []))
+    ) if isinstance(rule, Mapping) else ""
+    score = 0
+    if query_normalized and query_normalized in fingerprint_text:
+        score += 100
+    fingerprint_tokens = _tokens(fingerprint_text)
+    score += 12 * len(query_tokens & fingerprint_tokens)
+    for field in ("summary", "symptom", "root_cause", "resolution"):
+        value = rule.get(field, "") if isinstance(rule, Mapping) else ""
+        score += 4 * len(query_tokens & _tokens(str(value)))
+    general_text = " ".join(_iter_strings(entry))
+    score += len(query_tokens & _tokens(general_text))
+    return score
+
+
+def query_knowledge(
+    *,
+    knowledge_dir: Path,
+    query: str,
+    kinds: Sequence[str] | None = None,
+    limit: int = 3,
+    include_deprecated: bool = False,
+) -> list[dict[str, Any]]:
+    if limit < 1:
+        raise KnowledgeError("limit must be greater than zero")
+    selected = set(kinds or KNOWLEDGE_KINDS)
+    unknown = sorted(selected - KNOWLEDGE_KINDS)
+    if unknown:
+        raise KnowledgeError(f"unknown knowledge kinds: {', '.join(unknown)}")
+    matches: list[dict[str, Any]] = []
+    for filename, kind in KNOWLEDGE_FILES.items():
+        if kind not in selected:
+            continue
+        document = load_knowledge_file(knowledge_dir / filename)
+        validate_knowledge_document(
+            document, expected_kind=kind, path=str(knowledge_dir / filename)
+        )
+        for entry in document["entries"]:
+            if entry["status"] == "deprecated" and not include_deprecated:
+                continue
+            score = _entry_score(query, entry)
+            if score <= 0:
+                continue
+            rule = entry["rule"]
+            summary = str(
+                rule.get("summary")
+                or rule.get("symptom")
+                or entry["id"]
+            )
+            matches.append(
+                {
+                    "id": entry["id"],
+                    "kind": kind,
+                    "status": entry["status"],
+                    "summary": summary,
+                    "applicable_versions": entry["applicable_versions"],
+                    "score": score,
+                    "source_file": filename,
+                }
+            )
+    matches.sort(key=lambda item: (-item["score"], item["kind"], item["id"]))
+    return matches[:limit]
+
+
+def get_knowledge_entry(
+    *, knowledge_dir: Path, entry_id: str
+) -> dict[str, Any] | None:
+    for filename, kind in KNOWLEDGE_FILES.items():
+        document = load_knowledge_file(knowledge_dir / filename)
+        validate_knowledge_document(
+            document, expected_kind=kind, path=str(knowledge_dir / filename)
+        )
+        for entry in document["entries"]:
+            if entry["id"] == entry_id:
+                return {"kind": kind, "source_file": filename, "entry": entry}
+    return None
+
+
+def write_knowledge_document(path: Path, payload: Mapping[str, Any]) -> None:
+    expected_kind = KNOWLEDGE_FILES.get(path.name)
+    if expected_kind is None:
+        raise KnowledgeError(f"unsupported formal knowledge file: {path.name}")
+    validate_knowledge_document(
+        payload, expected_kind=expected_kind, path=str(path)
+    )
+    errors: list[str] = []
+    _scan_sensitive(payload, str(path), errors)
+    if errors:
+        raise KnowledgeError("; ".join(errors))
+    _write_json_atomic(path, payload)

--- a/.agents/lib/vaws_run_manifest.py
+++ b/.agents/lib/vaws_run_manifest.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Shared Run Manifest v1 helpers for workspace domain workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+import uuid
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping, Sequence
+
+SCHEMA_VERSION = 1
+RUN_TYPES = frozenset(
+    {
+        "change-validation",
+        "correctness",
+        "debug",
+        "performance",
+        "profiling",
+    }
+)
+RUN_STATUSES = frozenset(
+    {"planned", "running", "passed", "failed", "inconclusive", "cancelled"}
+)
+TERMINAL_STATUSES = frozenset({"passed", "failed", "inconclusive", "cancelled"})
+STATUS_TRANSITIONS = {
+    "planned": frozenset({"running", "cancelled"}),
+    "running": frozenset({"passed", "failed", "inconclusive", "cancelled"}),
+    "passed": frozenset(),
+    "failed": frozenset(),
+    "inconclusive": frozenset(),
+    "cancelled": frozenset(),
+}
+SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
+SECRET_ENV_RE = re.compile(
+    r"(?:^|_)(?:API_?KEY|ACCESS_?KEY|AUTH|CREDENTIAL|PASS(?:WORD)?|SECRET|TOKEN)(?:_|$)",
+    re.IGNORECASE,
+)
+
+
+class RunManifestError(ValueError):
+    """Raised when a manifest violates the v1 contract."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def generate_run_id(run_type: str, *, now: str | None = None) -> str:
+    if run_type not in RUN_TYPES:
+        raise RunManifestError(f"unsupported run_type: {run_type!r}")
+    timestamp = (now or utc_now()).replace("-", "").replace(":", "")
+    timestamp = timestamp.replace("T", "-").replace("Z", "").split(".", 1)[0]
+    return f"{run_type}-{timestamp}-{uuid.uuid4().hex[:8]}"
+
+
+def new_manifest(
+    *,
+    run_type: str,
+    run_id: str | None = None,
+    parent_run_id: str | None = None,
+    workspace_snapshot: Mapping[str, Any] | None = None,
+    environment: Mapping[str, Any] | None = None,
+    model: Mapping[str, Any] | None = None,
+    topology: Mapping[str, Any] | None = None,
+    command: Sequence[str] | None = None,
+    environment_variables: Mapping[str, str] | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    timestamp = created_at or utc_now()
+    manifest: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id or generate_run_id(run_type, now=timestamp),
+        "parent_run_id": parent_run_id,
+        "run_type": run_type,
+        "workspace_snapshot": dict(workspace_snapshot or {}),
+        "environment": dict(environment or {}),
+        "model": dict(model or {}),
+        "topology": dict(topology or {}),
+        "command": list(command or []),
+        "environment_variables": dict(environment_variables or {}),
+        "artifacts": [],
+        "status": "planned",
+        "created_at": timestamp,
+        "updated_at": timestamp,
+    }
+    validate_manifest(manifest)
+    return manifest
+
+
+def _require_mapping(value: Any, path: str, errors: list[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        errors.append(f"{path} must be an object")
+        return {}
+    return value
+
+
+def _validate_safe_id(value: Any, path: str, errors: list[str], *, nullable: bool = False) -> None:
+    if value is None and nullable:
+        return
+    if not isinstance(value, str) or not SAFE_ID_RE.fullmatch(value):
+        errors.append(f"{path} must match {SAFE_ID_RE.pattern}")
+
+
+def _validate_artifacts(value: Any, errors: list[str]) -> None:
+    if not isinstance(value, list):
+        errors.append("artifacts must be an array")
+        return
+    names: set[str] = set()
+    for index, artifact in enumerate(value):
+        item = _require_mapping(artifact, f"artifacts[{index}]", errors)
+        for field in ("name", "kind", "uri"):
+            if not isinstance(item.get(field), str) or not item[field].strip():
+                errors.append(f"artifacts[{index}].{field} must be a non-empty string")
+        name = item.get("name")
+        if isinstance(name, str):
+            if name in names:
+                errors.append(f"artifact name is duplicated: {name!r}")
+            names.add(name)
+        sha256 = item.get("sha256")
+        if sha256 is not None and (
+            not isinstance(sha256, str) or not SHA256_RE.fullmatch(sha256)
+        ):
+            errors.append(f"artifacts[{index}].sha256 must be 64 lowercase hex characters")
+
+
+def validate_manifest(manifest: Mapping[str, Any]) -> None:
+    errors: list[str] = []
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    _validate_safe_id(manifest.get("run_id"), "run_id", errors)
+    _validate_safe_id(manifest.get("parent_run_id"), "parent_run_id", errors, nullable=True)
+
+    run_type = manifest.get("run_type")
+    if run_type not in RUN_TYPES:
+        errors.append(f"run_type must be one of: {', '.join(sorted(RUN_TYPES))}")
+    status = manifest.get("status")
+    if status not in RUN_STATUSES:
+        errors.append(f"status must be one of: {', '.join(sorted(RUN_STATUSES))}")
+
+    for field in ("workspace_snapshot", "environment", "model", "topology"):
+        _require_mapping(manifest.get(field), field, errors)
+
+    command = manifest.get("command")
+    if not isinstance(command, list) or any(not isinstance(part, str) for part in command):
+        errors.append("command must be an array of strings")
+
+    env = _require_mapping(manifest.get("environment_variables"), "environment_variables", errors)
+    for key, value in env.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            errors.append("environment_variables keys and values must be strings")
+            continue
+        if SECRET_ENV_RE.search(key):
+            errors.append(f"environment_variables must not contain secret-like key: {key}")
+
+    _validate_artifacts(manifest.get("artifacts"), errors)
+
+    for field in ("created_at", "updated_at"):
+        timestamp = manifest.get(field)
+        if not isinstance(timestamp, str) or not RFC3339_UTC_RE.fullmatch(timestamp):
+            errors.append(f"{field} must be an RFC3339 UTC timestamp ending in Z")
+
+    allowed = {
+        "schema_version",
+        "run_id",
+        "parent_run_id",
+        "run_type",
+        "workspace_snapshot",
+        "environment",
+        "model",
+        "topology",
+        "command",
+        "environment_variables",
+        "artifacts",
+        "status",
+        "created_at",
+        "updated_at",
+    }
+    unknown = sorted(set(manifest) - allowed)
+    if unknown:
+        errors.append(f"unknown top-level fields: {', '.join(unknown)}")
+    missing = sorted(allowed - set(manifest))
+    if missing:
+        errors.append(f"missing top-level fields: {', '.join(missing)}")
+
+    if errors:
+        raise RunManifestError("; ".join(errors))
+
+
+def transition_status(
+    manifest: Mapping[str, Any], status: str, *, updated_at: str | None = None
+) -> dict[str, Any]:
+    validate_manifest(manifest)
+    current = manifest["status"]
+    if status not in STATUS_TRANSITIONS[current]:
+        raise RunManifestError(f"invalid status transition: {current} -> {status}")
+    updated = deepcopy(dict(manifest))
+    updated["status"] = status
+    updated["updated_at"] = updated_at or utc_now()
+    validate_manifest(updated)
+    return updated
+
+
+def add_artifact(
+    manifest: Mapping[str, Any],
+    *,
+    name: str,
+    kind: str,
+    uri: str,
+    sha256: str | None = None,
+    updated_at: str | None = None,
+) -> dict[str, Any]:
+    validate_manifest(manifest)
+    artifact = {"name": name, "kind": kind, "uri": uri}
+    if sha256 is not None:
+        artifact["sha256"] = sha256
+    updated = deepcopy(dict(manifest))
+    updated["artifacts"].append(artifact)
+    updated["updated_at"] = updated_at or utc_now()
+    validate_manifest(updated)
+    return updated
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunManifestError(f"cannot read manifest {path}: {exc}") from exc
+    if not isinstance(payload, MutableMapping):
+        raise RunManifestError("manifest root must be an object")
+    validate_manifest(payload)
+    return dict(payload)
+
+
+def write_manifest(path: Path, manifest: Mapping[str, Any]) -> None:
+    validate_manifest(manifest)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(manifest, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()

--- a/.agents/schemas/knowledge-candidate-v1.schema.json
+++ b/.agents/schemas/knowledge-candidate-v1.schema.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vllm-ascend-workspace.local/schemas/knowledge-candidate-v1.schema.json",
+  "title": "vLLM Ascend Workspace Knowledge Candidate v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "candidate_id",
+    "kind",
+    "summary",
+    "owner_skill",
+    "scope",
+    "fingerprints",
+    "symptom",
+    "root_cause",
+    "resolution",
+    "avoidance",
+    "applicable_versions",
+    "verification",
+    "evidence",
+    "confidence",
+    "status",
+    "occurrence_count",
+    "source",
+    "first_seen_at",
+    "last_seen_at",
+    "created_at",
+    "updated_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "candidate_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+    },
+    "kind": {
+      "enum": [
+        "version-compatibility",
+        "model-capabilities",
+        "parallelism-compatibility",
+        "backend-constraints",
+        "validation-rules",
+        "known-failure-signatures"
+      ]
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "owner_skill": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{0,127}$"
+    },
+    "scope": {
+      "type": "object"
+    },
+    "fingerprints": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "symptom": {
+      "type": "string",
+      "minLength": 1
+    },
+    "root_cause": {
+      "type": "string",
+      "minLength": 1
+    },
+    "resolution": {
+      "type": "string",
+      "minLength": 1
+    },
+    "avoidance": {
+      "type": "string"
+    },
+    "applicable_versions": {
+      "type": "string",
+      "minLength": 1
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "checks"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "passed",
+            "inconclusive"
+          ]
+        },
+        "checks": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "uri",
+          "stable"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uri": {
+            "type": "string",
+            "minLength": 1
+          },
+          "stable": {
+            "type": "boolean"
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    },
+    "confidence": {
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "status": {
+      "const": "candidate"
+    },
+    "occurrence_count": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "session_id": {
+          "type": "string"
+        },
+        "run_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "commits": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "first_seen_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "last_seen_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/.agents/schemas/knowledge-v1.schema.json
+++ b/.agents/schemas/knowledge-v1.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vllm-ascend-workspace.local/schemas/knowledge-v1.schema.json",
+  "title": "vLLM Ascend Workspace Knowledge Document v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "kind",
+    "updated_at",
+    "entries"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "kind": {
+      "type": "string",
+      "minLength": 1
+    },
+    "updated_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "source",
+          "applicable_versions",
+          "updated_at",
+          "status",
+          "rule"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1
+          },
+          "applicable_versions": {
+            "type": "string",
+            "minLength": 1
+          },
+          "updated_at": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+          },
+          "status": {
+            "enum": [
+              "active",
+              "deprecated",
+              "experimental"
+            ]
+          },
+          "rule": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.agents/schemas/run-manifest-v1.schema.json
+++ b/.agents/schemas/run-manifest-v1.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vllm-ascend-workspace.local/schemas/run-manifest-v1.schema.json",
+  "title": "vLLM Ascend Workspace Run Manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "parent_run_id",
+    "run_type",
+    "workspace_snapshot",
+    "environment",
+    "model",
+    "topology",
+    "command",
+    "environment_variables",
+    "artifacts",
+    "status",
+    "created_at",
+    "updated_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "run_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+    },
+    "parent_run_id": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+        }
+      ]
+    },
+    "run_type": {
+      "enum": [
+        "change-validation",
+        "correctness",
+        "debug",
+        "performance",
+        "profiling"
+      ]
+    },
+    "workspace_snapshot": {
+      "type": "object"
+    },
+    "environment": {
+      "type": "object"
+    },
+    "model": {
+      "type": "object"
+    },
+    "topology": {
+      "type": "object"
+    },
+    "command": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "environment_variables": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "kind",
+          "uri"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "kind": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uri": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    },
+    "status": {
+      "enum": [
+        "planned",
+        "running",
+        "passed",
+        "failed",
+        "inconclusive",
+        "cancelled"
+      ]
+    },
+    "created_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+    },
+    "updated_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+    }
+  }
+}

--- a/.agents/scripts/knowledge_capture.py
+++ b/.agents/scripts/knowledge_capture.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Capture or merge one verified workspace knowledge candidate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_knowledge import (  # noqa: E402
+    KnowledgeError,
+    capture_candidate,
+    knowledge_session_key,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument(
+        "--defer",
+        action="store_true",
+        help="stage the candidate for the current SessionEnd hook",
+    )
+    parser.add_argument(
+        "--session-id",
+        help="session identity for --defer; defaults to CODEX_THREAD_ID or source.session_id",
+    )
+    parser.add_argument(
+        "--candidate-dir",
+        type=Path,
+        default=ROOT / ".vaws-local" / "knowledge" / "candidates",
+    )
+    parser.add_argument(
+        "--pending-dir",
+        type=Path,
+        default=ROOT / ".vaws-local" / "knowledge" / "pending",
+    )
+    parser.add_argument(
+        "--knowledge-dir",
+        type=Path,
+        default=ROOT / ".agents" / "knowledge",
+    )
+    args = parser.parse_args(argv)
+    try:
+        payload = json.loads(args.input.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise KnowledgeError("input root must be an object")
+        candidate_dir = args.candidate_dir
+        if args.defer:
+            source = payload.setdefault("source", {})
+            if not isinstance(source, dict):
+                raise KnowledgeError("source must be an object")
+            session_id = (
+                args.session_id
+                or os.environ.get("CODEX_THREAD_ID")
+                or source.get("session_id")
+            )
+            if not session_id:
+                raise KnowledgeError(
+                    "--defer requires --session-id, CODEX_THREAD_ID, or source.session_id"
+                )
+            source["session_id"] = session_id
+            candidate_dir = args.pending_dir / knowledge_session_key(session_id)
+        result = capture_candidate(
+            payload,
+            candidate_dir=candidate_dir,
+            knowledge_dir=args.knowledge_dir,
+        )
+        if args.defer and result["status"] != "already-promoted":
+            result["deferred"] = True
+            result["session_key"] = knowledge_session_key(source["session_id"])
+    except (OSError, json.JSONDecodeError, KnowledgeError) as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}))
+        return 1
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_query.py
+++ b/.agents/scripts/knowledge_query.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Query compact workspace knowledge summaries or fetch one entry by id."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_knowledge import (  # noqa: E402
+    KnowledgeError,
+    get_knowledge_entry,
+    query_knowledge,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--query")
+    mode.add_argument("--id")
+    parser.add_argument("--kind", action="append", dest="kinds")
+    parser.add_argument("--limit", type=int, default=3)
+    parser.add_argument("--include-deprecated", action="store_true")
+    parser.add_argument(
+        "--knowledge-dir",
+        type=Path,
+        default=ROOT / ".agents" / "knowledge",
+    )
+    args = parser.parse_args(argv)
+    try:
+        if args.id:
+            result = get_knowledge_entry(
+                knowledge_dir=args.knowledge_dir, entry_id=args.id
+            )
+            payload = {
+                "status": "passed" if result else "not-found",
+                "id": args.id,
+                "result": result,
+            }
+        else:
+            matches = query_knowledge(
+                knowledge_dir=args.knowledge_dir,
+                query=args.query,
+                kinds=args.kinds,
+                limit=args.limit,
+                include_deprecated=args.include_deprecated,
+            )
+            payload = {
+                "status": "passed",
+                "query": args.query,
+                "matches": matches,
+            }
+    except KnowledgeError as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_validate.py
+++ b/.agents/scripts/knowledge_validate.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Validate all shared workspace knowledge documents."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_knowledge import KnowledgeError, validate_knowledge_dir  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--knowledge-dir",
+        type=Path,
+        default=ROOT / ".agents" / "knowledge",
+    )
+    args = parser.parse_args(argv)
+    try:
+        files = validate_knowledge_dir(args.knowledge_dir)
+    except KnowledgeError as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}))
+        return 1
+    print(
+        json.dumps(
+            {
+                "status": "passed",
+                "knowledge_dir": str(args.knowledge_dir.resolve()),
+                "files": files,
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/run_manifest.py
+++ b/.agents/scripts/run_manifest.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Create and validate workspace Run Manifest v1 files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_run_manifest import (  # noqa: E402
+    RUN_TYPES,
+    RunManifestError,
+    load_manifest,
+    new_manifest,
+    write_manifest,
+)
+
+
+def _json_object(raw: str, label: str) -> dict:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise argparse.ArgumentTypeError(f"{label} must be valid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise argparse.ArgumentTypeError(f"{label} must be a JSON object")
+    return value
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+
+    init = subparsers.add_parser("init", help="create a planned manifest")
+    init.add_argument("--run-type", required=True, choices=sorted(RUN_TYPES))
+    init.add_argument("--run-id")
+    init.add_argument("--parent-run-id")
+    init.add_argument("--output", required=True, type=Path)
+    init.add_argument("--workspace-snapshot", default="{}")
+    init.add_argument("--environment", default="{}")
+    init.add_argument("--model", default="{}")
+    init.add_argument("--topology", default="{}")
+    init.add_argument("--command", action="append", default=[])
+    init.add_argument("--env", action="append", default=[], metavar="NAME=VALUE")
+
+    validate = subparsers.add_parser("validate", help="validate an existing manifest")
+    validate.add_argument("manifest", type=Path)
+    return parser
+
+
+def _parse_env(items: list[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for item in items:
+        if "=" not in item:
+            raise RunManifestError(f"environment item must use NAME=VALUE: {item!r}")
+        key, value = item.split("=", 1)
+        result[key] = value
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.action == "init":
+            manifest = new_manifest(
+                run_type=args.run_type,
+                run_id=args.run_id,
+                parent_run_id=args.parent_run_id,
+                workspace_snapshot=_json_object(
+                    args.workspace_snapshot, "workspace-snapshot"
+                ),
+                environment=_json_object(args.environment, "environment"),
+                model=_json_object(args.model, "model"),
+                topology=_json_object(args.topology, "topology"),
+                command=args.command,
+                environment_variables=_parse_env(args.env),
+            )
+            write_manifest(args.output, manifest)
+            payload = {
+                "status": "created",
+                "manifest": str(args.output.resolve()),
+                "run_id": manifest["run_id"],
+                "run_type": manifest["run_type"],
+            }
+        else:
+            manifest = load_manifest(args.manifest)
+            payload = {
+                "status": "passed",
+                "manifest": str(args.manifest.resolve()),
+                "run_id": manifest["run_id"],
+                "run_type": manifest["run_type"],
+                "run_status": manifest["status"],
+            }
+    except (RunManifestError, argparse.ArgumentTypeError) as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}), file=sys.stdout)
+        return 1
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/curate-workspace-knowledge/SKILL.md
+++ b/.agents/skills/curate-workspace-knowledge/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: curate-workspace-knowledge
+description: Review, deduplicate, promote, merge, reject, or deprecate verified vLLM Ascend workspace knowledge candidates. Use only when the user explicitly asks to curate, persist, review, merge, promote, or deprecate project knowledge (沉淀、整理、复盘、合并、提升、废弃), or explicitly invokes this Skill to review `.vaws-local/knowledge/candidates`. Do not use during normal diagnosis, serving, benchmarking, profiling, remote execution, code review, or candidate capture/query; those workflows call the shared scripts directly without loading this Skill.
+---
+
+# Curate Workspace Knowledge
+
+Keep `.agents/knowledge/` as the only formal project knowledge source. Treat
+`.vaws-local/knowledge/candidates/` as an untracked review queue, never as a
+second authoritative store.
+
+## Workflow
+
+1. Run `scripts/knowledge_curate.py list`.
+2. Inspect one candidate and its possible formal matches.
+3. Check that the root cause is confirmed, the original symptom was rerun, and
+   at least one stable test, commit, issue, or PR evidence item exists.
+4. Choose exactly one disposition:
+   - `promote` a novel candidate;
+   - `merge` it into an existing entry with the same cause and scope;
+   - `reject` an unsupported, transient, secret-bearing, or duplicate candidate;
+   - `deprecate` a stale formal entry.
+5. Run `.agents/scripts/knowledge_validate.py` and the owning Skill's tests.
+6. Commit the formal knowledge change together with any regression protection.
+
+## Entry point
+
+`scripts/knowledge_curate.py` provides:
+
+- `list`: return compact candidate summaries;
+- `inspect`: return one full candidate plus possible formal matches;
+- `promote`: create one `experimental` or `active` formal entry;
+- `merge`: merge evidence and occurrences into an existing formal entry;
+- `reject`: archive a candidate locally without changing formal knowledge;
+- `deprecate`: retain a formal entry while marking it obsolete.
+
+Read only the reference needed for the active operation:
+
+- [Behavior contract](references/behavior.md)
+- [Command recipes](references/command-recipes.md)
+- [Acceptance](references/acceptance.md)
+
+## Rules
+
+- Never parse or persist a full transcript.
+- Never promote `inconclusive` verification.
+- Never promote knowledge supported only by untracked or unstable evidence.
+- Require a regression test or two verified occurrences before `active`.
+- Prefer `merge` over a new entry when cause and applicability match.
+- Use `--force-new` only after reviewing an identical fingerprint with a
+  different confirmed cause.
+- Keep deterministic behavior in the owning Skill's scripts and tests; store
+  only the cross-session explanation, scope, fingerprints, and evidence here.
+- Do not copy upstream model-adapter lessons or profiler-local counterexamples
+  into workspace knowledge unless the new record adds workspace-specific scope
+  and references the upstream source.

--- a/.agents/skills/curate-workspace-knowledge/agents/openai.yaml
+++ b/.agents/skills/curate-workspace-knowledge/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Curate Workspace Knowledge"
+  short_description: "Review and promote verified workspace knowledge"
+  default_prompt: "Use $curate-workspace-knowledge to review, deduplicate, and promote verified knowledge candidates."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/curate-workspace-knowledge/references/acceptance.md
+++ b/.agents/skills/curate-workspace-knowledge/references/acceptance.md
@@ -1,0 +1,13 @@
+# Acceptance
+
+- [ ] The Skill is not implicitly invoked.
+- [ ] Normal domain workflows can capture/query without loading this Skill.
+- [ ] Formal writes target only one existing `.agents/knowledge/*.yaml` file.
+- [ ] Inconclusive or unstable-only candidates cannot be promoted.
+- [ ] Active promotion requires repeat evidence or a regression test.
+- [ ] Exact fingerprint matches require merge or explicit `--force-new`.
+- [ ] Promotion and merge archive the candidate only after formal validation.
+- [ ] Rejection does not modify formal knowledge.
+- [ ] Deprecation retains the entry and records reason/replacement.
+- [ ] stdout contains one final JSON document.
+- [ ] Shared knowledge validation and owning Skill tests pass.

--- a/.agents/skills/curate-workspace-knowledge/references/behavior.md
+++ b/.agents/skills/curate-workspace-knowledge/references/behavior.md
@@ -1,0 +1,51 @@
+# Behavior contract
+
+## Source boundaries
+
+- `.agents/knowledge/` is the only formal, tracked project knowledge source.
+- `.vaws-local/knowledge/candidates/` is an untracked review queue.
+- `.vaws-local/knowledge/reviewed/` is an untracked disposition audit.
+- Codex local Memories remain personal generated state and never override formal
+  workspace knowledge.
+
+## Promotion gates
+
+An `experimental` entry requires:
+
+- verification status `passed`;
+- a confirmed root cause and resolution;
+- at least one stable evidence item;
+- no unresolved exact-fingerprint duplicate.
+
+An `active` entry additionally requires either:
+
+- two verified occurrences; or
+- stable `test`, `regression-test`, or `acceptance-test` evidence.
+
+Use `merge` when cause and applicability match. Use `--force-new` only after
+confirming that an identical fingerprint has a different cause.
+
+## Formal entry mapping
+
+Promotion keeps the existing formal v1 envelope:
+
+```text
+id
+source
+applicable_versions
+updated_at
+status
+rule
+```
+
+The structured candidate fields live inside `rule`, including candidate ids,
+scope, fingerprints, cause, resolution, verification, evidence, confidence,
+occurrences, and verification dates.
+
+## Failure behavior
+
+- Validate before writing.
+- Write formal documents and review archives atomically.
+- Archive a candidate only after the formal write succeeds.
+- Return one JSON document on stdout.
+- Return validation failures as JSON with a nonzero exit status.

--- a/.agents/skills/curate-workspace-knowledge/references/command-recipes.md
+++ b/.agents/skills/curate-workspace-knowledge/references/command-recipes.md
@@ -1,0 +1,44 @@
+# Command recipes
+
+List compact candidates:
+
+```bash
+python3 .agents/skills/curate-workspace-knowledge/scripts/knowledge_curate.py list
+```
+
+Inspect one candidate and possible matches:
+
+```bash
+python3 .agents/skills/curate-workspace-knowledge/scripts/knowledge_curate.py \
+  inspect --candidate-id <candidate-id>
+```
+
+Promote a novel candidate:
+
+```bash
+python3 .agents/skills/curate-workspace-knowledge/scripts/knowledge_curate.py \
+  promote --candidate-id <candidate-id> --entry-id <formal-id> \
+  --status experimental
+```
+
+Merge a matching candidate:
+
+```bash
+python3 .agents/skills/curate-workspace-knowledge/scripts/knowledge_curate.py \
+  merge --candidate-id <candidate-id> --entry-id <formal-id>
+```
+
+Reject a candidate:
+
+```bash
+python3 .agents/skills/curate-workspace-knowledge/scripts/knowledge_curate.py \
+  reject --candidate-id <candidate-id> --reason "<reason>"
+```
+
+Deprecate a formal entry without deleting history:
+
+```bash
+python3 .agents/skills/curate-workspace-knowledge/scripts/knowledge_curate.py \
+  deprecate --entry-id <formal-id> --superseded-by <replacement-id> \
+  --reason "<reason>"
+```

--- a/.agents/skills/curate-workspace-knowledge/scripts/knowledge_curate.py
+++ b/.agents/skills/curate-workspace-knowledge/scripts/knowledge_curate.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""Review and curate verified workspace knowledge candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_knowledge import (  # noqa: E402
+    KNOWLEDGE_FILES,
+    KnowledgeError,
+    get_knowledge_entry,
+    load_candidate,
+    load_knowledge_file,
+    normalize_fingerprint,
+    query_knowledge,
+    validate_knowledge_document,
+    write_knowledge_document,
+)
+
+SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+ACTIVE_EVIDENCE_KINDS = frozenset(
+    {"test", "regression-test", "acceptance-test"}
+)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def today(now: str | None = None) -> str:
+    return (now or utc_now())[:10]
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _candidate_path(candidate_dir: Path, candidate_id: str) -> Path:
+    if not SAFE_ID_RE.fullmatch(candidate_id):
+        raise KnowledgeError("candidate id must be a lowercase safe identifier")
+    return candidate_dir / f"{candidate_id}.json"
+
+
+def list_candidates(candidate_dir: Path) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    if not candidate_dir.exists():
+        return results
+    for path in sorted(candidate_dir.glob("*.json")):
+        candidate = load_candidate(path)
+        results.append(
+            {
+                "candidate_id": candidate["candidate_id"],
+                "kind": candidate["kind"],
+                "summary": candidate["summary"],
+                "owner_skill": candidate["owner_skill"],
+                "confidence": candidate["confidence"],
+                "verification_status": candidate["verification"]["status"],
+                "occurrence_count": candidate["occurrence_count"],
+                "updated_at": candidate["updated_at"],
+            }
+        )
+    return results
+
+
+def possible_matches(
+    candidate: Mapping[str, Any], knowledge_dir: Path, *, limit: int = 3
+) -> list[dict[str, Any]]:
+    query = " ".join(
+        [
+            *candidate["fingerprints"],
+            candidate["summary"],
+            candidate["root_cause"],
+        ]
+    )
+    return query_knowledge(
+        knowledge_dir=knowledge_dir,
+        query=query,
+        kinds=[candidate["kind"]],
+        limit=limit,
+        include_deprecated=True,
+    )
+
+
+def inspect_candidate(
+    candidate_id: str, *, candidate_dir: Path, knowledge_dir: Path
+) -> dict[str, Any]:
+    candidate = load_candidate(_candidate_path(candidate_dir, candidate_id))
+    return {
+        "candidate": candidate,
+        "possible_matches": possible_matches(candidate, knowledge_dir),
+    }
+
+
+def _stable_evidence(candidate: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [item for item in candidate["evidence"] if item["stable"]]
+
+
+def _check_promotion_gate(
+    candidate: Mapping[str, Any], status: str
+) -> None:
+    if status not in {"experimental", "active"}:
+        raise KnowledgeError("promotion status must be experimental or active")
+    if candidate["verification"]["status"] != "passed":
+        raise KnowledgeError("inconclusive candidates cannot be promoted")
+    stable = _stable_evidence(candidate)
+    if not stable:
+        raise KnowledgeError("promotion requires at least one stable evidence item")
+    if status == "active":
+        has_regression = any(
+            item["kind"].lower() in ACTIVE_EVIDENCE_KINDS for item in stable
+        )
+        if candidate["occurrence_count"] < 2 and not has_regression:
+            raise KnowledgeError(
+                "active promotion requires two occurrences or stable regression-test evidence"
+            )
+
+
+def _entry_fingerprints(entry: Mapping[str, Any]) -> set[str]:
+    rule = entry.get("rule", {})
+    if not isinstance(rule, Mapping):
+        return set()
+    values = rule.get("fingerprints", [])
+    if not isinstance(values, list):
+        return set()
+    return {
+        normalize_fingerprint(value)
+        for value in values
+        if isinstance(value, str)
+    }
+
+
+def _duplicate_fingerprint_entries(
+    candidate: Mapping[str, Any], document: Mapping[str, Any]
+) -> list[str]:
+    candidate_fingerprints = set(candidate["fingerprints"])
+    return [
+        entry["id"]
+        for entry in document["entries"]
+        if candidate_fingerprints & _entry_fingerprints(entry)
+        and entry["status"] != "deprecated"
+    ]
+
+
+def _candidate_rule(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "candidate_id": candidate["candidate_id"],
+        "candidate_ids": [candidate["candidate_id"]],
+        "summary": candidate["summary"],
+        "owner_skill": candidate["owner_skill"],
+        "scope": deepcopy(candidate["scope"]),
+        "fingerprints": list(candidate["fingerprints"]),
+        "symptom": candidate["symptom"],
+        "root_cause": candidate["root_cause"],
+        "resolution": candidate["resolution"],
+        "avoidance": candidate["avoidance"],
+        "verification": deepcopy(candidate["verification"]),
+        "evidence": deepcopy(candidate["evidence"]),
+        "confidence": candidate["confidence"],
+        "occurrence_count": candidate["occurrence_count"],
+        "first_seen_at": candidate["first_seen_at"],
+        "last_verified_at": candidate["last_seen_at"],
+    }
+
+
+def _archive_candidate(
+    candidate: Mapping[str, Any],
+    *,
+    candidate_path: Path,
+    reviewed_dir: Path,
+    disposition: str,
+    entry_id: str | None,
+    reason: str | None,
+    now: str,
+) -> Path:
+    archive_path = reviewed_dir / f"{candidate['candidate_id']}.json"
+    archive = {
+        "schema_version": 1,
+        "candidate_id": candidate["candidate_id"],
+        "disposition": disposition,
+        "entry_id": entry_id,
+        "reason": reason,
+        "reviewed_at": now,
+        "candidate": deepcopy(candidate),
+    }
+    _write_json_atomic(archive_path, archive)
+    candidate_path.unlink()
+    return archive_path
+
+
+def promote_candidate(
+    candidate_id: str,
+    *,
+    entry_id: str | None,
+    status: str,
+    force_new: bool,
+    candidate_dir: Path,
+    reviewed_dir: Path,
+    knowledge_dir: Path,
+    now: str | None = None,
+) -> dict[str, Any]:
+    timestamp = now or utc_now()
+    candidate_path = _candidate_path(candidate_dir, candidate_id)
+    candidate = load_candidate(candidate_path)
+    _check_promotion_gate(candidate, status)
+    formal_id = entry_id or candidate["candidate_id"]
+    if not SAFE_ID_RE.fullmatch(formal_id):
+        raise KnowledgeError("entry id must be a lowercase safe identifier")
+    filename = next(
+        name for name, kind in KNOWLEDGE_FILES.items() if kind == candidate["kind"]
+    )
+    knowledge_path = knowledge_dir / filename
+    document = load_knowledge_file(knowledge_path)
+    validate_knowledge_document(
+        document, expected_kind=candidate["kind"], path=str(knowledge_path)
+    )
+    if any(entry["id"] == formal_id for entry in document["entries"]):
+        raise KnowledgeError(f"formal entry already exists: {formal_id}")
+    duplicates = _duplicate_fingerprint_entries(candidate, document)
+    if duplicates and not force_new:
+        raise KnowledgeError(
+            "matching formal fingerprints already exist; use merge or --force-new: "
+            + ", ".join(duplicates)
+        )
+    stable_uris = [item["uri"] for item in _stable_evidence(candidate)]
+    document["entries"].append(
+        {
+            "id": formal_id,
+            "source": (
+                f"promoted from candidate {candidate_id}; stable evidence: "
+                + ", ".join(stable_uris)
+            ),
+            "applicable_versions": candidate["applicable_versions"],
+            "updated_at": today(timestamp),
+            "status": status,
+            "rule": _candidate_rule(candidate),
+        }
+    )
+    document["entries"].sort(key=lambda entry: entry["id"])
+    document["updated_at"] = today(timestamp)
+    write_knowledge_document(knowledge_path, document)
+    archive_path = _archive_candidate(
+        candidate,
+        candidate_path=candidate_path,
+        reviewed_dir=reviewed_dir,
+        disposition="promoted",
+        entry_id=formal_id,
+        reason=None,
+        now=timestamp,
+    )
+    return {
+        "status": "passed",
+        "action": "promoted",
+        "candidate_id": candidate_id,
+        "entry_id": formal_id,
+        "entry_status": status,
+        "knowledge_path": str(knowledge_path),
+        "archive_path": str(archive_path),
+    }
+
+
+def _unique_values(left: Sequence[Any], right: Sequence[Any]) -> list[Any]:
+    result: list[Any] = []
+    seen: set[str] = set()
+    for item in [*left, *right]:
+        key = json.dumps(item, ensure_ascii=False, sort_keys=True)
+        if key not in seen:
+            seen.add(key)
+            result.append(deepcopy(item))
+    return result
+
+
+def merge_candidate(
+    candidate_id: str,
+    *,
+    entry_id: str,
+    candidate_dir: Path,
+    reviewed_dir: Path,
+    knowledge_dir: Path,
+    now: str | None = None,
+) -> dict[str, Any]:
+    timestamp = now or utc_now()
+    candidate_path = _candidate_path(candidate_dir, candidate_id)
+    candidate = load_candidate(candidate_path)
+    _check_promotion_gate(candidate, "experimental")
+    found = get_knowledge_entry(knowledge_dir=knowledge_dir, entry_id=entry_id)
+    if found is None:
+        raise KnowledgeError(f"formal entry does not exist: {entry_id}")
+    if found["kind"] != candidate["kind"]:
+        raise KnowledgeError("candidate and formal entry kinds do not match")
+    knowledge_path = knowledge_dir / found["source_file"]
+    document = load_knowledge_file(knowledge_path)
+    target = next(entry for entry in document["entries"] if entry["id"] == entry_id)
+    rule = target["rule"]
+    if not isinstance(rule, dict):
+        raise KnowledgeError("formal entry rule must be an object")
+    candidate_rule = _candidate_rule(candidate)
+    for field in (
+        "summary",
+        "owner_skill",
+        "scope",
+        "symptom",
+        "root_cause",
+        "resolution",
+        "avoidance",
+        "verification",
+        "confidence",
+        "last_verified_at",
+    ):
+        rule[field] = deepcopy(candidate_rule[field])
+    rule["candidate_ids"] = _unique_values(
+        rule.get("candidate_ids", [rule.get("candidate_id")]),
+        [candidate_id],
+    )
+    rule["candidate_ids"] = [
+        value for value in rule["candidate_ids"] if isinstance(value, str)
+    ]
+    rule.setdefault("candidate_id", rule["candidate_ids"][0])
+    rule["fingerprints"] = _unique_values(
+        rule.get("fingerprints", []), candidate_rule["fingerprints"]
+    )
+    rule["evidence"] = _unique_values(
+        rule.get("evidence", []), candidate_rule["evidence"]
+    )
+    rule["occurrence_count"] = int(rule.get("occurrence_count", 1)) + candidate[
+        "occurrence_count"
+    ]
+    rule.setdefault("first_seen_at", candidate["first_seen_at"])
+    target["applicable_versions"] = candidate["applicable_versions"]
+    target["updated_at"] = today(timestamp)
+    target["source"] = (
+        target["source"] + f"; merged candidate {candidate_id}"
+    )
+    document["updated_at"] = today(timestamp)
+    write_knowledge_document(knowledge_path, document)
+    archive_path = _archive_candidate(
+        candidate,
+        candidate_path=candidate_path,
+        reviewed_dir=reviewed_dir,
+        disposition="merged",
+        entry_id=entry_id,
+        reason=None,
+        now=timestamp,
+    )
+    return {
+        "status": "passed",
+        "action": "merged",
+        "candidate_id": candidate_id,
+        "entry_id": entry_id,
+        "knowledge_path": str(knowledge_path),
+        "archive_path": str(archive_path),
+    }
+
+
+def reject_candidate(
+    candidate_id: str,
+    *,
+    reason: str,
+    candidate_dir: Path,
+    reviewed_dir: Path,
+    now: str | None = None,
+) -> dict[str, Any]:
+    if not reason.strip():
+        raise KnowledgeError("rejection reason must be non-empty")
+    timestamp = now or utc_now()
+    candidate_path = _candidate_path(candidate_dir, candidate_id)
+    candidate = load_candidate(candidate_path)
+    archive_path = _archive_candidate(
+        candidate,
+        candidate_path=candidate_path,
+        reviewed_dir=reviewed_dir,
+        disposition="rejected",
+        entry_id=None,
+        reason=reason.strip(),
+        now=timestamp,
+    )
+    return {
+        "status": "passed",
+        "action": "rejected",
+        "candidate_id": candidate_id,
+        "archive_path": str(archive_path),
+    }
+
+
+def deprecate_entry(
+    entry_id: str,
+    *,
+    superseded_by: str | None,
+    reason: str,
+    knowledge_dir: Path,
+    now: str | None = None,
+) -> dict[str, Any]:
+    if not reason.strip():
+        raise KnowledgeError("deprecation reason must be non-empty")
+    found = get_knowledge_entry(knowledge_dir=knowledge_dir, entry_id=entry_id)
+    if found is None:
+        raise KnowledgeError(f"formal entry does not exist: {entry_id}")
+    if superseded_by == entry_id:
+        raise KnowledgeError("an entry cannot supersede itself")
+    if superseded_by and get_knowledge_entry(
+        knowledge_dir=knowledge_dir, entry_id=superseded_by
+    ) is None:
+        raise KnowledgeError(f"superseding entry does not exist: {superseded_by}")
+    timestamp = now or utc_now()
+    knowledge_path = knowledge_dir / found["source_file"]
+    document = load_knowledge_file(knowledge_path)
+    target = next(entry for entry in document["entries"] if entry["id"] == entry_id)
+    target["status"] = "deprecated"
+    target["updated_at"] = today(timestamp)
+    target["rule"]["deprecation"] = {
+        "reason": reason.strip(),
+        "superseded_by": superseded_by,
+        "deprecated_at": today(timestamp),
+    }
+    document["updated_at"] = today(timestamp)
+    write_knowledge_document(knowledge_path, document)
+    return {
+        "status": "passed",
+        "action": "deprecated",
+        "entry_id": entry_id,
+        "superseded_by": superseded_by,
+        "knowledge_path": str(knowledge_path),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--candidate-dir",
+        type=Path,
+        default=ROOT / ".vaws-local" / "knowledge" / "candidates",
+    )
+    parser.add_argument(
+        "--reviewed-dir",
+        type=Path,
+        default=ROOT / ".vaws-local" / "knowledge" / "reviewed",
+    )
+    parser.add_argument(
+        "--knowledge-dir",
+        type=Path,
+        default=ROOT / ".agents" / "knowledge",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("list")
+    inspect_parser = subparsers.add_parser("inspect")
+    inspect_parser.add_argument("--candidate-id", required=True)
+    promote_parser = subparsers.add_parser("promote")
+    promote_parser.add_argument("--candidate-id", required=True)
+    promote_parser.add_argument("--entry-id")
+    promote_parser.add_argument(
+        "--status", choices=["experimental", "active"], default="experimental"
+    )
+    promote_parser.add_argument("--force-new", action="store_true")
+    merge_parser = subparsers.add_parser("merge")
+    merge_parser.add_argument("--candidate-id", required=True)
+    merge_parser.add_argument("--entry-id", required=True)
+    reject_parser = subparsers.add_parser("reject")
+    reject_parser.add_argument("--candidate-id", required=True)
+    reject_parser.add_argument("--reason", required=True)
+    deprecate_parser = subparsers.add_parser("deprecate")
+    deprecate_parser.add_argument("--entry-id", required=True)
+    deprecate_parser.add_argument("--superseded-by")
+    deprecate_parser.add_argument("--reason", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "list":
+            payload = {
+                "status": "passed",
+                "candidates": list_candidates(args.candidate_dir),
+            }
+        elif args.command == "inspect":
+            payload = {
+                "status": "passed",
+                **inspect_candidate(
+                    args.candidate_id,
+                    candidate_dir=args.candidate_dir,
+                    knowledge_dir=args.knowledge_dir,
+                ),
+            }
+        elif args.command == "promote":
+            payload = promote_candidate(
+                args.candidate_id,
+                entry_id=args.entry_id,
+                status=args.status,
+                force_new=args.force_new,
+                candidate_dir=args.candidate_dir,
+                reviewed_dir=args.reviewed_dir,
+                knowledge_dir=args.knowledge_dir,
+            )
+        elif args.command == "merge":
+            payload = merge_candidate(
+                args.candidate_id,
+                entry_id=args.entry_id,
+                candidate_dir=args.candidate_dir,
+                reviewed_dir=args.reviewed_dir,
+                knowledge_dir=args.knowledge_dir,
+            )
+        elif args.command == "reject":
+            payload = reject_candidate(
+                args.candidate_id,
+                reason=args.reason,
+                candidate_dir=args.candidate_dir,
+                reviewed_dir=args.reviewed_dir,
+            )
+        else:
+            payload = deprecate_entry(
+                args.entry_id,
+                superseded_by=args.superseded_by,
+                reason=args.reason,
+                knowledge_dir=args.knowledge_dir,
+            )
+    except (KnowledgeError, OSError) as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/curate-workspace-knowledge/tests/test_knowledge_curate.py
+++ b/.agents/skills/curate-workspace-knowledge/tests/test_knowledge_curate.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Tests for workspace knowledge curation."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+SCRIPT = (
+    ROOT
+    / ".agents"
+    / "skills"
+    / "curate-workspace-knowledge"
+    / "scripts"
+    / "knowledge_curate.py"
+)
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_knowledge import KNOWLEDGE_FILES, capture_candidate  # noqa: E402
+
+NOW = "2026-07-27T12:00:00Z"
+
+
+def load_module():
+    name = "_knowledge_curate_test"
+    spec = importlib.util.spec_from_file_location(name, SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+curate = load_module()
+
+
+def write_knowledge(root: Path, entries: dict[str, list[dict]] | None = None) -> None:
+    entries = entries or {}
+    root.mkdir(parents=True, exist_ok=True)
+    for filename, kind in KNOWLEDGE_FILES.items():
+        (root / filename).write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": kind,
+                    "updated_at": "2026-07-27",
+                    "entries": entries.get(kind, []),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+
+def candidate_payload(
+    *,
+    evidence_kind: str = "commit",
+    stable: bool = True,
+    verification_status: str = "passed",
+) -> dict:
+    return {
+        "kind": "known-failure-signatures",
+        "summary": "Lease visibility must reach child processes",
+        "owner_skill": "session-management",
+        "scope": {"component": ["session-runtime"], "machine": ["hvv-sz"]},
+        "fingerprints": ["child process sees devices outside its lease"],
+        "symptom": "A session-leased job sees every NPU.",
+        "root_cause": "The leased device list was not exported to child processes.",
+        "resolution": "Export ASCEND_RT_VISIBLE_DEVICES from the session lease.",
+        "avoidance": "Build child environments from the session snapshot.",
+        "applicable_versions": "workspace revisions before 823df4b",
+        "verification": {
+            "status": verification_status,
+            "checks": ["Child process reported only leased devices."],
+        },
+        "evidence": [
+            {
+                "kind": evidence_kind,
+                "uri": "commit:823df4b",
+                "stable": stable,
+            }
+        ],
+        "confidence": "high",
+        "source": {
+            "session_id": "test-thread",
+            "run_ids": ["lease-real"],
+            "commits": ["823df4b"],
+        },
+    }
+
+
+class CurationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.knowledge = self.root / "knowledge"
+        self.candidates = self.root / "candidates"
+        self.reviewed = self.root / "reviewed"
+        write_knowledge(self.knowledge)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def capture(self, payload: dict | None = None) -> str:
+        result = capture_candidate(
+            payload or candidate_payload(),
+            candidate_dir=self.candidates,
+            knowledge_dir=self.knowledge,
+            now=NOW,
+        )
+        return result["candidate_id"]
+
+    def formal_entries(self) -> list[dict]:
+        payload = json.loads(
+            (self.knowledge / "known-failure-signatures.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        return payload["entries"]
+
+    def test_list_is_compact(self) -> None:
+        candidate_id = self.capture()
+        listed = curate.list_candidates(self.candidates)
+        self.assertEqual(listed[0]["candidate_id"], candidate_id)
+        self.assertNotIn("root_cause", listed[0])
+
+    def test_experimental_promotion_writes_formal_and_archives(self) -> None:
+        candidate_id = self.capture()
+        result = curate.promote_candidate(
+            candidate_id,
+            entry_id="session-lease-child-visibility",
+            status="experimental",
+            force_new=False,
+            candidate_dir=self.candidates,
+            reviewed_dir=self.reviewed,
+            knowledge_dir=self.knowledge,
+            now=NOW,
+        )
+        entry = self.formal_entries()[0]
+        self.assertEqual(result["action"], "promoted")
+        self.assertEqual(entry["id"], "session-lease-child-visibility")
+        self.assertEqual(entry["rule"]["candidate_id"], candidate_id)
+        self.assertFalse((self.candidates / f"{candidate_id}.json").exists())
+        self.assertTrue((self.reviewed / f"{candidate_id}.json").is_file())
+
+    def test_inconclusive_candidate_cannot_be_promoted(self) -> None:
+        candidate_id = self.capture(
+            candidate_payload(verification_status="inconclusive")
+        )
+        with self.assertRaisesRegex(curate.KnowledgeError, "inconclusive"):
+            curate.promote_candidate(
+                candidate_id,
+                entry_id=None,
+                status="experimental",
+                force_new=False,
+                candidate_dir=self.candidates,
+                reviewed_dir=self.reviewed,
+                knowledge_dir=self.knowledge,
+                now=NOW,
+            )
+
+    def test_unstable_only_candidate_cannot_be_promoted(self) -> None:
+        candidate_id = self.capture(candidate_payload(stable=False))
+        with self.assertRaisesRegex(curate.KnowledgeError, "stable evidence"):
+            curate.promote_candidate(
+                candidate_id,
+                entry_id=None,
+                status="experimental",
+                force_new=False,
+                candidate_dir=self.candidates,
+                reviewed_dir=self.reviewed,
+                knowledge_dir=self.knowledge,
+                now=NOW,
+            )
+
+    def test_active_requires_repeat_or_regression_test(self) -> None:
+        candidate_id = self.capture()
+        with self.assertRaisesRegex(curate.KnowledgeError, "two occurrences"):
+            curate.promote_candidate(
+                candidate_id,
+                entry_id=None,
+                status="active",
+                force_new=False,
+                candidate_dir=self.candidates,
+                reviewed_dir=self.reviewed,
+                knowledge_dir=self.knowledge,
+                now=NOW,
+            )
+
+    def test_active_accepts_stable_regression_test(self) -> None:
+        candidate_id = self.capture(
+            candidate_payload(evidence_kind="regression-test")
+        )
+        result = curate.promote_candidate(
+            candidate_id,
+            entry_id=None,
+            status="active",
+            force_new=False,
+            candidate_dir=self.candidates,
+            reviewed_dir=self.reviewed,
+            knowledge_dir=self.knowledge,
+            now=NOW,
+        )
+        self.assertEqual(result["entry_status"], "active")
+
+    def test_duplicate_fingerprint_requires_merge_or_force(self) -> None:
+        candidate_id = self.capture()
+        duplicate = {
+            "id": "existing-lease-rule",
+            "source": "existing evidence",
+            "applicable_versions": "all",
+            "updated_at": "2026-07-27",
+            "status": "active",
+            "rule": {
+                "summary": "Existing",
+                "fingerprints": ["child process sees devices outside its lease"],
+            },
+        }
+        write_knowledge(
+            self.knowledge, {"known-failure-signatures": [duplicate]}
+        )
+        with self.assertRaisesRegex(curate.KnowledgeError, "use merge"):
+            curate.promote_candidate(
+                candidate_id,
+                entry_id="new-lease-rule",
+                status="experimental",
+                force_new=False,
+                candidate_dir=self.candidates,
+                reviewed_dir=self.reviewed,
+                knowledge_dir=self.knowledge,
+                now=NOW,
+            )
+
+    def test_merge_updates_existing_evidence_and_occurrences(self) -> None:
+        candidate_id = self.capture()
+        existing = {
+            "id": "existing-lease-rule",
+            "source": "existing evidence",
+            "applicable_versions": "old",
+            "updated_at": "2026-07-26",
+            "status": "experimental",
+            "rule": {
+                "candidate_id": "older-candidate",
+                "candidate_ids": ["older-candidate"],
+                "summary": "Old summary",
+                "owner_skill": "session-management",
+                "scope": {},
+                "fingerprints": ["older fingerprint"],
+                "symptom": "Old",
+                "root_cause": "Old",
+                "resolution": "Old",
+                "avoidance": "",
+                "verification": {"status": "passed", "checks": ["old"]},
+                "evidence": [
+                    {"kind": "commit", "uri": "commit:old", "stable": True}
+                ],
+                "confidence": "medium",
+                "occurrence_count": 1,
+                "first_seen_at": "2026-07-26T12:00:00Z",
+                "last_verified_at": "2026-07-26T12:00:00Z",
+            },
+        }
+        write_knowledge(
+            self.knowledge, {"known-failure-signatures": [existing]}
+        )
+        result = curate.merge_candidate(
+            candidate_id,
+            entry_id="existing-lease-rule",
+            candidate_dir=self.candidates,
+            reviewed_dir=self.reviewed,
+            knowledge_dir=self.knowledge,
+            now=NOW,
+        )
+        entry = self.formal_entries()[0]
+        self.assertEqual(result["action"], "merged")
+        self.assertEqual(entry["rule"]["occurrence_count"], 2)
+        self.assertIn(candidate_id, entry["rule"]["candidate_ids"])
+        self.assertEqual(len(entry["rule"]["evidence"]), 2)
+
+    def test_reject_does_not_modify_formal_knowledge(self) -> None:
+        candidate_id = self.capture()
+        before = (self.knowledge / "known-failure-signatures.yaml").read_text(
+            encoding="utf-8"
+        )
+        result = curate.reject_candidate(
+            candidate_id,
+            reason="Infrastructure-only transient.",
+            candidate_dir=self.candidates,
+            reviewed_dir=self.reviewed,
+            now=NOW,
+        )
+        after = (self.knowledge / "known-failure-signatures.yaml").read_text(
+            encoding="utf-8"
+        )
+        self.assertEqual(result["action"], "rejected")
+        self.assertEqual(before, after)
+
+    def test_deprecate_retains_entry_and_replacement(self) -> None:
+        old = {
+            "id": "old-rule",
+            "source": "old evidence",
+            "applicable_versions": "old",
+            "updated_at": "2026-07-26",
+            "status": "active",
+            "rule": {},
+        }
+        new = {
+            "id": "new-rule",
+            "source": "new evidence",
+            "applicable_versions": "new",
+            "updated_at": "2026-07-27",
+            "status": "active",
+            "rule": {},
+        }
+        write_knowledge(
+            self.knowledge, {"known-failure-signatures": [old, new]}
+        )
+        curate.deprecate_entry(
+            "old-rule",
+            superseded_by="new-rule",
+            reason="New transport supersedes it.",
+            knowledge_dir=self.knowledge,
+            now=NOW,
+        )
+        entries = {entry["id"]: entry for entry in self.formal_entries()}
+        self.assertEqual(entries["old-rule"]["status"], "deprecated")
+        self.assertEqual(
+            entries["old-rule"]["rule"]["deprecation"]["superseded_by"],
+            "new-rule",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_knowledge_flow.py
+++ b/.agents/tests/test_knowledge_flow.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""End-to-end test for the public workspace knowledge lifecycle."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CAPTURE = ROOT / ".agents" / "scripts" / "knowledge_capture.py"
+QUERY = ROOT / ".agents" / "scripts" / "knowledge_query.py"
+VALIDATE = ROOT / ".agents" / "scripts" / "knowledge_validate.py"
+HOOK = ROOT / ".agents" / "hooks" / "knowledge_session_end.py"
+CURATE = (
+    ROOT
+    / ".agents"
+    / "skills"
+    / "curate-workspace-knowledge"
+    / "scripts"
+    / "knowledge_curate.py"
+)
+
+
+def synthetic_candidate(session_id: str) -> dict:
+    """Return realistic evidence without encoding project knowledge."""
+
+    return {
+        "kind": "known-failure-signatures",
+        "summary": "Framed test transport requires acknowledgements",
+        "owner_skill": "remote-code-parity",
+        "scope": {"component": ["synthetic-transport"]},
+        "fingerprints": ["synthetic framed transfer acknowledgement timeout"],
+        "symptom": "The synthetic transfer stalls after its first frame.",
+        "root_cause": "The test sender does not wait for the receiver acknowledgement.",
+        "resolution": "Wait for one acknowledgement before sending the next test frame.",
+        "avoidance": "Keep the synthetic transport acknowledgement-gated.",
+        "applicable_versions": "test fixture only",
+        "verification": {
+            "status": "passed",
+            "checks": ["The acknowledgement-gated regression test completed."],
+        },
+        "evidence": [
+            {
+                "kind": "regression-test",
+                "uri": ".agents/tests/test_knowledge_flow.py",
+                "stable": True,
+            }
+        ],
+        "confidence": "high",
+        "source": {
+            "session_id": session_id,
+            "run_ids": ["synthetic-knowledge-flow"],
+            "commits": [],
+        },
+    }
+
+
+class KnowledgeFlowE2ETest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.sandbox = Path(self.temp.name)
+        self.formal = self.sandbox / ".agents" / "knowledge"
+        self.candidates = self.sandbox / ".vaws-local" / "knowledge" / "candidates"
+        self.pending = self.sandbox / ".vaws-local" / "knowledge" / "pending"
+        self.reviewed = self.sandbox / ".vaws-local" / "knowledge" / "reviewed"
+        self.session_end = self.sandbox / ".vaws-local" / "knowledge" / "session-end"
+        self.formal.parent.mkdir(parents=True)
+        shutil.copytree(ROOT / ".agents" / "knowledge", self.formal)
+
+        # The hook resolves the simulated repository from this marker but imports
+        # the implementation under test from the real worktree.
+        marker = self.sandbox / ".agents" / "lib" / "vaws_knowledge.py"
+        marker.parent.mkdir(parents=True)
+        marker.write_text("# simulated repository marker\n", encoding="utf-8")
+
+        self.source_knowledge = {
+            path.name: path.read_bytes()
+            for path in (ROOT / ".agents" / "knowledge").glob("*.yaml")
+        }
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def run_json(
+        self, script: Path, *arguments: str, stdin: dict | None = None
+    ) -> dict:
+        completed = subprocess.run(
+            [sys.executable, str(script), *arguments],
+            input=json.dumps(stdin) if stdin is not None else None,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertEqual(completed.stderr, "")
+        self.assertTrue(completed.stdout.strip(), f"{script.name} emitted no JSON")
+        return json.loads(completed.stdout)
+
+    def curate_json(self, *arguments: str) -> dict:
+        return self.run_json(
+            CURATE,
+            "--candidate-dir",
+            str(self.candidates),
+            "--reviewed-dir",
+            str(self.reviewed),
+            "--knowledge-dir",
+            str(self.formal),
+            *arguments,
+        )
+
+    def test_deferred_candidate_to_deprecated_formal_entry(self) -> None:
+        session_id = "synthetic-knowledge-flow-session"
+        input_path = self.sandbox / "candidate-input.json"
+        input_path.write_text(
+            json.dumps(synthetic_candidate(session_id)), encoding="utf-8"
+        )
+
+        deferred = self.run_json(
+            CAPTURE,
+            "--input",
+            str(input_path),
+            "--defer",
+            "--session-id",
+            session_id,
+            "--pending-dir",
+            str(self.pending),
+            "--knowledge-dir",
+            str(self.formal),
+        )
+        candidate_id = deferred["candidate_id"]
+        self.assertTrue(deferred["deferred"])
+        self.assertTrue(Path(deferred["path"]).is_file())
+
+        hook_input = {
+            "session_id": session_id,
+            "transcript_path": "/not/read/by/the/hook.jsonl",
+            "cwd": str(self.sandbox),
+            "hook_event_name": "SessionEnd",
+            "reason": "other",
+        }
+        hook = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input=json.dumps(hook_input),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(hook.returncode, 0)
+        self.assertEqual(hook.stdout, "")
+        self.assertEqual(hook.stderr, "")
+        self.assertTrue((self.candidates / f"{candidate_id}.json").is_file())
+        receipts = list(self.session_end.glob("*.json"))
+        self.assertEqual(len(receipts), 1)
+        self.assertEqual(
+            json.loads(receipts[0].read_text(encoding="utf-8"))["status"], "passed"
+        )
+
+        listed = self.curate_json("list")
+        self.assertEqual(
+            [item["candidate_id"] for item in listed["candidates"]], [candidate_id]
+        )
+        inspected = self.curate_json("inspect", "--candidate-id", candidate_id)
+        self.assertEqual(inspected["candidate"]["candidate_id"], candidate_id)
+        self.assertEqual(inspected["possible_matches"], [])
+
+        entry_id = "synthetic-framed-transfer"
+        promoted = self.curate_json(
+            "promote",
+            "--candidate-id",
+            candidate_id,
+            "--entry-id",
+            entry_id,
+            "--status",
+            "active",
+        )
+        self.assertEqual(promoted["action"], "promoted")
+        self.assertEqual(promoted["entry_status"], "active")
+        self.assertFalse((self.candidates / f"{candidate_id}.json").exists())
+        self.assertTrue((self.reviewed / f"{candidate_id}.json").is_file())
+
+        queried = self.run_json(
+            QUERY,
+            "--query",
+            "synthetic framed transfer acknowledgement timeout",
+            "--knowledge-dir",
+            str(self.formal),
+        )
+        self.assertEqual(queried["matches"][0]["id"], entry_id)
+
+        fetched = self.run_json(
+            QUERY,
+            "--id",
+            entry_id,
+            "--knowledge-dir",
+            str(self.formal),
+        )
+        self.assertEqual(fetched["result"]["entry"]["status"], "active")
+
+        recaptured = self.run_json(
+            CAPTURE,
+            "--input",
+            str(input_path),
+            "--candidate-dir",
+            str(self.candidates),
+            "--knowledge-dir",
+            str(self.formal),
+        )
+        self.assertEqual(recaptured["status"], "already-promoted")
+        self.assertEqual(list(self.candidates.glob("*.json")), [])
+
+        deprecated = self.curate_json(
+            "deprecate",
+            "--entry-id",
+            entry_id,
+            "--reason",
+            "Synthetic lifecycle completed.",
+        )
+        self.assertEqual(deprecated["action"], "deprecated")
+
+        hidden = self.run_json(
+            QUERY,
+            "--query",
+            "synthetic framed transfer acknowledgement timeout",
+            "--knowledge-dir",
+            str(self.formal),
+        )
+        self.assertEqual(hidden["matches"], [])
+        retained = self.run_json(
+            QUERY,
+            "--query",
+            "synthetic framed transfer acknowledgement timeout",
+            "--include-deprecated",
+            "--knowledge-dir",
+            str(self.formal),
+        )
+        self.assertEqual(retained["matches"][0]["id"], entry_id)
+
+        validated = self.run_json(
+            VALIDATE, "--knowledge-dir", str(self.formal)
+        )
+        self.assertEqual(validated["status"], "passed")
+
+        source_after = {
+            path.name: path.read_bytes()
+            for path in (ROOT / ".agents" / "knowledge").glob("*.yaml")
+        }
+        self.assertEqual(source_after, self.source_knowledge)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_knowledge_hook.py
+++ b/.agents/tests/test_knowledge_hook.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Tests for the lightweight SessionEnd knowledge hook."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+HOOK = ROOT / ".agents" / "hooks" / "knowledge_session_end.py"
+CODEX_EXAMPLE = ROOT / ".codex" / "config.example.toml"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_knowledge import (  # noqa: E402
+    KNOWLEDGE_FILES,
+    capture_candidate,
+    knowledge_session_key,
+)
+
+NOW = "2026-07-27T12:00:00Z"
+
+
+def load_hook():
+    name = "_knowledge_session_end_test"
+    spec = importlib.util.spec_from_file_location(name, HOOK)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+hook = load_hook()
+
+
+def write_knowledge(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    for filename, kind in KNOWLEDGE_FILES.items():
+        (root / filename).write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": kind,
+                    "updated_at": "2026-07-27",
+                    "entries": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+
+def candidate_payload(session_id: str) -> dict:
+    return {
+        "kind": "known-failure-signatures",
+        "summary": "Explicit master endpoint avoids DNS delay",
+        "owner_skill": "vllm-ascend-distributed-debug",
+        "scope": {"component": ["torchrun"], "machine": ["hvv-sz"]},
+        "fingerprints": ["torchrun standalone dns resolution delay"],
+        "symptom": "A two-rank smoke spends tens of seconds resolving hostnames.",
+        "root_cause": "Standalone rendezvous performs slow DNS resolution.",
+        "resolution": "Use an explicit loopback master address and leased port.",
+        "avoidance": "Prefer explicit rendezvous endpoints in deterministic smokes.",
+        "applicable_versions": "workspace-managed hvv-sz validation",
+        "verification": {
+            "status": "passed",
+            "checks": ["Two-rank all-reduce completed without DNS warnings."],
+        },
+        "evidence": [
+            {
+                "kind": "commit",
+                "uri": "commit:c015161",
+                "stable": True,
+            }
+        ],
+        "confidence": "medium",
+        "source": {
+            "session_id": session_id,
+            "run_ids": ["distributed-case-explicit"],
+            "commits": ["c015161"],
+        },
+    }
+
+
+class SessionEndHookTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        write_knowledge(self.root / ".agents" / "knowledge")
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def defer(self, session_id: str) -> str:
+        session_key = knowledge_session_key(session_id)
+        result = capture_candidate(
+            candidate_payload(session_id),
+            candidate_dir=(
+                self.root
+                / ".vaws-local"
+                / "knowledge"
+                / "pending"
+                / session_key
+            ),
+            knowledge_dir=self.root / ".agents" / "knowledge",
+            now=NOW,
+        )
+        return result["candidate_id"]
+
+    def payload(self, session_id: str) -> dict:
+        return {
+            "session_id": session_id,
+            "transcript_path": "/path/that/does/not/exist.jsonl",
+            "cwd": str(self.root),
+            "hook_event_name": "SessionEnd",
+            "reason": "other",
+        }
+
+    def test_no_pending_session_has_zero_artifacts(self) -> None:
+        result = hook.process_session_end(
+            self.payload("empty-session"), repo_root=self.root
+        )
+        self.assertIsNone(result)
+        self.assertFalse(
+            (self.root / ".vaws-local" / "knowledge" / "session-end").exists()
+        )
+
+    def test_matching_pending_candidate_is_flushed_without_transcript(self) -> None:
+        session_id = "thread-real"
+        candidate_id = self.defer(session_id)
+        formal_before = {
+            path.name: path.read_bytes()
+            for path in (self.root / ".agents" / "knowledge").glob("*.yaml")
+        }
+        result = hook.process_session_end(
+            self.payload(session_id), repo_root=self.root
+        )
+        self.assertEqual(result["status"], "passed")
+        self.assertEqual(result["processed"][0]["candidate_id"], candidate_id)
+        self.assertTrue(
+            (
+                self.root
+                / ".vaws-local"
+                / "knowledge"
+                / "candidates"
+                / f"{candidate_id}.json"
+            ).is_file()
+        )
+        self.assertFalse(
+            (
+                self.root
+                / ".vaws-local"
+                / "knowledge"
+                / "pending"
+                / knowledge_session_key(session_id)
+            ).exists()
+        )
+        formal_after = {
+            path.name: path.read_bytes()
+            for path in (self.root / ".agents" / "knowledge").glob("*.yaml")
+        }
+        self.assertEqual(formal_after, formal_before)
+
+    def test_symlink_and_oversize_pending_files_are_not_flushed(self) -> None:
+        session_id = "thread-invalid"
+        session_key = knowledge_session_key(session_id)
+        pending = (
+            self.root
+            / ".vaws-local"
+            / "knowledge"
+            / "pending"
+            / session_key
+        )
+        pending.mkdir(parents=True)
+        outside = self.root / "outside.json"
+        outside.write_text(json.dumps(candidate_payload(session_id)), encoding="utf-8")
+        (pending / "linked.json").symlink_to(outside)
+        (pending / "oversize.json").write_bytes(
+            b"{" + b"x" * (hook.MAX_CANDIDATE_BYTES + 1) + b"}"
+        )
+
+        result = hook.process_session_end(
+            self.payload(session_id), repo_root=self.root
+        )
+
+        self.assertEqual(result["status"], "partial")
+        self.assertEqual(len(result["errors"]), 2)
+        self.assertTrue((pending / "linked.json").is_symlink())
+        self.assertTrue((pending / "oversize.json").is_file())
+        candidate_dir = self.root / ".vaws-local" / "knowledge" / "candidates"
+        self.assertFalse(candidate_dir.exists())
+
+    def test_repeated_finalization_is_idempotent(self) -> None:
+        session_id = "thread-repeat"
+        candidate_id = self.defer(session_id)
+        first = hook.process_session_end(
+            self.payload(session_id), repo_root=self.root
+        )
+        second = hook.process_session_end(
+            self.payload(session_id), repo_root=self.root
+        )
+        self.assertEqual(first["processed"][0]["candidate_id"], candidate_id)
+        self.assertIsNone(second)
+        candidate_path = (
+            self.root
+            / ".vaws-local"
+            / "knowledge"
+            / "candidates"
+            / f"{candidate_id}.json"
+        )
+        self.assertEqual(
+            json.loads(candidate_path.read_text(encoding="utf-8"))["occurrence_count"],
+            1,
+        )
+
+    def test_other_session_pending_candidate_is_untouched(self) -> None:
+        other = "other-thread"
+        candidate_id = self.defer(other)
+        result = hook.process_session_end(
+            self.payload("current-thread"), repo_root=self.root
+        )
+        self.assertIsNone(result)
+        self.assertTrue(
+            (
+                self.root
+                / ".vaws-local"
+                / "knowledge"
+                / "pending"
+                / knowledge_session_key(other)
+                / f"{candidate_id}.json"
+            ).is_file()
+        )
+
+    def test_cli_emits_no_stdout_or_stderr(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input=json.dumps(
+                {
+                    "session_id": "no-pending",
+                    "transcript_path": None,
+                    "cwd": str(self.root),
+                    "hook_event_name": "SessionEnd",
+                    "reason": "other",
+                }
+            ),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(completed.stdout, "")
+        self.assertEqual(completed.stderr, "")
+
+    def test_malformed_cli_input_never_blocks_shutdown(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input="{bad-json",
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(completed.stdout, "")
+        self.assertEqual(completed.stderr, "")
+
+    def test_codex_example_registers_bounded_session_end_hook(self) -> None:
+        config = tomllib.loads(CODEX_EXAMPLE.read_text(encoding="utf-8"))
+        self.assertTrue(config["features"]["hooks"])
+        session_end = config["hooks"]["SessionEnd"]
+        self.assertEqual(len(session_end), 1)
+        command_hook = session_end[0]["hooks"][0]
+        self.assertEqual(command_hook["type"], "command")
+        self.assertIn(".agents/hooks/knowledge_session_end.py", command_hook["command"])
+        self.assertLessEqual(command_hook["timeout"], 3)
+        self.assertTrue(HOOK.is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_knowledge_memory.py
+++ b/.agents/tests/test_knowledge_memory.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Tests for compact knowledge capture and retrieval."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+CAPTURE_SCRIPT = ROOT / ".agents" / "scripts" / "knowledge_capture.py"
+QUERY_SCRIPT = ROOT / ".agents" / "scripts" / "knowledge_query.py"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_knowledge import (  # noqa: E402
+    KNOWLEDGE_FILES,
+    KnowledgeError,
+    capture_candidate,
+    get_knowledge_entry,
+    normalize_fingerprint,
+    normalize_candidate,
+    query_knowledge,
+)
+
+NOW = "2026-07-27T12:00:00Z"
+
+
+def write_knowledge_dir(root: Path, entries: dict[str, list[dict]] | None = None) -> None:
+    entries = entries or {}
+    root.mkdir(parents=True, exist_ok=True)
+    for filename, kind in KNOWLEDGE_FILES.items():
+        (root / filename).write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": kind,
+                    "updated_at": "2026-07-27",
+                    "entries": entries.get(kind, []),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+
+def candidate_payload() -> dict:
+    return {
+        "kind": "known-failure-signatures",
+        "summary": "Remote SSH frames require acknowledgements",
+        "owner_skill": "remote-code-parity",
+        "scope": {
+            "component": ["ssh-transport"],
+            "machine": ["hvv-sz"],
+        },
+        "fingerprints": [
+            "timed out waiting for framed transfer acknowledgement",
+        ],
+        "symptom": "Artifact uploads stall on hvv-sz.",
+        "root_cause": "The constrained SSH path drops oversized unacknowledged frames.",
+        "resolution": "Send base64 frames and wait for an acknowledgement per frame.",
+        "avoidance": "Keep each transport frame below the measured limit.",
+        "applicable_versions": "workspace revisions before and including 76c44b0",
+        "verification": {
+            "status": "passed",
+            "checks": [
+                "Uploaded a 4,934,277-byte artifact and matched SHA256.",
+            ],
+        },
+        "evidence": [
+            {
+                "kind": "commit",
+                "uri": "git:76c44b0",
+                "stable": True,
+            }
+        ],
+        "confidence": "high",
+        "source": {
+            "session_id": "thread-test",
+            "run_ids": ["remote-transfer-real"],
+            "commits": ["76c44b0"],
+        },
+    }
+
+
+class CandidateTests(unittest.TestCase):
+    def test_candidate_defaults_are_deterministic_and_valid(self) -> None:
+        first = normalize_candidate(candidate_payload(), now=NOW)
+        second = normalize_candidate(candidate_payload(), now=NOW)
+        self.assertEqual(first["candidate_id"], second["candidate_id"])
+        self.assertEqual(first["status"], "candidate")
+        self.assertEqual(first["occurrence_count"], 1)
+
+    def test_secret_like_values_are_rejected(self) -> None:
+        payload = candidate_payload()
+        payload["resolution"] = "Use token sk-abcdefghijklmnopqrstuvwxyz123456"
+        with self.assertRaisesRegex(KnowledgeError, "secret-like value"):
+            normalize_candidate(payload, now=NOW)
+
+    def test_absolute_evidence_paths_are_rejected(self) -> None:
+        payload = candidate_payload()
+        payload["evidence"][0]["uri"] = "/tmp/private-run.json"
+        with self.assertRaisesRegex(KnowledgeError, "repository-relative"):
+            normalize_candidate(payload, now=NOW)
+
+    def test_evidence_path_traversal_is_rejected(self) -> None:
+        payload = candidate_payload()
+        payload["evidence"][0]["uri"] = "../outside/run.json"
+        with self.assertRaisesRegex(KnowledgeError, "must not traverse"):
+            normalize_candidate(payload, now=NOW)
+
+    def test_volatile_fingerprint_values_are_normalized(self) -> None:
+        first = normalize_fingerprint(
+            "2026-07-27T12:00:00Z PID 123 failed at 0x7ffdeadbeef"
+        )
+        second = normalize_fingerprint(
+            "2026-07-28T13:01:02Z pid=987 failed at 0x7ffaabbccdd"
+        )
+        self.assertEqual(first, second)
+
+    def test_repeat_capture_merges_evidence_and_occurrence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            knowledge = root / "knowledge"
+            candidates = root / "candidates"
+            write_knowledge_dir(knowledge)
+            first = capture_candidate(
+                candidate_payload(),
+                candidate_dir=candidates,
+                knowledge_dir=knowledge,
+                now=NOW,
+            )
+            payload = candidate_payload()
+            payload["evidence"].append(
+                {"kind": "test", "uri": ".agents/tests/test_transport.py", "stable": True}
+            )
+            second = capture_candidate(
+                payload,
+                candidate_dir=candidates,
+                knowledge_dir=knowledge,
+                now="2026-07-27T13:00:00Z",
+            )
+            stored = json.loads(Path(second["path"]).read_text(encoding="utf-8"))
+            self.assertEqual(first["action"], "created")
+            self.assertEqual(second["action"], "updated")
+            self.assertEqual(stored["occurrence_count"], 2)
+            self.assertEqual(len(stored["evidence"]), 2)
+
+    def test_identical_capture_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            knowledge = root / "knowledge"
+            candidates = root / "candidates"
+            write_knowledge_dir(knowledge)
+            capture_candidate(
+                candidate_payload(),
+                candidate_dir=candidates,
+                knowledge_dir=knowledge,
+                now=NOW,
+            )
+            second = capture_candidate(
+                candidate_payload(),
+                candidate_dir=candidates,
+                knowledge_dir=knowledge,
+                now="2026-07-27T13:00:00Z",
+            )
+            stored = json.loads(Path(second["path"]).read_text(encoding="utf-8"))
+            self.assertEqual(second["action"], "unchanged")
+            self.assertEqual(stored["occurrence_count"], 1)
+
+    def test_promoted_candidate_is_not_written_again(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            normalized = normalize_candidate(candidate_payload(), now=NOW)
+            entry = {
+                "id": "remote-framed-transfer",
+                "source": "verified real-machine run",
+                "applicable_versions": "all",
+                "updated_at": "2026-07-27",
+                "status": "active",
+                "rule": {"candidate_id": normalized["candidate_id"]},
+            }
+            knowledge = root / "knowledge"
+            write_knowledge_dir(
+                knowledge, {"known-failure-signatures": [entry]}
+            )
+            result = capture_candidate(
+                candidate_payload(),
+                candidate_dir=root / "candidates",
+                knowledge_dir=knowledge,
+                now=NOW,
+            )
+            self.assertEqual(result["status"], "already-promoted")
+            self.assertFalse((root / "candidates").exists())
+
+
+class QueryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        active = {
+            "id": "remote-framed-transfer",
+            "source": "real hvv-sz validation",
+            "applicable_versions": "all",
+            "updated_at": "2026-07-27",
+            "status": "active",
+            "rule": {
+                "summary": "Acknowledge constrained SSH transfer frames",
+                "fingerprints": [
+                    "timed out waiting for framed transfer acknowledgement"
+                ],
+                "root_cause": "The SSH path drops oversized frames.",
+                "resolution": "Wait for one ACK per frame.",
+            },
+        }
+        deprecated = {
+            "id": "legacy-transfer",
+            "source": "old run",
+            "applicable_versions": "old",
+            "updated_at": "2026-07-27",
+            "status": "deprecated",
+            "rule": {
+                "summary": "Legacy transfer timeout",
+                "fingerprints": ["transfer timeout"],
+            },
+        }
+        write_knowledge_dir(
+            self.root,
+            {"known-failure-signatures": [active, deprecated]},
+        )
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_exact_fingerprint_is_ranked_and_compact(self) -> None:
+        matches = query_knowledge(
+            knowledge_dir=self.root,
+            query="timed out waiting for framed transfer acknowledgement",
+        )
+        self.assertEqual(matches[0]["id"], "remote-framed-transfer")
+        self.assertGreaterEqual(matches[0]["score"], 100)
+        self.assertNotIn("rule", matches[0])
+
+    def test_deprecated_entries_are_excluded_by_default(self) -> None:
+        matches = query_knowledge(
+            knowledge_dir=self.root, query="legacy transfer timeout"
+        )
+        self.assertNotIn("legacy-transfer", {match["id"] for match in matches})
+
+    def test_full_entry_is_fetched_only_by_id(self) -> None:
+        result = get_knowledge_entry(
+            knowledge_dir=self.root, entry_id="remote-framed-transfer"
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("rule", result["entry"])
+
+
+class CliTests(unittest.TestCase):
+    def test_capture_and_query_stdout_are_single_json_documents(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            knowledge = root / "knowledge"
+            candidates = root / "candidates"
+            write_knowledge_dir(knowledge)
+            input_path = root / "candidate.json"
+            input_path.write_text(
+                json.dumps(candidate_payload()), encoding="utf-8"
+            )
+            captured = subprocess.run(
+                [
+                    sys.executable,
+                    str(CAPTURE_SCRIPT),
+                    "--input",
+                    str(input_path),
+                    "--candidate-dir",
+                    str(candidates),
+                    "--knowledge-dir",
+                    str(knowledge),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(captured.returncode, 0, captured.stderr)
+            self.assertEqual(json.loads(captured.stdout)["status"], "passed")
+            self.assertEqual(captured.stderr, "")
+
+            queried = subprocess.run(
+                [
+                    sys.executable,
+                    str(QUERY_SCRIPT),
+                    "--query",
+                    "not present",
+                    "--knowledge-dir",
+                    str(knowledge),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(queried.returncode, 0, queried.stderr)
+            self.assertEqual(json.loads(queried.stdout)["matches"], [])
+            self.assertEqual(queried.stderr, "")
+
+    def test_deferred_capture_uses_session_scoped_pending_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            knowledge = root / "knowledge"
+            write_knowledge_dir(knowledge)
+            input_path = root / "candidate.json"
+            input_path.write_text(
+                json.dumps(candidate_payload()), encoding="utf-8"
+            )
+            captured = subprocess.run(
+                [
+                    sys.executable,
+                    str(CAPTURE_SCRIPT),
+                    "--input",
+                    str(input_path),
+                    "--defer",
+                    "--session-id",
+                    "thread-deferred",
+                    "--pending-dir",
+                    str(root / "pending"),
+                    "--knowledge-dir",
+                    str(knowledge),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            result = json.loads(captured.stdout)
+            self.assertEqual(captured.returncode, 0, captured.stderr)
+            self.assertTrue(result["deferred"])
+            self.assertIn(result["session_key"], result["path"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_run_manifest.py
+++ b/.agents/tests/test_run_manifest.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Tests for Run Manifest v1 and shared knowledge validation."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_knowledge import (  # noqa: E402
+    KNOWLEDGE_FILES,
+    KnowledgeError,
+    validate_knowledge_dir,
+    validate_knowledge_document,
+)
+from vaws_run_manifest import (  # noqa: E402
+    RunManifestError,
+    add_artifact,
+    load_manifest,
+    new_manifest,
+    transition_status,
+    write_manifest,
+)
+
+NOW = "2026-07-25T12:00:00Z"
+
+
+class RunManifestTests(unittest.TestCase):
+    def test_round_trip_and_status_transition(self) -> None:
+        manifest = new_manifest(
+            run_type="correctness",
+            run_id="correctness-case-1",
+            workspace_snapshot={"workspace": "abc123", "dirty": False},
+            command=["python", "run.py"],
+            created_at=NOW,
+        )
+        running = transition_status(manifest, "running", updated_at=NOW)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "manifest.json"
+            write_manifest(path, running)
+            self.assertEqual(load_manifest(path), running)
+
+    def test_invalid_status_transition_is_rejected(self) -> None:
+        manifest = new_manifest(
+            run_type="debug", run_id="debug-case-1", created_at=NOW
+        )
+        with self.assertRaises(RunManifestError):
+            transition_status(manifest, "passed", updated_at=NOW)
+
+    def test_secret_like_environment_key_is_rejected(self) -> None:
+        with self.assertRaisesRegex(RunManifestError, "secret-like key"):
+            new_manifest(
+                run_type="profiling",
+                run_id="profile-case-1",
+                environment_variables={"SERVICE_API_TOKEN": "do-not-store"},
+                created_at=NOW,
+            )
+
+    def test_duplicate_artifact_name_is_rejected(self) -> None:
+        manifest = new_manifest(
+            run_type="performance", run_id="perf-case-1", created_at=NOW
+        )
+        manifest = add_artifact(
+            manifest,
+            name="report",
+            kind="report",
+            uri="report.md",
+            updated_at=NOW,
+        )
+        with self.assertRaisesRegex(RunManifestError, "duplicated"):
+            add_artifact(
+                manifest,
+                name="report",
+                kind="raw",
+                uri="raw.json",
+                updated_at=NOW,
+            )
+
+
+class KnowledgeValidationTests(unittest.TestCase):
+    def test_repository_knowledge_files_are_valid(self) -> None:
+        files = validate_knowledge_dir(ROOT / ".agents" / "knowledge")
+        self.assertEqual(set(files), set(KNOWLEDGE_FILES))
+
+    def test_unknown_support_is_not_implicitly_valid(self) -> None:
+        document = {
+            "schema_version": 1,
+            "kind": "model-capabilities",
+            "updated_at": "2026-07-25",
+            "entries": [
+                {
+                    "id": "bad-entry",
+                    "source": "test",
+                    "applicable_versions": "all",
+                    "updated_at": "2026-07-25",
+                    "status": "unknown",
+                    "rule": {},
+                }
+            ],
+        }
+        with self.assertRaises(KnowledgeError):
+            validate_knowledge_document(
+                document, expected_kind="model-capabilities", path="test.yaml"
+            )
+
+    def test_json_compatible_yaml_requirement_is_enforced(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for filename, kind in KNOWLEDGE_FILES.items():
+                (root / filename).write_text(
+                    json.dumps(
+                        {
+                            "schema_version": 1,
+                            "kind": kind,
+                            "updated_at": "2026-07-25",
+                            "entries": [],
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+            (root / "model-capabilities.yaml").write_text(
+                "schema_version: 1\nkind: model-capabilities\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(KnowledgeError, "JSON-compatible YAML"):
+                validate_knowledge_dir(root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.codex/config.example.toml
+++ b/.codex/config.example.toml
@@ -16,3 +16,10 @@ type = "command"
 command = 'python3 "$(git rev-parse --show-toplevel)/.remote-dev/hooks/codex_remote_guard.py"'
 timeout = 30
 statusMessage = "Checking remote development policy"
+
+[[hooks.SessionEnd]]
+
+[[hooks.SessionEnd.hooks]]
+type = "command"
+command = 'python3 "$(git rev-parse --show-toplevel)/.agents/hooks/knowledge_session_end.py"'
+timeout = 3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ Repo-local skills live under `.agents/skills/`. Each has its own `SKILL.md` with
 | `ascend-memory-profiling` | Profile HBM memory usage on Ascend NPU for vLLM serving scenarios |
 | `ascend-profiling-collection` | Collect one Ascend torch-profiler case end-to-end (start service, bracket workload with `/start_profile` + `/stop_profile`, run `analyse()`, verify outputs, write manifest) |
 | `ascend-profiling-analysis` | Analyze collected Ascend torch-profiler roots/manifests and generate reports |
+| `curate-workspace-knowledge` | Explicitly review, deduplicate, promote, merge, reject, or deprecate verified knowledge candidates |
 
 None of these are gates for normal local coding, docs work, or unrelated Git tasks.
 For remote endpoint work, prefer `.remote-dev` tools first and use these skills
@@ -71,6 +72,11 @@ for domain workflows.
 - Keep `.gitmodules` on community upstream URLs.
 - Prefer `.remote-dev` remote companion tools or skill wrapper scripts over raw SSH / shell commands for remote operations.
 - Skill wrappers: progress on `stderr`, final JSON on `stdout`.
+- Execution skills must use Run Manifest v1 from `.agents/lib/vaws_run_manifest.py` for new cross-workflow runs and keep manifests under untracked `.vaws-local/`.
+- Read fast-changing compatibility, capability, validation, and failure-signature facts from `.agents/knowledge/`; treat missing facts as unknown rather than supported.
+- On a concrete practical failure, query compact formal matches with `.agents/scripts/knowledge_query.py` before repeating diagnosis. After a novel fix has a confirmed cause and verification evidence, capture a candidate with `.agents/scripts/knowledge_capture.py`.
+- Invoke `curate-workspace-knowledge` only for explicit knowledge review or promotion; normal workflows use the shared capture and query scripts directly.
+- Before reporting a blocking problem or asking the user to intervene, query `.agents/knowledge/` with `.agents/scripts/knowledge_query.py` using the observed failure signature. State explicitly when no verified match exists.
 - Use the remote-dev substrate for agent-facing remote read/edit/bash/search/patch/job/artifact work. Use the remote toolbox entrypoints as the managed VAWS compatibility backend before falling back to bare SSH.
 - For parallel managed remote work, create or reuse a `session-management` session and pass `--session-id` through parity, serving, benchmark, and profiling commands. Legacy `--machine` flows remain available for explicitly single-tenant work.
 - This repo targets Huawei Ascend NPU. Local machines (Mac/PC) cannot run `torch`/`torch_npu`-dependent code. Do not attempt local test execution — go straight to the remote container.

--- a/README.en.md
+++ b/README.en.md
@@ -43,6 +43,7 @@ The Agent will detect your environment, install required tools, and configure Gi
 | **ascend-memory-profiling** | Profile and attribute HBM memory usage on Ascend NPU, with per-component breakdown and evidence chains | When you need to analyze memory consumption of a vLLM serving workload |
 | **ascend-profiling-collection** | Collect Ascend torch-profiler data: start service, bracket profile window, run workload, remote analyse, and write a manifest | When you need kernel_details/trace_view captures |
 | **ascend-profiling-analysis** | Analyze collected profiler roots/manifests and generate step/layer/operator/cross-rank reports | When you need to analyze profiling output |
+| **curate-workspace-knowledge** | Review, deduplicate, promote, merge, reject, or deprecate verified project knowledge candidates | When explicitly curating or maintaining project knowledge |
 
 
 All skills are **optional**. Use any subset, or none at all.
@@ -96,7 +97,8 @@ When talking to an Agent:
 │   │   ├── vllm-ascend-benchmark/ # Performance benchmarking skill
 │   │   ├── ascend-memory-profiling/ # Memory profiling skill
 │   │   ├── ascend-profiling-collection/ # Torch profiler collection skill
-│   │   └── ascend-profiling-analysis/ # Profiling analysis/report skill
+│   │   ├── ascend-profiling-analysis/ # Profiling analysis/report skill
+│   │   └── curate-workspace-knowledge/ # Explicit knowledge curation skill
 │   ├── lib/               # Shared local-state library
 │   └── scripts/           # Shared helper scripts
 ├── .cursor/rules/         # Cursor IDE specific rules

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Agent 会自动检测你的环境、安装所需工具、配置 Git 远程仓库
 | **ascend-memory-profiling** | 采集并分析昇腾 NPU 的 HBM 显存占用，按组件拆分并溯源 | 需要分析 vLLM 推理服务的显存占用时 |
 | **ascend-profiling-collection** | 采集 Ascend torch profiler：起服务、控制 profile 窗口、运行 workload、远端 analyse 并写 manifest | 需要采集 kernel_details/trace_view 时 |
 | **ascend-profiling-analysis** | 分析已采集的 profiler root/manifest，生成 step/layer/operator/cross-rank 诊断报告 | 需要分析 profiling 结果或生成报告时 |
+| **curate-workspace-knowledge** | 审核、去重、提升、合并、拒绝或废弃已验证的项目知识候选 | 显式要求沉淀、整理或维护项目知识时 |
 
 
 所有技能都是**可选的**。你可以只用其中的一部分，也可以完全不用。
@@ -97,7 +98,8 @@ Agent 会自动检测你的环境、安装所需工具、配置 Git 远程仓库
 │   │   ├── vllm-ascend-benchmark/ # 性能基准测试技能
 │   │   ├── ascend-memory-profiling/ # 显存 profiling 技能
 │   │   ├── ascend-profiling-collection/ # torch profiler 采集技能
-│   │   └── ascend-profiling-analysis/ # profiling 分析报告技能
+│   │   ├── ascend-profiling-analysis/ # profiling 分析报告技能
+│   │   └── curate-workspace-knowledge/ # 显式知识整理技能
 │   ├── lib/               # 共享本地状态库
 │   └── scripts/           # 共享辅助脚本
 ├── .cursor/rules/         # Cursor IDE 专用规则


### PR DESCRIPTION
## Summary

- Add standalone Run Manifest v1 libraries, schemas, and CLI helpers.
- Add formal knowledge validation plus candidate capture, compact query, explicit curation, and bounded SessionEnd processing.
- Add the `curate-workspace-knowledge` Skill and repository integration guidance.
- Keep all six formal knowledge documents as empty `entries` skeletons; no local knowledge database, failure signatures, validation rules, or candidate queue is migrated.
- Add a public-CLI end-to-end lifecycle regression test and a reproducible validation report.

## Why

The knowledge-management and evidence-chain functionality previously lived only as part of a larger downstream branch. This PR extracts the reusable mechanism onto current `upstream/main` while keeping project-specific knowledge content out of the change.

## End-to-end flow exercised

The isolated test sandbox performs:

1. deferred candidate capture;
2. SessionEnd flush without transcript access;
3. candidate list and inspection;
4. active promotion gated by stable regression-test evidence;
5. compact query and full entry retrieval;
6. idempotent recapture returning `already-promoted`;
7. deprecation with retained history;
8. formal document validation.

The test snapshots the tracked knowledge YAML files before the flow and verifies their bytes remain unchanged afterward.

## Validation

- `.agents/tests/test_knowledge_flow.py`: 1 passed
- `.agents/tests/test_run_manifest.py`: 7 passed
- `.agents/tests/test_knowledge_memory.py`: 13 passed
- `.agents/tests/test_knowledge_hook.py`: 8 passed
- `curate-workspace-knowledge/tests/test_knowledge_curate.py`: 10 passed
- `.agents/scripts/knowledge_validate.py`: passed; 6 formal documents validated
- `git diff --check`: passed

Total: **39/39 tests passed**.

Full commands and isolation details are recorded in `.agents/knowledge/VALIDATION.md`.