### PR TITLE
feat: extract validation, Triton, and PD workflow skills

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -35,6 +35,17 @@ compatibility backend for managed sessions, sync, service adapters, and cleanup.
 - `.agents/skills/ascend-profiling-collection/` is the source-of-truth skill package for collecting Ascend torch-profiler traces and verified manifests.
 - `.agents/skills/ascend-profiling-analysis/` is the source-of-truth skill package for analyzing collected profiler roots/manifests and generating reports.
 - `.agents/skills/curate-workspace-knowledge/` is the explicit-only package for reviewing and promoting verified candidates into formal knowledge files.
+- `.agents/skills/vllm-ascend-graph-debug/` diagnoses graph compile, capture, replay, and graph/eager divergence.
+- `.agents/skills/vllm-ascend-correctness-validation/` compares normalized baseline/candidate and eager/graph correctness.
+- `.agents/skills/vllm-ascend-change-validation/` plans diff-driven validation and aggregates evidence.
+- `.agents/skills/vllm-ascend-performance-regression/` runs controlled alternating performance experiments.
+- `.agents/skills/vllm-ascend-distributed-debug/` records topology and per-rank distributed evidence.
+- `.agents/skills/ascend-operator-debug/` builds isolated Ascend operator case matrices.
+- `.agents/skills/ascend-triton-operator-development/` develops a first correct Ascend Triton candidate.
+- `.agents/skills/ascend-triton-kernel-validation/` gates fallback and correctness.
+- `.agents/skills/ascend-triton-kernel-optimization/` records profiler-driven tuning decisions.
+- `.agents/skills/ascend-triton-workflow/` links the Triton lifecycle through Run Manifest evidence.
+- `.agents/skills/vllm-ascend-pd-serving/` orchestrates grouped prefill/decode serving.
 - `.agents/scripts/workspace_profile.py` is the shared low-level helper for the local workspace machine profile.
 - `.agents/scripts/workspace_identity.py` manages the persistent local UUID4 and optional unified project/agent/resource alias.
 - `.agents/scripts/run_manifest.py` creates and validates shared Run Manifest v1 files.
@@ -75,6 +86,7 @@ Current primary helpers:
 - `session-management/scripts/session_list.py`
 - `session-management/scripts/session_status.py`
 - `session-management/scripts/session_remove.py`
+- `session-management/scripts/session_group.py`
 - `session-management/scripts/session_gc.py`
 - `scripts/remote_target_resolve.py`
 - `scripts/remote_probe.py`
@@ -117,6 +129,17 @@ Current primary helpers:
 - `ascend-profiling-analysis/scripts/profile_analyze.py`
 - `ascend-profiling-analysis/scripts/profile_sweep.py`
 - `curate-workspace-knowledge/scripts/knowledge_curate.py`
+- `vllm-ascend-graph-debug/scripts/graph_debug_case.py`
+- `vllm-ascend-correctness-validation/scripts/correctness_run.py`
+- `vllm-ascend-change-validation/scripts/change_validation.py`
+- `vllm-ascend-performance-regression/scripts/performance_regression.py`
+- `vllm-ascend-distributed-debug/scripts/distributed_debug.py`
+- `ascend-operator-debug/scripts/operator_debug.py`
+- `ascend-triton-operator-development/scripts/triton_development.py`
+- `ascend-triton-kernel-validation/scripts/triton_validation.py`
+- `ascend-triton-kernel-optimization/scripts/triton_optimization.py`
+- `ascend-triton-workflow/scripts/triton_workflow.py`
+- `vllm-ascend-pd-serving/scripts/pd_serving.py`
 - `scripts/run_manifest.py`
 - `scripts/knowledge_validate.py`
 - `scripts/knowledge_query.py`

--- a/.agents/scripts/skill_catalog.py
+++ b/.agents/scripts/skill_catalog.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Validate the repository-local skill catalog and package basics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+README_SKILL_RE = re.compile(r"^\|\s*\*\*([a-z0-9-]+)\*\*\s*\|", re.MULTILINE)
+AGENTS_SKILL_RE = re.compile(r"^\|\s*`([a-z0-9-]+)`\s*\|", re.MULTILINE)
+AGENTS_README_SKILL_RE = re.compile(
+    r"^-\s+`\.agents/skills/([a-z0-9-]+)/`", re.MULTILINE
+)
+
+
+@dataclass(frozen=True)
+class SkillRecord:
+    name: str
+    description: str
+    path: str
+    body_lines: int
+    resources: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Finding:
+    code: str
+    path: str
+    message: str
+
+
+class CatalogError(RuntimeError):
+    """Raised when a SKILL.md cannot be parsed."""
+
+
+def _parse_scalar(raw: str) -> str:
+    value = raw.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
+
+
+def parse_skill(skill_file: Path, repo_root: Path) -> SkillRecord:
+    text = skill_file.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        raise CatalogError("missing opening YAML frontmatter delimiter")
+    try:
+        end = next(index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---")
+    except StopIteration as exc:
+        raise CatalogError("missing closing YAML frontmatter delimiter") from exc
+
+    metadata: dict[str, str] = {}
+    for line in lines[1:end]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if ":" not in line:
+            raise CatalogError(f"invalid frontmatter line: {line!r}")
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = _parse_scalar(value)
+
+    unsupported = sorted(set(metadata) - {"name", "description"})
+    if unsupported:
+        raise CatalogError(f"unsupported frontmatter fields: {', '.join(unsupported)}")
+    for required in ("name", "description"):
+        if not metadata.get(required):
+            raise CatalogError(f"missing required frontmatter field: {required}")
+
+    resources = tuple(
+        name
+        for name in ("agents", "scripts", "references", "assets", "tests")
+        if (skill_file.parent / name).exists()
+    )
+    return SkillRecord(
+        name=metadata["name"],
+        description=metadata["description"],
+        path=skill_file.parent.relative_to(repo_root).as_posix(),
+        body_lines=max(0, len(lines) - end - 1),
+        resources=resources,
+    )
+
+
+def discover_skills(repo_root: Path) -> tuple[list[SkillRecord], list[Finding]]:
+    skills_root = repo_root / ".agents" / "skills"
+    findings: list[Finding] = []
+    records: list[SkillRecord] = []
+    if not skills_root.is_dir():
+        return [], [
+            Finding(
+                "skills-root-missing",
+                ".agents/skills",
+                "repository-local skills directory does not exist",
+            )
+        ]
+
+    for skill_dir in sorted(path for path in skills_root.iterdir() if path.is_dir()):
+        skill_file = skill_dir / "SKILL.md"
+        relative = skill_file.relative_to(repo_root).as_posix()
+        if not skill_file.is_file():
+            findings.append(Finding("skill-file-missing", relative, "SKILL.md does not exist"))
+            continue
+        try:
+            record = parse_skill(skill_file, repo_root)
+        except CatalogError as exc:
+            findings.append(Finding("frontmatter-invalid", relative, str(exc)))
+            continue
+        records.append(record)
+        if record.name != skill_dir.name:
+            findings.append(
+                Finding(
+                    "name-mismatch",
+                    relative,
+                    f"frontmatter name {record.name!r} does not match directory {skill_dir.name!r}",
+                )
+            )
+        if not SKILL_NAME_RE.fullmatch(record.name):
+            findings.append(
+                Finding(
+                    "name-invalid",
+                    relative,
+                    "skill name must contain only lowercase letters, digits, and hyphens",
+                )
+            )
+        if "<" in record.description or ">" in record.description:
+            findings.append(
+                Finding(
+                    "description-invalid",
+                    relative,
+                    "frontmatter description must not contain angle brackets",
+                )
+            )
+        if record.body_lines > 500:
+            findings.append(
+                Finding(
+                    "body-too-long",
+                    relative,
+                    f"SKILL.md body has {record.body_lines} lines; keep it at or below 500",
+                )
+            )
+        findings.extend(validate_markdown_links(skill_file, repo_root))
+
+    duplicate_names: dict[str, list[str]] = {}
+    for record in records:
+        duplicate_names.setdefault(record.name, []).append(record.path)
+    for name, paths in sorted(duplicate_names.items()):
+        if len(paths) > 1:
+            findings.append(
+                Finding(
+                    "duplicate-name",
+                    ".agents/skills",
+                    f"{name!r} is declared by: {', '.join(paths)}",
+                )
+            )
+    return records, findings
+
+
+def validate_markdown_links(skill_file: Path, repo_root: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    text = skill_file.read_text(encoding="utf-8")
+    for target in MARKDOWN_LINK_RE.findall(text):
+        clean_target = target.split("#", 1)[0].strip()
+        if not clean_target or "://" in clean_target or clean_target.startswith("mailto:"):
+            continue
+        candidate = (skill_file.parent / clean_target).resolve()
+        try:
+            candidate.relative_to(repo_root.resolve())
+        except ValueError:
+            findings.append(
+                Finding(
+                    "link-outside-repo",
+                    skill_file.relative_to(repo_root).as_posix(),
+                    f"local link escapes the repository: {target}",
+                )
+            )
+            continue
+        if not candidate.exists():
+            findings.append(
+                Finding(
+                    "link-missing",
+                    skill_file.relative_to(repo_root).as_posix(),
+                    f"local link target does not exist: {target}",
+                )
+            )
+    return findings
+
+
+def _extract_catalog_names(path: Path, pattern: re.Pattern[str]) -> set[str]:
+    if not path.is_file():
+        return set()
+    return set(pattern.findall(path.read_text(encoding="utf-8")))
+
+
+def validate_document_catalogs(
+    repo_root: Path, records: Iterable[SkillRecord]
+) -> list[Finding]:
+    expected = {record.name for record in records}
+    documents = (
+        ("README.md", README_SKILL_RE),
+        ("README.en.md", README_SKILL_RE),
+        ("AGENTS.md", AGENTS_SKILL_RE),
+        (".agents/README.md", AGENTS_README_SKILL_RE),
+    )
+    findings: list[Finding] = []
+    for relative, pattern in documents:
+        path = repo_root / relative
+        if not path.is_file():
+            findings.append(Finding("catalog-document-missing", relative, "file does not exist"))
+            continue
+        actual = _extract_catalog_names(path, pattern)
+        missing = sorted(expected - actual)
+        unknown = sorted(actual - expected)
+        if missing:
+            findings.append(
+                Finding(
+                    "catalog-entry-missing",
+                    relative,
+                    f"missing skills: {', '.join(missing)}",
+                )
+            )
+        if unknown:
+            findings.append(
+                Finding(
+                    "catalog-entry-unknown",
+                    relative,
+                    f"unknown skills: {', '.join(unknown)}",
+                )
+            )
+    return findings
+
+
+def validate_repo(repo_root: Path) -> tuple[list[SkillRecord], list[Finding]]:
+    records, findings = discover_skills(repo_root)
+    findings.extend(validate_document_catalogs(repo_root, records))
+    return records, sorted(findings, key=lambda item: (item.path, item.code, item.message))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="workspace root; defaults to the repository containing this script",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="output format",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    records, findings = validate_repo(repo_root)
+    payload = {
+        "status": "passed" if not findings else "failed",
+        "repo_root": str(repo_root),
+        "skill_count": len(records),
+        "skills": [asdict(record) for record in records],
+        "finding_count": len(findings),
+        "findings": [asdict(finding) for finding in findings],
+    }
+    if args.format == "json":
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        if findings:
+            for finding in findings:
+                print(
+                    f"{finding.path}: {finding.code}: {finding.message}",
+                    file=sys.stderr,
+                )
+        print(json.dumps(payload, ensure_ascii=False))
+    return 0 if not findings else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/ascend-operator-debug/SKILL.md
+++ b/.agents/skills/ascend-operator-debug/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: ascend-operator-debug
+description: Reduce an Ascend model-level failure to one torch_npu, ACLNN, or custom operator call, then validate explicit dtype, shape, layout, and eager/compile/graph cases against a reference implementation. Use for operator crashes, unsupported dtype or layout errors, shape-dependent numerical mismatches, or workspace API faults. Do not use for whole-model graph localization, multi-rank failures, performance benchmarking, or profiler analysis.
+---
+
+# Ascend Operator Debug
+
+Turn a suspected operator failure into a portable reproducer and an explicit
+case matrix. A model-level symptom is not an operator bug until the isolated call
+reproduces it.
+
+## Workflow
+
+1. Capture the failing call's operator name, arguments, input metadata, execution
+   mode, environment, and source stack without copying full tensors by default.
+2. Define a trusted reference implementation and tolerances before comparing.
+3. Create an explicit case matrix with `scripts/operator_debug.py plan`.
+4. Run the generated cases on a remote Ascend environment. Change one dimension
+   at a time: dtype, shape, layout, mode, or operator option.
+5. Record each normalized result with `record`.
+6. Run `analyze` to separate numerical mismatch, crash, unsupported combination,
+   missing evidence, and operator-pass/integration-fail outcomes.
+7. Add the smallest failing case as a regression test, then rerun the original
+   model integration after the operator fix.
+
+## Entry point
+
+`scripts/operator_debug.py` provides:
+
+- `plan`: validate the explicit case matrix and create the evidence layout;
+- `record`: accept one result for a planned case without overwriting evidence;
+- `analyze`: summarize failure axes and create a Run Manifest-linked report.
+
+Read only the reference needed for the current phase:
+
+- [Behavior contract](references/behavior.md)
+- [Command recipes](references/command-recipes.md)
+- [Acceptance](references/acceptance.md)
+
+## Boundaries
+
+- This skill begins after evidence identifies one operator boundary or the user
+  explicitly supplies an operator reproducer.
+- Whole-model eager-versus-graph localization belongs to
+  `vllm-ascend-graph-debug`; hand off only after one operator call is isolated.
+- Rank-dependent and collective failures belong to
+  `vllm-ascend-distributed-debug`.
+- Model-level throughput regressions belong to performance workflows. An optional
+  operator timing value here is only supporting evidence for the isolated case.
+
+## Rules
+
+- Do not run `torch_npu` locally; execute operator cases on a managed remote NPU.
+- Preserve exact input shape, stride, dtype, layout, device, and scalar options.
+- Never silently cast inputs or relax tolerances to make a case pass.
+- Record unsupported combinations separately from product failures.
+- Keep cases under `.vaws-local/operator-debug/`.

--- a/.agents/skills/ascend-operator-debug/agents/openai.yaml
+++ b/.agents/skills/ascend-operator-debug/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ascend Operator Debug"
+  short_description: "Reduce and validate isolated Ascend operator failures"
+  default_prompt: "Use $ascend-operator-debug to reduce this failure to one Ascend operator call and validate it against a reference implementation."

--- a/.agents/skills/ascend-operator-debug/references/acceptance.md
+++ b/.agents/skills/ascend-operator-debug/references/acceptance.md
@@ -1,0 +1,23 @@
+# Ascend operator debug acceptance
+
+## Reproduction
+
+- [ ] The failure reproduces with one operator invocation.
+- [ ] Input shape, stride, dtype, layout, device, and attributes are explicit.
+- [ ] The reference implementation is independent enough to detect the defect.
+- [ ] Tolerances were fixed before examining candidate output.
+
+## Matrix
+
+- [ ] Each case changes one meaningful dimension.
+- [ ] Eager, compile, or graph mode is explicit.
+- [ ] Unsupported cases are not counted as product failures.
+- [ ] Crash signatures and numerical comparisons retain raw evidence links.
+
+## Fix validation
+
+- [ ] The smallest failing case becomes a regression test when practical.
+- [ ] The isolated case passes after the fix.
+- [ ] Nearby dtype, shape, and layout cases still pass.
+- [ ] The original model integration passes after the fix.
+- [ ] Temporary tensor dumps and instrumentation are removed or documented.

--- a/.agents/skills/ascend-operator-debug/references/behavior.md
+++ b/.agents/skills/ascend-operator-debug/references/behavior.md
@@ -1,0 +1,66 @@
+# Ascend operator debug behavior contract
+
+## Operator config
+
+An operator case names the exact invocation and trusted reference. It records
+fixed absolute and relative tolerances before results are observed.
+
+Each explicit case contains:
+
+- a stable ID;
+- execution mode: `eager`, `compile`, or `graph`;
+- input names, shapes, strides, dtypes, and layouts;
+- scalar and boolean operator attributes.
+
+Prefer explicit cases over an uncontrolled Cartesian product. Add one case when
+one dimension answers a concrete hypothesis.
+
+## Result contract
+
+```json
+{
+  "schema_version": 1,
+  "case_id": "fp16-2x4-graph",
+  "status": "numerical_mismatch",
+  "comparisons": [
+    {
+      "output": "out",
+      "max_abs": 0.02,
+      "max_rel": 0.1,
+      "cosine": 0.998
+    }
+  ],
+  "timing_us": 41.2,
+  "source": "/path/to/raw-result.json"
+}
+```
+
+Statuses are `passed`, `numerical_mismatch`, `crash`, and `unsupported`.
+Crashes and unsupported cases require an error signature. Timing is optional
+supporting evidence and is not a model-level regression verdict.
+
+## Analysis semantics
+
+- `diagnosed`: at least one isolated case crashes or mismatches;
+- `inconclusive`: planned evidence is missing or a combination is unsupported;
+- `passed`: all isolated cases pass.
+
+If every isolated case passes while the source model still fails, the report
+routes investigation back to the integration boundary without claiming that the
+operator is correct for untested cases.
+
+## Case layout
+
+```text
+case/
+├── manifest.json
+├── operator-config.json
+├── case-matrix.json
+├── results.json
+├── raw-results/
+├── input-metadata/
+├── artifacts/
+├── analysis.json
+├── report.md
+└── reproduction.md
+```

--- a/.agents/skills/ascend-operator-debug/references/command-recipes.md
+++ b/.agents/skills/ascend-operator-debug/references/command-recipes.md
@@ -1,0 +1,33 @@
+# Ascend operator debug command recipes
+
+## Plan
+
+```bash
+python -B .agents/skills/ascend-operator-debug/scripts/operator_debug.py plan \
+  --output-dir .vaws-local/operator-debug/case-001 \
+  --config /path/to/operator-config.json
+```
+
+## Execute remotely
+
+Use the generated matrix to run one operator invocation per case on an Ascend
+NPU. Store raw stdout, stderr, stack traces, and input metadata under the case
+directory. Do not run `torch_npu` on the local machine.
+
+## Record
+
+```bash
+python -B .agents/skills/ascend-operator-debug/scripts/operator_debug.py record \
+  --output-dir .vaws-local/operator-debug/case-001 \
+  --result /path/to/normalized-case-result.json
+```
+
+Each case can be recorded once, so corrected evidence requires a new case ID or a
+new run.
+
+## Analyze
+
+```bash
+python -B .agents/skills/ascend-operator-debug/scripts/operator_debug.py analyze \
+  --output-dir .vaws-local/operator-debug/case-001
+```

--- a/.agents/skills/ascend-operator-debug/scripts/operator_debug.py
+++ b/.agents/skills/ascend-operator-debug/scripts/operator_debug.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+"""Plan, record, and analyze isolated Ascend operator debug matrices."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import tempfile
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_run_manifest import (  # noqa: E402
+    RunManifestError,
+    add_artifact,
+    load_manifest,
+    new_manifest,
+    transition_status,
+    write_manifest,
+)
+
+SCHEMA_VERSION = 1
+MODES = {"eager", "compile", "graph"}
+RESULT_STATUSES = {"passed", "numerical_mismatch", "crash", "unsupported"}
+
+
+class OperatorDebugError(ValueError):
+    """Raised when an operator case or result violates the contract."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    _atomic_write(
+        path, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise OperatorDebugError(f"cannot read {label} {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise OperatorDebugError(f"{label} root must be an object")
+    return payload
+
+
+def validate_input_spec(spec: Mapping[str, Any], path: str, errors: list[str]) -> None:
+    if not isinstance(spec.get("name"), str) or not spec["name"]:
+        errors.append(f"{path}.name must be a non-empty string")
+    shape = spec.get("shape")
+    if not isinstance(shape, list) or any(
+        not isinstance(size, int) or isinstance(size, bool) or size < 0
+        for size in shape
+    ):
+        errors.append(f"{path}.shape must be an array of non-negative integers")
+    for field in ("dtype", "layout"):
+        if not isinstance(spec.get(field), str) or not spec[field]:
+            errors.append(f"{path}.{field} must be a non-empty string")
+    strides = spec.get("strides")
+    if strides is not None and (
+        not isinstance(strides, list)
+        or any(
+            not isinstance(stride, int) or isinstance(stride, bool) or stride < 0
+            for stride in strides
+        )
+    ):
+        errors.append(f"{path}.strides must be an array of non-negative integers")
+
+
+def validate_config(config: Mapping[str, Any]) -> None:
+    errors: list[str] = []
+    if config.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    if not isinstance(config.get("run_id"), str) or not config["run_id"]:
+        errors.append("run_id must be a non-empty string")
+    operator = config.get("operator")
+    if not isinstance(operator, Mapping):
+        errors.append("operator must be an object")
+    else:
+        for field in ("name", "invocation", "reference"):
+            if not isinstance(operator.get(field), str) or not operator[field]:
+                errors.append(f"operator.{field} must be a non-empty string")
+    tolerance = config.get("tolerance")
+    if not isinstance(tolerance, Mapping):
+        errors.append("tolerance must be an object")
+    else:
+        for field in ("atol", "rtol"):
+            value = tolerance.get(field)
+            if (
+                not isinstance(value, (int, float))
+                or isinstance(value, bool)
+                or value < 0
+            ):
+                errors.append(f"tolerance.{field} must be non-negative")
+    cases = config.get("cases")
+    if not isinstance(cases, list) or not cases:
+        errors.append("cases must be a non-empty array")
+        cases = []
+    case_ids: set[str] = set()
+    for index, case in enumerate(cases):
+        path = f"cases[{index}]"
+        if not isinstance(case, Mapping):
+            errors.append(f"{path} must be an object")
+            continue
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not case_id:
+            errors.append(f"{path}.id must be a non-empty string")
+        elif case_id in case_ids:
+            errors.append(f"case id is duplicated: {case_id}")
+        else:
+            case_ids.add(case_id)
+        if case.get("mode") not in MODES:
+            errors.append(f"{path}.mode must be one of: {', '.join(sorted(MODES))}")
+        inputs = case.get("inputs")
+        if not isinstance(inputs, list) or not inputs:
+            errors.append(f"{path}.inputs must be a non-empty array")
+        else:
+            for input_index, spec in enumerate(inputs):
+                if not isinstance(spec, Mapping):
+                    errors.append(f"{path}.inputs[{input_index}] must be an object")
+                else:
+                    validate_input_spec(
+                        spec, f"{path}.inputs[{input_index}]", errors
+                    )
+        attributes = case.get("attributes", {})
+        if not isinstance(attributes, Mapping):
+            errors.append(f"{path}.attributes must be an object")
+    if errors:
+        raise OperatorDebugError("; ".join(errors))
+
+
+def validate_result(result: Mapping[str, Any], planned_ids: set[str]) -> None:
+    errors: list[str] = []
+    if result.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    if result.get("case_id") not in planned_ids:
+        errors.append("case_id must identify a planned case")
+    status = result.get("status")
+    if status not in RESULT_STATUSES:
+        errors.append(
+            f"status must be one of: {', '.join(sorted(RESULT_STATUSES))}"
+        )
+    comparisons = result.get("comparisons", [])
+    if not isinstance(comparisons, list):
+        errors.append("comparisons must be an array")
+        comparisons = []
+    for index, comparison in enumerate(comparisons):
+        if not isinstance(comparison, Mapping):
+            errors.append(f"comparisons[{index}] must be an object")
+            continue
+        if not isinstance(comparison.get("output"), str) or not comparison["output"]:
+            errors.append(f"comparisons[{index}].output must be a non-empty string")
+        for metric in ("max_abs", "max_rel", "cosine"):
+            value = comparison.get(metric)
+            if value is not None and (
+                not isinstance(value, (int, float))
+                or isinstance(value, bool)
+                or not math.isfinite(float(value))
+            ):
+                errors.append(f"comparisons[{index}].{metric} must be finite")
+    if status in {"crash", "unsupported"} and (
+        not isinstance(result.get("error"), str) or not result["error"]
+    ):
+        errors.append(f"{status} result requires error")
+    timing = result.get("timing_us")
+    if timing is not None and (
+        not isinstance(timing, (int, float))
+        or isinstance(timing, bool)
+        or not math.isfinite(float(timing))
+        or timing < 0
+    ):
+        errors.append("timing_us must be a non-negative finite number")
+    if errors:
+        raise OperatorDebugError("; ".join(errors))
+
+
+def plan(
+    output_dir: Path, *, config_path: Path, created_at: str | None = None
+) -> dict[str, Any]:
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise OperatorDebugError(f"output directory is not empty: {output_dir}")
+    config = _load_json(config_path, "operator config")
+    validate_config(config)
+    timestamp = created_at or utc_now()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for directory in ("raw-results", "input-metadata", "artifacts"):
+        (output_dir / directory).mkdir()
+    matrix = {
+        "schema_version": SCHEMA_VERSION,
+        "operator": config["operator"]["name"],
+        "cases": [
+            {
+                **case,
+                "status": "pending",
+            }
+            for case in config["cases"]
+        ],
+    }
+    _write_json(output_dir / "operator-config.json", config)
+    _write_json(output_dir / "case-matrix.json", matrix)
+    _write_json(
+        output_dir / "results.json",
+        {"schema_version": SCHEMA_VERSION, "results": []},
+    )
+    _atomic_write(
+        output_dir / "reproduction.md",
+        "# Operator reproduction\n\n"
+        f"- Operator: `{config['operator']['name']}`\n"
+        f"- Invocation: `{config['operator']['invocation']}`\n"
+        f"- Reference: `{config['operator']['reference']}`\n\n"
+        "Execute every explicit case on a remote Ascend NPU without implicit casts.\n",
+    )
+    manifest = new_manifest(
+        run_type="debug",
+        run_id=config["run_id"],
+        workspace_snapshot=config.get("workspace_snapshot", {}),
+        environment=config.get("environment", {}),
+        model=config.get("model", {}),
+        command=config.get("command", []),
+        created_at=timestamp,
+    )
+    for name, kind, uri in (
+        ("operator-config", "operator-config", "operator-config.json"),
+        ("case-matrix", "case-matrix", "case-matrix.json"),
+        ("results", "operator-results", "results.json"),
+        ("reproduction", "reproduction", "reproduction.md"),
+    ):
+        manifest = add_artifact(
+            manifest, name=name, kind=kind, uri=uri, updated_at=timestamp
+        )
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {
+        "status": "planned",
+        "run_id": config["run_id"],
+        "operator": config["operator"]["name"],
+        "case_count": len(config["cases"]),
+    }
+
+
+def record(
+    output_dir: Path, *, result_path: Path, recorded_at: str | None = None
+) -> dict[str, Any]:
+    matrix = _load_json(output_dir / "case-matrix.json", "case matrix")
+    results = _load_json(output_dir / "results.json", "results")
+    planned_ids = {case["id"] for case in matrix["cases"]}
+    result = _load_json(result_path, "operator result")
+    validate_result(result, planned_ids)
+    if any(row["case_id"] == result["case_id"] for row in results["results"]):
+        raise OperatorDebugError(f"case already recorded: {result['case_id']}")
+    case = next(row for row in matrix["cases"] if row["id"] == result["case_id"])
+    if case["status"] != "pending":
+        raise OperatorDebugError(f"case is not pending: {result['case_id']}")
+    timestamp = recorded_at or utc_now()
+    normalized = {
+        **result,
+        "comparisons": [
+            {
+                key: float(value) if key in {"max_abs", "max_rel", "cosine"} else value
+                for key, value in comparison.items()
+            }
+            for comparison in result.get("comparisons", [])
+        ],
+        "timing_us": (
+            float(result["timing_us"]) if result.get("timing_us") is not None else None
+        ),
+        "source": result.get("source", str(result_path.resolve())),
+        "recorded_at": timestamp,
+    }
+    results["results"].append(normalized)
+    case["status"] = "recorded"
+    _write_json(output_dir / "results.json", results)
+    _write_json(output_dir / "case-matrix.json", matrix)
+    manifest = load_manifest(output_dir / "manifest.json")
+    if manifest["status"] == "planned":
+        manifest = transition_status(manifest, "running", updated_at=timestamp)
+        write_manifest(output_dir / "manifest.json", manifest)
+    return {
+        "status": "recorded",
+        "case_id": result["case_id"],
+        "remaining": sum(case["status"] == "pending" for case in matrix["cases"]),
+    }
+
+
+def _case_axes(case: Mapping[str, Any]) -> dict[str, list[str]]:
+    axes: dict[str, list[str]] = {
+        "mode": [str(case["mode"])],
+        "dtype": sorted({str(spec["dtype"]) for spec in case["inputs"]}),
+        "layout": sorted({str(spec["layout"]) for spec in case["inputs"]}),
+        "shape": [
+            ",".join("x".join(str(size) for size in spec["shape"]) for spec in case["inputs"])
+        ],
+    }
+    for key, value in sorted(case.get("attributes", {}).items()):
+        axes[f"attribute:{key}"] = [json.dumps(value, sort_keys=True)]
+    return axes
+
+
+def analyze_documents(
+    config: Mapping[str, Any],
+    matrix: Mapping[str, Any],
+    results: Mapping[str, Any],
+) -> dict[str, Any]:
+    validate_config(config)
+    result_by_id = {row["case_id"]: row for row in results["results"]}
+    missing = [case["id"] for case in matrix["cases"] if case["id"] not in result_by_id]
+    status_counts = {status: 0 for status in sorted(RESULT_STATUSES)}
+    failure_axes: dict[str, dict[str, list[str]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for case in matrix["cases"]:
+        result = result_by_id.get(case["id"])
+        if result is None:
+            continue
+        status_counts[result["status"]] += 1
+        if result["status"] in {"numerical_mismatch", "crash"}:
+            for axis, values in _case_axes(case).items():
+                for value in values:
+                    failure_axes[axis][value].append(case["id"])
+    crashes = sorted(
+        row["case_id"] for row in results["results"] if row["status"] == "crash"
+    )
+    mismatches = sorted(
+        row["case_id"]
+        for row in results["results"]
+        if row["status"] == "numerical_mismatch"
+    )
+    unsupported = sorted(
+        row["case_id"]
+        for row in results["results"]
+        if row["status"] == "unsupported"
+    )
+    if missing:
+        status = "inconclusive"
+    elif crashes or mismatches:
+        status = "diagnosed"
+    elif unsupported:
+        status = "inconclusive"
+    else:
+        status = "passed"
+    integration_hint = (
+        "isolated-operator-cases-pass-check-integration-boundary"
+        if status == "passed" and bool(config.get("source_model_failure"))
+        else None
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "operator": config["operator"]["name"],
+        "missing_cases": missing,
+        "crash_cases": crashes,
+        "mismatch_cases": mismatches,
+        "unsupported_cases": unsupported,
+        "status_counts": status_counts,
+        "failure_axes": {
+            axis: {value: sorted(ids) for value, ids in sorted(values.items())}
+            for axis, values in sorted(failure_axes.items())
+        },
+        "integration_hint": integration_hint,
+        "results": results["results"],
+    }
+
+
+def render_report(analysis: Mapping[str, Any]) -> str:
+    lines = [
+        "# Ascend operator debug report",
+        "",
+        f"- Status: **{analysis['status']}**",
+        f"- Operator: `{analysis['operator']}`",
+        f"- Missing: {', '.join(analysis['missing_cases']) or 'none'}",
+        f"- Crashes: {', '.join(analysis['crash_cases']) or 'none'}",
+        f"- Numerical mismatches: {', '.join(analysis['mismatch_cases']) or 'none'}",
+        f"- Unsupported: {', '.join(analysis['unsupported_cases']) or 'none'}",
+        "",
+        "## Failure axes",
+        "",
+        "```json",
+        json.dumps(analysis["failure_axes"], ensure_ascii=False, indent=2, sort_keys=True),
+        "```",
+        "",
+    ]
+    if analysis["integration_hint"]:
+        lines.extend(
+            [
+                "## Integration boundary",
+                "",
+                "All isolated cases passed while a model-level failure remains. "
+                "Inspect caller-provided metadata, aliasing, stream/lifetime, graph "
+                "integration, and post-operator consumers before changing the operator.",
+                "",
+            ]
+        )
+    lines.extend(["## Results", "", "```json"])
+    lines.append(
+        json.dumps(analysis["results"], ensure_ascii=False, indent=2, sort_keys=True)
+    )
+    lines.extend(["```", ""])
+    return "\n".join(lines)
+
+
+def analyze(
+    output_dir: Path, *, updated_at: str | None = None
+) -> dict[str, Any]:
+    config = _load_json(output_dir / "operator-config.json", "operator config")
+    matrix = _load_json(output_dir / "case-matrix.json", "case matrix")
+    results = _load_json(output_dir / "results.json", "results")
+    analysis = analyze_documents(config, matrix, results)
+    _write_json(output_dir / "analysis.json", analysis)
+    _atomic_write(output_dir / "report.md", render_report(analysis))
+    timestamp = updated_at or utc_now()
+    manifest = load_manifest(output_dir / "manifest.json")
+    if manifest["status"] == "planned":
+        manifest = transition_status(manifest, "running", updated_at=timestamp)
+    for name, kind, uri in (
+        ("analysis", "analysis", "analysis.json"),
+        ("report", "report", "report.md"),
+    ):
+        manifest = add_artifact(
+            manifest, name=name, kind=kind, uri=uri, updated_at=timestamp
+        )
+    terminal = {
+        "passed": "passed",
+        "diagnosed": "failed",
+        "inconclusive": "inconclusive",
+    }[analysis["status"]]
+    manifest = transition_status(manifest, terminal, updated_at=timestamp)
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {
+        "status": analysis["status"],
+        "crash_cases": analysis["crash_cases"],
+        "mismatch_cases": analysis["mismatch_cases"],
+        "missing_cases": analysis["missing_cases"],
+        "analysis": str((output_dir / "analysis.json").resolve()),
+        "report": str((output_dir / "report.md").resolve()),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+    plan_parser = subparsers.add_parser("plan", help="create an operator case")
+    plan_parser.add_argument("--output-dir", required=True, type=Path)
+    plan_parser.add_argument("--config", required=True, type=Path)
+    record_parser = subparsers.add_parser("record", help="record a planned case")
+    record_parser.add_argument("--output-dir", required=True, type=Path)
+    record_parser.add_argument("--result", required=True, type=Path)
+    analyze_parser = subparsers.add_parser("analyze", help="analyze the case matrix")
+    analyze_parser.add_argument("--output-dir", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.action == "plan":
+            payload = plan(args.output_dir, config_path=args.config)
+        elif args.action == "record":
+            payload = record(args.output_dir, result_path=args.result)
+        else:
+            payload = analyze(args.output_dir)
+    except (OperatorDebugError, RunManifestError) as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/ascend-operator-debug/tests/test_operator_debug.py
+++ b/.agents/skills/ascend-operator-debug/tests/test_operator_debug.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Tests for the isolated Ascend operator case controller."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+SKILL = ROOT / ".agents" / "skills" / "ascend-operator-debug"
+
+
+def load_module():
+    name = "_operator_debug_test"
+    spec = importlib.util.spec_from_file_location(
+        name, SKILL / "scripts" / "operator_debug.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+operator = load_module()
+NOW = "2026-07-25T12:00:00Z"
+
+
+def case(case_id: str, mode: str, dtype: str = "float16") -> dict:
+    return {
+        "id": case_id,
+        "mode": mode,
+        "inputs": [
+            {
+                "name": "x",
+                "shape": [2, 4],
+                "strides": [4, 1],
+                "dtype": dtype,
+                "layout": "ND",
+            }
+        ],
+        "attributes": {"transpose": False},
+    }
+
+
+def config() -> dict:
+    return {
+        "schema_version": 1,
+        "run_id": "operator-case-1",
+        "operator": {
+            "name": "npu_example",
+            "invocation": "torch_npu.npu_example(x)",
+            "reference": "torch_ref(x.cpu())",
+        },
+        "tolerance": {"atol": 0.001, "rtol": 0.001},
+        "source_model_failure": "model output diverges",
+        "environment": {"torch_npu": "test"},
+        "cases": [
+            case("fp16-eager", "eager"),
+            case("fp16-graph", "graph"),
+        ],
+    }
+
+
+def result(case_id: str, status: str = "passed") -> dict:
+    payload = {
+        "schema_version": 1,
+        "case_id": case_id,
+        "status": status,
+        "comparisons": [
+            {
+                "output": "out",
+                "max_abs": 0.0,
+                "max_rel": 0.0,
+                "cosine": 1.0,
+            }
+        ],
+    }
+    if status in {"crash", "unsupported"}:
+        payload["error"] = "operator failed"
+        payload["comparisons"] = []
+    return payload
+
+
+class OperatorDebugTests(unittest.TestCase):
+    def test_duplicate_case_ids_are_rejected(self) -> None:
+        invalid = config()
+        invalid["cases"][1]["id"] = invalid["cases"][0]["id"]
+        with self.assertRaisesRegex(operator.OperatorDebugError, "duplicated"):
+            operator.validate_config(invalid)
+
+    def test_failure_axes_localize_graph_only_mismatch(self) -> None:
+        cfg = config()
+        matrix = {"cases": [{**row, "status": "recorded"} for row in cfg["cases"]]}
+        results = {
+            "results": [
+                result("fp16-eager"),
+                result("fp16-graph", "numerical_mismatch"),
+            ]
+        }
+        analysis = operator.analyze_documents(cfg, matrix, results)
+        self.assertEqual(analysis["status"], "diagnosed")
+        self.assertEqual(
+            analysis["failure_axes"]["mode"]["graph"], ["fp16-graph"]
+        )
+
+    def test_missing_case_is_inconclusive(self) -> None:
+        cfg = config()
+        matrix = {"cases": [{**row, "status": "pending"} for row in cfg["cases"]]}
+        analysis = operator.analyze_documents(
+            cfg, matrix, {"results": [result("fp16-eager")]}
+        )
+        self.assertEqual(analysis["status"], "inconclusive")
+        self.assertEqual(analysis["missing_cases"], ["fp16-graph"])
+
+    def test_all_isolated_cases_pass_points_to_integration(self) -> None:
+        cfg = config()
+        matrix = {"cases": [{**row, "status": "recorded"} for row in cfg["cases"]]}
+        analysis = operator.analyze_documents(
+            cfg,
+            matrix,
+            {"results": [result("fp16-eager"), result("fp16-graph")]},
+        )
+        self.assertEqual(analysis["status"], "passed")
+        self.assertIsNotNone(analysis["integration_hint"])
+
+    def test_full_lifecycle_rejects_duplicate_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(config()), encoding="utf-8")
+            output = root / "case"
+            operator.plan(output, config_path=config_path, created_at=NOW)
+            for case_id in ("fp16-eager", "fp16-graph"):
+                result_path = root / f"{case_id}.json"
+                result_path.write_text(
+                    json.dumps(result(case_id)), encoding="utf-8"
+                )
+                operator.record(output, result_path=result_path, recorded_at=NOW)
+                with self.assertRaisesRegex(operator.OperatorDebugError, "already"):
+                    operator.record(
+                        output, result_path=result_path, recorded_at=NOW
+                    )
+            analyzed = operator.analyze(output, updated_at=NOW)
+            self.assertEqual(analyzed["status"], "passed")
+            self.assertTrue((output / "report.md").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/ascend-triton-kernel-optimization/SKILL.md
+++ b/.agents/skills/ascend-triton-kernel-optimization/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: ascend-triton-kernel-optimization
+description: Profile and iteratively optimize a correctness-passed Ascend Triton kernel with explicit NPU baselines, per-shape measurements, UB live-set and physical-core reasoning, MTE/Vector/Scalar bottleneck attribution, one-hypothesis rounds, noise-aware KEEP/DISCARD decisions, and Run Manifest evidence. Use for single-kernel latency or throughput improvement after all planned correctness cases pass. Do not use to create or migrate the first correct kernel, bypass failed validation, assess whole-model serving regressions, attribute model HBM, or diagnose a non-Triton operator.
+---
+
+# Ascend Triton Kernel Optimization
+
+Optimize one correct kernel against a comparable NPU baseline. Preserve correctness and evidence integrity at every round.
+
+## Workflow
+
+1. Require a passed `ascend-triton-kernel-validation` manifest for the exact candidate hash and case set.
+2. Record target SoC/software versions, NPU baseline, warmup/repeat policy, per-case medians, noise threshold, case-regression limit, and performance objective.
+3. Query `.agents/knowledge/` with current profiler signals and failure signatures before selecting an optimization.
+4. Run `scripts/triton_optimization.py plan` to lock the baseline, objective, cases, and starting kernel.
+5. Use `msprof op` or the target version's supported operator profiler to compare device time, block count, MTE2/MTE3, Vector, Scalar/FLOWCTRL, and pipeline gaps against theoretical floors.
+6. Form one falsifiable hypothesis, change one primary mechanism, and rerun the full correctness gate on the candidate.
+7. Normalize per-case measurements and run `record`. The controller chooses `KEEP`, `DISCARD`, `NOISE`, or `FAIL`; never overwrite the best kernel.
+8. After repeated failures, enter diagnosis and change the bottleneck model rather than retrying the same parameter.
+9. Run `analyze` only when the objective is met, round budget is exhausted, or the run intentionally stops.
+
+## Entry point
+
+`scripts/triton_optimization.py` provides:
+
+- `plan`: validate correctness evidence and lock baseline/configuration;
+- `record`: enforce sequential rounds, parent hash, full-case validation, measurement coverage, and noise-aware decisions;
+- `analyze`: report best kernel, cumulative improvement, discarded hypotheses, and terminal objective status.
+
+Read:
+
+- [Behavior contract](references/behavior.md) for config, round, decision, and status semantics.
+- [Profiling decision tree](references/profiling-decision-tree.md) before choosing a hypothesis.
+- [Ascend optimization techniques](references/ascend-techniques.md) only for the diagnosed bottleneck.
+- [Command recipes](references/command-recipes.md) for the lifecycle.
+- [Acceptance](references/acceptance.md) before claiming an optimization.
+
+## Rules
+
+- Never benchmark a failed or inconclusive correctness candidate.
+- Compare like-for-like NPU states; GPU latency is context, not the only NPU acceptance baseline.
+- Exclude compile and warmup, preserve raw values, and remeasure noise before small decisions.
+- Treat core count, UB capacity, alignment, dtype support, and compiler options as target-specific capabilities.
+- Keep run state under `.vaws-local/ascend-triton/optimization/`.

--- a/.agents/skills/ascend-triton-kernel-optimization/agents/openai.yaml
+++ b/.agents/skills/ascend-triton-kernel-optimization/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ascend Triton Kernel Optimization"
+  short_description: "Profile and optimize Ascend Triton kernel performance"
+  default_prompt: "Use $ascend-triton-kernel-optimization to profile and optimize this correct Ascend Triton kernel."

--- a/.agents/skills/ascend-triton-kernel-optimization/references/acceptance.md
+++ b/.agents/skills/ascend-triton-kernel-optimization/references/acceptance.md
@@ -1,0 +1,24 @@
+# Ascend Triton optimization acceptance
+
+## Preconditions and parity
+
+- [ ] Starting kernel has a passed full-case validation manifest.
+- [ ] Target environment and starting kernel hash are recorded.
+- [ ] NPU baseline covers every case under one measurement policy.
+- [ ] Compile/warmup is excluded and raw measurements are preserved.
+
+## Iteration integrity
+
+- [ ] Each round states one hypothesis, change, and expected profiler signal.
+- [ ] Parent hash equals the current best hash.
+- [ ] Every measured candidate passed the full correctness matrix first.
+- [ ] KEEP/DISCARD/NOISE/FAIL came from the controller thresholds.
+- [ ] Best code was never overwritten by a discarded candidate.
+- [ ] Repeated failures triggered diagnosis rather than repetition.
+
+## Delivery
+
+- [ ] Per-case and aggregate results include the noise and regression policy.
+- [ ] Best hash, original baseline improvement, target, and target status are explicit.
+- [ ] GPU timing is labeled cross-platform context only.
+- [ ] Profiler artifacts support the claimed mechanism, not merely the latency delta.

--- a/.agents/skills/ascend-triton-kernel-optimization/references/ascend-techniques.md
+++ b/.agents/skills/ascend-triton-kernel-optimization/references/ascend-techniques.md
@@ -1,0 +1,72 @@
+# Ascend Triton optimization techniques
+
+## Contents
+
+- Grid and load balance
+- UB live set and multibuffer
+- MTE, Vector, and Scalar overlap
+- Masks and padding
+- Dtype and scalar lowering
+- Memory access
+- Specialization, fusion, and autotune
+
+## Grid and load balance
+
+Treat grid as physical resource mapping. Benchmark physical-core-scale
+grid-stride scheduling against compiler-supported blockification. Balance
+front/tail work and account for scalar division/modulo introduced by flattening.
+A 1D grid is a strong candidate, not a universal rule.
+
+## UB live set and multibuffer
+
+Budget peak simultaneous live bytes, including loads, widened temporaries,
+accumulators, masks, indices, slices, and values pending store:
+
+```text
+usable_per_stage = floor(UB_bytes * safety_factor / pipeline_stages)
+tile_count <= usable_per_stage / peak_live_bytes_per_tile
+```
+
+For a 192 KB UB, 85 KB is only a conservative two-stage heuristic. Query the
+target. Shorten live ranges, compute/store completed streams early, and avoid
+loading every input before any computation.
+
+## MTE, Vector, and Scalar overlap
+
+- Make iteration addresses independent (`base + iteration * stride`).
+- Interleave load, compute, and store in tiles.
+- Reorder independent loads to issue early without inflating the live set.
+- Hoist loop-invariant loads and address terms.
+- Ensure enough looped transfers exist for multibuffer to matter.
+
+## Masks and padding
+
+Default padding or `other` can introduce Vector fill dependencies. Try
+`care_padding=False` only after proving invalid lanes are dead or overwritten.
+Preserve reduction identities. Keep load and store masks semantically separate.
+
+## Dtype and scalar lowering
+
+Profile int64 arithmetic, integer compare/reduce, discrete masks, and complex
+divide/modulo. Use int32 only when ranges are safe. Do not cast large exact
+indices to fp32. Verify the backend actually lowers the revised code to Vector
+operations.
+
+## Memory access
+
+- Prefer contiguous aligned multi-row transfers.
+- Construct regular indices with `tl.arange` instead of reading computable tables.
+- Handle data-dependent gather/index access in continuous inner segments; large
+  discrete 2D masks may lower to scalar loops.
+- Include `.contiguous()` copies in end-to-end timing unless contiguity is part of
+  the public input contract.
+
+## Specialization, fusion, and autotune
+
+- Use `tl.constexpr` for bounded specialization, not every dynamic length.
+- Fuse passes when saved GM traffic exceeds new UB/synchronization/compile cost.
+- Split or specialize when fusion breaks UB/pipeline behavior or shapes need
+  different algorithms; retain a generic fallback and measure routing.
+- Tune BLOCK/tile/grid plus supported Ascend compiler options such as
+  `multibuffer`, `unit_flag`, and `auto_blockify_size` only when present in the
+  recorded software version.

--- a/.agents/skills/ascend-triton-kernel-optimization/references/behavior.md
+++ b/.agents/skills/ascend-triton-kernel-optimization/references/behavior.md
@@ -1,0 +1,91 @@
+# Ascend Triton optimization behavior contract
+
+## Contents
+
+- Optimization configuration
+- Baseline contract
+- Round result
+- Decision semantics
+- Final status
+
+## Optimization configuration
+
+```json
+{
+  "schema_version": 1,
+  "run_id": "softmax-optimization-001",
+  "parent_run_id": "triton-softmax-001",
+  "op_name": "softmax",
+  "kernel": {"path": "/src/softmax_ascend.py"},
+  "validation_manifest": "/runs/validation/manifest.json",
+  "target": {"soc": "Ascend910B2", "cann": "...", "triton_ascend": "..."},
+  "cases": [
+    {"id": "fp16-128x257", "weight": 1.0}
+  ],
+  "baseline": [
+    {"case_id": "fp16-128x257", "median_us": 18.2, "repeats": 50, "source": "/raw/baseline.json"}
+  ],
+  "objective": {
+    "target_relative_improvement": 0.10,
+    "min_relative_improvement": 0.01,
+    "noise_floor": 0.005,
+    "max_case_regression": 0.02
+  },
+  "max_rounds": 20,
+  "max_consecutive_failures": 3
+}
+```
+
+The validation manifest must be passed, use run type `correctness`, and cover the
+starting kernel. Baseline measurements must cover every case exactly once.
+
+## Baseline contract
+
+- use device time for the target kernel and separately record wrapper latency;
+- exclude compile and warmup;
+- preserve raw measurements and profiler artifacts;
+- use the same environment, workload, case definitions, and measurement policy
+  for every candidate;
+- use a comparable NPU implementation as the acceptance baseline.
+
+## Round result
+
+```json
+{
+  "schema_version": 1,
+  "round": 1,
+  "parent_kernel_sha256": "64-lowercase-hex",
+  "candidate": {"path": "/src/candidate.py"},
+  "hypothesis": "Batch four contiguous rows to reduce MTE instruction overhead",
+  "change": "ROWS_PER_ITER=1 -> 4",
+  "verification": {"manifest": "/runs/round-1-validation/manifest.json"},
+  "measurements": [
+    {"case_id": "fp16-128x257", "median_us": 15.4, "repeats": 50, "source": "/raw/round-1.json"}
+  ],
+  "profiler_signals": {"aiv_scalar_ratio": 0.12, "aiv_vec_ratio": 0.54}
+}
+```
+
+Rounds are sequential and their parent hash must equal the current best hash.
+The verification manifest must be passed and refer to this optimization run or
+its parent workflow. Failed verification may omit measurements and becomes `FAIL`.
+
+## Decision semantics
+
+- `KEEP`: weighted relative improvement meets `min_relative_improvement`, exceeds
+  noise, and no case exceeds `max_case_regression`;
+- `NOISE`: absolute weighted improvement is below `noise_floor`;
+- `DISCARD`: correct candidate does not meet keep conditions;
+- `FAIL`: validation is not passed.
+
+Only KEEP updates the best kernel and best per-case measurements. The controller
+also reports improvement from the original baseline and whether the target is met.
+
+## Final status
+
+- `passed`: target relative improvement is met;
+- `failed`: target is unmet and round budget is exhausted or diagnosis threshold
+  is reached;
+- `inconclusive`: target is unmet but additional planned rounds remain.
+
+The manifest uses run type `performance`.

--- a/.agents/skills/ascend-triton-kernel-optimization/references/command-recipes.md
+++ b/.agents/skills/ascend-triton-kernel-optimization/references/command-recipes.md
@@ -1,0 +1,30 @@
+# Ascend Triton optimization command recipes
+
+## Plan
+
+```bash
+python -B .agents/skills/ascend-triton-kernel-optimization/scripts/triton_optimization.py plan \
+  --output-dir .vaws-local/ascend-triton/optimization/softmax-001 \
+  --config /path/to/optimization-config.json
+```
+
+## Record one round
+
+```bash
+python -B .agents/skills/ascend-triton-kernel-optimization/scripts/triton_optimization.py record \
+  --output-dir .vaws-local/ascend-triton/optimization/softmax-001 \
+  --result /path/to/normalized-round-result.json
+```
+
+Read the returned decision and `needs_diagnosis`; do not manually promote a
+discarded candidate.
+
+## Analyze
+
+```bash
+python -B .agents/skills/ascend-triton-kernel-optimization/scripts/triton_optimization.py analyze \
+  --output-dir .vaws-local/ascend-triton/optimization/softmax-001
+```
+
+Run `analyze` when the objective is met, the round budget is exhausted, or the
+workflow intentionally stops and an inconclusive terminal record is desired.

--- a/.agents/skills/ascend-triton-kernel-optimization/references/profiling-decision-tree.md
+++ b/.agents/skills/ascend-triton-kernel-optimization/references/profiling-decision-tree.md
@@ -1,0 +1,52 @@
+# Ascend Triton profiling decision tree
+
+## Contents
+
+- Establish floors
+- Classify the bottleneck
+- Choose the next experiment
+- Stop conditions
+
+## Establish floors
+
+Estimate before editing:
+
+```text
+memory_floor = (GM read bytes + GM write bytes) / effective GM bandwidth
+vector_floor = vector elements / effective vector throughput
+launch_floor = measured empty or tiny kernel cost
+```
+
+Use target-specific effective values rather than marketing peaks. Save device
+time, wrapper time, block count, and per-pipeline evidence.
+
+## Classify the bottleneck
+
+| Evidence | Likely bottleneck | First experiment |
+|---|---|---|
+| Blocks greatly exceed usable physical cores; dispatch visible | repeated launch/block scheduling | physical-core grid-stride or supported blockification |
+| Blocks below usable cores | insufficient parallelism | smaller inter-core tile or additional independent task axis |
+| MTE2/MTE3 long; Vector gaps | memory or broken overlap | contiguous larger transfers, tile change, multibuffer eligibility |
+| Scalar/FLOWCTRL long | address, mask, divide/modulo, dtype lowering | linearize indices, merge dimensions, hoist invariants, avoid unsupported integer ops |
+| Vector long near floor | compute bound | pass fusion, libdevice, algebraic removal, explicitly approved approximation |
+| UB overflow or multibuffer disabled | live set too large | shrink tile, shorten live ranges, early store, reduce widening/temp tensors |
+| Tiny shapes dominated by fixed cost | launch/wrapper bound | specialization or fusion; include routing cost |
+
+## Choose the next experiment
+
+Write a hypothesis with one expected profiler signal. Change one primary
+mechanism. Examples:
+
+- “Reducing flattened `//`/`%` address reconstruction will reduce Scalar time.”
+- “Four-row batching will reduce MTE instruction gaps while staying within the
+  two-stage UB budget.”
+- “Moving the invariant weight load outside the inner loop will reduce MTE2 bytes.”
+
+If the expected signal does not change, discard the causal model even when timing
+noise happens to improve.
+
+## Stop conditions
+
+Stop and diagnose when the same failure fingerprint repeats, measurement CV/noise
+prevents a decision, or the theoretical floor leaves insufficient headroom. Do
+not promise an arbitrary speedup that the measured floor cannot support.

--- a/.agents/skills/ascend-triton-kernel-optimization/scripts/triton_optimization.py
+++ b/.agents/skills/ascend-triton-kernel-optimization/scripts/triton_optimization.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Plan, record, and analyze single-kernel Ascend Triton optimization rounds."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_run_manifest import (  # noqa: E402
+    RunManifestError,
+    add_artifact,
+    load_manifest,
+    new_manifest,
+    sha256_file,
+    transition_status,
+    write_manifest,
+)
+
+SCHEMA_VERSION = 1
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class OptimizationError(ValueError):
+    """Raised when optimization evidence violates the contract."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    _atomic_write(path, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise OptimizationError(f"cannot read {label} {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise OptimizationError(f"{label} root must be an object")
+    return payload
+
+
+def _artifact(manifest: Mapping[str, Any], name: str) -> Mapping[str, Any]:
+    artifact = next((item for item in manifest["artifacts"] if item["name"] == name), None)
+    if artifact is None:
+        raise OptimizationError(f"validation manifest is missing {name} artifact")
+    return artifact
+
+
+def _artifact_path(manifest_path: Path, artifact: Mapping[str, Any]) -> Path:
+    path = Path(str(artifact["uri"]))
+    return path if path.is_absolute() else manifest_path.parent / path
+
+
+def _require_validation_coverage(
+    manifest_path: Path,
+    manifest: Mapping[str, Any],
+    *,
+    kernel_sha256: str,
+    case_ids: set[str],
+) -> None:
+    kernel_artifact = _artifact(manifest, "kernel")
+    if kernel_artifact.get("sha256") != kernel_sha256:
+        raise OptimizationError("validation kernel hash does not match the candidate")
+    matrix_artifact = _artifact(manifest, "case-matrix")
+    matrix = _load_json(_artifact_path(manifest_path, matrix_artifact), "validation case matrix")
+    matrix_kernel = matrix.get("kernel")
+    if not isinstance(matrix_kernel, Mapping) or matrix_kernel.get("sha256") != kernel_sha256:
+        raise OptimizationError("validation case matrix does not match the candidate")
+    rows = matrix.get("cases")
+    if not isinstance(rows, list) or any(not isinstance(row, Mapping) for row in rows):
+        raise OptimizationError("validation case matrix cases must be an array of objects")
+    validated_ids = {row.get("id") for row in rows}
+    if validated_ids != case_ids:
+        raise OptimizationError("validation case set does not match the optimization case set")
+
+
+def _finite_positive(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(float(value)) and value > 0
+
+
+def _measurement_map(rows: Any, case_ids: set[str], label: str) -> dict[str, dict[str, Any]]:
+    if not isinstance(rows, list):
+        raise OptimizationError(f"{label} must be an array")
+    mapped: dict[str, dict[str, Any]] = {}
+    for index, row in enumerate(rows):
+        if not isinstance(row, Mapping):
+            raise OptimizationError(f"{label}[{index}] must be an object")
+        case_id = row.get("case_id")
+        if case_id not in case_ids:
+            raise OptimizationError(f"{label}[{index}].case_id is not planned")
+        if case_id in mapped:
+            raise OptimizationError(f"{label} duplicates case_id {case_id}")
+        if not _finite_positive(row.get("median_us")):
+            raise OptimizationError(f"{label}[{index}].median_us must be positive and finite")
+        repeats = row.get("repeats")
+        if not isinstance(repeats, int) or isinstance(repeats, bool) or repeats < 1:
+            raise OptimizationError(f"{label}[{index}].repeats must be a positive integer")
+        mapped[str(case_id)] = {**row, "median_us": float(row["median_us"])}
+    missing = sorted(case_ids - set(mapped))
+    if missing:
+        raise OptimizationError(f"{label} is missing cases: {', '.join(missing)}")
+    return mapped
+
+
+def validate_config(config: Mapping[str, Any]) -> None:
+    errors: list[str] = []
+    if config.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    for field in ("run_id", "op_name", "validation_manifest"):
+        if not isinstance(config.get(field), str) or not config[field]:
+            errors.append(f"{field} must be a non-empty string")
+    kernel = config.get("kernel")
+    if not isinstance(kernel, Mapping) or not isinstance(kernel.get("path"), str) or not kernel.get("path"):
+        errors.append("kernel.path must be a non-empty string")
+    target = config.get("target")
+    if not isinstance(target, Mapping) or not isinstance(target.get("soc"), str) or not target.get("soc"):
+        errors.append("target.soc must be a non-empty string")
+    cases = config.get("cases")
+    if not isinstance(cases, list) or not cases:
+        errors.append("cases must be a non-empty array")
+        cases = []
+    case_ids: set[str] = set()
+    total_weight = 0.0
+    for index, case in enumerate(cases):
+        if not isinstance(case, Mapping) or not isinstance(case.get("id"), str) or not case.get("id"):
+            errors.append(f"cases[{index}].id must be a non-empty string")
+            continue
+        if case["id"] in case_ids:
+            errors.append(f"case id is duplicated: {case['id']}")
+        case_ids.add(case["id"])
+        weight = case.get("weight", 1.0)
+        if not _finite_positive(weight):
+            errors.append(f"cases[{index}].weight must be positive and finite")
+        else:
+            total_weight += float(weight)
+    if total_weight <= 0:
+        errors.append("case weights must sum to a positive value")
+    objective = config.get("objective")
+    if not isinstance(objective, Mapping):
+        errors.append("objective must be an object")
+    else:
+        for field in ("target_relative_improvement", "min_relative_improvement", "noise_floor", "max_case_regression"):
+            value = objective.get(field)
+            if not isinstance(value, (int, float)) or isinstance(value, bool) or not math.isfinite(float(value)) or value < 0:
+                errors.append(f"objective.{field} must be non-negative and finite")
+    for field in ("max_rounds", "max_consecutive_failures"):
+        value = config.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            errors.append(f"{field} must be a positive integer")
+    if errors:
+        raise OptimizationError("; ".join(errors))
+    _measurement_map(config.get("baseline"), case_ids, "baseline")
+
+
+def plan(output_dir: Path, *, config_path: Path, created_at: str | None = None) -> dict[str, Any]:
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise OptimizationError(f"output directory is not empty: {output_dir}")
+    config = _load_json(config_path, "optimization config")
+    validate_config(config)
+    kernel_path = Path(config["kernel"]["path"])
+    if not kernel_path.is_file():
+        raise OptimizationError(f"kernel does not exist: {kernel_path}")
+    validation_path = Path(config["validation_manifest"])
+    validation = load_manifest(validation_path)
+    if validation["run_type"] != "correctness" or validation["status"] != "passed":
+        raise OptimizationError("starting validation manifest must be passed correctness evidence")
+    timestamp = created_at or utc_now()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "round-artifacts").mkdir()
+    kernel_hash = sha256_file(kernel_path)
+    case_ids = {case["id"] for case in config["cases"]}
+    _require_validation_coverage(
+        validation_path,
+        validation,
+        kernel_sha256=kernel_hash,
+        case_ids=case_ids,
+    )
+    baseline = _measurement_map(config["baseline"], case_ids, "baseline")
+    state = {
+        "schema_version": SCHEMA_VERSION,
+        "next_round": 1,
+        "current_best_sha256": kernel_hash,
+        "current_best_path": str(kernel_path.resolve()),
+        "original_baseline": baseline,
+        "current_best_measurements": baseline,
+        "kept_rounds": [],
+        "consecutive_failures": 0,
+        "target_met": False,
+    }
+    _write_json(output_dir / "optimization-config.json", config)
+    _write_json(output_dir / "state.json", state)
+    _write_json(output_dir / "rounds.json", {"schema_version": SCHEMA_VERSION, "rounds": []})
+    manifest = new_manifest(
+        run_type="performance",
+        run_id=config["run_id"],
+        parent_run_id=config.get("parent_run_id"),
+        workspace_snapshot=config.get("workspace_snapshot", {}),
+        environment=config.get("environment", {}),
+        topology={"target": config["target"]},
+        command=config.get("command", []),
+        created_at=timestamp,
+    )
+    for name, kind, uri, digest in (
+        ("starting-kernel", "triton-kernel", str(kernel_path.resolve()), kernel_hash),
+        ("starting-validation", "run-manifest", str(validation_path.resolve()), None),
+        ("optimization-config", "optimization-config", "optimization-config.json", None),
+        ("optimization-state", "state", "state.json", None),
+        ("rounds", "optimization-rounds", "rounds.json", None),
+    ):
+        manifest = add_artifact(manifest, name=name, kind=kind, uri=uri, sha256=digest, updated_at=timestamp)
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {"status": "planned", "run_id": config["run_id"], "kernel_sha256": kernel_hash, "case_count": len(case_ids)}
+
+
+def _weighted_improvement(current: Mapping[str, Mapping[str, Any]], candidate: Mapping[str, Mapping[str, Any]], cases: list[Mapping[str, Any]]) -> tuple[float, float]:
+    total_weight = sum(float(case.get("weight", 1.0)) for case in cases)
+    improvement = 0.0
+    worst_regression = -math.inf
+    for case in cases:
+        case_id = str(case["id"])
+        weight = float(case.get("weight", 1.0)) / total_weight
+        old = float(current[case_id]["median_us"])
+        new = float(candidate[case_id]["median_us"])
+        improvement += weight * ((old - new) / old)
+        worst_regression = max(worst_regression, (new - old) / old)
+    return improvement, worst_regression
+
+
+def record(output_dir: Path, *, result_path: Path, recorded_at: str | None = None) -> dict[str, Any]:
+    config = _load_json(output_dir / "optimization-config.json", "optimization config")
+    state = _load_json(output_dir / "state.json", "optimization state")
+    rounds = _load_json(output_dir / "rounds.json", "rounds")
+    result = _load_json(result_path, "round result")
+    if result.get("schema_version") != SCHEMA_VERSION:
+        raise OptimizationError(f"schema_version must be {SCHEMA_VERSION}")
+    if result.get("round") != state["next_round"]:
+        raise OptimizationError(f"round must be {state['next_round']}")
+    if result["round"] > config["max_rounds"]:
+        raise OptimizationError("round budget exhausted")
+    if result.get("parent_kernel_sha256") != state["current_best_sha256"]:
+        raise OptimizationError("parent_kernel_sha256 does not match current best")
+    for field in ("hypothesis", "change"):
+        if not isinstance(result.get(field), str) or not result[field].strip():
+            raise OptimizationError(f"{field} must be a non-empty string")
+    candidate = result.get("candidate")
+    if not isinstance(candidate, Mapping) or not isinstance(candidate.get("path"), str) or not candidate.get("path"):
+        raise OptimizationError("candidate.path must be a non-empty string")
+    candidate_path = Path(candidate["path"])
+    if not candidate_path.is_file():
+        raise OptimizationError(f"candidate does not exist: {candidate_path}")
+    candidate_hash = sha256_file(candidate_path)
+    verification = result.get("verification")
+    if not isinstance(verification, Mapping) or not isinstance(verification.get("manifest"), str):
+        raise OptimizationError("verification.manifest must be a path")
+    verification_manifest = load_manifest(Path(verification["manifest"]))
+    if verification_manifest["run_type"] != "correctness":
+        raise OptimizationError("round verification must use run_type correctness")
+    valid_parents = {config["run_id"], config.get("parent_run_id")} - {None}
+    if verification_manifest["parent_run_id"] not in valid_parents:
+        raise OptimizationError("round validation parent_run_id must identify this run or its parent workflow")
+    case_ids = {case["id"] for case in config["cases"]}
+    _require_validation_coverage(
+        Path(verification["manifest"]),
+        verification_manifest,
+        kernel_sha256=candidate_hash,
+        case_ids=case_ids,
+    )
+    timestamp = recorded_at or utc_now()
+    decision = "FAIL"
+    improvement = None
+    worst_regression = None
+    cumulative = 0.0
+    measurements: dict[str, dict[str, Any]] | None = None
+    if verification_manifest["status"] == "passed":
+        measurements = _measurement_map(result.get("measurements"), case_ids, "measurements")
+        improvement, worst_regression = _weighted_improvement(state["current_best_measurements"], measurements, config["cases"])
+        objective = config["objective"]
+        if abs(improvement) < float(objective["noise_floor"]):
+            decision = "NOISE"
+        elif improvement >= float(objective["min_relative_improvement"]) and worst_regression <= float(objective["max_case_regression"]):
+            decision = "KEEP"
+        else:
+            decision = "DISCARD"
+        if decision == "KEEP":
+            state["current_best_sha256"] = candidate_hash
+            state["current_best_path"] = str(candidate_path.resolve())
+            state["current_best_measurements"] = measurements
+            state["kept_rounds"].append(result["round"])
+            state["consecutive_failures"] = 0
+        else:
+            state["consecutive_failures"] += 1
+    else:
+        state["consecutive_failures"] += 1
+    cumulative, _ = _weighted_improvement(state["original_baseline"], state["current_best_measurements"], config["cases"])
+    state["target_met"] = cumulative >= float(config["objective"]["target_relative_improvement"])
+    state["next_round"] += 1
+    normalized = {
+        **result,
+        "candidate": {"path": str(candidate_path.resolve()), "sha256": candidate_hash},
+        "verification": {"manifest": str(Path(verification["manifest"]).resolve()), "run_id": verification_manifest["run_id"], "status": verification_manifest["status"]},
+        "measurements": list(measurements.values()) if measurements is not None else [],
+        "decision": decision,
+        "relative_improvement_vs_current": improvement,
+        "worst_case_regression": worst_regression,
+        "relative_improvement_vs_original": cumulative,
+        "recorded_at": timestamp,
+    }
+    rounds["rounds"].append(normalized)
+    _write_json(output_dir / "rounds.json", rounds)
+    _write_json(output_dir / "state.json", state)
+    manifest = load_manifest(output_dir / "manifest.json")
+    if manifest["status"] == "planned":
+        manifest = transition_status(manifest, "running", updated_at=timestamp)
+        write_manifest(output_dir / "manifest.json", manifest)
+    return {
+        "status": "recorded",
+        "round": result["round"],
+        "decision": decision,
+        "target_met": state["target_met"],
+        "needs_diagnosis": state["consecutive_failures"] >= config["max_consecutive_failures"],
+        "remaining_rounds": config["max_rounds"] - len(rounds["rounds"]),
+    }
+
+
+def analyze(output_dir: Path, *, updated_at: str | None = None) -> dict[str, Any]:
+    config = _load_json(output_dir / "optimization-config.json", "optimization config")
+    state = _load_json(output_dir / "state.json", "optimization state")
+    rounds = _load_json(output_dir / "rounds.json", "rounds")
+    exhausted = len(rounds["rounds"]) >= config["max_rounds"]
+    diagnosis = state["consecutive_failures"] >= config["max_consecutive_failures"]
+    if state["target_met"]:
+        status = "passed"
+    elif exhausted or diagnosis:
+        status = "failed"
+    else:
+        status = "inconclusive"
+    cumulative, _ = _weighted_improvement(state["original_baseline"], state["current_best_measurements"], config["cases"])
+    analysis = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "op_name": config["op_name"],
+        "best_kernel": {"path": state["current_best_path"], "sha256": state["current_best_sha256"]},
+        "relative_improvement_vs_original": cumulative,
+        "target_relative_improvement": config["objective"]["target_relative_improvement"],
+        "target_met": state["target_met"],
+        "kept_rounds": state["kept_rounds"],
+        "round_count": len(rounds["rounds"]),
+        "needs_diagnosis": diagnosis,
+        "rounds": rounds["rounds"],
+    }
+    _write_json(output_dir / "analysis.json", analysis)
+    _atomic_write(
+        output_dir / "report.md",
+        "# Ascend Triton optimization report\n\n"
+        f"- Status: **{status}**\n"
+        f"- Operator: `{config['op_name']}`\n"
+        f"- Best kernel: `{state['current_best_path']}`\n"
+        f"- Improvement vs original: {cumulative:.4%}\n"
+        f"- Target: {float(config['objective']['target_relative_improvement']):.4%}\n"
+        f"- Kept rounds: {', '.join(str(value) for value in state['kept_rounds']) or 'none'}\n"
+        f"- Diagnosis required: {diagnosis}\n",
+    )
+    timestamp = updated_at or utc_now()
+    manifest = load_manifest(output_dir / "manifest.json")
+    if manifest["status"] == "planned":
+        manifest = transition_status(manifest, "running", updated_at=timestamp)
+    for name, kind, uri in (("analysis", "analysis", "analysis.json"), ("report", "report", "report.md")):
+        manifest = add_artifact(manifest, name=name, kind=kind, uri=uri, updated_at=timestamp)
+    manifest = transition_status(manifest, status, updated_at=timestamp)
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {"status": status, "target_met": state["target_met"], "best_kernel_sha256": state["current_best_sha256"], "analysis": str((output_dir / "analysis.json").resolve())}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+    plan_parser = subparsers.add_parser("plan")
+    plan_parser.add_argument("--output-dir", required=True, type=Path)
+    plan_parser.add_argument("--config", required=True, type=Path)
+    record_parser = subparsers.add_parser("record")
+    record_parser.add_argument("--output-dir", required=True, type=Path)
+    record_parser.add_argument("--result", required=True, type=Path)
+    analyze_parser = subparsers.add_parser("analyze")
+    analyze_parser.add_argument("--output-dir", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.action == "plan":
+            payload = plan(args.output_dir, config_path=args.config)
+        elif args.action == "record":
+            payload = record(args.output_dir, result_path=args.result)
+        else:
+            payload = analyze(args.output_dir)
+    except (OptimizationError, RunManifestError) as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/ascend-triton-kernel-optimization/tests/test_triton_optimization.py
+++ b/.agents/skills/ascend-triton-kernel-optimization/tests/test_triton_optimization.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Tests for Ascend Triton optimization round control."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+SKILL = ROOT / ".agents" / "skills" / "ascend-triton-kernel-optimization"
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_run_manifest import add_artifact, new_manifest, sha256_file, transition_status, write_manifest
+
+
+def load_module():
+    name = "_triton_optimization_test"
+    spec = importlib.util.spec_from_file_location(name, SKILL / "scripts" / "triton_optimization.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+optimization = load_module()
+NOW = "2026-08-03T12:00:00Z"
+
+
+def passed_manifest(path: Path, run_id: str, parent: str, kernel: Path, case_ids: list[str]) -> None:
+    matrix = {
+        "schema_version": 1,
+        "kernel": {"path": str(kernel), "sha256": sha256_file(kernel)},
+        "cases": [{"id": case_id} for case_id in case_ids],
+    }
+    matrix_path = path.parent / f"{path.stem}-case-matrix.json"
+    matrix_path.write_text(json.dumps(matrix), encoding="utf-8")
+    manifest = new_manifest(run_type="correctness", run_id=run_id, parent_run_id=parent, created_at=NOW)
+    manifest = add_artifact(
+        manifest,
+        name="kernel",
+        kind="triton-kernel",
+        uri=str(kernel),
+        sha256=sha256_file(kernel),
+        updated_at=NOW,
+    )
+    manifest = add_artifact(
+        manifest,
+        name="case-matrix",
+        kind="case-matrix",
+        uri=str(matrix_path),
+        updated_at=NOW,
+    )
+    manifest = transition_status(manifest, "running", updated_at=NOW)
+    manifest = transition_status(manifest, "passed", updated_at=NOW)
+    write_manifest(path, manifest)
+
+
+class OptimizationTests(unittest.TestCase):
+    def test_keep_updates_best_and_meets_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            kernel = root / "kernel.py"
+            kernel.write_text("baseline", encoding="utf-8")
+            validation_path = root / "start-validation.json"
+            passed_manifest(validation_path, "start-validation", "triton-softmax-001", kernel, ["case-1"])
+            config = {
+                "schema_version": 1,
+                "run_id": "softmax-optimization-001",
+                "parent_run_id": "triton-softmax-001",
+                "op_name": "softmax",
+                "kernel": {"path": str(kernel)},
+                "validation_manifest": str(validation_path),
+                "target": {"soc": "Ascend910B2"},
+                "cases": [{"id": "case-1", "weight": 1.0}],
+                "baseline": [{"case_id": "case-1", "median_us": 10.0, "repeats": 50}],
+                "objective": {"target_relative_improvement": 0.1, "min_relative_improvement": 0.01, "noise_floor": 0.005, "max_case_regression": 0.02},
+                "max_rounds": 3,
+                "max_consecutive_failures": 2,
+            }
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(config), encoding="utf-8")
+            output = root / "optimization"
+            planned = optimization.plan(output, config_path=config_path, created_at=NOW)
+            candidate = root / "candidate.py"
+            candidate.write_text("candidate", encoding="utf-8")
+            round_validation = root / "round-validation.json"
+            passed_manifest(round_validation, "round-validation", "softmax-optimization-001", candidate, ["case-1"])
+            round_result = {
+                "schema_version": 1,
+                "round": 1,
+                "parent_kernel_sha256": planned["kernel_sha256"],
+                "candidate": {"path": str(candidate)},
+                "hypothesis": "reduce scalar address work",
+                "change": "linearize indices",
+                "verification": {"manifest": str(round_validation)},
+                "measurements": [{"case_id": "case-1", "median_us": 8.0, "repeats": 50}],
+            }
+            round_path = root / "round.json"
+            round_path.write_text(json.dumps(round_result), encoding="utf-8")
+            recorded = optimization.record(output, result_path=round_path, recorded_at=NOW)
+            self.assertEqual(recorded["decision"], "KEEP")
+            self.assertTrue(recorded["target_met"])
+            analyzed = optimization.analyze(output, updated_at=NOW)
+            self.assertEqual(analyzed["status"], "passed")
+
+    def test_parent_hash_mismatch_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            kernel = root / "kernel.py"
+            kernel.write_text("baseline", encoding="utf-8")
+            validation_path = root / "validation.json"
+            passed_manifest(validation_path, "start-validation", "parent", kernel, ["case"])
+            config = {
+                "schema_version": 1, "run_id": "optimization", "parent_run_id": "parent", "op_name": "op",
+                "kernel": {"path": str(kernel)}, "validation_manifest": str(validation_path), "target": {"soc": "Ascend910B2"},
+                "cases": [{"id": "case", "weight": 1}], "baseline": [{"case_id": "case", "median_us": 10, "repeats": 5}],
+                "objective": {"target_relative_improvement": 0.1, "min_relative_improvement": 0.01, "noise_floor": 0.005, "max_case_regression": 0.02},
+                "max_rounds": 2, "max_consecutive_failures": 2,
+            }
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(config), encoding="utf-8")
+            output = root / "optimization"
+            optimization.plan(output, config_path=config_path, created_at=NOW)
+            candidate = root / "candidate.py"
+            candidate.write_text("candidate", encoding="utf-8")
+            round_validation = root / "round-validation.json"
+            passed_manifest(round_validation, "round-validation", "optimization", candidate, ["case"])
+            result = {"schema_version": 1, "round": 1, "parent_kernel_sha256": "0" * 64, "candidate": {"path": str(candidate)}, "hypothesis": "x", "change": "y", "verification": {"manifest": str(round_validation)}}
+            result_path = root / "round.json"
+            result_path.write_text(json.dumps(result), encoding="utf-8")
+            with self.assertRaisesRegex(optimization.OptimizationError, "current best"):
+                optimization.record(output, result_path=result_path, recorded_at=NOW)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/ascend-triton-kernel-validation/SKILL.md
+++ b/.agents/skills/ascend-triton-kernel-validation/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: ascend-triton-kernel-validation
+description: Validate one Ascend Triton kernel against a trusted reference across an explicit shape, dtype, layout, stride, scalar-option, and execution-mode case matrix, with static detection of missing kernel launches and PyTorch computation fallback plus Run Manifest evidence. Use before any performance claim, after migration or implementation changes, or for shape-dependent compile/runtime/numerical failures in a Triton candidate. Do not use to generate the kernel, optimize an already-correct kernel, diagnose a non-Triton torch_npu or ACLNN call, or localize a whole-model graph failure.
+---
+
+# Ascend Triton Kernel Validation
+
+Turn a candidate into explicit compile and correctness evidence. A successful process exit or benchmark run is not correctness proof.
+
+## Workflow
+
+1. Freeze the candidate hash, trusted reference, predeclared tolerances, target environment, and explicit case matrix.
+2. Query `.agents/knowledge/` with any observed compile, runtime, or numerical signature before repeating diagnosis.
+3. Run `scripts/triton_validation.py plan`. It invokes `validate_triton_impl.py` and rejects missing Triton kernels, a `ModelNew.forward` path that does not launch them, or reachable PyTorch tensor computation fallback.
+4. Before remote execution, establish `remote-code-parity`. Run every planned case on a managed Ascend NPU; do not run `torch_npu` locally.
+5. Compare shape and dtype first, then NaN/Inf behavior and numeric values. Preserve raw stdout, stderr, stack, and comparison artifacts.
+6. Normalize one result per case and run `record`. Do not overwrite evidence.
+7. Run `analyze`. Only `passed_cases == total_cases > 0` produces a passed manifest.
+8. Hand the passed manifest to development or optimization. Do not benchmark a failed or inconclusive candidate.
+
+## Entry points
+
+- `scripts/validate_triton_impl.py`: AST-only fallback and launch gate.
+- `scripts/triton_validation.py`:
+  - `plan`: validate config and candidate, create case matrix and Run Manifest v1;
+  - `record`: accept one normalized case result;
+  - `analyze`: classify the full matrix and generate the report.
+
+Read:
+
+- [Behavior contract](references/behavior.md) for config, result, and status schemas.
+- [Case design](references/case-design.md) before choosing the matrix and tolerances.
+- [Command recipes](references/command-recipes.md) for the lifecycle.
+- [Acceptance](references/acceptance.md) before declaring correctness.
+
+## Rules
+
+- Keep compile error, runtime error, numerical mismatch, unsupported, and missing evidence distinct.
+- Never silently cast, make inputs contiguous, remove difficult shapes, or relax tolerance to pass.
+- Load masks protect readable input addresses; store masks protect writable output positions.
+- Treat tail blocks, fully masked blocks, non-power-of-two shapes, and dynamic specialization boundaries as first-class cases.
+- Keep run state under `.vaws-local/ascend-triton/validation/`.

--- a/.agents/skills/ascend-triton-kernel-validation/agents/openai.yaml
+++ b/.agents/skills/ascend-triton-kernel-validation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ascend Triton Kernel Validation"
+  short_description: "Validate Ascend Triton kernels across explicit cases"
+  default_prompt: "Use $ascend-triton-kernel-validation to validate this Ascend Triton kernel across an explicit case matrix."

--- a/.agents/skills/ascend-triton-kernel-validation/references/acceptance.md
+++ b/.agents/skills/ascend-triton-kernel-validation/references/acceptance.md
@@ -1,0 +1,22 @@
+# Ascend Triton validation acceptance
+
+## Static integrity
+
+- [ ] Candidate hash is recorded.
+- [ ] At least one Triton kernel exists and is reachable from `ModelNew.forward`.
+- [ ] Reachable wrapper code has no PyTorch computation fallback.
+- [ ] Manual review covers dynamic calls the AST gate cannot prove.
+
+## Matrix and execution
+
+- [ ] Reference, tolerance, environment, and every case are explicit.
+- [ ] Boundary shapes, tails, dtypes, layouts, strides, and scalar branches are covered.
+- [ ] Every case ran on the same intended Ascend environment.
+- [ ] No implicit cast, contiguous copy, or case deletion changed the contract.
+
+## Result integrity
+
+- [ ] Output structure, shape, dtype, NaN/Inf behavior, and values were compared.
+- [ ] Raw evidence links exist for every failure.
+- [ ] Passed count comes from validation, not benchmark process success.
+- [ ] `passed_cases == total_cases > 0` before any performance workflow begins.

--- a/.agents/skills/ascend-triton-kernel-validation/references/behavior.md
+++ b/.agents/skills/ascend-triton-kernel-validation/references/behavior.md
@@ -1,0 +1,91 @@
+# Ascend Triton validation behavior contract
+
+## Contents
+
+- Validation configuration
+- Static gate
+- Case result
+- Analysis semantics
+- Artifact layout
+
+## Validation configuration
+
+```json
+{
+  "schema_version": 1,
+  "run_id": "softmax-validation-001",
+  "parent_run_id": "triton-softmax-001",
+  "op_name": "softmax",
+  "reference": {"kind": "torch", "path": "/src/ref.py"},
+  "target": {"soc": "Ascend910B2", "cann": "...", "triton_ascend": "..."},
+  "tolerances": {"float16": {"atol": 0.001, "rtol": 0.001}},
+  "cases": [
+    {
+      "id": "fp16-128x257",
+      "mode": "eager",
+      "inputs": [
+        {"name": "x", "shape": [128, 257], "strides": [257, 1], "dtype": "float16", "layout": "ND"}
+      ],
+      "scalars": {}
+    }
+  ]
+}
+```
+
+Modes are `eager`, `compile`, and `graph`. Use only modes the candidate contract
+actually promises. Every dtype in the cases requires a predeclared tolerance.
+
+## Static gate
+
+The AST gate checks:
+
+- at least one `@triton.jit` function exists;
+- a reachable path from `ModelNew.forward` launches a kernel;
+- reachable wrapper code contains no unapproved `torch.*`, `torch.nn.functional.*`,
+  or common tensor-method computation fallback.
+
+Allocation and device-context calls are allowed. The AST gate is conservative;
+manual review is still required for dynamic indirection.
+
+## Case result
+
+```json
+{
+  "schema_version": 1,
+  "case_id": "fp16-128x257",
+  "status": "passed",
+  "comparisons": [
+    {"output": "out", "max_abs": 0.0004, "max_rel": 0.0008, "cosine": 0.99999}
+  ],
+  "nan_match": true,
+  "inf_match": true,
+  "source": "/path/to/raw-result.json"
+}
+```
+
+Statuses are `passed`, `numerical_mismatch`, `compilation_error`,
+`runtime_error`, and `unsupported`. Every non-passed status requires an error
+signature. Timing is optional diagnostic evidence and never a performance verdict.
+
+## Analysis semantics
+
+- `passed`: all planned cases recorded as passed;
+- `failed`: at least one compile, runtime, or numerical failure;
+- `inconclusive`: evidence is missing or at least one case is unsupported and no
+  product failure is present.
+
+The manifest uses run type `correctness`.
+
+## Artifact layout
+
+```text
+validation/
+├── manifest.json
+├── validation-config.json
+├── static-check.json
+├── case-matrix.json
+├── results.json
+├── raw-results/
+├── analysis.json
+└── report.md
+```

--- a/.agents/skills/ascend-triton-kernel-validation/references/case-design.md
+++ b/.agents/skills/ascend-triton-kernel-validation/references/case-design.md
@@ -1,0 +1,51 @@
+# Ascend Triton validation case design
+
+## Contents
+
+- Contract-driven matrix
+- Boundary shapes
+- Layout and indexing
+- Numerical distributions
+- Tolerances and comparisons
+
+## Contract-driven matrix
+
+Select the minimum matrix that covers every implementation branch and public
+promise. Do not execute an uncontrolled Cartesian product, but do not omit a
+dimension merely because it is expensive.
+
+Change one meaningful axis per diagnostic case when localizing a failure:
+shape, dtype, layout/stride, execution mode, or scalar option.
+
+## Boundary shapes
+
+Include as applicable:
+
+- minimum, representative, and maximum supported sizes;
+- power-of-two and non-power-of-two sizes;
+- aligned and non-aligned tails;
+- empty or singleton dimensions when legal;
+- values around tile, block, reduction, and specialization boundaries;
+- enough tasks to exercise fewer-than-core, near-core, and more-than-core grids.
+
+## Layout and indexing
+
+Record exact strides and layout. If arbitrary strides are supported, test them
+without silently calling `.contiguous()`. For gather/index/atomic kernels include
+negative/invalid cases when the contract defines them, repeated indices, and
+data-dependent discrete access.
+
+## Numerical distributions
+
+Include zeros, signs, extrema, near-overflow and near-underflow values, NaN/Inf
+when defined, and distributions that stress reduction order. Validate padding
+identity with fully or partially masked lanes.
+
+## Tolerances and comparisons
+
+- Fix `atol` and `rtol` before observing candidate results.
+- Compare output structure, shape, dtype, NaN/Inf locations, then numeric values.
+- Use exact comparison for integer and boolean outputs unless semantics state otherwise.
+- Use fp32 accumulation expectations where the algorithm requires it.
+- Record max absolute, max relative, and a stable similarity metric when useful;
+  none replaces elementwise acceptance by itself.

--- a/.agents/skills/ascend-triton-kernel-validation/references/command-recipes.md
+++ b/.agents/skills/ascend-triton-kernel-validation/references/command-recipes.md
@@ -1,0 +1,29 @@
+# Ascend Triton validation command recipes
+
+## Plan and static gate
+
+```bash
+python -B .agents/skills/ascend-triton-kernel-validation/scripts/triton_validation.py plan \
+  --output-dir .vaws-local/ascend-triton/validation/softmax-001 \
+  --config /path/to/validation-config.json \
+  --kernel /path/to/softmax_ascend.py
+```
+
+Inspect `static-check.json` before remote execution.
+
+## Record one remote result
+
+```bash
+python -B .agents/skills/ascend-triton-kernel-validation/scripts/triton_validation.py record \
+  --output-dir .vaws-local/ascend-triton/validation/softmax-001 \
+  --result /path/to/normalized-case-result.json
+```
+
+## Analyze
+
+```bash
+python -B .agents/skills/ascend-triton-kernel-validation/scripts/triton_validation.py analyze \
+  --output-dir .vaws-local/ascend-triton/validation/softmax-001
+```
+
+Consume `analysis.json` and `manifest.json`, not mixed runtime stdout.

--- a/.agents/skills/ascend-triton-kernel-validation/scripts/triton_validation.py
+++ b/.agents/skills/ascend-triton-kernel-validation/scripts/triton_validation.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Plan, record, and analyze Ascend Triton correctness evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import tempfile
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from validate_triton_impl import analyze_file  # noqa: E402
+from vaws_run_manifest import (  # noqa: E402
+    RunManifestError,
+    add_artifact,
+    load_manifest,
+    new_manifest,
+    sha256_file,
+    transition_status,
+    write_manifest,
+)
+
+SCHEMA_VERSION = 1
+MODES = {"eager", "compile", "graph"}
+RESULT_STATUSES = {"passed", "numerical_mismatch", "compilation_error", "runtime_error", "unsupported"}
+
+
+class ValidationError(ValueError):
+    """Raised when validation evidence violates the contract."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    _atomic_write(path, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"cannot read {label} {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValidationError(f"{label} root must be an object")
+    return payload
+
+
+def _validate_input(spec: Mapping[str, Any], path: str, errors: list[str]) -> None:
+    if not isinstance(spec.get("name"), str) or not spec["name"]:
+        errors.append(f"{path}.name must be a non-empty string")
+    shape = spec.get("shape")
+    if not isinstance(shape, list) or any(not isinstance(value, int) or isinstance(value, bool) or value < 0 for value in shape):
+        errors.append(f"{path}.shape must contain non-negative integers")
+    for field in ("dtype", "layout"):
+        if not isinstance(spec.get(field), str) or not spec[field]:
+            errors.append(f"{path}.{field} must be a non-empty string")
+    strides = spec.get("strides")
+    if strides is not None and (not isinstance(strides, list) or any(not isinstance(value, int) or isinstance(value, bool) or value < 0 for value in strides)):
+        errors.append(f"{path}.strides must contain non-negative integers")
+
+
+def validate_config(config: Mapping[str, Any]) -> None:
+    errors: list[str] = []
+    if config.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    for field in ("run_id", "op_name"):
+        if not isinstance(config.get(field), str) or not config[field]:
+            errors.append(f"{field} must be a non-empty string")
+    reference = config.get("reference")
+    if not isinstance(reference, Mapping) or not isinstance(reference.get("path"), str) or not reference.get("path"):
+        errors.append("reference.path must be a non-empty string")
+    target = config.get("target")
+    if not isinstance(target, Mapping) or not isinstance(target.get("soc"), str) or not target.get("soc"):
+        errors.append("target.soc must be a non-empty string")
+    tolerances = config.get("tolerances")
+    if not isinstance(tolerances, Mapping) or not tolerances:
+        errors.append("tolerances must be a non-empty object")
+        tolerances = {}
+    cases = config.get("cases")
+    if not isinstance(cases, list) or not cases:
+        errors.append("cases must be a non-empty array")
+        cases = []
+    seen: set[str] = set()
+    for index, case in enumerate(cases):
+        path = f"cases[{index}]"
+        if not isinstance(case, Mapping):
+            errors.append(f"{path} must be an object")
+            continue
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not case_id:
+            errors.append(f"{path}.id must be a non-empty string")
+        elif case_id in seen:
+            errors.append(f"case id is duplicated: {case_id}")
+        else:
+            seen.add(case_id)
+        if case.get("mode") not in MODES:
+            errors.append(f"{path}.mode must be one of: {', '.join(sorted(MODES))}")
+        inputs = case.get("inputs")
+        if not isinstance(inputs, list) or not inputs:
+            errors.append(f"{path}.inputs must be a non-empty array")
+        else:
+            for input_index, spec in enumerate(inputs):
+                if not isinstance(spec, Mapping):
+                    errors.append(f"{path}.inputs[{input_index}] must be an object")
+                    continue
+                _validate_input(spec, f"{path}.inputs[{input_index}]", errors)
+                if spec.get("dtype") not in tolerances:
+                    errors.append(f"no tolerance declared for dtype {spec.get('dtype')}")
+    if errors:
+        raise ValidationError("; ".join(errors))
+
+
+def validate_result(result: Mapping[str, Any], planned_ids: set[str]) -> None:
+    errors: list[str] = []
+    if result.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    if result.get("case_id") not in planned_ids:
+        errors.append("case_id must identify a planned case")
+    status = result.get("status")
+    if status not in RESULT_STATUSES:
+        errors.append(f"status must be one of: {', '.join(sorted(RESULT_STATUSES))}")
+    if status != "passed" and (not isinstance(result.get("error"), str) or not result["error"]):
+        errors.append(f"{status} result requires error")
+    comparisons = result.get("comparisons", [])
+    if not isinstance(comparisons, list):
+        errors.append("comparisons must be an array")
+        comparisons = []
+    for index, comparison in enumerate(comparisons):
+        if not isinstance(comparison, Mapping):
+            errors.append(f"comparisons[{index}] must be an object")
+            continue
+        if not isinstance(comparison.get("output"), str) or not comparison["output"]:
+            errors.append(f"comparisons[{index}].output must be a non-empty string")
+        for metric in ("max_abs", "max_rel", "cosine"):
+            value = comparison.get(metric)
+            if value is not None and (not isinstance(value, (int, float)) or isinstance(value, bool) or not math.isfinite(float(value))):
+                errors.append(f"comparisons[{index}].{metric} must be finite")
+    if errors:
+        raise ValidationError("; ".join(errors))
+
+
+def plan(output_dir: Path, *, config_path: Path, kernel: Path, created_at: str | None = None) -> dict[str, Any]:
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise ValidationError(f"output directory is not empty: {output_dir}")
+    if not kernel.is_file():
+        raise ValidationError(f"kernel does not exist: {kernel}")
+    config = _load_json(config_path, "validation config")
+    validate_config(config)
+    static_check = analyze_file(kernel)
+    if not static_check.get("valid"):
+        raise ValidationError(f"static Triton gate failed: {json.dumps(static_check, ensure_ascii=False)}")
+    timestamp = created_at or utc_now()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "raw-results").mkdir()
+    _write_json(output_dir / "validation-config.json", config)
+    _write_json(output_dir / "static-check.json", static_check)
+    _write_json(
+        output_dir / "case-matrix.json",
+        {"schema_version": SCHEMA_VERSION, "kernel": {"path": str(kernel.resolve()), "sha256": sha256_file(kernel)}, "cases": [{**case, "status": "pending"} for case in config["cases"]]},
+    )
+    _write_json(output_dir / "results.json", {"schema_version": SCHEMA_VERSION, "results": []})
+    manifest = new_manifest(
+        run_type="correctness",
+        run_id=config["run_id"],
+        parent_run_id=config.get("parent_run_id"),
+        workspace_snapshot=config.get("workspace_snapshot", {}),
+        environment=config.get("environment", {}),
+        topology={"target": config["target"]},
+        command=config.get("command", []),
+        created_at=timestamp,
+    )
+    for name, kind, uri, digest in (
+        ("kernel", "triton-kernel", str(kernel.resolve()), sha256_file(kernel)),
+        ("validation-config", "validation-config", "validation-config.json", None),
+        ("static-check", "static-check", "static-check.json", None),
+        ("case-matrix", "case-matrix", "case-matrix.json", None),
+        ("results", "validation-results", "results.json", None),
+    ):
+        manifest = add_artifact(manifest, name=name, kind=kind, uri=uri, sha256=digest, updated_at=timestamp)
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {"status": "planned", "run_id": config["run_id"], "case_count": len(config["cases"]), "kernel_sha256": sha256_file(kernel)}
+
+
+def record(output_dir: Path, *, result_path: Path, recorded_at: str | None = None) -> dict[str, Any]:
+    matrix = _load_json(output_dir / "case-matrix.json", "case matrix")
+    results = _load_json(output_dir / "results.json", "results")
+    planned_ids = {case["id"] for case in matrix["cases"]}
+    result = _load_json(result_path, "case result")
+    validate_result(result, planned_ids)
+    if any(row["case_id"] == result["case_id"] for row in results["results"]):
+        raise ValidationError(f"case already recorded: {result['case_id']}")
+    case = next(row for row in matrix["cases"] if row["id"] == result["case_id"])
+    timestamp = recorded_at or utc_now()
+    normalized = {**result, "source": result.get("source", str(result_path.resolve())), "recorded_at": timestamp}
+    results["results"].append(normalized)
+    case["status"] = "recorded"
+    _write_json(output_dir / "results.json", results)
+    _write_json(output_dir / "case-matrix.json", matrix)
+    manifest = load_manifest(output_dir / "manifest.json")
+    if manifest["status"] == "planned":
+        manifest = transition_status(manifest, "running", updated_at=timestamp)
+        write_manifest(output_dir / "manifest.json", manifest)
+    return {"status": "recorded", "case_id": result["case_id"], "remaining": sum(row["status"] == "pending" for row in matrix["cases"])}
+
+
+def analyze(output_dir: Path, *, updated_at: str | None = None) -> dict[str, Any]:
+    config = _load_json(output_dir / "validation-config.json", "validation config")
+    matrix = _load_json(output_dir / "case-matrix.json", "case matrix")
+    results = _load_json(output_dir / "results.json", "results")
+    result_by_id = {row["case_id"]: row for row in results["results"]}
+    missing = [case["id"] for case in matrix["cases"] if case["id"] not in result_by_id]
+    counts = Counter(row["status"] for row in results["results"])
+    failure_statuses = {"numerical_mismatch", "compilation_error", "runtime_error"}
+    failures = sorted(row["case_id"] for row in results["results"] if row["status"] in failure_statuses)
+    unsupported = sorted(row["case_id"] for row in results["results"] if row["status"] == "unsupported")
+    passed = sorted(row["case_id"] for row in results["results"] if row["status"] == "passed")
+    if failures:
+        status = "failed"
+    elif missing or unsupported:
+        status = "inconclusive"
+    else:
+        status = "passed"
+    analysis = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "op_name": config["op_name"],
+        "total_cases": len(matrix["cases"]),
+        "passed_cases": len(passed),
+        "missing_cases": missing,
+        "failed_cases": failures,
+        "unsupported_cases": unsupported,
+        "status_counts": dict(sorted(counts.items())),
+        "results": results["results"],
+    }
+    _write_json(output_dir / "analysis.json", analysis)
+    report = (
+        "# Ascend Triton validation report\n\n"
+        f"- Status: **{status}**\n"
+        f"- Operator: `{config['op_name']}`\n"
+        f"- Passed: {len(passed)} / {len(matrix['cases'])}\n"
+        f"- Missing: {', '.join(missing) or 'none'}\n"
+        f"- Failed: {', '.join(failures) or 'none'}\n"
+        f"- Unsupported: {', '.join(unsupported) or 'none'}\n"
+    )
+    _atomic_write(output_dir / "report.md", report)
+    timestamp = updated_at or utc_now()
+    manifest = load_manifest(output_dir / "manifest.json")
+    if manifest["status"] == "planned":
+        manifest = transition_status(manifest, "running", updated_at=timestamp)
+    for name, kind, uri in (("analysis", "analysis", "analysis.json"), ("report", "report", "report.md")):
+        manifest = add_artifact(manifest, name=name, kind=kind, uri=uri, updated_at=timestamp)
+    manifest = transition_status(manifest, status, updated_at=timestamp)
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {"status": status, "passed_cases": len(passed), "total_cases": len(matrix["cases"]), "analysis": str((output_dir / "analysis.json").resolve())}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+    plan_parser = subparsers.add_parser("plan")
+    plan_parser.add_argument("--output-dir", required=True, type=Path)
+    plan_parser.add_argument("--config", required=True, type=Path)
+    plan_parser.add_argument("--kernel", required=True, type=Path)
+    record_parser = subparsers.add_parser("record")
+    record_parser.add_argument("--output-dir", required=True, type=Path)
+    record_parser.add_argument("--result", required=True, type=Path)
+    analyze_parser = subparsers.add_parser("analyze")
+    analyze_parser.add_argument("--output-dir", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.action == "plan":
+            payload = plan(args.output_dir, config_path=args.config, kernel=args.kernel)
+        elif args.action == "record":
+            payload = record(args.output_dir, result_path=args.result)
+        else:
+            payload = analyze(args.output_dir)
+    except (ValidationError, RunManifestError) as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/ascend-triton-kernel-validation/scripts/validate_triton_impl.py
+++ b/.agents/skills/ascend-triton-kernel-validation/scripts/validate_triton_impl.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Statically reject missing Triton launches and PyTorch computation fallback."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+ALLOWED_TORCH_CALLS = {
+    "torch.empty",
+    "torch.empty_like",
+    "torch.zeros",
+    "torch.zeros_like",
+    "torch.ones",
+    "torch.ones_like",
+    "torch.full",
+    "torch.full_like",
+    "torch.npu.current_device",
+    "torch.npu.device",
+}
+FORBIDDEN_METHODS = {
+    "add", "sub", "mul", "div", "matmul", "mm", "bmm", "sum", "mean",
+    "max", "min", "softmax", "exp", "log", "sqrt", "pow", "where",
+}
+
+
+def _dotted(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _dotted(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return None
+
+
+def _decorator_is_triton_jit(node: ast.AST) -> bool:
+    name = _dotted(node.func if isinstance(node, ast.Call) else node)
+    return name in {"triton.jit", "jit"}
+
+
+def _call_target(node: ast.Call) -> str | None:
+    function = node.func
+    if isinstance(function, ast.Subscript):
+        function = function.value
+    name = _dotted(function)
+    return name.split(".")[-1] if name else None
+
+
+def analyze_tree(tree: ast.Module) -> dict[str, Any]:
+    kernels = {
+        node.name
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and any(_decorator_is_triton_jit(item) for item in node.decorator_list)
+    }
+    functions: dict[str, ast.AST] = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    forward: ast.AST | None = None
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "ModelNew":
+            for item in node.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    functions[item.name] = item
+                    if item.name == "forward":
+                        forward = item
+    reachable: set[str] = set()
+    kernel_calls: set[str] = set()
+    violations: list[dict[str, Any]] = []
+
+    def walk_function(name: str, node: ast.AST) -> None:
+        if name in reachable:
+            return
+        reachable.add(name)
+        for call in (item for item in ast.walk(node) if isinstance(item, ast.Call)):
+            target = _call_target(call)
+            if target in kernels:
+                kernel_calls.add(target)
+            if target in functions and target != name:
+                walk_function(target, functions[target])
+            dotted = _dotted(call.func)
+            if dotted and (dotted.startswith("torch.") or dotted.startswith("F.")):
+                if dotted not in ALLOWED_TORCH_CALLS:
+                    violations.append({"line": call.lineno, "call": dotted})
+            elif target in FORBIDDEN_METHODS:
+                violations.append({"line": call.lineno, "call": dotted or target})
+
+    if forward is not None:
+        walk_function("forward", forward)
+    checks = {
+        "triton_kernel_exists": {"passed": bool(kernels), "kernels": sorted(kernels)},
+        "kernel_called_from_forward": {"passed": bool(kernel_calls), "called": sorted(kernel_calls)},
+        "no_pytorch_fallback": {"passed": not violations, "violations": violations},
+    }
+    valid = all(item["passed"] for item in checks.values())
+    return {"valid": valid, "checks": checks, "reachable_functions": sorted(reachable)}
+
+
+def analyze_file(path: Path) -> dict[str, Any]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError) as exc:
+        return {"valid": False, "error": f"{type(exc).__name__}: {exc}", "checks": {}}
+    return analyze_tree(tree)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    result = analyze_file(args.path)
+    print(json.dumps(result, ensure_ascii=False, indent=2 if args.json else None))
+    return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/ascend-triton-kernel-validation/tests/test_triton_validation.py
+++ b/.agents/skills/ascend-triton-kernel-validation/tests/test_triton_validation.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Tests for Ascend Triton static and correctness gates."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+SKILL = ROOT / ".agents" / "skills" / "ascend-triton-kernel-validation"
+
+
+def load_script(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, SKILL / "scripts" / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+static = load_script("validate_triton_impl", "validate_triton_impl.py")
+validation = load_script("_triton_validation_test", "triton_validation.py")
+NOW = "2026-08-03T12:00:00Z"
+
+
+def kernel_source(fallback: bool = False) -> str:
+    body = "return torch.sum(x)" if fallback else "out = torch.empty_like(x)\n        _kernel[(1,)](x, out, 1)\n        return out"
+    return (
+        "import torch\nimport triton\nimport triton.language as tl\n"
+        "@triton.jit\ndef _kernel(x, out, n: tl.constexpr):\n    tl.store(out, tl.load(x))\n"
+        "class ModelNew:\n    def forward(self, x):\n        " + body + "\n"
+    )
+
+
+def config() -> dict:
+    return {
+        "schema_version": 1,
+        "run_id": "softmax-validation-001",
+        "parent_run_id": "triton-softmax-001",
+        "op_name": "softmax",
+        "reference": {"path": "/src/ref.py"},
+        "target": {"soc": "Ascend910B2"},
+        "tolerances": {"float16": {"atol": 0.001, "rtol": 0.001}},
+        "cases": [
+            {
+                "id": "case-1",
+                "mode": "eager",
+                "inputs": [{"name": "x", "shape": [2, 4], "strides": [4, 1], "dtype": "float16", "layout": "ND"}],
+            }
+        ],
+    }
+
+
+class ValidationTests(unittest.TestCase):
+    def test_static_gate_detects_fallback(self) -> None:
+        tree = __import__("ast").parse(kernel_source(fallback=True))
+        result = static.analyze_tree(tree)
+        self.assertFalse(result["valid"])
+        self.assertFalse(result["checks"]["no_pytorch_fallback"]["passed"])
+
+    def test_full_lifecycle_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            kernel = root / "kernel.py"
+            kernel.write_text(kernel_source(), encoding="utf-8")
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(config()), encoding="utf-8")
+            output = root / "validation"
+            validation.plan(output, config_path=config_path, kernel=kernel, created_at=NOW)
+            result_path = root / "result.json"
+            result_path.write_text(json.dumps({"schema_version": 1, "case_id": "case-1", "status": "passed", "comparisons": [{"output": "out", "max_abs": 0.0, "max_rel": 0.0, "cosine": 1.0}]}), encoding="utf-8")
+            validation.record(output, result_path=result_path, recorded_at=NOW)
+            result = validation.analyze(output, updated_at=NOW)
+            self.assertEqual(result["status"], "passed")
+            self.assertEqual(result["passed_cases"], 1)
+
+    def test_missing_case_is_inconclusive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            kernel = root / "kernel.py"
+            kernel.write_text(kernel_source(), encoding="utf-8")
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(config()), encoding="utf-8")
+            output = root / "validation"
+            validation.plan(output, config_path=config_path, kernel=kernel, created_at=NOW)
+            result = validation.analyze(output, updated_at=NOW)
+            self.assertEqual(result["status"], "inconclusive")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/ascend-triton-operator-development/SKILL.md
+++ b/.agents/skills/ascend-triton-operator-development/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: ascend-triton-operator-development
+description: Develop a first correct Ascend Triton operator from a PyTorch reference or migrate an existing GPU Triton kernel to Ascend, including semantic audit, explicit task contracts, hardware-aware grid and tiling design, implementation, and handoff to correctness validation. Use for new kernel implementation, CUDA/GPU Triton migration, or repairing a candidate that has not yet passed correctness. Do not use for a kernel that already passes all planned cases and only needs performance tuning, for isolated torch_npu or ACLNN debugging, or for model-level graph failures.
+---
+
+# Ascend Triton Operator Development
+
+Produce a traceable candidate and prove its correctness through the validation Skill before claiming success.
+
+## Workflow
+
+1. Record the exact source, reference, target SoC, CANN/Triton-Ascend versions, supported shapes, dtypes, layouts, strides, scalar options, tolerances, and side effects.
+2. Query `.agents/knowledge/` for target capability and known failure signatures. Treat absent facts as unknown.
+3. Run `scripts/triton_development.py plan` to create the task contract and development Run Manifest.
+4. Complete the generated semantic report before changing code. For GPU Triton input, audit every load, store, mask, index, grid dimension, reduction identity, atomic, and alias.
+5. Write one hardware-aware sketch: logical work, physical-core mapping, tile sizes, estimated UB live set, padding semantics, and specialization boundaries.
+6. Implement the smallest correct candidate. Keep the host wrapper limited to allocation, metadata extraction, dispatch, and launch; keep core computation in `@triton.jit`.
+7. Use `ascend-triton-kernel-validation` on a managed remote NPU. Do not run `torch_npu` locally.
+8. Run `finalize` with the candidate, completed audit, sketch, and terminal validation manifest.
+
+## Entry point
+
+`scripts/triton_development.py` provides:
+
+- `plan`: validate the task config and create audit/sketch templates plus Run Manifest v1;
+- `finalize`: hash and register the candidate artifacts, consume terminal correctness evidence, and generate the development report.
+
+Read:
+
+- [Behavior contract](references/behavior.md) for task and finalization semantics.
+- [Semantic review](references/semantic-review.md) before migrating or implementing.
+- [Architecture and code generation](references/architecture-and-codegen.md) while designing the kernel.
+- [Command recipes](references/command-recipes.md) for controller usage.
+- [Acceptance](references/acceptance.md) before claiming the first correct kernel exists.
+
+## Rules
+
+- Preserve the reference semantics; do not optimize away masks, padding, dtype width, or side effects without proof.
+- Do not hard-code core count, UB capacity, alignment, or compiler capability across SoCs and versions.
+- Keep all planned cases; never reduce a multi-shape task to the easiest case.
+- Do not use GPU latency as the NPU acceptance baseline.
+- A development run passes only when its linked validation manifest passes.
+- Keep run state under `.vaws-local/ascend-triton/development/`.

--- a/.agents/skills/ascend-triton-operator-development/agents/openai.yaml
+++ b/.agents/skills/ascend-triton-operator-development/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ascend Triton Operator Development"
+  short_description: "Develop or migrate a correct Ascend Triton kernel"
+  default_prompt: "Use $ascend-triton-operator-development to develop or migrate this operator into a correct Ascend Triton kernel."

--- a/.agents/skills/ascend-triton-operator-development/references/acceptance.md
+++ b/.agents/skills/ascend-triton-operator-development/references/acceptance.md
@@ -1,0 +1,23 @@
+# Ascend Triton development acceptance
+
+## Contract and audit
+
+- [ ] Source, reference, target environment, cases, and tolerances are explicit.
+- [ ] Every load, store, mask, index, grid dimension, and side effect is audited.
+- [ ] Multi-shape and non-aligned cases were not discarded.
+- [ ] Unknown target capabilities are marked unknown.
+
+## Design and implementation
+
+- [ ] Sketch records grid mapping, tiling, UB live-set estimate, padding, and specialization.
+- [ ] Core computation is in Triton rather than a PyTorch fallback.
+- [ ] First candidate preserves correct padding and numerical identities.
+- [ ] Candidate source, audit, and sketch are non-empty and hashed.
+
+## Evidence
+
+- [ ] Static fallback check passed.
+- [ ] Every planned correctness case passed on a managed Ascend NPU.
+- [ ] Validation used the same reference, cases, and predeclared tolerances.
+- [ ] Validation manifest is linked and terminal.
+- [ ] No performance claim is made by this Skill.

--- a/.agents/skills/ascend-triton-operator-development/references/architecture-and-codegen.md
+++ b/.agents/skills/ascend-triton-operator-development/references/architecture-and-codegen.md
@@ -1,0 +1,62 @@
+# Ascend Triton architecture and code generation
+
+## Contents
+
+- Capability snapshot
+- Grid and physical cores
+- UB and tiling
+- Pipeline and dtype
+- Code-generation rules
+
+## Capability snapshot
+
+Before design, record the exact SoC, Vector/Cube core counts, CANN, driver,
+`torch_npu`, and `triton-ascend` versions. Query runtime/device properties where
+available. Mark UB, alignment, or compiler options unknown rather than copying a
+different SoC's constants.
+
+## Grid and physical cores
+
+Ascend grid selection is a physical resource mapping decision. Evaluate:
+
+1. physical-core-scale grid plus a grid-stride loop;
+2. a larger logical grid with supported blockification/compiler options;
+3. a legal multidimensional mapping when it avoids expensive flattening.
+
+Balance per-core iterations and keep front/tail work close. Count scalar
+division, modulo, branch, and address-generation work introduced by task
+reconstruction.
+
+## UB and tiling
+
+Budget the peak live set, not total input size:
+
+```text
+usable_per_stage = floor(UB_bytes * safety_factor / pipeline_stages)
+tiles_per_iteration <= usable_per_stage / peak_live_bytes_per_tile
+```
+
+Include simultaneous loads, widened fp32 temporaries, accumulators, masks,
+indices, slice/broadcast temporaries, and values still live at store. A fixed
+85 KB budget is only a 192 KB/double-buffer heuristic, not a portable contract.
+
+Start with a conservative correct tile. Optimization owns later tile expansion.
+
+## Pipeline and dtype
+
+Design address generation, GM-to-UB loads, Vector computation, and UB-to-GM
+stores so later optimization can overlap them. Keep iteration addresses
+independent when possible. Avoid unnecessary int64 arithmetic and unsupported
+integer vector operations, but do not cast large indices to fp32 when exactness
+would be lost.
+
+## Code-generation rules
+
+- Keep core computation inside one or more `@triton.jit` kernels.
+- Limit the host wrapper to allocation, metadata, safe dispatch, and launch.
+- Do not call PyTorch tensor computation as a fallback for unsupported cases.
+- Keep mask and identity semantics explicit in the first candidate.
+- Use `tl.constexpr` only for bounded specialization dimensions and operations
+  that require compile-time values.
+- Preserve a generic fallback when adding shape-specialized kernels.
+- Write complete code with no placeholders before handing off to validation.

--- a/.agents/skills/ascend-triton-operator-development/references/behavior.md
+++ b/.agents/skills/ascend-triton-operator-development/references/behavior.md
@@ -1,0 +1,69 @@
+# Ascend Triton development behavior contract
+
+## Contents
+
+- Task configuration
+- Development artifacts
+- Validation handoff
+- Final status
+
+## Task configuration
+
+```json
+{
+  "schema_version": 1,
+  "run_id": "softmax-development-001",
+  "parent_run_id": "triton-softmax-001",
+  "op_name": "softmax",
+  "mode": "gpu-migration",
+  "source": {"kind": "gpu-triton", "path": "/src/softmax.py"},
+  "reference": {"kind": "torch", "path": "/src/softmax_ref.py"},
+  "target": {"soc": "Ascend910B2", "cann": "...", "triton_ascend": "..."},
+  "tolerances": {"float16": {"atol": 0.001, "rtol": 0.001}},
+  "cases": [
+    {
+      "id": "fp16-128x257",
+      "inputs": [
+        {"name": "x", "shape": [128, 257], "dtype": "float16", "layout": "ND", "strides": [257, 1]}
+      ],
+      "scalars": {}
+    }
+  ]
+}
+```
+
+`mode` is `direct` or `gpu-migration`. Every case has a stable ID and explicit
+input metadata. The config records the supported contract, not just the cases
+that happen to pass.
+
+## Development artifacts
+
+`plan` creates:
+
+- `task-config.json`: immutable input contract;
+- `task-contract.json`: compact operator/case handoff;
+- `semantic-report.md`: mandatory audit template;
+- `sketch.md`: mandatory design template;
+- `candidates/` and `artifacts/` directories;
+- `manifest.json`: Run Manifest v1 with run type `debug`.
+
+The semantic report and sketch must be completed, not left with unchecked
+placeholders. The controller rejects empty files but cannot judge design quality;
+use the acceptance checklist.
+
+## Validation handoff
+
+`finalize` accepts a terminal `correctness` Run Manifest. Its `parent_run_id`
+must point either to this development run or to the same parent workflow. This
+supports standalone development and sibling stages under one workflow.
+
+The candidate source, semantic report, and sketch are hashed into the manifest.
+The validation manifest path and status are recorded in `development-result.json`.
+
+## Final status
+
+- validation `passed` -> development `passed`;
+- validation `failed` -> development `failed`;
+- validation `inconclusive` or `cancelled` -> development `inconclusive`.
+
+No validation manifest means the run remains unfinished; `finalize` rejects it.

--- a/.agents/skills/ascend-triton-operator-development/references/command-recipes.md
+++ b/.agents/skills/ascend-triton-operator-development/references/command-recipes.md
@@ -1,0 +1,28 @@
+# Ascend Triton development command recipes
+
+## Plan
+
+```bash
+python -B .agents/skills/ascend-triton-operator-development/scripts/triton_development.py plan \
+  --output-dir .vaws-local/ascend-triton/development/softmax-001 \
+  --config /path/to/development-config.json
+```
+
+Complete `semantic-report.md` and `sketch.md`, then place candidates under the
+generated `candidates/` directory.
+
+## Validate remotely
+
+Use `ascend-triton-kernel-validation` with the same cases and tolerances. Set the
+validation run's `parent_run_id` to this development run or the shared workflow.
+
+## Finalize
+
+```bash
+python -B .agents/skills/ascend-triton-operator-development/scripts/triton_development.py finalize \
+  --output-dir .vaws-local/ascend-triton/development/softmax-001 \
+  --kernel /path/to/softmax_ascend.py \
+  --semantic-report .vaws-local/ascend-triton/development/softmax-001/semantic-report.md \
+  --sketch .vaws-local/ascend-triton/development/softmax-001/sketch.md \
+  --validation-manifest /path/to/validation/manifest.json
+```

--- a/.agents/skills/ascend-triton-operator-development/references/semantic-review.md
+++ b/.agents/skills/ascend-triton-operator-development/references/semantic-review.md
@@ -1,0 +1,71 @@
+# Ascend Triton semantic review
+
+## Contents
+
+- Operator contract
+- Loads and stores
+- Masks and padding
+- Index and grid mapping
+- Numerical and side-effect semantics
+- Migration checklist
+
+## Operator contract
+
+Record input/output shapes, dtypes, layouts, strides, scalar parameters, aliases,
+in-place behavior, atomics, randomness, and supported dynamic ranges. Separate
+what the source currently assumes from what the public operator contract promises.
+
+## Loads and stores
+
+For every `tl.load`, record:
+
+- pointer expression and source tensor;
+- logical lane shape;
+- input-validity mask;
+- `other` or padding identity;
+- whether an invalid lane reaches reduce, divide, exp, compare, index, or store.
+
+For every `tl.store`, record the output-validity mask independently. A load mask
+answers which input addresses are readable; a store mask answers which output
+positions must be written. Reusing one for the other can silently skip valid
+outputs.
+
+## Masks and padding
+
+- Use bitwise tensor operators (`&`, `|`) rather than Python boolean operators.
+- Preserve mathematical identities: sum uses zero, max commonly uses negative
+  infinity, and min commonly uses positive infinity.
+- Treat `care_padding=False` as an optimization that requires proof that padded
+  lanes are dead or overwritten before use.
+- Revalidate tail blocks, fully masked blocks, tiny shapes, NaN, and Inf whenever
+  padding behavior changes.
+
+## Index and grid mapping
+
+Classify each address as contiguous, regular-strided, or data-dependent discrete.
+Map every GPU `program_id` dimension to one logical task. If dimensions are
+flattened for Ascend, record the reconstruction formula and the added scalar
+division/modulo cost.
+
+Do not automatically flatten a legal regular 2D mapping. Do not automatically
+preserve a very large GPU logical grid. Design and measure both physical-core
+grid-stride and compiler-assisted blockification candidates when supported.
+
+## Numerical and side-effect semantics
+
+- Record accumulation dtype and reduction order.
+- Record math approximations separately from architecture migration.
+- Preserve repeated-index and atomic semantics.
+- Preserve output initialization and untouched-output behavior.
+- Never relax tolerance after observing a failure without a documented numerical
+  justification.
+
+## Migration checklist
+
+- [ ] GPU-only host APIs and device contexts are identified.
+- [ ] Triton language features are checked against the target version.
+- [ ] Grid semantics are mapped, not merely renamed.
+- [ ] Every mask and padding identity is explained.
+- [ ] All dynamic shapes and scalar specializations remain represented.
+- [ ] External dependencies and hidden fallbacks are removed or made explicit.
+- [ ] The source is left intact; the Ascend candidate is a separate artifact.

--- a/.agents/skills/ascend-triton-operator-development/scripts/triton_development.py
+++ b/.agents/skills/ascend-triton-operator-development/scripts/triton_development.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Plan and finalize an Ascend Triton development or migration run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_run_manifest import (  # noqa: E402
+    RunManifestError,
+    TERMINAL_STATUSES,
+    add_artifact,
+    load_manifest,
+    new_manifest,
+    sha256_file,
+    transition_status,
+    write_manifest,
+)
+
+SCHEMA_VERSION = 1
+MODES = {"direct", "gpu-migration"}
+SOURCE_KINDS = {"torch-reference", "gpu-triton"}
+
+
+class DevelopmentError(ValueError):
+    """Raised when development evidence violates the contract."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    _atomic_write(path, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DevelopmentError(f"cannot read {label} {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise DevelopmentError(f"{label} root must be an object")
+    return payload
+
+
+def _validate_input(spec: Mapping[str, Any], path: str, errors: list[str]) -> None:
+    if not isinstance(spec.get("name"), str) or not spec["name"]:
+        errors.append(f"{path}.name must be a non-empty string")
+    shape = spec.get("shape")
+    if not isinstance(shape, list) or any(not isinstance(value, int) or isinstance(value, bool) or value < 0 for value in shape):
+        errors.append(f"{path}.shape must contain non-negative integers")
+    for field in ("dtype", "layout"):
+        if not isinstance(spec.get(field), str) or not spec[field]:
+            errors.append(f"{path}.{field} must be a non-empty string")
+    strides = spec.get("strides")
+    if strides is not None and (not isinstance(strides, list) or any(not isinstance(value, int) or isinstance(value, bool) or value < 0 for value in strides)):
+        errors.append(f"{path}.strides must contain non-negative integers")
+
+
+def validate_config(config: Mapping[str, Any]) -> None:
+    errors: list[str] = []
+    if config.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    for field in ("run_id", "op_name"):
+        if not isinstance(config.get(field), str) or not config[field]:
+            errors.append(f"{field} must be a non-empty string")
+    if config.get("mode") not in MODES:
+        errors.append(f"mode must be one of: {', '.join(sorted(MODES))}")
+    source = config.get("source")
+    if not isinstance(source, Mapping):
+        errors.append("source must be an object")
+    else:
+        if source.get("kind") not in SOURCE_KINDS:
+            errors.append(f"source.kind must be one of: {', '.join(sorted(SOURCE_KINDS))}")
+        if not isinstance(source.get("path"), str) or not source["path"]:
+            errors.append("source.path must be a non-empty string")
+    reference = config.get("reference")
+    if not isinstance(reference, Mapping) or not isinstance(reference.get("path"), str) or not reference.get("path"):
+        errors.append("reference.path must be a non-empty string")
+    target = config.get("target")
+    if not isinstance(target, Mapping) or not isinstance(target.get("soc"), str) or not target.get("soc"):
+        errors.append("target.soc must be a non-empty string")
+    cases = config.get("cases")
+    if not isinstance(cases, list) or not cases:
+        errors.append("cases must be a non-empty array")
+        cases = []
+    seen: set[str] = set()
+    for index, case in enumerate(cases):
+        path = f"cases[{index}]"
+        if not isinstance(case, Mapping):
+            errors.append(f"{path} must be an object")
+            continue
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not case_id:
+            errors.append(f"{path}.id must be a non-empty string")
+        elif case_id in seen:
+            errors.append(f"case id is duplicated: {case_id}")
+        else:
+            seen.add(case_id)
+        inputs = case.get("inputs")
+        if not isinstance(inputs, list) or not inputs:
+            errors.append(f"{path}.inputs must be a non-empty array")
+        else:
+            for input_index, spec in enumerate(inputs):
+                if not isinstance(spec, Mapping):
+                    errors.append(f"{path}.inputs[{input_index}] must be an object")
+                else:
+                    _validate_input(spec, f"{path}.inputs[{input_index}]", errors)
+    if not isinstance(config.get("tolerances"), Mapping) or not config.get("tolerances"):
+        errors.append("tolerances must be a non-empty object")
+    if errors:
+        raise DevelopmentError("; ".join(errors))
+
+
+def plan(output_dir: Path, *, config_path: Path, created_at: str | None = None) -> dict[str, Any]:
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise DevelopmentError(f"output directory is not empty: {output_dir}")
+    config = _load_json(config_path, "development config")
+    validate_config(config)
+    timestamp = created_at or utc_now()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "candidates").mkdir()
+    (output_dir / "artifacts").mkdir()
+    contract = {
+        "schema_version": SCHEMA_VERSION,
+        "op_name": config["op_name"],
+        "mode": config["mode"],
+        "source": config["source"],
+        "reference": config["reference"],
+        "target": config["target"],
+        "tolerances": config["tolerances"],
+        "cases": config["cases"],
+    }
+    _write_json(output_dir / "task-config.json", config)
+    _write_json(output_dir / "task-contract.json", contract)
+    _atomic_write(
+        output_dir / "semantic-report.md",
+        "# Semantic report\n\n"
+        "## Contract\n\n- [ ] Inputs, outputs, dynamic ranges, layouts, strides, and side effects recorded.\n\n"
+        "## Loads and stores\n\n- [ ] Every load/store pointer and mask explained.\n\n"
+        "## Padding and numerical semantics\n\n- [ ] Identities, accumulation dtype, atomics, aliases, and tail behavior explained.\n\n"
+        "## Grid mapping\n\n- [ ] Logical tasks and target physical-core mapping explained.\n",
+    )
+    _atomic_write(
+        output_dir / "sketch.md",
+        "# Kernel sketch\n\n"
+        "## Logical work\n\n"
+        "## Grid and per-core scheduling\n\n"
+        "## Tiling and UB peak live set\n\n"
+        "## Masks, padding, dtype, and specialization\n\n",
+    )
+    manifest = new_manifest(
+        run_type="debug",
+        run_id=config["run_id"],
+        parent_run_id=config.get("parent_run_id"),
+        workspace_snapshot=config.get("workspace_snapshot", {}),
+        environment=config.get("environment", {}),
+        topology={"target": config["target"]},
+        command=config.get("command", []),
+        created_at=timestamp,
+    )
+    for name, kind, uri in (
+        ("task-config", "development-config", "task-config.json"),
+        ("task-contract", "task-contract", "task-contract.json"),
+    ):
+        manifest = add_artifact(manifest, name=name, kind=kind, uri=uri, updated_at=timestamp)
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {"status": "planned", "run_id": config["run_id"], "case_count": len(config["cases"])}
+
+
+def _require_nonempty(path: Path, label: str) -> None:
+    if not path.is_file() or path.stat().st_size == 0:
+        raise DevelopmentError(f"{label} must be a non-empty file: {path}")
+
+
+def _artifact(manifest: Mapping[str, Any], name: str) -> Mapping[str, Any]:
+    artifact = next((item for item in manifest["artifacts"] if item["name"] == name), None)
+    if artifact is None:
+        raise DevelopmentError(f"validation manifest is missing {name} artifact")
+    return artifact
+
+
+def _artifact_path(manifest_path: Path, artifact: Mapping[str, Any]) -> Path:
+    path = Path(str(artifact["uri"]))
+    return path if path.is_absolute() else manifest_path.parent / path
+
+
+def finalize(
+    output_dir: Path,
+    *,
+    kernel: Path,
+    semantic_report: Path,
+    sketch: Path,
+    validation_manifest: Path,
+    updated_at: str | None = None,
+) -> dict[str, Any]:
+    for path, label in ((kernel, "kernel"), (semantic_report, "semantic report"), (sketch, "sketch")):
+        _require_nonempty(path, label)
+    manifest = load_manifest(output_dir / "manifest.json")
+    validation = load_manifest(validation_manifest)
+    if validation["run_type"] != "correctness":
+        raise DevelopmentError("validation manifest must use run_type correctness")
+    valid_parents = {manifest["run_id"], manifest["parent_run_id"]} - {None}
+    if validation["parent_run_id"] not in valid_parents:
+        raise DevelopmentError("validation parent_run_id must identify this run or its parent workflow")
+    if validation["status"] not in TERMINAL_STATUSES:
+        raise DevelopmentError("validation manifest must be terminal")
+    kernel_hash = sha256_file(kernel)
+    kernel_artifact = _artifact(validation, "kernel")
+    if kernel_artifact.get("sha256") != kernel_hash:
+        raise DevelopmentError("validation kernel hash does not match the development candidate")
+    matrix_artifact = _artifact(validation, "case-matrix")
+    matrix = _load_json(_artifact_path(validation_manifest, matrix_artifact), "validation case matrix")
+    matrix_kernel = matrix.get("kernel")
+    if not isinstance(matrix_kernel, Mapping) or matrix_kernel.get("sha256") != kernel_hash:
+        raise DevelopmentError("validation case matrix does not match the development candidate")
+    config = _load_json(output_dir / "task-config.json", "development config")
+    expected_cases = {case["id"] for case in config["cases"]}
+    matrix_cases = matrix.get("cases")
+    if not isinstance(matrix_cases, list) or any(not isinstance(case, Mapping) for case in matrix_cases):
+        raise DevelopmentError("validation case matrix cases must be an array of objects")
+    if {case.get("id") for case in matrix_cases} != expected_cases:
+        raise DevelopmentError("validation case set does not match the development case set")
+    terminal = {
+        "passed": "passed",
+        "failed": "failed",
+        "inconclusive": "inconclusive",
+        "cancelled": "inconclusive",
+    }[validation["status"]]
+    timestamp = updated_at or utc_now()
+    result = {
+        "schema_version": SCHEMA_VERSION,
+        "status": terminal,
+        "kernel": {"path": str(kernel.resolve()), "sha256": kernel_hash},
+        "semantic_report": {"path": str(semantic_report.resolve()), "sha256": sha256_file(semantic_report)},
+        "sketch": {"path": str(sketch.resolve()), "sha256": sha256_file(sketch)},
+        "validation": {
+            "run_id": validation["run_id"],
+            "status": validation["status"],
+            "manifest": str(validation_manifest.resolve()),
+        },
+    }
+    _write_json(output_dir / "development-result.json", result)
+    if manifest["status"] == "planned":
+        manifest = transition_status(manifest, "running", updated_at=timestamp)
+    artifacts = (
+        ("kernel", "triton-kernel", str(kernel.resolve()), kernel_hash),
+        ("semantic-report", "semantic-report", str(semantic_report.resolve()), sha256_file(semantic_report)),
+        ("sketch", "kernel-sketch", str(sketch.resolve()), sha256_file(sketch)),
+        ("development-result", "result", "development-result.json", None),
+        ("validation-manifest", "run-manifest", str(validation_manifest.resolve()), None),
+    )
+    for name, kind, uri, digest in artifacts:
+        manifest = add_artifact(manifest, name=name, kind=kind, uri=uri, sha256=digest, updated_at=timestamp)
+    report = (
+        "# Ascend Triton development report\n\n"
+        f"- Status: **{terminal}**\n"
+        f"- Kernel: `{kernel.resolve()}`\n"
+        f"- Kernel SHA256: `{result['kernel']['sha256']}`\n"
+        f"- Validation: `{validation['run_id']}` ({validation['status']})\n"
+    )
+    _atomic_write(output_dir / "development-report.md", report)
+    manifest = add_artifact(
+        manifest,
+        name="development-report",
+        kind="report",
+        uri="development-report.md",
+        updated_at=timestamp,
+    )
+    manifest = transition_status(manifest, terminal, updated_at=timestamp)
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {"status": terminal, "kernel_sha256": result["kernel"]["sha256"], "result": str((output_dir / "development-result.json").resolve())}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+    plan_parser = subparsers.add_parser("plan")
+    plan_parser.add_argument("--output-dir", required=True, type=Path)
+    plan_parser.add_argument("--config", required=True, type=Path)
+    finalize_parser = subparsers.add_parser("finalize")
+    finalize_parser.add_argument("--output-dir", required=True, type=Path)
+    finalize_parser.add_argument("--kernel", required=True, type=Path)
+    finalize_parser.add_argument("--semantic-report", required=True, type=Path)
+    finalize_parser.add_argument("--sketch", required=True, type=Path)
+    finalize_parser.add_argument("--validation-manifest", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.action == "plan":
+            payload = plan(args.output_dir, config_path=args.config)
+        else:
+            payload = finalize(
+                args.output_dir,
+                kernel=args.kernel,
+                semantic_report=args.semantic_report,
+                sketch=args.sketch,
+                validation_manifest=args.validation_manifest,
+            )
+    except (DevelopmentError, RunManifestError) as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/ascend-triton-operator-development/tests/test_triton_development.py
+++ b/.agents/skills/ascend-triton-operator-development/tests/test_triton_development.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Tests for Ascend Triton development control-plane logic."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+SKILL = ROOT / ".agents" / "skills" / "ascend-triton-operator-development"
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_run_manifest import add_artifact, new_manifest, sha256_file, transition_status, write_manifest
+
+
+def load_module():
+    name = "_triton_development_test"
+    spec = importlib.util.spec_from_file_location(name, SKILL / "scripts" / "triton_development.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+development = load_module()
+NOW = "2026-08-03T12:00:00Z"
+
+
+def config() -> dict:
+    return {
+        "schema_version": 1,
+        "run_id": "softmax-development-001",
+        "parent_run_id": "triton-softmax-001",
+        "op_name": "softmax",
+        "mode": "gpu-migration",
+        "source": {"kind": "gpu-triton", "path": "/src/softmax.py"},
+        "reference": {"path": "/src/ref.py"},
+        "target": {"soc": "Ascend910B2"},
+        "tolerances": {"float16": {"atol": 0.001, "rtol": 0.001}},
+        "cases": [
+            {
+                "id": "case-1",
+                "inputs": [
+                    {"name": "x", "shape": [2, 4], "strides": [4, 1], "dtype": "float16", "layout": "ND"}
+                ],
+            }
+        ],
+    }
+
+
+class DevelopmentTests(unittest.TestCase):
+    def test_duplicate_cases_rejected(self) -> None:
+        payload = config()
+        payload["cases"].append(payload["cases"][0])
+        with self.assertRaisesRegex(development.DevelopmentError, "duplicated"):
+            development.validate_config(payload)
+
+    def test_finalize_follows_validation_status(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(config()), encoding="utf-8")
+            output = root / "development"
+            development.plan(output, config_path=config_path, created_at=NOW)
+            kernel = root / "kernel.py"
+            kernel.write_text("import triton\n", encoding="utf-8")
+            validation = new_manifest(
+                run_type="correctness",
+                run_id="validation-child",
+                parent_run_id="triton-softmax-001",
+                created_at=NOW,
+            )
+            matrix_path = root / "case-matrix.json"
+            matrix_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "kernel": {"path": str(kernel), "sha256": sha256_file(kernel)},
+                        "cases": [{"id": "case-1"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            validation = add_artifact(
+                validation,
+                name="kernel",
+                kind="triton-kernel",
+                uri=str(kernel),
+                sha256=sha256_file(kernel),
+                updated_at=NOW,
+            )
+            validation = add_artifact(
+                validation,
+                name="case-matrix",
+                kind="case-matrix",
+                uri=str(matrix_path),
+                updated_at=NOW,
+            )
+            validation = transition_status(validation, "running", updated_at=NOW)
+            validation = transition_status(validation, "passed", updated_at=NOW)
+            validation_path = root / "validation.json"
+            write_manifest(validation_path, validation)
+            result = development.finalize(
+                output,
+                kernel=kernel,
+                semantic_report=output / "semantic-report.md",
+                sketch=output / "sketch.md",
+                validation_manifest=validation_path,
+                updated_at=NOW,
+            )
+            self.assertEqual(result["status"], "passed")
+            self.assertEqual(len(result["kernel_sha256"]), 64)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/ascend-triton-workflow/SKILL.md
+++ b/.agents/skills/ascend-triton-workflow/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: ascend-triton-workflow
+description: Orchestrate an end-to-end Ascend Triton operator effort across task definition, GPU-to-NPU migration or direct development, explicit correctness validation, profiler-driven optimization, and evidence aggregation with Run Manifest v1. Use when the request spans two or more lifecycle stages or asks for a complete operator delivery. Do not use for only implementing, validating, or optimizing an already-scoped kernel; route those to the owning stage Skill.
+---
+
+# Ascend Triton Workflow
+
+Coordinate the lifecycle without duplicating the implementation owned by the stage Skills.
+
+## Workflow
+
+1. Freeze the source, operator contract, target SoC, software versions, case set, and requested performance objective.
+2. Query `.agents/knowledge/` for relevant capability, validation, and failure-signature facts. Treat missing facts as unknown.
+3. Run `scripts/triton_workflow.py plan` to create the stage plan and parent Run Manifest.
+4. Execute required stages with their owners:
+   - first correct kernel or GPU migration: `ascend-triton-operator-development`;
+   - compile and full-case correctness gate: `ascend-triton-kernel-validation`;
+   - single-kernel profiling and performance iteration: `ascend-triton-kernel-optimization`.
+5. Before remote execution, establish `remote-code-parity`; run `torch_npu` and Triton only in a managed Ascend environment.
+6. Link every child Run Manifest to its planned stage with `link`.
+7. Run `finalize` and deliver the workflow report with missing, failed, and untested coverage explicit.
+
+## Entry point
+
+`scripts/triton_workflow.py` provides:
+
+- `plan`: validate the workflow config, create ordered stage items, and initialize a parent Run Manifest;
+- `link`: bind one terminal child Run Manifest to one stage without overwriting prior evidence;
+- `finalize`: aggregate required-stage evidence and produce `workflow-report.md`.
+
+Read:
+
+- [Behavior contract](references/behavior.md) for config, stage, link, and status semantics.
+- [Command recipes](references/command-recipes.md) for the complete lifecycle.
+- [Acceptance](references/acceptance.md) before claiming an operator workflow complete.
+
+## Rules
+
+- Keep stage ownership strict; do not implement migration, validation, or optimization inside this Skill.
+- Never let performance evidence substitute for correctness evidence.
+- A passed workflow requires every required stage to have a passed terminal child manifest.
+- A failed child makes the workflow failed; missing, unsupported, cancelled, or inconclusive required evidence makes it inconclusive.
+- Record GPU timing only as cross-platform context; use a comparable NPU baseline for NPU optimization acceptance.
+- Keep orchestration state under `.vaws-local/ascend-triton/workflows/`.

--- a/.agents/skills/ascend-triton-workflow/agents/openai.yaml
+++ b/.agents/skills/ascend-triton-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ascend Triton Workflow"
+  short_description: "Orchestrate traceable Ascend Triton operator development"
+  default_prompt: "Use $ascend-triton-workflow to plan and coordinate this Ascend Triton operator workflow."

--- a/.agents/skills/ascend-triton-workflow/references/acceptance.md
+++ b/.agents/skills/ascend-triton-workflow/references/acceptance.md
@@ -1,0 +1,23 @@
+# Ascend Triton workflow acceptance
+
+## Contract
+
+- [ ] Source kind and immutable source identity are recorded.
+- [ ] Target SoC and software versions are explicit or marked unknown.
+- [ ] Required stages match the requested outcome.
+- [ ] Optimization is not scheduled without validation.
+
+## Evidence
+
+- [ ] Each required stage has exactly one linked terminal child manifest.
+- [ ] Child run types and parent run IDs match the plan.
+- [ ] Correctness evidence precedes performance acceptance.
+- [ ] GPU timing is not used as the only NPU performance baseline.
+- [ ] Unknown and unsupported combinations remain visible.
+
+## Delivery
+
+- [ ] Parent and child manifests are preserved.
+- [ ] Workflow summary and report agree on terminal status.
+- [ ] Missing, failed, inconclusive, and optional evidence are explicit.
+- [ ] No secrets or full tensor dumps are present in tracked artifacts.

--- a/.agents/skills/ascend-triton-workflow/references/behavior.md
+++ b/.agents/skills/ascend-triton-workflow/references/behavior.md
@@ -1,0 +1,82 @@
+# Ascend Triton workflow behavior contract
+
+## Contents
+
+- Workflow configuration
+- Stage semantics
+- Child evidence
+- Final status
+- Artifact layout
+
+## Workflow configuration
+
+```json
+{
+  "schema_version": 1,
+  "run_id": "triton-softmax-001",
+  "op_name": "softmax",
+  "source": {
+    "kind": "gpu-triton",
+    "path": "/workspace/softmax_gpu.py",
+    "sha256": "optional-source-hash"
+  },
+  "target": {
+    "soc": "Ascend910B2",
+    "cann": "target-version",
+    "triton_ascend": "target-version"
+  },
+  "required_stages": ["development", "validation", "optimization"],
+  "workspace_snapshot": {},
+  "environment": {},
+  "command": []
+}
+```
+
+`source.kind` is `torch-reference`, `gpu-triton`, or `ascend-triton`. Paths are
+recorded as evidence; the controller does not copy source files.
+
+## Stage semantics
+
+| Stage | Owner | Child run type | Meaning of passed |
+|---|---|---|---|
+| `development` | `ascend-triton-operator-development` | `debug` | A candidate exists and its linked validation passed |
+| `validation` | `ascend-triton-kernel-validation` | `correctness` | Static gate and every planned case passed |
+| `optimization` | `ascend-triton-kernel-optimization` | `performance` | The configured performance objective was met |
+
+Optimization depends on validation. Development is required for a new or
+migrated kernel but may be omitted when the source is already an Ascend Triton
+candidate.
+
+## Child evidence
+
+Each child manifest must:
+
+- use Run Manifest v1;
+- have `parent_run_id` equal to the workflow run ID;
+- have the expected run type for its stage;
+- be terminal before linking;
+- be linked once to one stage.
+
+The link records the child run ID, status, run type, manifest path, and artifact
+list. A later child does not overwrite earlier evidence; start a new workflow to
+replace a stage result.
+
+## Final status
+
+- `passed`: every required stage has a passed child;
+- `failed`: at least one required child is failed;
+- `inconclusive`: required evidence is missing, cancelled, or inconclusive.
+
+An optional failed stage is reported but does not change a passed required set.
+
+## Artifact layout
+
+```text
+workflow/
+├── manifest.json
+├── workflow-config.json
+├── stage-plan.json
+├── evidence-links.json
+├── workflow-summary.json
+└── workflow-report.md
+```

--- a/.agents/skills/ascend-triton-workflow/references/command-recipes.md
+++ b/.agents/skills/ascend-triton-workflow/references/command-recipes.md
@@ -1,0 +1,33 @@
+# Ascend Triton workflow command recipes
+
+## Plan
+
+```bash
+python -B .agents/skills/ascend-triton-workflow/scripts/triton_workflow.py plan \
+  --output-dir .vaws-local/ascend-triton/workflows/softmax-001 \
+  --config /path/to/workflow-config.json
+```
+
+Read `stage-plan.json` and execute only the next stage with its owning Skill.
+
+## Link one child
+
+```bash
+python -B .agents/skills/ascend-triton-workflow/scripts/triton_workflow.py link \
+  --output-dir .vaws-local/ascend-triton/workflows/softmax-001 \
+  --stage validation \
+  --manifest /path/to/validation/manifest.json
+```
+
+The child manifest must already be terminal and must name this workflow as its
+parent.
+
+## Finalize
+
+```bash
+python -B .agents/skills/ascend-triton-workflow/scripts/triton_workflow.py finalize \
+  --output-dir .vaws-local/ascend-triton/workflows/softmax-001
+```
+
+Inspect `workflow-summary.json` and `workflow-report.md`. Do not infer completion
+from console output alone.

--- a/.agents/skills/ascend-triton-workflow/scripts/triton_workflow.py
+++ b/.agents/skills/ascend-triton-workflow/scripts/triton_workflow.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Plan, link, and finalize an Ascend Triton operator workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_run_manifest import (  # noqa: E402
+    RunManifestError,
+    TERMINAL_STATUSES,
+    add_artifact,
+    load_manifest,
+    new_manifest,
+    transition_status,
+    write_manifest,
+)
+
+SCHEMA_VERSION = 1
+STAGES = ("development", "validation", "optimization")
+SOURCE_KINDS = {"torch-reference", "gpu-triton", "ascend-triton"}
+EXPECTED_RUN_TYPES = {
+    "development": "debug",
+    "validation": "correctness",
+    "optimization": "performance",
+}
+
+
+class WorkflowError(ValueError):
+    """Raised when workflow evidence violates the contract."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    _atomic_write(
+        path, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise WorkflowError(f"cannot read {label} {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise WorkflowError(f"{label} root must be an object")
+    return payload
+
+
+def validate_config(config: Mapping[str, Any]) -> None:
+    errors: list[str] = []
+    if config.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    for field in ("run_id", "op_name"):
+        if not isinstance(config.get(field), str) or not config[field]:
+            errors.append(f"{field} must be a non-empty string")
+    source = config.get("source")
+    if not isinstance(source, Mapping):
+        errors.append("source must be an object")
+    else:
+        if source.get("kind") not in SOURCE_KINDS:
+            errors.append(f"source.kind must be one of: {', '.join(sorted(SOURCE_KINDS))}")
+        if not isinstance(source.get("path"), str) or not source["path"]:
+            errors.append("source.path must be a non-empty string")
+    target = config.get("target")
+    if not isinstance(target, Mapping):
+        errors.append("target must be an object")
+    elif not isinstance(target.get("soc"), str) or not target["soc"]:
+        errors.append("target.soc must be a non-empty string")
+    required = config.get("required_stages")
+    if not isinstance(required, list) or not required:
+        errors.append("required_stages must be a non-empty array")
+        required = []
+    elif len(set(required)) != len(required):
+        errors.append("required_stages must not contain duplicates")
+    unknown = sorted(set(required) - set(STAGES))
+    if unknown:
+        errors.append(f"unknown required stages: {', '.join(unknown)}")
+    if "optimization" in required and "validation" not in required:
+        errors.append("optimization requires validation")
+    if errors:
+        raise WorkflowError("; ".join(errors))
+
+
+def plan(output_dir: Path, *, config_path: Path, created_at: str | None = None) -> dict[str, Any]:
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise WorkflowError(f"output directory is not empty: {output_dir}")
+    config = _load_json(config_path, "workflow config")
+    validate_config(config)
+    timestamp = created_at or utc_now()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    required = set(config["required_stages"])
+    stage_plan = {
+        "schema_version": SCHEMA_VERSION,
+        "op_name": config["op_name"],
+        "stages": [
+            {
+                "id": stage,
+                "required": stage in required,
+                "depends_on": ["validation"] if stage == "optimization" else [],
+                "expected_run_type": EXPECTED_RUN_TYPES[stage],
+                "status": "pending",
+            }
+            for stage in STAGES
+            if stage in required
+        ],
+    }
+    links = {"schema_version": SCHEMA_VERSION, "links": []}
+    _write_json(output_dir / "workflow-config.json", config)
+    _write_json(output_dir / "stage-plan.json", stage_plan)
+    _write_json(output_dir / "evidence-links.json", links)
+    manifest = new_manifest(
+        run_type="change-validation",
+        run_id=config["run_id"],
+        workspace_snapshot=config.get("workspace_snapshot", {}),
+        environment=config.get("environment", {}),
+        topology={"target": config["target"]},
+        command=config.get("command", []),
+        created_at=timestamp,
+    )
+    for name, kind, uri in (
+        ("workflow-config", "workflow-config", "workflow-config.json"),
+        ("stage-plan", "stage-plan", "stage-plan.json"),
+        ("evidence-links", "evidence-links", "evidence-links.json"),
+    ):
+        manifest = add_artifact(manifest, name=name, kind=kind, uri=uri, updated_at=timestamp)
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {"status": "planned", "run_id": config["run_id"], "stages": config["required_stages"]}
+
+
+def link(output_dir: Path, *, stage: str, child_path: Path, updated_at: str | None = None) -> dict[str, Any]:
+    plan_doc = _load_json(output_dir / "stage-plan.json", "stage plan")
+    links = _load_json(output_dir / "evidence-links.json", "evidence links")
+    stage_row = next((row for row in plan_doc["stages"] if row["id"] == stage), None)
+    if stage_row is None:
+        raise WorkflowError(f"stage is not planned: {stage}")
+    if any(row["stage"] == stage for row in links["links"]):
+        raise WorkflowError(f"stage already linked: {stage}")
+    parent = load_manifest(output_dir / "manifest.json")
+    child = load_manifest(child_path)
+    if child["parent_run_id"] != parent["run_id"]:
+        raise WorkflowError("child parent_run_id does not match workflow run_id")
+    if child["run_type"] != stage_row["expected_run_type"]:
+        raise WorkflowError(
+            f"stage {stage} requires run_type {stage_row['expected_run_type']}, got {child['run_type']}"
+        )
+    if child["status"] not in TERMINAL_STATUSES:
+        raise WorkflowError("child manifest must be terminal before linking")
+    timestamp = updated_at or utc_now()
+    links["links"].append(
+        {
+            "stage": stage,
+            "run_id": child["run_id"],
+            "run_type": child["run_type"],
+            "status": child["status"],
+            "manifest": str(child_path.resolve()),
+            "artifacts": child["artifacts"],
+            "linked_at": timestamp,
+        }
+    )
+    stage_row["status"] = "linked"
+    _write_json(output_dir / "evidence-links.json", links)
+    _write_json(output_dir / "stage-plan.json", plan_doc)
+    if parent["status"] == "planned":
+        parent = transition_status(parent, "running", updated_at=timestamp)
+        write_manifest(output_dir / "manifest.json", parent)
+    return {"status": "linked", "stage": stage, "child_status": child["status"]}
+
+
+def _render_report(summary: Mapping[str, Any]) -> str:
+    lines = [
+        "# Ascend Triton workflow report",
+        "",
+        f"- Status: **{summary['status']}**",
+        f"- Operator: `{summary['op_name']}`",
+        f"- Missing required stages: {', '.join(summary['missing_required']) or 'none'}",
+        f"- Failed required stages: {', '.join(summary['failed_required']) or 'none'}",
+        f"- Inconclusive required stages: {', '.join(summary['inconclusive_required']) or 'none'}",
+        "",
+        "## Stage evidence",
+        "",
+        "```json",
+        json.dumps(summary["stages"], ensure_ascii=False, indent=2, sort_keys=True),
+        "```",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def finalize(output_dir: Path, *, updated_at: str | None = None) -> dict[str, Any]:
+    config = _load_json(output_dir / "workflow-config.json", "workflow config")
+    plan_doc = _load_json(output_dir / "stage-plan.json", "stage plan")
+    links = _load_json(output_dir / "evidence-links.json", "evidence links")
+    link_by_stage = {row["stage"]: row for row in links["links"]}
+    required = [row["id"] for row in plan_doc["stages"] if row["required"]]
+    missing = [stage for stage in required if stage not in link_by_stage]
+    failed = [stage for stage in required if link_by_stage.get(stage, {}).get("status") == "failed"]
+    inconclusive = [
+        stage
+        for stage in required
+        if link_by_stage.get(stage, {}).get("status") in {"inconclusive", "cancelled"}
+    ]
+    if failed:
+        status = "failed"
+    elif missing or inconclusive:
+        status = "inconclusive"
+    else:
+        status = "passed"
+    summary = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "op_name": config["op_name"],
+        "missing_required": missing,
+        "failed_required": failed,
+        "inconclusive_required": inconclusive,
+        "stages": links["links"],
+    }
+    _write_json(output_dir / "workflow-summary.json", summary)
+    _atomic_write(output_dir / "workflow-report.md", _render_report(summary))
+    timestamp = updated_at or utc_now()
+    manifest = load_manifest(output_dir / "manifest.json")
+    if manifest["status"] == "planned":
+        manifest = transition_status(manifest, "running", updated_at=timestamp)
+    for name, kind, uri in (
+        ("workflow-summary", "summary", "workflow-summary.json"),
+        ("workflow-report", "report", "workflow-report.md"),
+    ):
+        manifest = add_artifact(manifest, name=name, kind=kind, uri=uri, updated_at=timestamp)
+    manifest = transition_status(manifest, status, updated_at=timestamp)
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {"status": status, "summary": str((output_dir / "workflow-summary.json").resolve()), "report": str((output_dir / "workflow-report.md").resolve())}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+    plan_parser = subparsers.add_parser("plan")
+    plan_parser.add_argument("--output-dir", required=True, type=Path)
+    plan_parser.add_argument("--config", required=True, type=Path)
+    link_parser = subparsers.add_parser("link")
+    link_parser.add_argument("--output-dir", required=True, type=Path)
+    link_parser.add_argument("--stage", required=True, choices=STAGES)
+    link_parser.add_argument("--manifest", required=True, type=Path)
+    finalize_parser = subparsers.add_parser("finalize")
+    finalize_parser.add_argument("--output-dir", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.action == "plan":
+            payload = plan(args.output_dir, config_path=args.config)
+        elif args.action == "link":
+            payload = link(args.output_dir, stage=args.stage, child_path=args.manifest)
+        else:
+            payload = finalize(args.output_dir)
+    except (WorkflowError, RunManifestError) as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/ascend-triton-workflow/tests/test_triton_workflow.py
+++ b/.agents/skills/ascend-triton-workflow/tests/test_triton_workflow.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Tests for Ascend Triton workflow orchestration."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+SKILL = ROOT / ".agents" / "skills" / "ascend-triton-workflow"
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_run_manifest import new_manifest, transition_status, write_manifest
+
+
+def load_module():
+    name = "_triton_workflow_test"
+    spec = importlib.util.spec_from_file_location(name, SKILL / "scripts" / "triton_workflow.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+workflow = load_module()
+NOW = "2026-08-03T12:00:00Z"
+
+
+def config() -> dict:
+    return {
+        "schema_version": 1,
+        "run_id": "triton-softmax-001",
+        "op_name": "softmax",
+        "source": {"kind": "gpu-triton", "path": "/src/softmax.py"},
+        "target": {"soc": "Ascend910B2"},
+        "required_stages": ["development", "validation"],
+    }
+
+
+class WorkflowTests(unittest.TestCase):
+    def test_optimization_requires_validation(self) -> None:
+        payload = config()
+        payload["required_stages"] = ["optimization"]
+        with self.assertRaisesRegex(workflow.WorkflowError, "requires validation"):
+            workflow.validate_config(payload)
+
+    def test_full_lifecycle_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(config()), encoding="utf-8")
+            output = root / "workflow"
+            workflow.plan(output, config_path=config_path, created_at=NOW)
+            for stage, run_type in (("development", "debug"), ("validation", "correctness")):
+                child = new_manifest(
+                    run_type=run_type,
+                    run_id=f"{stage}-child",
+                    parent_run_id="triton-softmax-001",
+                    created_at=NOW,
+                )
+                child = transition_status(child, "running", updated_at=NOW)
+                child = transition_status(child, "passed", updated_at=NOW)
+                child_path = root / f"{stage}.json"
+                write_manifest(child_path, child)
+                workflow.link(output, stage=stage, child_path=child_path, updated_at=NOW)
+            result = workflow.finalize(output, updated_at=NOW)
+            self.assertEqual(result["status"], "passed")
+
+    def test_missing_stage_is_inconclusive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(config()), encoding="utf-8")
+            output = root / "workflow"
+            workflow.plan(output, config_path=config_path, created_at=NOW)
+            result = workflow.finalize(output, updated_at=NOW)
+            self.assertEqual(result["status"], "inconclusive")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/machine-management/scripts/_workflow_common.py
+++ b/.agents/skills/machine-management/scripts/_workflow_common.py
@@ -521,6 +521,7 @@ def bootstrap_container(
     public_key_file: str | None = None,
     replace_container_on_image_change: bool = False,
     use_prepared_image_cache: bool = False,
+    visible_devices: list[int] | None = None,
 ) -> dict[str, Any]:
     key_path, private_key, public_key, needs_input = ensure_local_public_key(public_key_file)
     if needs_input is not None:
@@ -542,6 +543,7 @@ def bootstrap_container(
             machine_type or "",
             soc or "",
             "true" if use_prepared_image_cache else "false",
+            ",".join(str(device) for device in (visible_devices or [])),
         ],
         batch_mode=True,
         timeout_seconds=machine_ops.DEFAULT_BOOTSTRAP_TIMEOUT_SECONDS,

--- a/.agents/skills/machine-management/scripts/manage_machine.py
+++ b/.agents/skills/machine-management/scripts/manage_machine.py
@@ -1229,6 +1229,7 @@ replace_on_image_change="${7:-false}"
 machine_type_input="${8:-}"
 soc_input="${9:-}"
 use_prepared_image_cache="${10:-false}"
+visible_devices="${11:-}"
 
 emit_json() {
   python3 - "$1" <<'PY'
@@ -1554,7 +1555,7 @@ INNER_PKG
 }
 
 configure_container_state() {
-  docker exec -i "$container" bash -s -- "$port" "$pubkey" "$machine_type" "$container_type" "$soc" "$selected_image" "$workdir" "$namespace" <<'INNER_CFG'
+  docker exec -i "$container" bash -s -- "$port" "$pubkey" "$machine_type" "$container_type" "$soc" "$selected_image" "$workdir" "$namespace" "$visible_devices" <<'INNER_CFG'
 set -euo pipefail
 port="$1"
 pubkey="$2"
@@ -1564,6 +1565,7 @@ soc="$5"
 image="$6"
 workdir="$7"
 namespace="$8"
+visible_devices="$9"
 export PATH="/usr/local/bin:/usr/local/sbin:${PATH:-}"
 export LD_LIBRARY_PATH="/usr/local/Ascend/driver/lib64/common:/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/driver/lib64:${LD_LIBRARY_PATH:-}"
 if [ -z "${ASCEND_HOME_PATH:-}" ]; then
@@ -1660,12 +1662,15 @@ fi
 if [ -n "$image" ]; then
   export VAWS_CONTAINER_IMAGE="$image"
 fi
+if [ -n "$visible_devices" ]; then
+  export ASCEND_RT_VISIBLE_DEVICES="$visible_devices"
+fi
 EOF_CONTAINER_ENV
 chmod 0644 /etc/profile.d/vaws-ascend-env.sh
-python3 - "$machine_type" "$container_type" "$soc" "$image" "$workdir" "$namespace" "$_vaws_atb_cxx_abi" > /etc/vaws/container-info.json <<'PY'
+python3 - "$machine_type" "$container_type" "$soc" "$image" "$workdir" "$namespace" "$_vaws_atb_cxx_abi" "$visible_devices" > /etc/vaws/container-info.json <<'PY'
 import json
 import sys
-machine_type, container_type, soc, image, workdir, namespace, atb_cxx_abi = sys.argv[1:]
+machine_type, container_type, soc, image, workdir, namespace, atb_cxx_abi, visible_devices = sys.argv[1:]
 print(json.dumps({
     "machine_type": machine_type or None,
     "container_type": container_type or None,
@@ -1674,6 +1679,7 @@ print(json.dumps({
     "workdir": workdir,
     "namespace": namespace or None,
     "atb_cxx_abi": atb_cxx_abi or None,
+    "visible_devices": [int(item) for item in visible_devices.split(",") if item] if visible_devices else [],
     "env_file": "/etc/profile.d/vaws-ascend-env.sh",
 }, ensure_ascii=False, indent=2))
 PY
@@ -1714,6 +1720,9 @@ PrintMotd no
 AuthorizedKeysFile .ssh/authorized_keys
 PidFile /run/sshd_vaws.pid
 EOF_SSH
+if [ -n "$visible_devices" ]; then
+  printf 'SetEnv ASCEND_RT_VISIBLE_DEVICES=%s\n' "$visible_devices" >> /etc/ssh/sshd_vaws_config
+fi
 /usr/sbin/sshd -t -f /etc/ssh/sshd_vaws_config
 if [ -f /run/sshd_vaws.pid ]; then
   kill "$(cat /run/sshd_vaws.pid)" 2>/dev/null || true
@@ -1916,6 +1925,12 @@ else
     fi
   done
 
+  visibility_args=()
+  if [ -n "$visible_devices" ]; then
+    visibility_args+=("--env" "ASCEND_RT_VISIBLE_DEVICES=$visible_devices")
+    visibility_args+=("--label" "com.vaws.visible_devices=$visible_devices")
+  fi
+
   emit_progress "container" "running" "creating managed container" 45
   docker run --name "$container" -it -d --network host --shm-size=500g \
     --privileged=true \
@@ -1937,6 +1952,7 @@ else
     -v /usr/local/sbin:/usr/local/sbin \
     -v /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime:ro \
     "${mount_args[@]}" \
+    "${visibility_args[@]}" \
     --label com.vaws.base_image="$selected_image" \
     --label com.vaws.run_image="$run_image" \
     --label com.vaws.prepared_image="$prepared_image" \
@@ -2003,7 +2019,7 @@ elif command -v firewall-cmd >/dev/null 2>&1 && firewall-cmd --state >/dev/null 
   firewall="firewalld"
 fi
 
-payload=$(python3 - <<'PY' "$container" "$port" "$image_request_json" "$selected_image" "$image_resolution" "$workdir" "$namespace" "$created" "$started" "$pulled" "$installed_ssh" "$firewall" "${actions[*]}" "$previous_image" "$replace_on_image_change" "$machine_type" "$container_type" "$soc" "$host_env_file" "$host_metadata_file" "$container_env_file" "$container_metadata_file" "$package_bootstrap" "$run_image" "$prepared_image" "$use_prepared_image_cache" "$used_prepared_image_cache" "$created_prepared_image_cache" "$docker_pull_policy"
+payload=$(python3 - <<'PY' "$container" "$port" "$image_request_json" "$selected_image" "$image_resolution" "$workdir" "$namespace" "$created" "$started" "$pulled" "$installed_ssh" "$firewall" "${actions[*]}" "$previous_image" "$replace_on_image_change" "$machine_type" "$container_type" "$soc" "$host_env_file" "$host_metadata_file" "$container_env_file" "$container_metadata_file" "$package_bootstrap" "$run_image" "$prepared_image" "$use_prepared_image_cache" "$used_prepared_image_cache" "$created_prepared_image_cache" "$docker_pull_policy" "$visible_devices"
 import json
 import sys
 (
@@ -2036,6 +2052,7 @@ import sys
     used_prepared_image_cache,
     created_prepared_image_cache,
     docker_pull_policy,
+    visible_devices,
 ) = sys.argv[1:]
 image_request = json.loads(image_request_json)
 print(json.dumps({
@@ -2055,6 +2072,7 @@ print(json.dumps({
     "created_prepared_image_cache": created_prepared_image_cache == "true",
     "image_resolution": image_resolution,
     "docker_pull_policy": docker_pull_policy,
+    "visible_devices": [int(item) for item in visible_devices.split(",") if item] if visible_devices else [],
     "image_candidates": list(image_request.get("candidates") or []),
     "image_mirror_order": list(image_request.get("mirror_order") or []),
     "workdir": workdir,
@@ -2197,6 +2215,8 @@ try:
             "torch_version": getattr(torch, "__version__", None),
             "shape": list(x.shape),
             "device": str(x.device),
+            "device_count": torch.npu.device_count(),
+            "visible_devices": os.environ.get("ASCEND_RT_VISIBLE_DEVICES"),
         }
     )
     if not str(x.device).startswith("npu"):

--- a/.agents/skills/remote-code-parity/SKILL.md
+++ b/.agents/skills/remote-code-parity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: remote-code-parity
-description: Ensure a ready remote runtime runs the exact current local workspace state before any remote smoke, service launch, or benchmark. Use automatically immediately before remote execution when direct local -> container SSH already works and local uncommitted changes must be reflected remotely. Do not use for initial machine attach, generic Git topology work, or unrelated local-only coding.
+description: Ensure a ready remote runtime runs the exact current local workspace state before any remote smoke, service launch, or benchmark. Use automatically immediately before remote execution when direct local-to-container SSH already works and local uncommitted changes must be reflected remotely. Do not use for initial machine attach, generic Git topology work, or unrelated local-only coding.
 ---
 
 # Remote Code Parity

--- a/.agents/skills/session-management/SKILL.md
+++ b/.agents/skills/session-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-management
-description: Create, list, inspect, remove, and garbage-collect isolated VAWS agent sessions, and optionally coordinate NPU task intent across independent agents on one host. Use before remote execution when tasks must not share worktrees, containers, serving state, or resource leases, or when cooperative NPU queueing is requested. Do not use for service lifecycle, code sync, benchmarks, or distributed failure diagnosis.
+description: Create, list, inspect, remove, garbage-collect, and group isolated VAWS agent sessions, and optionally coordinate NPU task intent across independent agents on one host. Use before remote execution when tasks must not share worktrees, containers, serving state, or resource leases, when cooperative NPU queueing is requested, or when one distributed scenario needs an ordered set of existing sessions. Do not use for service lifecycle, code sync, benchmarks, or distributed failure diagnosis.
 ---
 
 # Session Management
@@ -18,6 +18,10 @@ Each session binds:
 - one remote session container
 - one `.vaws-local/sessions/<session-id>/` state namespace
 - local leases for container SSH port, service port, and optional NPU devices
+
+A session group binds two or more ready sessions with the same code and
+submodule snapshot, plus explicit startup and reverse shutdown order. Grouping
+does not create another container or duplicate member leases.
 
 ## Use This Skill When
 
@@ -78,6 +82,20 @@ and never stops an observed external or human process. It automatically
 publishes the persistent workspace UUID plus configured agent alias;
 `--agent-id` and `--agent-alias` remain explicit overrides.
 
+```bash
+python3 .agents/skills/session-management/scripts/session_group.py create \
+  --group-id <id> \
+  --member <name>=<session-id> \
+  --member <name>=<session-id> \
+  [--startup-order <name,name,...>]
+
+python3 .agents/skills/session-management/scripts/session_group.py status --group-id <id>
+python3 .agents/skills/session-management/scripts/session_group.py list
+python3 .agents/skills/session-management/scripts/session_group.py teardown \
+  --group-id <id> \
+  [--remove-containers] [--remove-worktrees] [--release-leases] [--force]
+```
+
 Progress is emitted on `stderr` as `__VAWS_SESSION_PROGRESS__=<json>`. Final output is JSON on `stdout`.
 
 By default session creation uses a host-local prepared image cache keyed by the selected base image id. The first session for a base image may still install container SSH packages, then commits `vaws-session-prepared:<image-hash>-ssh-v2`; later sessions start from that prepared image and skip the repeated `openssh` package install and cached pip/pytest bootstrap. Use `--disable-prepared-image-cache` only when validating raw base-image bootstrap behavior.
@@ -94,6 +112,7 @@ Local untracked state lives under `.vaws-local/sessions/`:
 - `<session-id>/session.json`
 - `<session-id>/serving.json`
 - `<session-id>/benchmark/`
+- `groups/<group-id>/group.json`
 
 Worktree bindings are written to `<worktree>/.vaws-local/current-session.json` and include the absolute base session file path so scripts run from the worktree can find the base session state.
 

--- a/.agents/skills/session-management/SKILL.md
+++ b/.agents/skills/session-management/SKILL.md
@@ -20,7 +20,8 @@ Each session binds:
 - local leases for container SSH port, service port, and optional NPU devices
 
 A session group binds two or more ready sessions with the same code and
-submodule snapshot, plus explicit startup and reverse shutdown order. Grouping
+submodule snapshot, including content-level parity for dirty worktrees, plus
+explicit startup and reverse shutdown order. Grouping
 does not create another container or duplicate member leases.
 
 ## Use This Skill When

--- a/.agents/skills/session-management/references/acceptance.md
+++ b/.agents/skills/session-management/references/acceptance.md
@@ -33,6 +33,9 @@
 - Legacy `--machine` commands continue to work against the base machine state.
 - A session group requires at least two unique ready sessions.
 - Group creation fails when live workspace or recursive submodule snapshots differ.
+- Dirty snapshots include a content digest of tracked changes, untracked files,
+  and recursively dirty submodules; matching HEADs and a shared `dirty: true`
+  flag are not sufficient for grouping.
 - Startup order contains every member exactly once; shutdown order is its reverse.
 - Group teardown delegates to `session_remove.py` for every member and retains `needs_repair` when any member fails.
 - Shared NPU coordination state defaults to the bare-metal host's `/tmp/vaws-npu-coordinator/v1/` and recreates a new coordination epoch after state loss.

--- a/.agents/skills/session-management/references/acceptance.md
+++ b/.agents/skills/session-management/references/acceptance.md
@@ -12,6 +12,11 @@
 - `session_create.py --disable-prepared-image-cache` keeps the raw base-image bootstrap path available.
 - Default session creation reports `verification_mode: ssh` and `npu_smoke_skipped: true` after host/container SSH checks.
 - `session_create.py --verification-mode full` keeps the full `torch` / `torch_npu` smoke check available.
+- A Session with leased NPU devices persists the exact
+  `ASCEND_RT_VISIBLE_DEVICES` through Docker, the runtime profile, dedicated
+  sshd, and container metadata.
+- Session creation and status return `needs_repair` when the observed
+  `ASCEND_RT_VISIBLE_DEVICES` differs from a non-empty lease.
 - `session_create.py` without `--session-id`, `VAWS_SESSION_ID`, or `VAWS_AGENT_SESSION_ID` generates a fresh session id instead of reusing repo-root `.vaws-local/current-session.json`.
 - Explicit `session_create.py --session-id <id> --no-worktree` does not overwrite the repo-root `.vaws-local/current-session.json`.
 - Session container SSH port allocation does not hold the lease lock while running per-port remote SSH probes.
@@ -21,9 +26,15 @@
 - `bench_run.py --session-id s2` stops only `s2`'s service at cleanup time.
 - `parity_sync.py --session-id s1` derives `workspace_id=s1` and `container_identity=<s1-container>@<runtime-root>`.
 - `session_remove.py --remove-container --release-leases` can skip `serve_stop.py` when no session serving state exists and still release leases after the container is removed or the stop result is `not_found`.
+- `session_remove.py --remove-worktree` deinitializes populated submodules before asking Git to remove the worktree.
 - `session_remove.py` returns `needs_repair` instead of `removed` when requested container or worktree removal fails.
+- An exception during remote cleanup marks the Session `needs_repair` and keeps its leases.
 - `session_gc.py` does not release leases for generic `failed` sessions.
 - Legacy `--machine` commands continue to work against the base machine state.
+- A session group requires at least two unique ready sessions.
+- Group creation fails when live workspace or recursive submodule snapshots differ.
+- Startup order contains every member exactly once; shutdown order is its reverse.
+- Group teardown delegates to `session_remove.py` for every member and retains `needs_repair` when any member fails.
 - Shared NPU coordination state defaults to the bare-metal host's `/tmp/vaws-npu-coordinator/v1/` and recreates a new coordination epoch after state loss.
 - Shared NPU coordination is optional and does not gate existing Session, serving, benchmark, profiling, or remote-command entry points.
 - Multiple agents use SQLite transactions to grant a multi-device request atomically.

--- a/.agents/skills/session-management/references/behavior.md
+++ b/.agents/skills/session-management/references/behavior.md
@@ -33,7 +33,7 @@ If a worktree already exists and is bound to the same session, it is reused. If 
 
 ## Container Behavior
 
-Session containers use the base machine image, host mounts, workdir, and Ascend bootstrap logic, but get a distinct container name and SSH port.
+Session containers use the base machine image, host mounts, workdir, and Ascend bootstrap logic, but get a distinct container name and SSH port. When NPU devices are leased, bootstrap persists the exact physical-device list as `ASCEND_RT_VISIBLE_DEVICES` in the container environment, runtime profile, dedicated sshd environment, and container metadata.
 
 The default container name is:
 
@@ -61,7 +61,11 @@ The first implementation protects:
 - service ports
 - explicitly requested or auto-counted NPU devices
 
-Session-aware serving uses the session NPU lease as its default device set. If a launch requests explicit devices, they must be contained inside the session's leased device list.
+Session bootstrap and Session-aware serving use the session NPU lease as the
+default device set. If a launch requests explicit devices, they must be
+contained inside the session's leased device list. A ready Session with a
+non-empty NPU lease must expose exactly the recorded
+`ASCEND_RT_VISIBLE_DEVICES`; visibility drift is `needs_repair`.
 
 Session creation probes host listening ports once before taking the lease lock, then selects a container SSH port from that snapshot. This avoids holding the global lease file lock across one SSH round trip per candidate port.
 
@@ -70,6 +74,22 @@ NPU leases are released by `session_remove.py --release-leases`, not by `serve_s
 When `session_remove.py --remove-container` sees no session serving state file, it skips the serving stop wrapper and relies on container removal to terminate any untracked process. This keeps teardown cheap for sessions that were created only for parity, bootstrap timing, or compile work.
 
 `session_remove.py` marks a session `removed` only when the requested container/worktree removal succeeds. Failed removal leaves the session in `needs_repair`. `session_gc.py` releases leases for `removed` or missing-state sessions; it does not release leases for generic `failed` sessions because those may still protect partially created remote resources.
+
+If remote cleanup raises before normal result aggregation, Session removal still
+persists `needs_repair` and keeps every lease. A transport exception must not
+leave an unreachable Session advertised as `ready`.
+
+## Session Groups
+
+`session_group.py create` binds existing ready sessions. It requires unique
+member names, unique session IDs, and identical live workspace plus recursive
+submodule snapshots. This prevents a distributed service from silently mixing
+code states.
+
+The caller declares startup order. Shutdown always uses the reverse order.
+`teardown` delegates each member to `session_remove.py`, continues through every
+member to maximize cleanup, and keeps the group record with `needs_repair` if any
+member fails. Grouping never duplicates leases or service state.
 
 ## Optional Shared NPU Coordination
 

--- a/.agents/skills/session-management/references/behavior.md
+++ b/.agents/skills/session-management/references/behavior.md
@@ -83,8 +83,10 @@ leave an unreachable Session advertised as `ready`.
 
 `session_group.py create` binds existing ready sessions. It requires unique
 member names, unique session IDs, and identical live workspace plus recursive
-submodule snapshots. This prevents a distributed service from silently mixing
-code states.
+submodule snapshots. Dirty worktrees are compared with a content digest that
+covers tracked diffs, untracked files, and recursively dirty submodules rather
+than a boolean dirty flag. This prevents a distributed service from silently
+mixing code states.
 
 The caller declares startup order. Shutdown always uses the reverse order.
 `teardown` delegates each member to `session_remove.py`, continues through every

--- a/.agents/skills/session-management/references/command-recipes.md
+++ b/.agents/skills/session-management/references/command-recipes.md
@@ -6,6 +6,27 @@ Inspect the agent identity used for new session attribution:
 python3 .agents/scripts/workspace_identity.py summary
 ```
 
+## Multi-session group
+
+After creating each isolated member session:
+
+```bash
+python3 .agents/skills/session-management/scripts/session_group.py create \
+  --group-id pd-a \
+  --member ray-head=head-session \
+  --member ray-worker=worker-session \
+  --startup-order ray-head,ray-worker
+```
+
+Use the parameterized Ray helpers inside the corresponding member containers:
+
+```bash
+scripts/ray_head.sh --node-ip 10.0.0.1 --port 6379 --interface eth0
+scripts/ray_worker.sh --head-address 10.0.0.1:6379 --node-ip 10.0.0.2 --interface eth0
+```
+
+Neither helper stops an existing cluster unless `--stop-existing` is explicit.
+
 Create a session on a ready base machine:
 
 ```bash

--- a/.agents/skills/session-management/scripts/session_create.py
+++ b/.agents/skills/session-management/scripts/session_create.py
@@ -217,6 +217,7 @@ def verify_session_ssh(
     *,
     container_ssh_port: int,
     public_key_file: str | None,
+    visible_devices: list[int],
 ) -> dict[str, Any]:
     """Verify only host/container SSH for a newly bootstrapped session container."""
     try:
@@ -236,6 +237,33 @@ def verify_session_ssh(
     )
     host_check = machine_ops.check_direct_ssh(host, identity_file=identity_file)
     container_check = machine_ops.check_direct_ssh(container, identity_file=identity_file)
+    expected_visibility = ",".join(str(device) for device in visible_devices)
+    visibility_check: dict[str, Any] = {
+        "expected": expected_visibility,
+        "observed": None,
+        "matches": not expected_visibility,
+    }
+    if container_check.get("ok") and expected_visibility:
+        try:
+            result = machine_ops.run_local(
+                machine_ops.ssh_command(
+                    container,
+                    batch_mode=True,
+                    identity_file=identity_file,
+                )
+                + ["sh", "-c", "printf '%s' \"${ASCEND_RT_VISIBLE_DEVICES-}\""]
+            )
+            observed = result.stdout.strip()
+            visibility_check.update(
+                {
+                    "observed": observed,
+                    "matches": result.returncode == 0 and observed == expected_visibility,
+                    "returncode": result.returncode,
+                    "stderr": result.stderr.strip(),
+                }
+            )
+        except machine_ops.MachineManagementError as exc:
+            visibility_check.update({"matches": False, "error": str(exc)})
     payload: dict[str, Any] = {
         "verification_mode": "ssh",
         "identity_file": str(identity_file) if identity_file is not None else None,
@@ -246,6 +274,7 @@ def verify_session_ssh(
             "skipped": "session creation defaulted to SSH-only verification; use --verification-mode full for torch/torch_npu smoke",
         },
         "npu_smoke_skipped": True,
+        "device_visibility": visibility_check,
     }
     local_tool_errors = []
     for check in (host_check, container_check):
@@ -264,7 +293,11 @@ def verify_session_ssh(
             }
         )
         return payload
-    ready = bool(host_check.get("ok") and container_check.get("ok"))
+    ready = bool(
+        host_check.get("ok")
+        and container_check.get("ok")
+        and visibility_check.get("matches")
+    )
     payload.update(
         {
             "success": ready,
@@ -274,7 +307,9 @@ def verify_session_ssh(
         }
     )
     if not ready:
-        payload["message"] = "session container SSH is not ready"
+        payload["message"] = (
+            "session container SSH or leased-device visibility is not ready"
+        )
     return payload
 
 
@@ -506,6 +541,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "workdir": workdir,
                     "runtime_root": runtime_root,
                     "machine_type": base_record["container"].get("machine_type") or base_record["host"].get("machine_type"),
+                    "visible_devices": leases.get("npu_devices", []),
                 },
             },
             "leases": {
@@ -556,6 +592,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 public_key_file=args.public_key_file,
                 replace_container_on_image_change=args.replace_container_on_image_change,
                 use_prepared_image_cache=not args.disable_prepared_image_cache,
+                visible_devices=leases.get("npu_devices", []),
             )
             if container_payload.get("status") in {"needs_input", "needs_repair", "blocked"}:
                 session["status"] = "failed"
@@ -581,12 +618,42 @@ def main(argv: Sequence[str] | None = None) -> int:
                 emit_progress("verify", "running full session verification", session_id=sid)
                 verify = verify_machine(record)
                 verify["verification_mode"] = "full"
+                expected_visibility = ",".join(
+                    str(device) for device in leases.get("npu_devices", [])
+                )
+                smoke = verify.get("smoke", {})
+                observed_visibility = smoke.get("visible_devices")
+                observed_count = smoke.get("device_count")
+                visibility_matches = (
+                    not expected_visibility
+                    or (
+                        observed_visibility == expected_visibility
+                        and observed_count == len(leases.get("npu_devices", []))
+                    )
+                )
+                verify["device_visibility"] = {
+                    "expected": expected_visibility,
+                    "observed": observed_visibility,
+                    "observed_count": observed_count,
+                    "matches": visibility_matches,
+                }
+                if verify.get("status") == "ready" and not visibility_matches:
+                    verify.update(
+                        {
+                            "success": False,
+                            "ready": False,
+                            "status": "needs_repair",
+                            "action": "verify-found-device-visibility-drift",
+                            "message": "leased NPU visibility does not match the Session record",
+                        }
+                    )
             else:
                 emit_progress("verify", "checking session SSH readiness", session_id=sid)
                 verify = verify_session_ssh(
                     base_record,
                     container_ssh_port=leases["container_ssh_port"],
                     public_key_file=args.public_key_file,
+                    visible_devices=leases.get("npu_devices", []),
                 )
             container_payload["verify"] = verify
             if verify.get("status") != "ready":

--- a/.agents/skills/session-management/scripts/session_group.py
+++ b/.agents/skills/session-management/scripts/session_group.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Create, inspect, and tear down groups of existing VAWS sessions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_session_state import (  # noqa: E402
+    SessionStateError,
+    load_session_lookup,
+    require_session_id,
+)
+
+SCHEMA_VERSION = 1
+GROUP_SUBDIR = Path(".vaws-local/sessions/groups")
+
+
+class SessionGroupError(ValueError):
+    """Raised when group membership or lifecycle state is invalid."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def _atomic_write(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def group_file(group_id: str, repo_root: Path = ROOT) -> Path:
+    return repo_root / GROUP_SUBDIR / require_session_id(group_id) / "group.json"
+
+
+def parse_members(values: Sequence[str]) -> list[dict[str, str]]:
+    members: list[dict[str, str]] = []
+    names: set[str] = set()
+    sessions: set[str] = set()
+    for value in values:
+        name, separator, session_id = value.partition("=")
+        if not separator or not name.strip() or not session_id.strip():
+            raise SessionGroupError(f"member must use NAME=SESSION_ID, got: {value}")
+        normalized_name = require_session_id(name.strip())
+        normalized_session = require_session_id(session_id.strip())
+        if normalized_name in names:
+            raise SessionGroupError(f"member name is duplicated: {normalized_name}")
+        if normalized_session in sessions:
+            raise SessionGroupError(
+                f"session is assigned more than once: {normalized_session}"
+            )
+        names.add(normalized_name)
+        sessions.add(normalized_session)
+        members.append({"name": normalized_name, "session_id": normalized_session})
+    if len(members) < 2:
+        raise SessionGroupError("a session group requires at least two members")
+    return members
+
+
+def workspace_snapshot(session: Mapping[str, Any]) -> dict[str, Any]:
+    worktree = Path(session["local"]["worktree_root"])
+    if not worktree.is_dir():
+        raise SessionGroupError(f"session worktree does not exist: {worktree}")
+
+    def git(*args: str) -> str:
+        result = subprocess.run(
+            ["git", "-C", str(worktree), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise SessionGroupError(
+                result.stderr.strip() or f"git {' '.join(args)} failed in {worktree}"
+            )
+        return result.stdout.strip()
+
+    return {
+        "workspace_head": git("rev-parse", "HEAD"),
+        "submodules": git("submodule", "status", "--recursive").splitlines(),
+        "dirty": bool(git("status", "--porcelain=v1", "--untracked-files=normal")),
+    }
+
+
+def _group_snapshot_key(snapshot: Mapping[str, Any]) -> str:
+    return json.dumps(snapshot, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def create_group(
+    *,
+    repo_root: Path,
+    group_id: str,
+    member_specs: Sequence[str],
+    startup_order: Sequence[str] | None = None,
+    snapshot_resolver: Callable[[Mapping[str, Any]], Mapping[str, Any]] = workspace_snapshot,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    gid = require_session_id(group_id)
+    path = group_file(gid, repo_root)
+    if path.exists():
+        raise SessionGroupError(f"session group already exists: {gid}")
+    members = parse_members(member_specs)
+    member_names = [member["name"] for member in members]
+    order = list(startup_order or member_names)
+    if len(order) != len(set(order)) or set(order) != set(member_names):
+        raise SessionGroupError(
+            "startup order must contain every member name exactly once"
+        )
+    snapshots: dict[str, Mapping[str, Any]] = {}
+    resolved: list[dict[str, Any]] = []
+    for member in members:
+        lookup = load_session_lookup(
+            session_id=member["session_id"],
+            repo_root=repo_root,
+        )
+        session = lookup.session
+        if session.get("status") != "ready":
+            raise SessionGroupError(
+                f"session {member['session_id']} must be ready, got {session.get('status')}"
+            )
+        snapshot = dict(snapshot_resolver(session))
+        snapshots[member["name"]] = snapshot
+        resolved.append(
+            {
+                **member,
+                "session_file": str(lookup.session_file),
+                "base_machine": session["base_machine"],
+                "container": session["remote"]["container"]["name"],
+                "leased_devices": session.get("leases", {}).get("npu_devices", []),
+                "snapshot": snapshot,
+            }
+        )
+    snapshot_keys = {_group_snapshot_key(snapshot) for snapshot in snapshots.values()}
+    if len(snapshot_keys) != 1:
+        raise SessionGroupError(
+            "all group members must use the same workspace and submodule snapshot"
+        )
+    timestamp = created_at or utc_now()
+    group = {
+        "schema_version": SCHEMA_VERSION,
+        "group_id": gid,
+        "status": "ready",
+        "members": resolved,
+        "startup_order": order,
+        "shutdown_order": list(reversed(order)),
+        "created_at": timestamp,
+        "updated_at": timestamp,
+    }
+    _atomic_write(path, group)
+    return group
+
+
+def load_group(group_id: str, repo_root: Path = ROOT) -> dict[str, Any]:
+    path = group_file(group_id, repo_root)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SessionGroupError(f"session group does not exist: {group_id}") from exc
+    except json.JSONDecodeError as exc:
+        raise SessionGroupError(f"invalid group state {path}: {exc}") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != SCHEMA_VERSION:
+        raise SessionGroupError(f"unsupported session group schema: {path}")
+    return payload
+
+
+def inspect_group(
+    *,
+    repo_root: Path,
+    group_id: str,
+    snapshot_resolver: Callable[[Mapping[str, Any]], Mapping[str, Any]] = workspace_snapshot,
+) -> dict[str, Any]:
+    group = load_group(group_id, repo_root)
+    members: list[dict[str, Any]] = []
+    snapshots: set[str] = set()
+    for member in group["members"]:
+        try:
+            lookup = load_session_lookup(
+                session_id=member["session_id"],
+                repo_root=repo_root,
+            )
+            session = lookup.session
+            snapshot = dict(snapshot_resolver(session))
+            snapshots.add(_group_snapshot_key(snapshot))
+            members.append(
+                {
+                    "name": member["name"],
+                    "session_id": member["session_id"],
+                    "status": session.get("status"),
+                    "snapshot_matches_created": snapshot == member["snapshot"],
+                    "snapshot": snapshot,
+                }
+            )
+        except (SessionStateError, SessionGroupError) as exc:
+            members.append(
+                {
+                    "name": member["name"],
+                    "session_id": member["session_id"],
+                    "status": "missing",
+                    "error": str(exc),
+                    "snapshot_matches_created": False,
+                }
+            )
+    ready = all(
+        row["status"] == "ready" and row["snapshot_matches_created"] for row in members
+    )
+    same_snapshot = len(snapshots) == 1 and len(snapshots) == len(
+        {row.get("snapshot") and _group_snapshot_key(row["snapshot"]) for row in members}
+        - {None}
+    )
+    status = "ready" if ready and same_snapshot else "needs_repair"
+    return {
+        "status": status,
+        "group_id": group["group_id"],
+        "startup_order": group["startup_order"],
+        "shutdown_order": group["shutdown_order"],
+        "same_snapshot": same_snapshot,
+        "members": members,
+        "group_file": str(group_file(group_id, repo_root)),
+    }
+
+
+def list_groups(repo_root: Path = ROOT) -> dict[str, Any]:
+    root = repo_root / GROUP_SUBDIR
+    groups: list[dict[str, Any]] = []
+    if root.is_dir():
+        for path in sorted(root.glob("*/group.json")):
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+                groups.append(
+                    {
+                        "group_id": payload.get("group_id"),
+                        "status": payload.get("status"),
+                        "member_count": len(payload.get("members", [])),
+                        "group_file": str(path),
+                    }
+                )
+            except (OSError, json.JSONDecodeError):
+                groups.append({"status": "invalid", "group_file": str(path)})
+    return {"status": "ok", "groups": groups, "count": len(groups)}
+
+
+def teardown_group(
+    *,
+    repo_root: Path,
+    group_id: str,
+    remove_containers: bool,
+    remove_worktrees: bool,
+    release_leases: bool,
+    force: bool,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    updated_at: str | None = None,
+) -> dict[str, Any]:
+    group = load_group(group_id, repo_root)
+    by_name = {member["name"]: member for member in group["members"]}
+    results: list[dict[str, Any]] = []
+    script = (
+        repo_root
+        / ".agents"
+        / "skills"
+        / "session-management"
+        / "scripts"
+        / "session_remove.py"
+    )
+    for name in group["shutdown_order"]:
+        member = by_name[name]
+        command = [
+            sys.executable,
+            str(script),
+            "--session-id",
+            member["session_id"],
+        ]
+        if remove_containers:
+            command.append("--remove-container")
+        if remove_worktrees:
+            command.append("--remove-worktree")
+        if release_leases:
+            command.append("--release-leases")
+        if force:
+            command.append("--force")
+        completed = runner(
+            command,
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        try:
+            payload = json.loads(completed.stdout) if completed.stdout.strip() else {}
+        except json.JSONDecodeError:
+            payload = {"stdout_tail": completed.stdout[-500:]}
+        results.append(
+            {
+                "name": name,
+                "session_id": member["session_id"],
+                "returncode": completed.returncode,
+                "result": payload,
+                "stderr_tail": completed.stderr[-500:],
+            }
+        )
+    success = all(row["returncode"] == 0 for row in results)
+    group["status"] = "removed" if success else "needs_repair"
+    group["updated_at"] = updated_at or utc_now()
+    group["teardown"] = results
+    _atomic_write(group_file(group_id, repo_root), group)
+    return {
+        "status": group["status"],
+        "group_id": group["group_id"],
+        "results": results,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+    create_parser = subparsers.add_parser("create", help="bind ready sessions")
+    create_parser.add_argument("--group-id", required=True)
+    create_parser.add_argument(
+        "--member", action="append", required=True, metavar="NAME=SESSION_ID"
+    )
+    create_parser.add_argument(
+        "--startup-order",
+        help="comma-separated member names; defaults to --member order",
+    )
+    status_parser = subparsers.add_parser("status", help="inspect one group")
+    status_parser.add_argument("--group-id", required=True)
+    subparsers.add_parser("list", help="list groups")
+    remove_parser = subparsers.add_parser(
+        "teardown", help="stop and optionally remove group members"
+    )
+    remove_parser.add_argument("--group-id", required=True)
+    remove_parser.add_argument("--remove-containers", action="store_true")
+    remove_parser.add_argument("--remove-worktrees", action="store_true")
+    remove_parser.add_argument("--release-leases", action="store_true")
+    remove_parser.add_argument("--force", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.action == "create":
+            order = args.startup_order.split(",") if args.startup_order else None
+            payload = create_group(
+                repo_root=ROOT,
+                group_id=args.group_id,
+                member_specs=args.member,
+                startup_order=order,
+            )
+        elif args.action == "status":
+            payload = inspect_group(repo_root=ROOT, group_id=args.group_id)
+        elif args.action == "list":
+            payload = list_groups(ROOT)
+        else:
+            payload = teardown_group(
+                repo_root=ROOT,
+                group_id=args.group_id,
+                remove_containers=args.remove_containers,
+                remove_worktrees=args.remove_worktrees,
+                release_leases=args.release_leases,
+                force=args.force,
+            )
+    except (SessionGroupError, SessionStateError) as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/session-management/scripts/session_group.py
+++ b/.agents/skills/session-management/scripts/session_group.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import subprocess
@@ -84,28 +85,145 @@ def parse_members(values: Sequence[str]) -> list[dict[str, str]]:
     return members
 
 
+def _git_bytes(
+    repo: Path,
+    *args: str,
+    allowed_returncodes: tuple[int, ...] = (0,),
+) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode not in allowed_returncodes:
+        message = result.stderr.decode("utf-8", errors="replace").strip()
+        raise SessionGroupError(
+            message or f"git {' '.join(args)} failed in {repo}"
+        )
+    return result.stdout
+
+
+def _git_text(repo: Path, *args: str) -> str:
+    return (
+        _git_bytes(repo, *args)
+        .decode("utf-8", errors="surrogateescape")
+        .strip()
+    )
+
+
+def _digest_value(digest: Any, label: bytes, value: bytes) -> None:
+    digest.update(len(label).to_bytes(4, "big"))
+    digest.update(label)
+    digest.update(len(value).to_bytes(8, "big"))
+    digest.update(value)
+
+
+def _submodule_paths(repo: Path) -> list[Path]:
+    gitmodules = repo / ".gitmodules"
+    if not gitmodules.is_file():
+        return []
+    output = _git_bytes(
+        repo,
+        "config",
+        "--file",
+        str(gitmodules),
+        "--get-regexp",
+        r"^submodule\..*\.path$",
+        allowed_returncodes=(0, 1),
+    )
+    paths: list[Path] = []
+    for raw_line in output.splitlines():
+        _key, separator, raw_path = raw_line.partition(b" ")
+        if not separator or not raw_path:
+            continue
+        relative = Path(os.fsdecode(raw_path))
+        child = repo / relative
+        if child.is_dir() and (child / ".git").exists():
+            paths.append(relative)
+    return sorted(paths, key=lambda item: os.fsencode(item.as_posix()))
+
+
+def _dirty_worktree_digest(repo: Path) -> str:
+    """Hash executable source state not represented by HEAD or gitlinks."""
+    digest = hashlib.sha256()
+    tracked_diff = _git_bytes(
+        repo,
+        "diff",
+        "--binary",
+        "--full-index",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--submodule=short",
+        "HEAD",
+        "--",
+    )
+    _digest_value(digest, b"tracked-diff", tracked_diff)
+
+    untracked = _git_bytes(
+        repo,
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "-z",
+    )
+    for raw_path in sorted(item for item in untracked.split(b"\0") if item):
+        path = repo / Path(os.fsdecode(raw_path))
+        metadata = path.lstat()
+        _digest_value(digest, b"untracked-path", raw_path)
+        _digest_value(
+            digest, b"untracked-mode", str(metadata.st_mode).encode("ascii")
+        )
+        if path.is_symlink():
+            _digest_value(
+                digest, b"untracked-symlink", os.fsencode(os.readlink(path))
+            )
+            continue
+        if not path.is_file():
+            _digest_value(digest, b"untracked-special", b"")
+            continue
+        file_digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            while chunk := stream.read(1024 * 1024):
+                file_digest.update(chunk)
+        _digest_value(digest, b"untracked-content", file_digest.digest())
+
+    for relative in _submodule_paths(repo):
+        child = repo / relative
+        child_status = _git_text(
+            child, "status", "--porcelain=v1", "--untracked-files=normal"
+        )
+        if not child_status:
+            continue
+        _digest_value(digest, b"submodule-path", os.fsencode(relative.as_posix()))
+        _digest_value(
+            digest,
+            b"submodule-head",
+            _git_text(child, "rev-parse", "HEAD").encode("ascii"),
+        )
+        _digest_value(
+            digest,
+            b"submodule-dirty",
+            bytes.fromhex(_dirty_worktree_digest(child)),
+        )
+    return digest.hexdigest()
+
+
 def workspace_snapshot(session: Mapping[str, Any]) -> dict[str, Any]:
     worktree = Path(session["local"]["worktree_root"])
     if not worktree.is_dir():
         raise SessionGroupError(f"session worktree does not exist: {worktree}")
 
-    def git(*args: str) -> str:
-        result = subprocess.run(
-            ["git", "-C", str(worktree), *args],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode != 0:
-            raise SessionGroupError(
-                result.stderr.strip() or f"git {' '.join(args)} failed in {worktree}"
-            )
-        return result.stdout.strip()
-
+    status = _git_text(
+        worktree, "status", "--porcelain=v1", "--untracked-files=normal"
+    )
+    dirty = bool(status)
     return {
-        "workspace_head": git("rev-parse", "HEAD"),
-        "submodules": git("submodule", "status", "--recursive").splitlines(),
-        "dirty": bool(git("status", "--porcelain=v1", "--untracked-files=normal")),
+        "workspace_head": _git_text(worktree, "rev-parse", "HEAD"),
+        "submodules": _git_text(
+            worktree, "submodule", "status", "--recursive"
+        ).splitlines(),
+        "dirty": dirty,
+        "dirty_digest": _dirty_worktree_digest(worktree) if dirty else None,
     }
 
 

--- a/.agents/skills/session-management/scripts/session_remove.py
+++ b/.agents/skills/session-management/scripts/session_remove.py
@@ -40,13 +40,49 @@ def print_json(data: dict[str, Any]) -> None:
     print(json.dumps(data, indent=2, ensure_ascii=False))
 
 
-def run_git(args: list[str], *, check: bool = False) -> subprocess.CompletedProcess[str]:
+def run_git(
+    args: list[str],
+    *,
+    cwd: Path = ROOT,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["git", "-C", str(ROOT), *args],
+        ["git", "-C", str(cwd), *args],
         capture_output=True,
         text=True,
-        check=False,
+        check=check,
     )
+
+
+def remove_session_worktree(
+    worktree_root: Path,
+    *,
+    force: bool,
+    runner=run_git,
+) -> dict[str, Any]:
+    deinit: dict[str, Any] | None = None
+    if worktree_root.exists():
+        proc = runner(
+            ["submodule", "deinit", "--force", "--all"],
+            cwd=worktree_root,
+        )
+        deinit = {
+            "returncode": proc.returncode,
+            "stdout_tail": proc.stdout[-500:],
+            "stderr_tail": proc.stderr[-500:],
+        }
+
+    cmd = ["worktree", "remove"]
+    if force:
+        cmd.extend(["--force", "--force"])
+    cmd.append(str(worktree_root))
+    proc = runner(cmd, cwd=ROOT)
+    return {
+        "returncode": proc.returncode,
+        "stdout_tail": proc.stdout[-500:],
+        "stderr_tail": proc.stderr[-500:],
+        "submodule_deinit": deinit,
+    }
 
 
 def stop_session(session_id: str, *, session_file: Path | None = None, force: bool) -> dict[str, Any]:
@@ -94,6 +130,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     args = build_parser().parse_args()
+    lookup = None
+    sid: str | None = None
     try:
         if not args.session_id and not args.session_file:
             print_json(
@@ -133,16 +171,7 @@ def main() -> int:
         if args.remove_worktree:
             worktree_root = Path(session["local"]["worktree_root"])
             emit_progress("worktree", "removing session worktree", path=str(worktree_root))
-            cmd = ["worktree", "remove"]
-            if args.force:
-                cmd.extend(["--force", "--force"])
-            cmd.append(str(worktree_root))
-            proc = run_git(cmd)
-            results["worktree"] = {
-                "returncode": proc.returncode,
-                "stdout_tail": proc.stdout[-500:],
-                "stderr_tail": proc.stderr[-500:],
-            }
+            results["worktree"] = remove_session_worktree(worktree_root, force=args.force)
 
         if args.release_leases:
             can_release = stop_result_allows_lease_release(results["stop"]) or container_result_allows_lease_release(
@@ -180,7 +209,24 @@ def main() -> int:
         print_json({"status": updated["status"], "session_id": sid, "results": results})
         return 0 if updated["status"] in {"removed", "stopped"} else 1
     except Exception as exc:
-        print_json({"status": "failed", "error": str(exc)})
+        payload: dict[str, Any] = {"status": "failed", "error": str(exc)}
+        if lookup is not None and sid is not None:
+            try:
+                updated = mark_session_status(
+                    repo_root=lookup.state_repo_root,
+                    session_id=sid,
+                    status="needs_repair",
+                )
+                payload.update(
+                    {
+                        "status": updated["status"],
+                        "session_id": sid,
+                        "leases_released": False,
+                    }
+                )
+            except Exception as state_exc:
+                payload["state_error"] = str(state_exc)
+        print_json(payload)
         return 2
 
 

--- a/.agents/skills/session-management/scripts/session_status.py
+++ b/.agents/skills/session-management/scripts/session_status.py
@@ -120,6 +120,36 @@ def main() -> int:
             "root",
             "true",
         )
+        leased_devices = [
+            int(item) for item in session.get("leases", {}).get("npu_devices", [])
+        ]
+        expected_visibility = ",".join(str(device) for device in leased_devices)
+        visibility_probe = (
+            ssh_check(
+                remote["host"],
+                int(container["ssh_port"]),
+                "root",
+                "printf '%s' \"${ASCEND_RT_VISIBLE_DEVICES-}\"",
+            )
+            if container_ssh["ok"] and expected_visibility
+            else None
+        )
+        observed_visibility = (
+            visibility_probe.get("stdout_tail", "").strip()
+            if visibility_probe is not None
+            else ""
+        )
+        visibility = {
+            "expected": expected_visibility,
+            "observed": observed_visibility or None,
+            "matches": not expected_visibility
+            or bool(
+                visibility_probe
+                and visibility_probe.get("ok")
+                and observed_visibility == expected_visibility
+            ),
+            "probe": visibility_probe,
+        }
         service: dict[str, Any] | None = None
         if serving and serving.get("pid"):
             pid = int(serving["pid"])
@@ -134,6 +164,8 @@ def main() -> int:
             status = "needs_repair"
         if status == "ready" and not container_ssh["ok"]:
             status = "needs_repair"
+        if status == "ready" and not visibility["matches"]:
+            status = "needs_repair"
         print_json(
             {
                 "status": status,
@@ -144,6 +176,7 @@ def main() -> int:
                     "name": container["name"],
                     "ssh_port": container["ssh_port"],
                     "ssh": container_ssh,
+                    "device_visibility": visibility,
                 },
                 "serving": serving,
                 "service_alive": service,

--- a/.agents/skills/session-management/tests/test_session_group.py
+++ b/.agents/skills/session-management/tests/test_session_group.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Tests for grouping existing isolated sessions."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+SKILL = ROOT / ".agents" / "skills" / "session-management"
+
+
+def load_module():
+    name = "_session_group_test"
+    spec = importlib.util.spec_from_file_location(
+        name, SKILL / "scripts" / "session_group.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+groups = load_module()
+NOW = "2026-07-25T12:00:00Z"
+
+
+def write_session(repo: Path, session_id: str, machine: str) -> None:
+    path = repo / ".vaws-local" / "sessions" / session_id / "session.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": 1,
+        "session_id": session_id,
+        "base_machine": machine,
+        "status": "ready",
+        "local": {"worktree_root": str(repo / "worktrees" / session_id)},
+        "remote": {
+            "host": machine,
+            "container": {
+                "name": f"container-{session_id}",
+                "ssh_port": 46000,
+            },
+        },
+        "leases": {"npu_devices": [0]},
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def same_snapshot(_session: dict) -> dict:
+    return {
+        "workspace_head": "abc",
+        "submodules": [" def vllm", " ghi vllm-ascend"],
+        "dirty": False,
+    }
+
+
+class SessionGroupTests(unittest.TestCase):
+    def test_requires_two_distinct_members(self) -> None:
+        with self.assertRaisesRegex(groups.SessionGroupError, "at least two"):
+            groups.parse_members(["head=session-a"])
+        with self.assertRaisesRegex(groups.SessionGroupError, "more than once"):
+            groups.parse_members(["head=session-a", "worker=session-a"])
+
+    def test_create_enforces_snapshot_parity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            write_session(repo, "session-a", "host-a")
+            write_session(repo, "session-b", "host-b")
+            calls = 0
+
+            def different(_session: dict) -> dict:
+                nonlocal calls
+                calls += 1
+                return {
+                    "workspace_head": f"commit-{calls}",
+                    "submodules": [],
+                    "dirty": False,
+                }
+
+            with self.assertRaisesRegex(groups.SessionGroupError, "same workspace"):
+                groups.create_group(
+                    repo_root=repo,
+                    group_id="pd-group",
+                    member_specs=["prefill=session-a", "decode=session-b"],
+                    snapshot_resolver=different,
+                    created_at=NOW,
+                )
+
+    def test_create_and_status(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            write_session(repo, "session-a", "host-a")
+            write_session(repo, "session-b", "host-b")
+            created = groups.create_group(
+                repo_root=repo,
+                group_id="pd-group",
+                member_specs=["prefill=session-a", "decode=session-b"],
+                startup_order=["decode", "prefill"],
+                snapshot_resolver=same_snapshot,
+                created_at=NOW,
+            )
+            self.assertEqual(created["shutdown_order"], ["prefill", "decode"])
+            status = groups.inspect_group(
+                repo_root=repo,
+                group_id="pd-group",
+                snapshot_resolver=same_snapshot,
+            )
+            self.assertEqual(status["status"], "ready")
+            self.assertTrue(status["same_snapshot"])
+
+    def test_teardown_uses_reverse_startup_order(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            write_session(repo, "session-a", "host-a")
+            write_session(repo, "session-b", "host-b")
+            groups.create_group(
+                repo_root=repo,
+                group_id="pd-group",
+                member_specs=["prefill=session-a", "decode=session-b"],
+                startup_order=["prefill", "decode"],
+                snapshot_resolver=same_snapshot,
+                created_at=NOW,
+            )
+            calls: list[str] = []
+
+            def runner(command, **_kwargs):
+                calls.append(command[command.index("--session-id") + 1])
+                return subprocess.CompletedProcess(
+                    args=command,
+                    returncode=0,
+                    stdout='{"status":"removed"}',
+                    stderr="",
+                )
+
+            result = groups.teardown_group(
+                repo_root=repo,
+                group_id="pd-group",
+                remove_containers=True,
+                remove_worktrees=True,
+                release_leases=True,
+                force=True,
+                runner=runner,
+                updated_at=NOW,
+            )
+            self.assertEqual(calls, ["session-b", "session-a"])
+            self.assertEqual(result["status"], "removed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/session-management/tests/test_session_group.py
+++ b/.agents/skills/session-management/tests/test_session_group.py
@@ -34,7 +34,13 @@ groups = load_module()
 NOW = "2026-07-25T12:00:00Z"
 
 
-def write_session(repo: Path, session_id: str, machine: str) -> None:
+def write_session(
+    repo: Path,
+    session_id: str,
+    machine: str,
+    *,
+    worktree: Path | None = None,
+) -> None:
     path = repo / ".vaws-local" / "sessions" / session_id / "session.json"
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -42,7 +48,9 @@ def write_session(repo: Path, session_id: str, machine: str) -> None:
         "session_id": session_id,
         "base_machine": machine,
         "status": "ready",
-        "local": {"worktree_root": str(repo / "worktrees" / session_id)},
+        "local": {
+            "worktree_root": str(worktree or repo / "worktrees" / session_id)
+        },
         "remote": {
             "host": machine,
             "container": {
@@ -61,6 +69,66 @@ def same_snapshot(_session: dict) -> dict:
         "submodules": [" def vllm", " ghi vllm-ascend"],
         "dirty": False,
     }
+
+
+def run_git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout)
+    return result.stdout.strip()
+
+
+def create_test_worktrees(root: Path) -> tuple[Path, Path]:
+    first = root / "first"
+    second = root / "second"
+    first.mkdir()
+    run_git(first, "init")
+    run_git(first, "config", "user.name", "Session Group Test")
+    run_git(first, "config", "user.email", "session-group@example.invalid")
+    (first / "tracked.txt").write_text("base\n", encoding="utf-8")
+    run_git(first, "add", "tracked.txt")
+    run_git(first, "commit", "-m", "base")
+    run_git(first, "worktree", "add", "--detach", str(second), "HEAD")
+    return first, second
+
+
+def create_test_worktrees_with_submodule(root: Path) -> tuple[Path, Path]:
+    child = root / "child-source"
+    child.mkdir()
+    run_git(child, "init")
+    run_git(child, "config", "user.name", "Session Group Test")
+    run_git(child, "config", "user.email", "session-group@example.invalid")
+    (child / "child.txt").write_text("base-child\n", encoding="utf-8")
+    run_git(child, "add", "child.txt")
+    run_git(child, "commit", "-m", "child base")
+
+    first, second = create_test_worktrees(root)
+    run_git(
+        first,
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        str(child),
+        "module",
+    )
+    run_git(first, "commit", "-am", "add submodule")
+    run_git(first, "worktree", "remove", "--force", str(second))
+    run_git(first, "worktree", "add", "--detach", str(second), "HEAD")
+    run_git(
+        second,
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "update",
+        "--init",
+    )
+    return first, second
 
 
 class SessionGroupTests(unittest.TestCase):
@@ -93,6 +161,98 @@ class SessionGroupTests(unittest.TestCase):
                     member_specs=["prefill=session-a", "decode=session-b"],
                     snapshot_resolver=different,
                     created_at=NOW,
+                )
+
+    def test_rejects_same_head_with_different_tracked_contents(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            first, second = create_test_worktrees(repo)
+            (first / "tracked.txt").write_text("candidate-a\n", encoding="utf-8")
+            (second / "tracked.txt").write_text("candidate-b\n", encoding="utf-8")
+            write_session(repo, "session-a", "host-a", worktree=first)
+            write_session(repo, "session-b", "host-b", worktree=second)
+
+            first_snapshot = groups.workspace_snapshot(
+                {"local": {"worktree_root": str(first)}}
+            )
+            second_snapshot = groups.workspace_snapshot(
+                {"local": {"worktree_root": str(second)}}
+            )
+            self.assertEqual(
+                first_snapshot["workspace_head"], second_snapshot["workspace_head"]
+            )
+            self.assertTrue(first_snapshot["dirty"])
+            self.assertNotEqual(
+                first_snapshot["dirty_digest"], second_snapshot["dirty_digest"]
+            )
+            with self.assertRaisesRegex(groups.SessionGroupError, "same workspace"):
+                groups.create_group(
+                    repo_root=repo,
+                    group_id="dirty-tracked",
+                    member_specs=["prefill=session-a", "decode=session-b"],
+                )
+
+    def test_rejects_same_head_with_different_untracked_contents(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            first, second = create_test_worktrees(repo)
+            (first / "candidate.txt").write_text("candidate-a\n", encoding="utf-8")
+            (second / "candidate.txt").write_text("candidate-b\n", encoding="utf-8")
+            write_session(repo, "session-a", "host-a", worktree=first)
+            write_session(repo, "session-b", "host-b", worktree=second)
+
+            with self.assertRaisesRegex(groups.SessionGroupError, "same workspace"):
+                groups.create_group(
+                    repo_root=repo,
+                    group_id="dirty-untracked",
+                    member_specs=["prefill=session-a", "decode=session-b"],
+                )
+
+    def test_accepts_same_head_with_identical_dirty_contents(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            first, second = create_test_worktrees(repo)
+            for worktree in (first, second):
+                (worktree / "tracked.txt").write_text(
+                    "same-candidate\n", encoding="utf-8"
+                )
+                (worktree / "candidate.txt").write_text(
+                    "same-untracked\n", encoding="utf-8"
+                )
+            write_session(repo, "session-a", "host-a", worktree=first)
+            write_session(repo, "session-b", "host-b", worktree=second)
+
+            created = groups.create_group(
+                repo_root=repo,
+                group_id="same-dirty",
+                member_specs=["prefill=session-a", "decode=session-b"],
+                created_at=NOW,
+            )
+
+            self.assertEqual(created["status"], "ready")
+            self.assertEqual(
+                created["members"][0]["snapshot"]["dirty_digest"],
+                created["members"][1]["snapshot"]["dirty_digest"],
+            )
+
+    def test_rejects_different_dirty_submodule_contents(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            first, second = create_test_worktrees_with_submodule(repo)
+            (first / "module" / "child.txt").write_text(
+                "candidate-a\n", encoding="utf-8"
+            )
+            (second / "module" / "child.txt").write_text(
+                "candidate-b\n", encoding="utf-8"
+            )
+            write_session(repo, "session-a", "host-a", worktree=first)
+            write_session(repo, "session-b", "host-b", worktree=second)
+
+            with self.assertRaisesRegex(groups.SessionGroupError, "same workspace"):
+                groups.create_group(
+                    repo_root=repo,
+                    group_id="dirty-submodule",
+                    member_specs=["prefill=session-a", "decode=session-b"],
                 )
 
     def test_create_and_status(self) -> None:

--- a/.agents/skills/session-management/tests/test_session_remove.py
+++ b/.agents/skills/session-management/tests/test_session_remove.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Tests for bounded session worktree cleanup."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[4]
+SKILL = ROOT / ".agents" / "skills" / "session-management"
+
+
+def load_module():
+    name = "_session_remove_test"
+    spec = importlib.util.spec_from_file_location(
+        name, SKILL / "scripts" / "session_remove.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+session_remove = load_module()
+
+
+class SessionRemoveTests(unittest.TestCase):
+    def test_remote_cleanup_exception_marks_session_needs_repair(self) -> None:
+        lookup = SimpleNamespace(
+            session={"session_id": "cleanup-session"},
+            session_file=Path("/tmp/session.json"),
+            state_repo_root=Path("/tmp/state"),
+        )
+        with (
+            mock.patch.object(
+                session_remove,
+                "load_session_lookup",
+                return_value=lookup,
+            ),
+            mock.patch.object(
+                session_remove,
+                "session_serving_state_path",
+                return_value=Path("/definitely/missing/serving.json"),
+            ),
+            mock.patch.object(
+                session_remove,
+                "session_record_for_execution",
+                return_value={},
+            ),
+            mock.patch.object(
+                session_remove,
+                "remove_container",
+                side_effect=RuntimeError("host unreachable"),
+            ),
+            mock.patch.object(
+                session_remove,
+                "mark_session_status",
+                return_value={"status": "needs_repair"},
+            ) as mark_status,
+            mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "session_remove.py",
+                    "--session-id",
+                    "cleanup-session",
+                    "--remove-container",
+                    "--release-leases",
+                ],
+            ),
+            mock.patch("builtins.print"),
+        ):
+            returncode = session_remove.main()
+
+        self.assertEqual(returncode, 2)
+        mark_status.assert_called_once_with(
+            repo_root=lookup.state_repo_root,
+            session_id="cleanup-session",
+            status="needs_repair",
+        )
+
+    def test_deinitializes_submodules_before_removing_worktree(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            worktree = Path(tmp)
+            calls: list[tuple[Path, list[str]]] = []
+
+            def runner(args: list[str], *, cwd: Path, check: bool = False):
+                del check
+                calls.append((cwd, args))
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=0,
+                    stdout="ok",
+                    stderr="",
+                )
+
+            result = session_remove.remove_session_worktree(
+                worktree,
+                force=False,
+                runner=runner,
+            )
+
+            self.assertEqual(
+                calls,
+                [
+                    (worktree, ["submodule", "deinit", "--force", "--all"]),
+                    (
+                        session_remove.ROOT,
+                        ["worktree", "remove", str(worktree)],
+                    ),
+                ],
+            )
+            self.assertEqual(result["returncode"], 0)
+            self.assertEqual(result["submodule_deinit"]["returncode"], 0)
+
+    def test_force_is_forwarded_to_worktree_removal(self) -> None:
+        missing = Path("/definitely/missing/session-worktree")
+        calls: list[tuple[Path, list[str]]] = []
+
+        def runner(args: list[str], *, cwd: Path, check: bool = False):
+            del check
+            calls.append((cwd, args))
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+
+        result = session_remove.remove_session_worktree(
+            missing,
+            force=True,
+            runner=runner,
+        )
+
+        self.assertEqual(
+            calls,
+            [
+                (
+                    session_remove.ROOT,
+                    [
+                        "worktree",
+                        "remove",
+                        "--force",
+                        "--force",
+                        str(missing),
+                    ],
+                )
+            ],
+        )
+        self.assertIsNone(result["submodule_deinit"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/session-management/tests/test_session_visibility.py
+++ b/.agents/skills/session-management/tests/test_session_visibility.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Regression tests for leased NPU visibility checks."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+MACHINE_SCRIPTS = ROOT / ".agents" / "skills" / "machine-management" / "scripts"
+SESSION_SCRIPT = (
+    ROOT / ".agents" / "skills" / "session-management" / "scripts" / "session_create.py"
+)
+for path in (LIB, MACHINE_SCRIPTS):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("_session_visibility_test", SESSION_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+session_create = load_module()
+
+
+class SessionVisibilityTests(unittest.TestCase):
+    def verify(self, observed: str):
+        ready = {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "ok",
+            "stderr": "",
+        }
+        visibility = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=observed,
+            stderr="",
+        )
+        with (
+            mock.patch.object(
+                session_create.machine_ops,
+                "find_public_key",
+                return_value=Path("/keys/id.pub"),
+            ),
+            mock.patch.object(
+                session_create.machine_ops,
+                "private_key_for_public_key",
+                return_value=Path("/keys/id"),
+            ),
+            mock.patch.object(
+                session_create.machine_ops,
+                "check_direct_ssh",
+                return_value=ready,
+            ),
+            mock.patch.object(
+                session_create.machine_ops,
+                "run_local",
+                return_value=visibility,
+            ),
+        ):
+            return session_create.verify_session_ssh(
+                {
+                    "host": {
+                        "ip": "192.0.2.1",
+                        "user": "root",
+                        "port": 22,
+                    }
+                },
+                container_ssh_port=46001,
+                public_key_file=None,
+                visible_devices=[0, 1],
+            )
+
+    def test_matching_visibility_is_ready(self) -> None:
+        result = self.verify("0,1")
+
+        self.assertEqual(result["status"], "ready")
+        self.assertTrue(result["device_visibility"]["matches"])
+
+    def test_visibility_drift_needs_repair(self) -> None:
+        result = self.verify("")
+
+        self.assertEqual(result["status"], "needs_repair")
+        self.assertFalse(result["device_visibility"]["matches"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/session-management/tests/test_session_visibility.py
+++ b/.agents/skills/session-management/tests/test_session_visibility.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import inspect
 import subprocess
 import sys
 import unittest
@@ -34,6 +35,30 @@ session_create = load_module()
 
 
 class SessionVisibilityTests(unittest.TestCase):
+    def test_bootstrap_helper_accepts_and_persists_visible_devices(self) -> None:
+        parameters = inspect.signature(session_create.bootstrap_container).parameters
+        self.assertIn("visible_devices", parameters)
+        helper_source = inspect.getsource(session_create.bootstrap_container)
+        self.assertIn(
+            '",".join(str(device) for device in (visible_devices or []))',
+            helper_source,
+        )
+
+        script = session_create.machine_ops.render_bootstrap_host_script()
+        self.assertIn('visible_devices="${11:-}"', script)
+        self.assertIn('ASCEND_RT_VISIBLE_DEVICES=$visible_devices', script)
+        self.assertIn('SetEnv ASCEND_RT_VISIBLE_DEVICES=%s', script)
+        self.assertIn('"visible_devices": [int(item)', script)
+
+    def test_full_smoke_reports_visibility_fields(self) -> None:
+        script = session_create.machine_ops.render_smoke_script()
+
+        self.assertIn('"device_count": torch.npu.device_count()', script)
+        self.assertIn(
+            '"visible_devices": os.environ.get("ASCEND_RT_VISIBLE_DEVICES")',
+            script,
+        )
+
     def verify(self, observed: str):
         ready = {
             "ok": True,

--- a/.agents/skills/vllm-ascend-change-validation/SKILL.md
+++ b/.agents/skills/vllm-ascend-change-validation/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: vllm-ascend-change-validation
+description: Analyze vLLM and vllm-ascend diffs, map affected components to the minimum sufficient correctness, build, performance, graph, operator, distributed, and profiling evidence, link downstream Run Manifest results, and produce a PR-ready validation report. Use for PR validation, workspace-diff risk analysis, deciding what tests a change requires, or documenting untested combinations. Do not use as a replacement for the downstream execution skills or for a change with no accessible diff.
+---
+
+# vLLM Ascend Change Validation
+
+Use this Skill as the validation planner and evidence aggregator for a code change.
+
+## Workflow
+
+1. Obtain the exact baseline and candidate diff, including relevant untracked files.
+2. Run `scripts/change_validation.py plan`.
+3. Review `impact-analysis.json` and `validation-plan.json`; correct false-positive or missing mappings before consuming NPU resources.
+4. Execute required items with the owning Skill:
+   - correctness evidence: `vllm-ascend-correctness-validation`;
+   - eager-pass/graph-fail diagnosis: `vllm-ascend-graph-debug`;
+   - service lifecycle: `vllm-ascend-serving`;
+   - benchmark and profiling evidence: their dedicated Skills;
+   - distributed, operator, or performance workflows when those Skills are available.
+5. Link each downstream Run Manifest with the plan item IDs it covers.
+6. Run `finalize`.
+7. Deliver `pr-validation-report.md` with explicit missing and recommended coverage.
+
+The planner defaults to the versioned rules in `references/validation-rules.yaml`,
+so the Skill remains functional when the formal workspace knowledge store is
+empty. Use `--knowledge PATH` to supply a reviewed workspace-specific rule set.
+Missing matches produce a generic targeted smoke plus manual-review flag; they
+never imply that no validation is needed.
+
+## Entry point
+
+`scripts/change_validation.py` provides:
+
+- `plan`: collect or read a unified diff, classify impact, write a validation plan, and create a parent Run Manifest;
+- `link`: associate a downstream Run Manifest with one or more plan items;
+- `finalize`: assess required coverage and child statuses, then generate the final PR report.
+
+Read:
+
+- [Behavior contract](references/behavior.md) for diff, rule, plan, link, and final-status semantics.
+- [Command recipes](references/command-recipes.md) for worktree, commit-range, and imported-diff examples.
+- [Acceptance](references/acceptance.md) before claiming the change is validated.
+
+## Rules
+
+- Keep the reason and source rule for every plan item.
+- Distinguish `required` and `recommended`; resource constraints do not silently downgrade required evidence.
+- Treat child `failed` as failed, child non-terminal/inconclusive or missing required coverage as inconclusive.
+- A passed parent requires every required item to be covered by at least one passed child run.
+- Record unsupported, unknown, and intentionally omitted combinations under known limitations.
+- Do not duplicate Serving, correctness, Benchmark, Profiling, graph-debug, distributed-debug, or operator-debug implementation.
+- Keep run state under `.vaws-local/change-validation/`.

--- a/.agents/skills/vllm-ascend-change-validation/agents/openai.yaml
+++ b/.agents/skills/vllm-ascend-change-validation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "vLLM Ascend Change Validation"
+  short_description: "Map code changes to evidence-backed validation plans"
+  default_prompt: "Use $vllm-ascend-change-validation to analyze this diff, plan the minimum sufficient validation, and prepare a PR report."

--- a/.agents/skills/vllm-ascend-change-validation/references/acceptance.md
+++ b/.agents/skills/vllm-ascend-change-validation/references/acceptance.md
@@ -1,0 +1,29 @@
+# Change validation acceptance
+
+## Diff and impact
+
+- [ ] Baseline, candidate, target repositories, and user goal are recorded.
+- [ ] The diff includes relevant staged, unstaged, and untracked changes.
+- [ ] Cross-repository changes use a combined diff or equivalent complete evidence.
+- [ ] Every matched impact links to a versioned Skill-owned rule or an explicit reviewed knowledge override.
+- [ ] Unclassified changes are manually reviewed.
+
+## Plan
+
+- [ ] Every item records priority, rationale, and source.
+- [ ] Required items have not been silently downgraded for resource reasons.
+- [ ] The plan was reviewed before expensive NPU execution.
+- [ ] Omitted combinations are listed as limitations.
+
+## Evidence
+
+- [ ] Each linked run has a valid Run Manifest.
+- [ ] Each link names the plan item IDs it covers.
+- [ ] Failed, inconclusive, cancelled, running, and planned children are not treated as passing.
+- [ ] Correctness, performance, graph, distributed, operator, and profiling evidence use their owning workflows.
+
+## Delivery
+
+- [ ] Every required plan item has passed evidence before parent status is passed.
+- [ ] `pr-validation-report.md` contains change summary, impact, validation matrix, results, limitations, reproduction, and artifact locations.
+- [ ] Parent Run Manifest validates and links all child manifests.

--- a/.agents/skills/vllm-ascend-change-validation/references/behavior.md
+++ b/.agents/skills/vllm-ascend-change-validation/references/behavior.md
@@ -1,0 +1,84 @@
+# Change validation behavior contract
+
+## Contents
+
+- [Diff input](#diff-input)
+- [Knowledge routing](#knowledge-routing)
+- [Plan items](#plan-items)
+- [Linked evidence](#linked-evidence)
+- [Final status](#final-status)
+- [Artifacts](#artifacts)
+
+## Diff input
+
+`plan` accepts either:
+
+- `--repo-root` with a baseline and candidate ref;
+- `--repo-root` with candidate `WORKTREE`, including non-ignored untracked text files;
+- `--diff-file` containing a unified diff assembled across one or more repositories.
+
+The persisted `diff-summary.json` stores file paths, line counts, and a SHA256 digest, not the full source diff.
+
+For cross-repository changes, create one combined unified diff and list each target with `--target-repository`.
+
+## Knowledge routing
+
+Default rules live in `references/validation-rules.yaml`. The `--knowledge`
+option may replace them with a reviewed workspace-specific rule set. A rule
+contains:
+
+- `path_patterns`: regular expressions matched only against changed paths;
+- optional `content_patterns`: regular expressions matched against added and removed lines when symbol-level routing is necessary;
+- `category`: affected component;
+- `required_checks`;
+- optional `recommended_checks`;
+- optional route conditions such as `route_on_hang`.
+
+Every plan item records the rule IDs and categories that caused it. Multiple rules producing the same check merge into one item, and required wins over recommended.
+
+If no rule matches, emit required `correctness:targeted-smoke` and set `manual_review_required=true`.
+
+## Plan items
+
+Each item has:
+
+- stable `id`;
+- human-readable `check`;
+- `required` or `recommended` priority;
+- source rules;
+- rationale categories;
+- coverage status.
+
+Review the plan before running expensive hardware validation. Correcting a false mapping is allowed; silently deleting required evidence is not.
+
+## Linked evidence
+
+Link the downstream `manifest.json` and one or more plan IDs. The parent records:
+
+- child run ID and type;
+- current child status;
+- absolute manifest location;
+- covered plan items.
+
+A child with another non-null parent ID cannot be linked. Duplicate child run IDs are rejected.
+
+## Final status
+
+- `passed`: every required item has at least one linked passed run, every linked run is passed, and no manual review remains;
+- `failed`: any linked child run is failed;
+- `inconclusive`: required coverage is missing, manual review remains, or any child is planned, running, inconclusive, or cancelled.
+
+Recommended evidence may remain missing without changing a fully proved required plan from passed, but the report keeps it visible.
+
+## Artifacts
+
+```text
+change-validation/
+├── manifest.json
+├── run.json
+├── diff-summary.json
+├── impact-analysis.json
+├── validation-plan.json
+├── linked-runs.json
+└── pr-validation-report.md
+```

--- a/.agents/skills/vllm-ascend-change-validation/references/command-recipes.md
+++ b/.agents/skills/vllm-ascend-change-validation/references/command-recipes.md
@@ -1,0 +1,61 @@
+# Change validation command recipes
+
+## Current worktree
+
+```bash
+python -B .agents/skills/vllm-ascend-change-validation/scripts/change_validation.py plan \
+  --output-dir .vaws-local/change-validation/change-001 \
+  --run-id change-validation-001 \
+  --baseline HEAD \
+  --candidate WORKTREE \
+  --repo-root . \
+  --target-repository vllm-ascend \
+  --goal "Fix DCP metadata propagation"
+```
+
+## Commit range
+
+```bash
+python -B .agents/skills/vllm-ascend-change-validation/scripts/change_validation.py plan \
+  --output-dir .vaws-local/change-validation/change-002 \
+  --run-id change-validation-002 \
+  --baseline origin/main \
+  --candidate feature-branch \
+  --repo-root . \
+  --target-repository vllm \
+  --target-repository vllm-ascend
+```
+
+## Imported cross-repository diff
+
+```bash
+python -B .agents/skills/vllm-ascend-change-validation/scripts/change_validation.py plan \
+  --output-dir .vaws-local/change-validation/change-003 \
+  --run-id change-validation-003 \
+  --baseline recorded-baselines \
+  --candidate workspace-snapshots \
+  --diff-file /path/to/combined.diff \
+  --target-repository vllm \
+  --target-repository vllm-ascend
+```
+
+## Link evidence
+
+Read `validation-plan.json`, then link the exact plan IDs:
+
+```bash
+python -B .agents/skills/vllm-ascend-change-validation/scripts/change_validation.py link \
+  --output-dir .vaws-local/change-validation/change-001 \
+  --run-manifest .vaws-local/correctness/change-001/manifest.json \
+  --covers correctness-multi-rank-metadata-consistency \
+  --covers correctness-eager
+```
+
+## Finalize
+
+```bash
+python -B .agents/skills/vllm-ascend-change-validation/scripts/change_validation.py finalize \
+  --output-dir .vaws-local/change-validation/change-001
+```
+
+An inconclusive result is expected until every required item is covered by passed evidence.

--- a/.agents/skills/vllm-ascend-change-validation/references/validation-rules.yaml
+++ b/.agents/skills/vllm-ascend-change-validation/references/validation-rules.yaml
@@ -1,0 +1,249 @@
+{
+  "schema_version": 1,
+  "kind": "validation-rules",
+  "updated_at": "2026-07-25",
+  "entries": [
+    {
+      "id": "graph-path-requires-eager-graph-comparison",
+      "source": "workspace skill roadmap and vllm-ascend-graph-debug contract",
+      "applicable_versions": "all workspace-managed revisions",
+      "updated_at": "2026-07-25",
+      "status": "active",
+      "rule": {
+        "category": "graph",
+        "path_patterns": [
+          "(?i)(acl.?graph|cudagraph|graph_mode)"
+        ],
+        "required_checks": [
+          "correctness:eager",
+          "correctness:graph"
+        ],
+        "route_on_divergence": "vllm-ascend-graph-debug"
+      }
+    },
+    {
+      "id": "custom-op-change-requires-operator-matrix",
+      "source": "workspace skill roadmap",
+      "applicable_versions": "all workspace-managed revisions",
+      "updated_at": "2026-07-25",
+      "status": "experimental",
+      "rule": {
+        "category": "custom-op",
+        "path_patterns": [
+          "(?i)(custom_op|ops/|kernel)"
+        ],
+        "required_checks": [
+          "operator:dtype-shape-layout",
+          "correctness:model-smoke"
+        ],
+        "recommended_checks": [
+          "performance:operator-microbenchmark"
+        ]
+      }
+    },
+    {
+      "id": "parallel-metadata-change-requires-rank-consistency",
+      "source": "workspace skill roadmap",
+      "applicable_versions": "all workspace-managed revisions",
+      "updated_at": "2026-07-25",
+      "status": "experimental",
+      "rule": {
+        "category": "parallel-metadata",
+        "path_patterns": [
+          "(?i)(parallel|metadata|communicator|process_group)"
+        ],
+        "required_checks": [
+          "correctness:multi-rank-metadata-consistency"
+        ],
+        "route_on_hang": "vllm-ascend-distributed-debug"
+      }
+    },
+    {
+      "id": "model-runner-change-requires-override-and-smoke",
+      "source": "workspace skill roadmap",
+      "applicable_versions": "all workspace-managed revisions",
+      "updated_at": "2026-07-25",
+      "status": "active",
+      "rule": {
+        "category": "model-runner",
+        "path_patterns": [
+          "(?i)(model_runner|runner/)"
+        ],
+        "required_checks": [
+          "compatibility:vllm-ascend-override",
+          "build:import-smoke",
+          "correctness:single-card-model-smoke"
+        ]
+      }
+    },
+    {
+      "id": "attention-backend-change-requires-backend-correctness",
+      "source": "workspace skill roadmap",
+      "applicable_versions": "all workspace-managed revisions",
+      "updated_at": "2026-07-25",
+      "status": "active",
+      "rule": {
+        "category": "attention-backend",
+        "path_patterns": [
+          "(?i)(attention|attn_backend)"
+        ],
+        "required_checks": [
+          "correctness:affected-attention-backend",
+          "correctness:eager"
+        ],
+        "recommended_checks": [
+          "correctness:graph"
+        ]
+      }
+    },
+    {
+      "id": "kv-cache-change-requires-cache-feature-matrix",
+      "source": "workspace skill roadmap",
+      "applicable_versions": "all workspace-managed revisions",
+      "updated_at": "2026-07-25",
+      "status": "active",
+      "rule": {
+        "category": "kv-cache",
+        "path_patterns": [
+          "(?i)(kv_cache|prefix_cache|block_table)"
+        ],
+        "required_checks": [
+          "correctness:kv-cache",
+          "correctness:prefix-cache"
+        ],
+        "recommended_checks": [
+          "correctness:chunked-prefill"
+        ]
+      }
+    },
+    {
+      "id": "scheduler-change-requires-online-cases",
+      "source": "workspace skill roadmap",
+      "applicable_versions": "all workspace-managed revisions",
+      "updated_at": "2026-07-25",
+      "status": "active",
+      "rule": {
+        "category": "scheduler",
+        "path_patterns": [
+          "(?i)(scheduler|request_queue)"
+        ],
+        "required_checks": [
+          "correctness:online-chat",
+          "correctness:mixed-request-shapes"
+        ],
+        "recommended_checks": [
+          "performance:online-serving"
+        ]
+      }
+    },
+    {
+      "id": "worker-change-requires-multi-rank-smoke",
+      "source": "workspace skill roadmap",
+      "applicable_versions": "all workspace-managed revisions",
+      "updated_at": "2026-07-25",
+      "status": "active",
+      "rule": {
+        "category": "worker",
+        "path_patterns": [
+          "(?i)(worker|executor)"
+        ],
+        "required_checks": [
+          "correctness:single-rank-smoke",
+          "correctness:multi-rank-smoke"
+        ],
+        "route_on_hang": "vllm-ascend-distributed-debug"
+      }
+    },
+    {
+      "id": "quantization-change-requires-dtype-and-model-smoke",
+      "source": "workspace skill roadmap",
+      "applicable_versions": "all workspace-managed revisions",
+      "updated_at": "2026-07-25",
+      "status": "active",
+      "rule": {
+        "category": "quantization",
+        "path_patterns": [
+          "(?i)(quant|w8a8|fp8|int8)"
+        ],
+        "required_checks": [
+          "operator:quantized-dtype-shape",
+          "correctness:quantized-model-smoke"
+        ],
+        "recommended_checks": [
+          "performance:quantized-model"
+        ]
+      }
+    },
+    {
+      "id": "model-adapter-change-requires-model-smoke",
+      "source": "workspace skill roadmap",
+      "applicable_versions": "all workspace-managed revisions",
+      "updated_at": "2026-07-25",
+      "status": "active",
+      "rule": {
+        "category": "model-adapter",
+        "path_patterns": [
+          "(?i)(models/|model_adapter|registry)"
+        ],
+        "required_checks": [
+          "build:model-import",
+          "correctness:dummy-weight-smoke",
+          "correctness:real-weight-smoke"
+        ]
+      }
+    },
+    {
+      "id": "kv-connector-change-requires-transfer-smoke",
+      "source": "workspace skill roadmap",
+      "applicable_versions": "all workspace-managed revisions",
+      "updated_at": "2026-07-25",
+      "status": "active",
+      "rule": {
+        "category": "kv-connector",
+        "path_patterns": [
+          "(?i)(nixl|mooncake|kv_connector|kv_transfer|disaggreg)"
+        ],
+        "required_checks": [
+          "correctness:kv-transfer-smoke",
+          "correctness:prefill-decode-smoke"
+        ],
+        "recommended_checks": [
+          "performance:pd-serving"
+        ]
+      }
+    },
+    {
+      "id": "build-change-requires-build-and-import",
+      "source": "workspace skill roadmap",
+      "applicable_versions": "all workspace-managed revisions",
+      "updated_at": "2026-07-25",
+      "status": "active",
+      "rule": {
+        "category": "build",
+        "path_patterns": [
+          "(?i)(cmakelists|pyproject|setup\\.py|requirements|dockerfile|\\.github/workflows)"
+        ],
+        "required_checks": [
+          "build:package",
+          "build:import-smoke"
+        ]
+      }
+    },
+    {
+      "id": "test-change-requires-targeted-test-suite",
+      "source": "workspace skill roadmap",
+      "applicable_versions": "all workspace-managed revisions",
+      "updated_at": "2026-07-25",
+      "status": "active",
+      "rule": {
+        "category": "test",
+        "path_patterns": [
+          "(?i)(^|/)(tests?|ci)(/|$)"
+        ],
+        "required_checks": [
+          "test:targeted-suite"
+        ]
+      }
+    }
+  ]
+}

--- a/.agents/skills/vllm-ascend-change-validation/scripts/change_validation.py
+++ b/.agents/skills/vllm-ascend-change-validation/scripts/change_validation.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""Plan and aggregate evidence for vLLM Ascend code changes."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[4]
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_VALIDATION_RULES = SKILL_ROOT / "references" / "validation-rules.yaml"
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_knowledge import load_knowledge_file  # noqa: E402
+from vaws_run_manifest import (  # noqa: E402
+    RunManifestError,
+    add_artifact,
+    load_manifest,
+    new_manifest,
+    transition_status,
+    write_manifest,
+)
+
+SCHEMA_VERSION = 1
+SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+DIFF_HEADER_RE = re.compile(r"^diff --git a/(.+) b/(.+)$")
+PLAN_PRIORITIES = frozenset({"required", "recommended"})
+
+
+class ChangeValidationError(ValueError):
+    """Raised when change-validation input or state is invalid."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def emit_progress(phase: str, **details: Any) -> None:
+    print(json.dumps({"phase": phase, **details}, ensure_ascii=False), file=sys.stderr)
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    _atomic_write(
+        path, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ChangeValidationError(f"cannot read {label} {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ChangeValidationError(f"{label} root must be an object")
+    return payload
+
+
+def _run_git(repo_root: Path, arguments: Sequence[str]) -> str:
+    process = subprocess.run(
+        ["git", "-C", str(repo_root), *arguments],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if process.returncode != 0:
+        raise ChangeValidationError(
+            f"git {' '.join(arguments)} failed: {process.stderr.strip()}"
+        )
+    return process.stdout
+
+
+def collect_git_diff(repo_root: Path, *, baseline: str, candidate: str) -> str:
+    if candidate == "WORKTREE":
+        diff = _run_git(repo_root, ["diff", "--no-ext-diff", "--unified=0", baseline, "--"])
+        untracked = _run_git(
+            repo_root, ["ls-files", "--others", "--exclude-standard"]
+        ).splitlines()
+        additions: list[str] = []
+        for relative in sorted(path for path in untracked if path):
+            path = repo_root / relative
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                text = ""
+            additions.extend(
+                [
+                    f"diff --git a/{relative} b/{relative}",
+                    "new file mode 100644",
+                    "--- /dev/null",
+                    f"+++ b/{relative}",
+                    "@@ -0,0 +1 @@",
+                    *[f"+{line}" for line in text.splitlines()],
+                ]
+            )
+        if additions:
+            diff = diff.rstrip("\n") + "\n" + "\n".join(additions) + "\n"
+        return diff
+    return _run_git(
+        repo_root,
+        ["diff", "--no-ext-diff", "--unified=0", f"{baseline}...{candidate}", "--"],
+    )
+
+
+def parse_diff(diff_text: str) -> dict[str, Any]:
+    files: dict[str, dict[str, Any]] = {}
+    current: str | None = None
+    changed_text: list[str] = []
+    for line in diff_text.splitlines():
+        header = DIFF_HEADER_RE.match(line)
+        if header:
+            current = header.group(2)
+            files.setdefault(current, {"path": current, "additions": 0, "deletions": 0})
+            continue
+        if current is None:
+            continue
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            files[current]["additions"] += 1
+            changed_text.append(line[1:])
+        elif line.startswith("-"):
+            files[current]["deletions"] += 1
+            changed_text.append(line[1:])
+    file_rows = sorted(files.values(), key=lambda row: row["path"])
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "sha256": hashlib.sha256(diff_text.encode("utf-8")).hexdigest(),
+        "file_count": len(file_rows),
+        "additions": sum(row["additions"] for row in file_rows),
+        "deletions": sum(row["deletions"] for row in file_rows),
+        "files": file_rows,
+        "matching_paths": "\n".join(row["path"] for row in file_rows),
+        "matching_text": "\n".join(changed_text),
+    }
+
+
+def _safe_item_id(check: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", check.lower()).strip("-")
+    if not slug:
+        raise ChangeValidationError(f"cannot generate plan id from {check!r}")
+    return slug[:120]
+
+
+def build_plan(
+    diff_summary: Mapping[str, Any],
+    knowledge_document: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    path_haystack = str(diff_summary.get("matching_paths", ""))
+    content_haystack = str(diff_summary.get("matching_text", ""))
+    impacts: list[dict[str, Any]] = []
+    item_map: dict[str, dict[str, Any]] = {}
+    routes: list[dict[str, str]] = []
+    for entry in knowledge_document.get("entries", []):
+        if not isinstance(entry, Mapping) or entry.get("status") == "deprecated":
+            continue
+        rule = entry.get("rule", {})
+        if not isinstance(rule, Mapping):
+            continue
+        path_patterns = rule.get("path_patterns", [])
+        content_patterns = rule.get("content_patterns", [])
+        matched_path_patterns = [
+            pattern
+            for pattern in path_patterns
+            if isinstance(pattern, str) and re.search(pattern, path_haystack)
+        ]
+        matched_content_patterns = [
+            pattern
+            for pattern in content_patterns
+            if isinstance(pattern, str) and re.search(pattern, content_haystack)
+        ]
+        if not matched_path_patterns and not matched_content_patterns:
+            continue
+        category = str(rule.get("category", entry.get("id", "uncategorized")))
+        impacts.append(
+            {
+                "category": category,
+                "rule_id": entry["id"],
+                "matched_path_patterns": matched_path_patterns,
+                "matched_content_patterns": matched_content_patterns,
+                "source": entry.get("source"),
+                "status": entry.get("status"),
+            }
+        )
+        for priority, field in (
+            ("required", "required_checks"),
+            ("recommended", "recommended_checks"),
+        ):
+            for check in rule.get(field, []):
+                item_id = _safe_item_id(str(check))
+                item = item_map.setdefault(
+                    item_id,
+                    {
+                        "id": item_id,
+                        "check": str(check),
+                        "priority": priority,
+                        "sources": [],
+                        "rationale": [],
+                        "status": "planned",
+                    },
+                )
+                if priority == "required":
+                    item["priority"] = "required"
+                item["sources"].append(entry["id"])
+                item["rationale"].append(category)
+        for key, value in rule.items():
+            if key.startswith("route_on_") and isinstance(value, str):
+                routes.append({"condition": key.removeprefix("route_on_"), "skill": value})
+
+    manual_review = False
+    if not item_map:
+        manual_review = True
+        item_map["correctness-targeted-smoke"] = {
+            "id": "correctness-targeted-smoke",
+            "check": "correctness:targeted-smoke",
+            "priority": "required",
+            "sources": ["fallback-no-rule-match"],
+            "rationale": ["unclassified-change"],
+            "status": "planned",
+        }
+    for item in item_map.values():
+        item["sources"] = sorted(set(item["sources"]))
+        item["rationale"] = sorted(set(item["rationale"]))
+    impact_document = {
+        "schema_version": SCHEMA_VERSION,
+        "manual_review_required": manual_review,
+        "impacts": sorted(impacts, key=lambda row: (row["category"], row["rule_id"])),
+        "routes": sorted(
+            {f"{route['condition']}:{route['skill']}": route for route in routes}.values(),
+            key=lambda row: (row["condition"], row["skill"]),
+        ),
+    }
+    plan_document = {
+        "schema_version": SCHEMA_VERSION,
+        "manual_review_required": manual_review,
+        "items": sorted(
+            item_map.values(),
+            key=lambda item: (item["priority"] != "required", item["id"]),
+        ),
+    }
+    return impact_document, plan_document
+
+
+def render_report(
+    *,
+    run_state: Mapping[str, Any],
+    diff_summary: Mapping[str, Any],
+    impact: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    links: Mapping[str, Any],
+    final_status: str,
+) -> str:
+    coverage: dict[str, list[Mapping[str, Any]]] = {}
+    for link in links.get("runs", []):
+        for item_id in link.get("covers", []):
+            coverage.setdefault(item_id, []).append(link)
+    lines = [
+        "# PR validation report",
+        "",
+        "## Change summary",
+        "",
+        f"- Goal: {run_state.get('goal') or 'Not provided'}",
+        f"- Baseline: `{run_state['baseline']}`",
+        f"- Candidate: `{run_state['candidate']}`",
+        f"- Target repositories: {', '.join(run_state.get('target_repositories', [])) or 'Not provided'}",
+        f"- Files changed: {diff_summary['file_count']}",
+        f"- Lines: +{diff_summary['additions']} / -{diff_summary['deletions']}",
+        f"- Validation status: **{final_status}**",
+        "",
+        "## Impact modules",
+        "",
+    ]
+    if impact.get("impacts"):
+        for row in impact["impacts"]:
+            lines.append(f"- `{row['category']}` via `{row['rule_id']}`")
+    else:
+        lines.append("- No domain rule matched; manual review is required.")
+    lines.extend(
+        [
+            "",
+            "## Validation matrix",
+            "",
+            "| Requirement | Priority | Evidence | Result |",
+            "|---|---|---|---|",
+        ]
+    )
+    for item in plan["items"]:
+        evidence = coverage.get(item["id"], [])
+        evidence_text = ", ".join(f"`{row['run_id']}`" for row in evidence) or "missing"
+        statuses = ", ".join(str(row["status"]) for row in evidence) or "not run"
+        lines.append(
+            f"| `{item['check']}` | {item['priority']} | {evidence_text} | {statuses} |"
+        )
+    lines.extend(["", "## Known limitations and missing coverage", ""])
+    missing = [
+        item
+        for item in plan["items"]
+        if item["priority"] == "required" and not coverage.get(item["id"])
+    ]
+    nonpassing = [
+        link for link in links.get("runs", []) if link.get("status") != "passed"
+    ]
+    if not missing and not nonpassing and not plan.get("manual_review_required"):
+        lines.append("- None recorded.")
+    for item in missing:
+        lines.append(f"- Required evidence missing: `{item['check']}`.")
+    for link in nonpassing:
+        lines.append(
+            f"- Linked run `{link['run_id']}` is `{link['status']}` and does not prove acceptance."
+        )
+    if plan.get("manual_review_required"):
+        lines.append("- Change classification requires manual review.")
+    lines.extend(["", "## Reproduction and artifacts", ""])
+    for link in links.get("runs", []):
+        lines.append(f"- `{link['run_id']}`: `{link['manifest']}`")
+    return "\n".join(lines) + "\n"
+
+
+def plan_change(
+    output_dir: Path,
+    *,
+    run_id: str,
+    baseline: str,
+    candidate: str,
+    goal: str,
+    target_repositories: Sequence[str],
+    diff_text: str,
+    knowledge_path: Path,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise ChangeValidationError(f"output directory is not empty: {output_dir}")
+    if not SAFE_ID_RE.fullmatch(run_id):
+        raise ChangeValidationError("run-id must be a lowercase safe identifier")
+    knowledge = load_knowledge_file(knowledge_path)
+    diff_summary = parse_diff(diff_text)
+    if diff_summary["file_count"] == 0:
+        raise ChangeValidationError("diff contains no changed files")
+    impact, validation_plan = build_plan(diff_summary, knowledge)
+    timestamp = created_at or utc_now()
+    run_state = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "baseline": baseline,
+        "candidate": candidate,
+        "goal": goal,
+        "target_repositories": list(target_repositories),
+        "status": "planned",
+        "created_at": timestamp,
+        "updated_at": timestamp,
+    }
+    links = {"schema_version": SCHEMA_VERSION, "runs": []}
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(output_dir / "run.json", run_state)
+    stored_summary = dict(diff_summary)
+    stored_summary.pop("matching_paths", None)
+    stored_summary.pop("matching_text", None)
+    _write_json(output_dir / "diff-summary.json", stored_summary)
+    _write_json(output_dir / "impact-analysis.json", impact)
+    _write_json(output_dir / "validation-plan.json", validation_plan)
+    _write_json(output_dir / "linked-runs.json", links)
+    report = render_report(
+        run_state=run_state,
+        diff_summary=stored_summary,
+        impact=impact,
+        plan=validation_plan,
+        links=links,
+        final_status="planned",
+    )
+    _atomic_write(output_dir / "pr-validation-report.md", report)
+    manifest = new_manifest(
+        run_type="change-validation",
+        run_id=run_id,
+        workspace_snapshot={
+            "baseline": baseline,
+            "candidate": candidate,
+            "diff_sha256": diff_summary["sha256"],
+        },
+        created_at=timestamp,
+    )
+    for name, kind, uri in (
+        ("diff-summary", "diff-summary", "diff-summary.json"),
+        ("impact-analysis", "impact-analysis", "impact-analysis.json"),
+        ("validation-plan", "validation-plan", "validation-plan.json"),
+        ("linked-runs", "linked-runs", "linked-runs.json"),
+        ("pr-report", "report", "pr-validation-report.md"),
+    ):
+        manifest = add_artifact(
+            manifest, name=name, kind=kind, uri=uri, updated_at=timestamp
+        )
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {
+        "status": "planned",
+        "run_id": run_id,
+        "file_count": diff_summary["file_count"],
+        "impact_count": len(impact["impacts"]),
+        "required_count": sum(
+            item["priority"] == "required" for item in validation_plan["items"]
+        ),
+        "recommended_count": sum(
+            item["priority"] == "recommended" for item in validation_plan["items"]
+        ),
+    }
+
+
+def link_run(
+    output_dir: Path,
+    *,
+    child_manifest_path: Path,
+    covers: Sequence[str],
+    updated_at: str | None = None,
+) -> dict[str, Any]:
+    plan = _load_json(output_dir / "validation-plan.json", "validation plan")
+    valid_ids = {item["id"] for item in plan["items"]}
+    unknown = sorted(set(covers) - valid_ids)
+    if unknown:
+        raise ChangeValidationError(f"unknown plan item ids: {', '.join(unknown)}")
+    if not covers:
+        raise ChangeValidationError("at least one --covers item is required")
+    child = load_manifest(child_manifest_path)
+    parent = load_manifest(output_dir / "manifest.json")
+    if child.get("parent_run_id") not in {None, parent["run_id"]}:
+        raise ChangeValidationError(
+            f"child parent_run_id belongs to another run: {child.get('parent_run_id')}"
+        )
+    links = _load_json(output_dir / "linked-runs.json", "linked runs")
+    if any(link["run_id"] == child["run_id"] for link in links["runs"]):
+        raise ChangeValidationError(f"child run is already linked: {child['run_id']}")
+    timestamp = updated_at or utc_now()
+    link = {
+        "run_id": child["run_id"],
+        "run_type": child["run_type"],
+        "status": child["status"],
+        "manifest": str(child_manifest_path.resolve()),
+        "covers": sorted(set(covers)),
+        "linked_at": timestamp,
+    }
+    links["runs"].append(link)
+    links["runs"].sort(key=lambda row: row["run_id"])
+    _write_json(output_dir / "linked-runs.json", links)
+    parent = add_artifact(
+        parent,
+        name=f"linked-run-{child['run_id']}",
+        kind="linked-run-manifest",
+        uri=str(child_manifest_path.resolve()),
+        updated_at=timestamp,
+    )
+    write_manifest(output_dir / "manifest.json", parent)
+    return link
+
+
+def finalize(
+    output_dir: Path, *, updated_at: str | None = None
+) -> dict[str, Any]:
+    run_state = _load_json(output_dir / "run.json", "run state")
+    if run_state.get("status") != "planned":
+        raise ChangeValidationError(f"run is already {run_state.get('status')}")
+    diff_summary = _load_json(output_dir / "diff-summary.json", "diff summary")
+    impact = _load_json(output_dir / "impact-analysis.json", "impact analysis")
+    plan = _load_json(output_dir / "validation-plan.json", "validation plan")
+    links = _load_json(output_dir / "linked-runs.json", "linked runs")
+    coverage: dict[str, list[Mapping[str, Any]]] = {}
+    for link in links["runs"]:
+        for item_id in link["covers"]:
+            coverage.setdefault(item_id, []).append(link)
+    required = [item for item in plan["items"] if item["priority"] == "required"]
+    missing = [item["id"] for item in required if not coverage.get(item["id"])]
+    child_statuses = {link["status"] for link in links["runs"]}
+    if "failed" in child_statuses:
+        status = "failed"
+    elif (
+        missing
+        or plan.get("manual_review_required")
+        or any(child_status != "passed" for child_status in child_statuses)
+    ):
+        status = "inconclusive"
+    else:
+        status = "passed"
+    for item in plan["items"]:
+        evidence = coverage.get(item["id"], [])
+        item["status"] = (
+            "passed"
+            if evidence and all(link["status"] == "passed" for link in evidence)
+            else "missing"
+            if not evidence
+            else "nonpassing"
+        )
+    _write_json(output_dir / "validation-plan.json", plan)
+    timestamp = updated_at or utc_now()
+    run_state["status"] = status
+    run_state["updated_at"] = timestamp
+    _write_json(output_dir / "run.json", run_state)
+    _atomic_write(
+        output_dir / "pr-validation-report.md",
+        render_report(
+            run_state=run_state,
+            diff_summary=diff_summary,
+            impact=impact,
+            plan=plan,
+            links=links,
+            final_status=status,
+        ),
+    )
+    manifest = load_manifest(output_dir / "manifest.json")
+    manifest = transition_status(manifest, "running", updated_at=timestamp)
+    manifest = transition_status(manifest, status, updated_at=timestamp)
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {
+        "status": status,
+        "run_id": run_state["run_id"],
+        "missing_required": missing,
+        "linked_runs": len(links["runs"]),
+        "report": str((output_dir / "pr-validation-report.md").resolve()),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+    plan_parser = subparsers.add_parser("plan", help="analyze a diff and create a plan")
+    plan_parser.add_argument("--output-dir", required=True, type=Path)
+    plan_parser.add_argument("--run-id", required=True)
+    plan_parser.add_argument("--baseline", required=True)
+    plan_parser.add_argument("--candidate", default="WORKTREE")
+    plan_parser.add_argument("--goal", default="")
+    plan_parser.add_argument("--target-repository", action="append", default=[])
+    source = plan_parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--diff-file", type=Path)
+    source.add_argument("--repo-root", type=Path)
+    plan_parser.add_argument(
+        "--knowledge",
+        type=Path,
+        default=DEFAULT_VALIDATION_RULES,
+    )
+
+    link_parser = subparsers.add_parser("link", help="link a downstream run")
+    link_parser.add_argument("--output-dir", required=True, type=Path)
+    link_parser.add_argument("--run-manifest", required=True, type=Path)
+    link_parser.add_argument("--covers", action="append", required=True)
+
+    finalize_parser = subparsers.add_parser("finalize", help="finalize coverage and report")
+    finalize_parser.add_argument("--output-dir", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.action == "plan":
+            emit_progress("collect-diff", baseline=args.baseline, candidate=args.candidate)
+            if args.diff_file is not None:
+                diff_text = args.diff_file.read_text(encoding="utf-8")
+            else:
+                diff_text = collect_git_diff(
+                    args.repo_root.resolve(),
+                    baseline=args.baseline,
+                    candidate=args.candidate,
+                )
+            payload = plan_change(
+                args.output_dir,
+                run_id=args.run_id,
+                baseline=args.baseline,
+                candidate=args.candidate,
+                goal=args.goal,
+                target_repositories=args.target_repository,
+                diff_text=diff_text,
+                knowledge_path=args.knowledge,
+            )
+        elif args.action == "link":
+            emit_progress("link-run", manifest=str(args.run_manifest))
+            link = link_run(
+                args.output_dir,
+                child_manifest_path=args.run_manifest,
+                covers=args.covers,
+            )
+            payload = {"status": "linked", "run": link}
+        else:
+            emit_progress("finalize", output_dir=str(args.output_dir))
+            payload = finalize(args.output_dir)
+    except (ChangeValidationError, RunManifestError, OSError) as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/vllm-ascend-change-validation/tests/test_change_validation.py
+++ b/.agents/skills/vllm-ascend-change-validation/tests/test_change_validation.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Tests for change impact planning and evidence aggregation."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+SKILL = ROOT / ".agents" / "skills" / "vllm-ascend-change-validation"
+KNOWLEDGE = SKILL / "references" / "validation-rules.yaml"
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_run_manifest import new_manifest, transition_status, write_manifest  # noqa: E402
+
+
+def load_module():
+    name = "_change_validation_test"
+    spec = importlib.util.spec_from_file_location(
+        name, SKILL / "scripts" / "change_validation.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+change_validation = load_module()
+NOW = "2026-07-25T12:00:00Z"
+
+
+def unified_diff(path: str, added: str = "changed") -> str:
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        "@@ -1 +1 @@\n"
+        "-old\n"
+        f"+{added}\n"
+    )
+
+
+class PlanningTests(unittest.TestCase):
+    def test_graph_change_requires_eager_and_graph(self) -> None:
+        knowledge = json.loads(KNOWLEDGE.read_text(encoding="utf-8"))
+        summary = change_validation.parse_diff(
+            unified_diff("vllm_ascend/graph/acl_graph.py")
+        )
+        impact, plan = change_validation.build_plan(summary, knowledge)
+        checks = {item["check"] for item in plan["items"]}
+        self.assertIn("correctness:eager", checks)
+        self.assertIn("correctness:graph", checks)
+        self.assertIn("graph", {row["category"] for row in impact["impacts"]})
+
+    def test_unknown_change_gets_required_fallback(self) -> None:
+        knowledge = json.loads(KNOWLEDGE.read_text(encoding="utf-8"))
+        summary = change_validation.parse_diff(unified_diff("docs/niche_note.md"))
+        _impact, plan = change_validation.build_plan(summary, knowledge)
+        self.assertTrue(plan["manual_review_required"])
+        self.assertEqual(plan["items"][0]["check"], "correctness:targeted-smoke")
+        self.assertEqual(plan["items"][0]["priority"], "required")
+
+    def test_duplicate_checks_merge_and_required_wins(self) -> None:
+        knowledge = {
+            "entries": [
+                {
+                    "id": "one",
+                    "status": "active",
+                    "rule": {
+                        "category": "a",
+                        "path_patterns": ["target"],
+                        "recommended_checks": ["correctness:smoke"],
+                    },
+                },
+                {
+                    "id": "two",
+                    "status": "active",
+                    "rule": {
+                        "category": "b",
+                        "path_patterns": ["target"],
+                        "required_checks": ["correctness:smoke"],
+                    },
+                },
+            ]
+        }
+        summary = change_validation.parse_diff(unified_diff("target.py"))
+        _impact, plan = change_validation.build_plan(summary, knowledge)
+        self.assertEqual(len(plan["items"]), 1)
+        self.assertEqual(plan["items"][0]["priority"], "required")
+        self.assertEqual(plan["items"][0]["sources"], ["one", "two"])
+
+    def test_path_keywords_in_changed_document_text_do_not_trigger(self) -> None:
+        knowledge = json.loads(KNOWLEDGE.read_text(encoding="utf-8"))
+        summary = change_validation.parse_diff(
+            unified_diff("docs/note.md", added="graph worker quantization scheduler")
+        )
+        impact, plan = change_validation.build_plan(summary, knowledge)
+        self.assertEqual(impact["impacts"], [])
+        self.assertTrue(plan["manual_review_required"])
+
+
+class AggregationTests(unittest.TestCase):
+    def test_passed_child_can_complete_required_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            output = root / "change"
+            change_validation.plan_change(
+                output,
+                run_id="change-validation-1",
+                baseline="base",
+                candidate="candidate",
+                goal="graph fix",
+                target_repositories=["vllm-ascend"],
+                diff_text=unified_diff("graph_mode.py"),
+                knowledge_path=KNOWLEDGE,
+                created_at=NOW,
+            )
+            plan = json.loads(
+                (output / "validation-plan.json").read_text(encoding="utf-8")
+            )
+            required_ids = [
+                item["id"] for item in plan["items"] if item["priority"] == "required"
+            ]
+            child_path = root / "child-manifest.json"
+            child = new_manifest(
+                run_type="correctness",
+                run_id="correctness-child-1",
+                parent_run_id="change-validation-1",
+                created_at=NOW,
+            )
+            child = transition_status(child, "running", updated_at=NOW)
+            child = transition_status(child, "passed", updated_at=NOW)
+            write_manifest(child_path, child)
+            change_validation.link_run(
+                output,
+                child_manifest_path=child_path,
+                covers=required_ids,
+                updated_at=NOW,
+            )
+            result = change_validation.finalize(output, updated_at=NOW)
+            self.assertEqual(result["status"], "passed")
+            report = (output / "pr-validation-report.md").read_text(encoding="utf-8")
+            self.assertIn("correctness-child-1", report)
+
+    def test_missing_required_evidence_is_inconclusive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "change"
+            change_validation.plan_change(
+                output,
+                run_id="change-validation-2",
+                baseline="base",
+                candidate="candidate",
+                goal="graph fix",
+                target_repositories=["vllm-ascend"],
+                diff_text=unified_diff("graph_mode.py"),
+                knowledge_path=KNOWLEDGE,
+                created_at=NOW,
+            )
+            result = change_validation.finalize(output, updated_at=NOW)
+            self.assertEqual(result["status"], "inconclusive")
+            self.assertTrue(result["missing_required"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/vllm-ascend-correctness-validation/SKILL.md
+++ b/.agents/skills/vllm-ascend-correctness-validation/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: vllm-ascend-correctness-validation
+description: Plan, execute, normalize, and compare vLLM Ascend inference correctness across baseline and candidate code states, eager and graph modes, offline generate or chat, online chat completions, and AISBench task metrics. Use for accuracy validation, token-output comparison, graph-versus-eager checks, deterministic regression testing, or failure classification. Do not use to root-cause an already reproduced graph-only or isolated-operator failure, or for throughput benchmarking, HBM attribution, or profiling-only analysis.
+---
+
+# vLLM Ascend Correctness Validation
+
+Produce traceable correctness evidence instead of treating a successful request as proof of correctness.
+
+## Workflow
+
+1. Define cases and the smallest affected validation matrix.
+2. Create independent baseline and candidate code states or eager and graph states.
+3. Before remote execution, use `remote-code-parity` for each state.
+4. For offline cases, run `scripts/remote_correctness_harness.py` inside the remote NPU container. The harness prioritizes the materialized `vllm/` and `vllm-ascend/` source roots and propagates them through `PYTHONPATH`, so launching from `/vllm-workspace` or spawning a `python -m` child cannot resolve the outer repository directory as a false `vllm` namespace package.
+5. For online cases, use `vllm-ascend-serving`, then run the same harness in `online-chat` mode.
+6. Use `scripts/correctness_run.py init` to create the run directory and Run Manifest v1.
+7. Use `scripts/correctness_run.py compare` to normalize the evidence into a classification and report.
+8. Route failures:
+   - eager pass and graph fail: `vllm-ascend-graph-debug`;
+   - multi-rank hang or inconsistent rank metadata: `vllm-ascend-distributed-debug` when available;
+   - performance-only change: `vllm-ascend-performance-regression` when available;
+   - task metric execution: use the bundled AISBench adapter.
+
+Do not run the full execution-mode, parallelism, and feature Cartesian product. Select cases from the code impact and `.agents/knowledge/validation-rules.yaml`; record omitted combinations as risks.
+
+## Determinism
+
+For exact token or text comparison:
+
+- set `temperature=0`;
+- set an explicit seed;
+- keep prompts, messages, chat template, max tokens, model weights, tokenizer, parallel topology, and feature flags identical;
+- repeat each case at least twice when nondeterminism is suspected;
+- never compare baseline and candidate results produced from different case files.
+
+Use task-level metrics when exact output is not an appropriate acceptance condition. Use numeric tolerances only for explicitly captured logits, hidden states, KV samples, or other numeric evidence.
+
+## Result classes
+
+The comparator emits exactly one primary class per case:
+
+- `exact_match`
+- `token_divergence`
+- `numerical_difference_within_tolerance`
+- `numerical_regression`
+- `task_metric_regression`
+- `flaky_or_nondeterministic`
+- `infrastructure_failure`
+- `unsupported_combination`
+
+Do not relabel infrastructure failures as correctness regressions. Do not treat unsupported or untested combinations as passing.
+
+## Structured entry points
+
+- `scripts/correctness_run.py`: initialize a run, compare normalized baseline and candidate outputs, write `comparison.json`, `report.md`, `reproduction.sh`, and update Run Manifest v1.
+- `scripts/remote_correctness_harness.py`: execute offline generate, offline chat, or online chat cases and write the normalized result contract.
+- `scripts/aisbench_adapter.py`: prepare an AISBench accuracy command/config and normalize task metrics into the correctness result contract.
+
+Read as needed:
+
+- [Behavior contract](references/behavior.md) for case, result, comparison, and artifact schemas.
+- [Command recipes](references/command-recipes.md) for local control-plane and remote harness examples.
+- [AISBench adapter](references/aisbench.md) before preparing or importing AISBench results.
+- [Acceptance](references/acceptance.md) before marking a run passed.
+
+## Boundaries
+
+- Keep runtime state under `.vaws-local/correctness/`.
+- Keep progress on stderr and the final machine-readable payload on stdout.
+- Never put passwords, tokens, API keys, or credentials in configs or manifests.
+- Run torch and torch_npu code only in the remote Ascend container.
+- Treat the normalized output file, not mixed runtime stdout, as the comparison source.

--- a/.agents/skills/vllm-ascend-correctness-validation/agents/openai.yaml
+++ b/.agents/skills/vllm-ascend-correctness-validation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "vLLM Ascend Correctness Validation"
+  short_description: "Compare Ascend inference correctness across revisions"
+  default_prompt: "Use $vllm-ascend-correctness-validation to plan and compare baseline and candidate correctness results."

--- a/.agents/skills/vllm-ascend-correctness-validation/references/acceptance.md
+++ b/.agents/skills/vllm-ascend-correctness-validation/references/acceptance.md
@@ -1,0 +1,32 @@
+# Correctness validation acceptance
+
+## Reproducibility
+
+- [ ] Baseline and candidate use the same case document.
+- [ ] Workspace snapshots, environment, model, weights, tokenizer, topology, and feature flags are recorded.
+- [ ] Exact-comparison cases use `temperature=0` and an explicit seed.
+- [ ] Commands or equivalent executor configurations are recorded.
+
+## Execution
+
+- [ ] Code parity was established immediately before each remote execution.
+- [ ] Offline or online executor produced a normalized result file.
+- [ ] Offline execution and its Python subprocesses resolve the materialized packages rather than the outer `vllm/` repository namespace.
+- [ ] Service health was confirmed before online cases.
+- [ ] Repeated outputs are stable or the case is classified flaky.
+- [ ] Infrastructure and unsupported failures are not counted as product regressions.
+
+## Comparison
+
+- [ ] Every planned case has baseline and candidate evidence.
+- [ ] Token or text comparison is used where exactness is meaningful.
+- [ ] Numeric tolerances are explicit and justified.
+- [ ] Task metric direction and regression thresholds are explicit.
+- [ ] Eager/graph divergence routes to graph debug.
+
+## Delivery
+
+- [ ] `manifest.json`, `cases.json`, `comparison.json`, `report.md`, raw outputs, and `reproduction.sh` exist.
+- [ ] Run Manifest v1 validates and links every delivered artifact.
+- [ ] The report lists unsupported and untested combinations.
+- [ ] A passed run contains only exact or within-tolerance cases.

--- a/.agents/skills/vllm-ascend-correctness-validation/references/aisbench.md
+++ b/.agents/skills/vllm-ascend-correctness-validation/references/aisbench.md
@@ -1,0 +1,62 @@
+# AISBench adapter
+
+## Purpose
+
+Use AISBench as a task-metric backend inside correctness validation. Do not make AISBench the source of run identity, environment truth, or pass/fail policy.
+
+The adapter:
+
+- generates an isolated custom `VLLMCustomAPIChat` model config;
+- uses AISBench `--config-dir` without modifying the `benchmark` submodule;
+- fixes `temperature=0` and an explicit seed;
+- generates a reusable case file with metric direction and regression thresholds;
+- converts `summary_*.csv` rows into the normalized correctness result contract.
+
+## Prepare
+
+```bash
+python -B .agents/skills/vllm-ascend-correctness-validation/scripts/aisbench_adapter.py prepare \
+  --output-dir .vaws-local/correctness/aisbench-baseline \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --served-model example \
+  --dataset gsm8k_gen_4_shot_cot_str \
+  --work-dir /remote/output/aisbench-baseline \
+  --metric accuracy \
+  --direction higher \
+  --max-absolute-regression 0.5 \
+  --max-relative-regression 0.01
+```
+
+The output contains:
+
+```text
+output-dir/
+├── configs/models/vaws_correctness.py
+├── aisbench-cases.json
+├── command.json
+└── run.sh
+```
+
+Run `run.sh` only where AISBench is installed and the target service is reachable.
+
+## Normalize
+
+Select the exact `summary_*.csv` produced by the run:
+
+```bash
+python -B .agents/skills/vllm-ascend-correctness-validation/scripts/aisbench_adapter.py normalize \
+  --summary-csv /remote/output/summary/summary_20260725_120000.csv \
+  --label baseline \
+  --output /remote/output/baseline-normalized.json
+```
+
+Repeat with the candidate summary. Compare both normalized files with the same `aisbench-cases.json`.
+
+## Metric scale
+
+AISBench summaries may report percentages such as `56.70` rather than fractions such as `0.567`. Set absolute thresholds in the same scale as the selected summary. Do not silently rescale metrics.
+
+## Secrets
+
+The generated model config leaves `api_key` empty. If a service requires authentication, arrange it outside tracked configs and extend the remote runtime deliberately; never write a live key into the adapter inputs or artifacts.

--- a/.agents/skills/vllm-ascend-correctness-validation/references/behavior.md
+++ b/.agents/skills/vllm-ascend-correctness-validation/references/behavior.md
@@ -1,0 +1,128 @@
+# Correctness validation behavior contract
+
+## Contents
+
+- [Case document](#case-document)
+- [Normalized result](#normalized-result)
+- [Comparison precedence](#comparison-precedence)
+- [Run artifacts](#run-artifacts)
+- [Routing](#routing)
+
+## Case document
+
+Use one JSON document for both baseline and candidate:
+
+```json
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "id": "chat-smoke",
+      "mode": "online-chat",
+      "repeats": 2,
+      "sampling": {
+        "temperature": 0,
+        "seed": 7,
+        "max_tokens": 32
+      },
+      "request": {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Return the word ready."
+          }
+        ]
+      },
+      "comparison": {
+        "atol": 0.00001,
+        "rtol": 0.0001,
+        "metric_rules": {}
+      },
+      "matrix": {
+        "execution_mode": "eager",
+        "tp": 2,
+        "features": []
+      }
+    }
+  ]
+}
+```
+
+Valid modes are `offline-generate`, `offline-chat`, `online-chat`, and `aisbench`. Non-AISBench exact-comparison cases require `temperature=0` and an explicit seed.
+
+## Normalized result
+
+Each state writes:
+
+```json
+{
+  "schema_version": 1,
+  "label": "baseline",
+  "cases": [
+    {
+      "id": "chat-smoke",
+      "status": "ok",
+      "outputs": [
+        {
+          "text": "ready",
+          "token_ids": [1234],
+          "tokens": ["ready"],
+          "numerics": {
+            "logprobs": [-0.01]
+          }
+        }
+      ],
+      "metrics": {
+        "accuracy": 0.75
+      }
+    }
+  ]
+}
+```
+
+`status` is `ok`, `error`, or `unsupported`. An executor may provide text, token IDs, token strings, numeric evidence, task metrics, or a relevant subset.
+
+## Comparison precedence
+
+Primary classification precedence is:
+
+1. missing or errored result → `infrastructure_failure`;
+2. unsupported state → `unsupported_combination`;
+3. repeats disagree → `flaky_or_nondeterministic`;
+4. configured metric exceeds its regression threshold → `task_metric_regression`;
+5. comparable token IDs, tokens, or text disagree → `token_divergence`;
+6. numeric evidence exceeds tolerance → `numerical_regression`;
+7. numeric evidence differs within tolerance → `numerical_difference_within_tolerance`;
+8. otherwise → `exact_match`.
+
+Run status:
+
+- `passed`: every case is exact or within tolerance;
+- `failed`: at least one correctness or task-metric regression and no inconclusive case;
+- `inconclusive`: any infrastructure, unsupported, or flaky case.
+
+## Run artifacts
+
+```text
+correctness-run/
+├── manifest.json
+├── run.json
+├── cases.json
+├── environment.json
+├── raw_outputs/
+│   ├── baseline.json
+│   └── candidate.json
+├── comparison.json
+├── report.md
+└── reproduction.sh
+```
+
+The normalized files are the comparison source. Mixed service or vLLM stdout is supporting evidence, not a parser contract.
+
+## Routing
+
+- eager passes, graph fails: route to `vllm-ascend-graph-debug`;
+- multi-rank hang or metadata mismatch: route to distributed debug;
+- output is correct but slower: route to performance regression;
+- executor cannot start or reach a service: repair infrastructure and rerun the identical case;
+- missing compatibility fact: report unsupported or unknown, never pass.

--- a/.agents/skills/vllm-ascend-correctness-validation/references/command-recipes.md
+++ b/.agents/skills/vllm-ascend-correctness-validation/references/command-recipes.md
@@ -1,0 +1,64 @@
+# Correctness validation command recipes
+
+Run control-plane commands from the workspace root. Run the offline harness only inside a remote Ascend container.
+
+## Initialize
+
+```bash
+python -B .agents/skills/vllm-ascend-correctness-validation/scripts/correctness_run.py init \
+  --run-dir .vaws-local/correctness/change-001 \
+  --run-id correctness-change-001 \
+  --cases /path/to/cases.json \
+  --baseline-label baseline \
+  --candidate-label candidate \
+  --workspace-snapshot '{"workspace":"<snapshot>","dirty":false}' \
+  --environment '{"machine":"<alias>","cann":"<version>","torch_npu":"<version>"}' \
+  --model '{"path":"<remote-model-path>"}' \
+  --topology '{"tp":2,"devices":[0,1]}'
+```
+
+## Execute normalized cases
+
+Remote offline:
+
+```bash
+python -B .agents/skills/vllm-ascend-correctness-validation/scripts/remote_correctness_harness.py \
+  --config /remote/path/baseline-harness.json \
+  --output /remote/path/baseline-result.json
+```
+
+Online, after `vllm-ascend-serving` reports healthy:
+
+```bash
+python -B .agents/skills/vllm-ascend-correctness-validation/scripts/remote_correctness_harness.py \
+  --config /remote/path/candidate-online-harness.json \
+  --output /remote/path/candidate-result.json
+```
+
+Harness config includes the case array plus:
+
+```json
+{
+  "schema_version": 1,
+  "label": "candidate",
+  "model": "/models/example",
+  "engine_args": {
+    "tensor_parallel_size": 2,
+    "enforce_eager": true
+  },
+  "base_url": "http://127.0.0.1:8000",
+  "served_model": "example",
+  "cases": []
+}
+```
+
+## Compare
+
+```bash
+python -B .agents/skills/vllm-ascend-correctness-validation/scripts/correctness_run.py compare \
+  --run-dir .vaws-local/correctness/change-001 \
+  --baseline /path/to/baseline-result.json \
+  --candidate /path/to/candidate-result.json
+```
+
+Read the compact stdout first, then inspect `report.md` and only the relevant raw evidence.

--- a/.agents/skills/vllm-ascend-correctness-validation/scripts/aisbench_adapter.py
+++ b/.agents/skills/vllm-ascend-correctness-validation/scripts/aisbench_adapter.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Prepare AISBench accuracy runs and normalize summary CSV metrics."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import shlex
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+SCHEMA_VERSION = 1
+SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$")
+MODEL_TASK = "vaws_correctness"
+MODEL_ABBR = "vaws-correctness"
+
+
+class AisbenchAdapterError(ValueError):
+    """Raised when AISBench preparation or normalization is invalid."""
+
+
+def emit_progress(phase: str, **details: Any) -> None:
+    print(json.dumps({"phase": phase, **details}, ensure_ascii=False), file=sys.stderr)
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    if not slug:
+        raise AisbenchAdapterError(f"cannot create safe case id from {value!r}")
+    return slug[:96]
+
+
+def _validate_prepare(
+    *,
+    host: str,
+    port: int,
+    served_model: str,
+    datasets: Sequence[str],
+    metric: str,
+    max_out_len: int,
+    batch_size: int,
+    num_prompts: int | None,
+) -> None:
+    if not host.strip() or any(character.isspace() for character in host):
+        raise AisbenchAdapterError("host must be a non-empty address without whitespace")
+    if not 1 <= port <= 65535:
+        raise AisbenchAdapterError("port must be between 1 and 65535")
+    if not served_model.strip():
+        raise AisbenchAdapterError("served-model must be non-empty")
+    if not datasets:
+        raise AisbenchAdapterError("at least one dataset is required")
+    for dataset in datasets:
+        if not SAFE_NAME_RE.fullmatch(dataset):
+            raise AisbenchAdapterError(f"invalid dataset name: {dataset!r}")
+    if not SAFE_NAME_RE.fullmatch(metric):
+        raise AisbenchAdapterError(f"invalid metric name: {metric!r}")
+    if max_out_len < 1 or batch_size < 1:
+        raise AisbenchAdapterError("max-out-len and batch-size must be positive")
+    if num_prompts is not None and num_prompts < 1:
+        raise AisbenchAdapterError("num-prompts must be positive")
+
+
+def render_model_config(
+    *,
+    host: str,
+    port: int,
+    served_model: str,
+    max_out_len: int,
+    batch_size: int,
+    temperature: float,
+    seed: int,
+) -> str:
+    return f'''from ais_bench.benchmark.models import VLLMCustomAPIChat
+from ais_bench.benchmark.utils.postprocess.model_postprocessors import extract_non_reasoning_content
+
+models = [
+    dict(
+        attr="service",
+        type=VLLMCustomAPIChat,
+        abbr={MODEL_ABBR!r},
+        path="",
+        model={served_model!r},
+        stream=False,
+        request_rate=0,
+        use_timestamp=False,
+        retry=2,
+        api_key="",
+        host_ip={host!r},
+        host_port={port},
+        url="",
+        max_out_len={max_out_len},
+        batch_size={batch_size},
+        trust_remote_code=False,
+        generation_kwargs=dict(
+            temperature={temperature!r},
+            seed={seed},
+            ignore_eos=False,
+        ),
+        pred_postprocessor=dict(type=extract_non_reasoning_content),
+    )
+]
+'''
+
+
+def prepare(
+    output_dir: Path,
+    *,
+    host: str,
+    port: int,
+    served_model: str,
+    datasets: Sequence[str],
+    work_dir: Path,
+    metric: str,
+    direction: str,
+    max_absolute_regression: float,
+    max_relative_regression: float,
+    max_out_len: int,
+    batch_size: int,
+    temperature: float,
+    seed: int,
+    num_prompts: int | None,
+) -> dict[str, Any]:
+    _validate_prepare(
+        host=host,
+        port=port,
+        served_model=served_model,
+        datasets=datasets,
+        metric=metric,
+        max_out_len=max_out_len,
+        batch_size=batch_size,
+        num_prompts=num_prompts,
+    )
+    if direction not in {"higher", "lower"}:
+        raise AisbenchAdapterError("direction must be higher or lower")
+    if max_absolute_regression < 0 or max_relative_regression < 0:
+        raise AisbenchAdapterError("regression thresholds must be non-negative")
+    if temperature != 0:
+        raise AisbenchAdapterError("temperature must be 0 for deterministic accuracy runs")
+
+    model_config = output_dir / "configs" / "models" / f"{MODEL_TASK}.py"
+    _atomic_write(
+        model_config,
+        render_model_config(
+            host=host,
+            port=port,
+            served_model=served_model,
+            max_out_len=max_out_len,
+            batch_size=batch_size,
+            temperature=temperature,
+            seed=seed,
+        ),
+    )
+    command = [
+        "ais_bench",
+        "--config-dir",
+        str((output_dir / "configs").resolve()),
+        "--models",
+        MODEL_TASK,
+        "--datasets",
+        *datasets,
+        "--work-dir",
+        str(work_dir),
+        "--dump-eval-details",
+        "--num-warmups",
+        "0",
+    ]
+    if num_prompts is not None:
+        command.extend(["--num-prompts", str(num_prompts)])
+    cases = {
+        "schema_version": SCHEMA_VERSION,
+        "cases": [
+            {
+                "id": f"aisbench-{_slug(dataset)}-{_slug(metric)}",
+                "mode": "aisbench",
+                "repeats": 1,
+                "sampling": {},
+                "request": {},
+                "comparison": {
+                    "metric_rules": {
+                        metric: {
+                            "direction": direction,
+                            "max_absolute_regression": max_absolute_regression,
+                            "max_relative_regression": max_relative_regression,
+                        }
+                    }
+                },
+                "matrix": {"dataset": dataset, "model_task": MODEL_TASK},
+            }
+            for dataset in datasets
+        ],
+    }
+    _atomic_write(
+        output_dir / "command.json",
+        json.dumps({"command": command}, ensure_ascii=False, indent=2) + "\n",
+    )
+    _atomic_write(
+        output_dir / "run.sh",
+        "#!/usr/bin/env bash\nset -euo pipefail\n" + shlex.join(command) + "\n",
+    )
+    _atomic_write(
+        output_dir / "aisbench-cases.json",
+        json.dumps(cases, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    )
+    return {
+        "status": "prepared",
+        "model_config": str(model_config.resolve()),
+        "command": command,
+        "cases": str((output_dir / "aisbench-cases.json").resolve()),
+    }
+
+
+def normalize_summary(
+    summary_csv: Path,
+    *,
+    label: str,
+    model_column: str = MODEL_ABBR,
+) -> dict[str, Any]:
+    try:
+        stream = summary_csv.open("r", encoding="utf-8-sig", newline="")
+    except OSError as exc:
+        raise AisbenchAdapterError(f"cannot read summary CSV {summary_csv}: {exc}") from exc
+    with stream:
+        reader = csv.DictReader(stream)
+        required = {"dataset", "metric", model_column}
+        missing = required - set(reader.fieldnames or [])
+        if missing:
+            raise AisbenchAdapterError(
+                f"summary CSV is missing columns: {', '.join(sorted(missing))}"
+            )
+        cases: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for row_number, row in enumerate(reader, start=2):
+            dataset = (row.get("dataset") or "").strip()
+            metric = (row.get("metric") or "").strip()
+            case_id = f"aisbench-{_slug(dataset)}-{_slug(metric)}"
+            if case_id in seen:
+                raise AisbenchAdapterError(
+                    f"{summary_csv}:{row_number}: duplicate dataset/metric row"
+                )
+            seen.add(case_id)
+            raw_value = (row.get(model_column) or "").strip()
+            try:
+                metric_value = float(raw_value)
+            except ValueError:
+                cases.append(
+                    {
+                        "id": case_id,
+                        "status": "error",
+                        "error": f"non-numeric AISBench metric: {raw_value!r}",
+                        "outputs": [],
+                        "metrics": {},
+                        "source": {
+                            "dataset": dataset,
+                            "metric": metric,
+                            "row": row_number,
+                        },
+                    }
+                )
+            else:
+                cases.append(
+                    {
+                        "id": case_id,
+                        "status": "ok",
+                        "outputs": [],
+                        "metrics": {metric: metric_value},
+                        "source": {
+                            "dataset": dataset,
+                            "metric": metric,
+                            "row": row_number,
+                        },
+                    }
+                )
+    if not cases:
+        raise AisbenchAdapterError("summary CSV contains no metric rows")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "label": label,
+        "adapter": {
+            "name": "aisbench",
+            "summary_csv": str(summary_csv.resolve()),
+            "model_column": model_column,
+        },
+        "cases": cases,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+    prepare_parser = subparsers.add_parser("prepare", help="prepare an AISBench run")
+    prepare_parser.add_argument("--output-dir", required=True, type=Path)
+    prepare_parser.add_argument("--host", required=True)
+    prepare_parser.add_argument("--port", required=True, type=int)
+    prepare_parser.add_argument("--served-model", required=True)
+    prepare_parser.add_argument("--dataset", action="append", required=True)
+    prepare_parser.add_argument("--work-dir", required=True, type=Path)
+    prepare_parser.add_argument("--metric", default="accuracy")
+    prepare_parser.add_argument("--direction", choices=("higher", "lower"), default="higher")
+    prepare_parser.add_argument("--max-absolute-regression", type=float, default=0.0)
+    prepare_parser.add_argument("--max-relative-regression", type=float, default=0.0)
+    prepare_parser.add_argument("--max-out-len", type=int, default=512)
+    prepare_parser.add_argument("--batch-size", type=int, default=1)
+    prepare_parser.add_argument("--temperature", type=float, default=0.0)
+    prepare_parser.add_argument("--seed", type=int, default=1)
+    prepare_parser.add_argument("--num-prompts", type=int)
+
+    normalize = subparsers.add_parser("normalize", help="normalize AISBench summary CSV")
+    normalize.add_argument("--summary-csv", required=True, type=Path)
+    normalize.add_argument("--label", required=True)
+    normalize.add_argument("--model-column", default=MODEL_ABBR)
+    normalize.add_argument("--output", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.action == "prepare":
+            emit_progress("prepare-aisbench", output_dir=str(args.output_dir))
+            payload = prepare(
+                args.output_dir,
+                host=args.host,
+                port=args.port,
+                served_model=args.served_model,
+                datasets=args.dataset,
+                work_dir=args.work_dir,
+                metric=args.metric,
+                direction=args.direction,
+                max_absolute_regression=args.max_absolute_regression,
+                max_relative_regression=args.max_relative_regression,
+                max_out_len=args.max_out_len,
+                batch_size=args.batch_size,
+                temperature=args.temperature,
+                seed=args.seed,
+                num_prompts=args.num_prompts,
+            )
+        else:
+            emit_progress("normalize-aisbench", summary=str(args.summary_csv))
+            normalized = normalize_summary(
+                args.summary_csv,
+                label=args.label,
+                model_column=args.model_column,
+            )
+            _atomic_write(
+                args.output,
+                json.dumps(normalized, ensure_ascii=False, indent=2, sort_keys=True)
+                + "\n",
+            )
+            payload = {
+                "status": "normalized",
+                "output": str(args.output.resolve()),
+                "case_count": len(normalized["cases"]),
+                "error_count": sum(
+                    case["status"] == "error" for case in normalized["cases"]
+                ),
+            }
+    except AisbenchAdapterError as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/vllm-ascend-correctness-validation/scripts/correctness_run.py
+++ b/.agents/skills/vllm-ascend-correctness-validation/scripts/correctness_run.py
@@ -1,0 +1,686 @@
+#!/usr/bin/env python3
+"""Create and compare normalized vLLM Ascend correctness runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import shlex
+import shutil
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_run_manifest import (  # noqa: E402
+    RunManifestError,
+    add_artifact,
+    load_manifest,
+    new_manifest,
+    transition_status,
+    write_manifest,
+)
+
+SCHEMA_VERSION = 1
+SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+CASE_MODES = frozenset({"offline-generate", "offline-chat", "online-chat", "aisbench"})
+RESULT_STATUSES = frozenset({"ok", "error", "unsupported"})
+PASS_CLASSES = frozenset({"exact_match", "numerical_difference_within_tolerance"})
+FAIL_CLASSES = frozenset(
+    {"token_divergence", "numerical_regression", "task_metric_regression"}
+)
+INCONCLUSIVE_CLASSES = frozenset(
+    {"flaky_or_nondeterministic", "infrastructure_failure", "unsupported_combination"}
+)
+CLASS_PRIORITY = {
+    "infrastructure_failure": 0,
+    "unsupported_combination": 1,
+    "flaky_or_nondeterministic": 2,
+    "task_metric_regression": 3,
+    "token_divergence": 4,
+    "numerical_regression": 5,
+    "numerical_difference_within_tolerance": 6,
+    "exact_match": 7,
+}
+
+
+class CorrectnessError(ValueError):
+    """Raised when correctness input or state is invalid."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def emit_progress(phase: str, **details: Any) -> None:
+    print(json.dumps({"phase": phase, **details}, ensure_ascii=False), file=sys.stderr)
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    _atomic_write_text(
+        path, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CorrectnessError(f"cannot read {label} {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise CorrectnessError(f"{label} root must be an object")
+    return payload
+
+
+def validate_cases_document(document: Mapping[str, Any]) -> None:
+    errors: list[str] = []
+    if document.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    cases = document.get("cases")
+    if not isinstance(cases, list) or not cases:
+        errors.append("cases must be a non-empty array")
+        cases = []
+    seen: set[str] = set()
+    for index, case in enumerate(cases):
+        prefix = f"cases[{index}]"
+        if not isinstance(case, Mapping):
+            errors.append(f"{prefix} must be an object")
+            continue
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not SAFE_ID_RE.fullmatch(case_id):
+            errors.append(f"{prefix}.id must be a lowercase safe identifier")
+        elif case_id in seen:
+            errors.append(f"{prefix}.id is duplicated: {case_id}")
+        else:
+            seen.add(case_id)
+        mode = case.get("mode")
+        if mode not in CASE_MODES:
+            errors.append(f"{prefix}.mode must be one of: {', '.join(sorted(CASE_MODES))}")
+        repeats = case.get("repeats", 1)
+        if not isinstance(repeats, int) or isinstance(repeats, bool) or repeats < 1:
+            errors.append(f"{prefix}.repeats must be a positive integer")
+        sampling = case.get("sampling", {})
+        if not isinstance(sampling, Mapping):
+            errors.append(f"{prefix}.sampling must be an object")
+        elif mode != "aisbench":
+            if sampling.get("temperature", 0) != 0:
+                errors.append(f"{prefix}.sampling.temperature must be 0 for exact comparison")
+            if "seed" not in sampling:
+                errors.append(f"{prefix}.sampling.seed is required")
+        request = case.get("request")
+        if mode != "aisbench" and not isinstance(request, Mapping):
+            errors.append(f"{prefix}.request must be an object")
+        comparison = case.get("comparison", {})
+        if not isinstance(comparison, Mapping):
+            errors.append(f"{prefix}.comparison must be an object")
+    if errors:
+        raise CorrectnessError("; ".join(errors))
+
+
+def validate_result_document(document: Mapping[str, Any], *, label: str) -> None:
+    errors: list[str] = []
+    if document.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"{label}.schema_version must be {SCHEMA_VERSION}")
+    cases = document.get("cases")
+    if not isinstance(cases, list):
+        errors.append(f"{label}.cases must be an array")
+        cases = []
+    seen: set[str] = set()
+    for index, case in enumerate(cases):
+        prefix = f"{label}.cases[{index}]"
+        if not isinstance(case, Mapping):
+            errors.append(f"{prefix} must be an object")
+            continue
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not SAFE_ID_RE.fullmatch(case_id):
+            errors.append(f"{prefix}.id must be a lowercase safe identifier")
+        elif case_id in seen:
+            errors.append(f"{prefix}.id is duplicated")
+        else:
+            seen.add(case_id)
+        if case.get("status") not in RESULT_STATUSES:
+            errors.append(
+                f"{prefix}.status must be one of: {', '.join(sorted(RESULT_STATUSES))}"
+            )
+        outputs = case.get("outputs", [])
+        if not isinstance(outputs, list):
+            errors.append(f"{prefix}.outputs must be an array")
+        if not isinstance(case.get("metrics", {}), Mapping):
+            errors.append(f"{prefix}.metrics must be an object")
+    if errors:
+        raise CorrectnessError("; ".join(errors))
+
+
+def init_run(
+    run_dir: Path,
+    *,
+    run_id: str,
+    cases_path: Path,
+    baseline_label: str,
+    candidate_label: str,
+    workspace_snapshot: Mapping[str, Any] | None = None,
+    environment: Mapping[str, Any] | None = None,
+    model: Mapping[str, Any] | None = None,
+    topology: Mapping[str, Any] | None = None,
+    baseline_command: Sequence[str] | None = None,
+    candidate_command: Sequence[str] | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise CorrectnessError(f"run directory is not empty: {run_dir}")
+    cases_document = _load_json(cases_path, "cases file")
+    validate_cases_document(cases_document)
+    timestamp = created_at or utc_now()
+    run_dir.mkdir(parents=True, exist_ok=True)
+    copied_cases = run_dir / "cases.json"
+    _atomic_write_json(copied_cases, cases_document)
+    _atomic_write_json(run_dir / "environment.json", dict(environment or {}))
+    run_state = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "baseline_label": baseline_label,
+        "candidate_label": candidate_label,
+        "baseline_command": list(baseline_command or []),
+        "candidate_command": list(candidate_command or []),
+        "status": "planned",
+        "created_at": timestamp,
+        "updated_at": timestamp,
+    }
+    _atomic_write_json(run_dir / "run.json", run_state)
+    reproduction = (
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n\n"
+        f"# Baseline: {baseline_label}\n"
+        f"{shlex.join(baseline_command) if baseline_command else '# command not recorded'}\n\n"
+        f"# Candidate: {candidate_label}\n"
+        f"{shlex.join(candidate_command) if candidate_command else '# command not recorded'}\n"
+    )
+    _atomic_write_text(run_dir / "reproduction.sh", reproduction)
+    manifest = new_manifest(
+        run_type="correctness",
+        run_id=run_id,
+        workspace_snapshot=workspace_snapshot,
+        environment=environment,
+        model=model,
+        topology=topology,
+        command=list(candidate_command or []),
+        created_at=timestamp,
+    )
+    for name, kind, uri in (
+        ("cases", "validation-cases", "cases.json"),
+        ("environment", "environment", "environment.json"),
+        ("reproduction", "reproduction", "reproduction.sh"),
+    ):
+        manifest = add_artifact(
+            manifest, name=name, kind=kind, uri=uri, updated_at=timestamp
+        )
+    write_manifest(run_dir / "manifest.json", manifest)
+    return run_state
+
+
+def _flatten_numbers(value: Any, *, label: str) -> list[float]:
+    if isinstance(value, bool):
+        raise CorrectnessError(f"{label} contains a boolean")
+    if isinstance(value, (int, float)):
+        return [float(value)]
+    if isinstance(value, list):
+        result: list[float] = []
+        for index, item in enumerate(value):
+            result.extend(_flatten_numbers(item, label=f"{label}[{index}]"))
+        return result
+    raise CorrectnessError(f"{label} must contain numbers or nested arrays")
+
+
+def _close(left: float, right: float, *, atol: float, rtol: float) -> bool:
+    if math.isnan(left) or math.isnan(right):
+        return math.isnan(left) and math.isnan(right)
+    if math.isinf(left) or math.isinf(right):
+        return left == right
+    return math.isclose(left, right, abs_tol=atol, rel_tol=rtol)
+
+
+def _output_signature(output: Mapping[str, Any]) -> tuple[str, Any] | None:
+    for field in ("token_ids", "tokens", "text"):
+        if field in output:
+            value = output[field]
+            if isinstance(value, list):
+                return field, tuple(value)
+            if isinstance(value, str):
+                return field, value
+    return None
+
+
+def _is_stable(outputs: list[Any]) -> bool:
+    if len(outputs) <= 1:
+        return True
+    signatures: list[tuple[str, Any] | None] = []
+    for output in outputs:
+        if not isinstance(output, Mapping):
+            return False
+        signatures.append(_output_signature(output))
+    return signatures[0] is not None and all(
+        signature == signatures[0] for signature in signatures[1:]
+    )
+
+
+def _compare_metrics(
+    baseline: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    rules: Mapping[str, Any],
+) -> tuple[list[dict[str, Any]], bool]:
+    regressions: list[dict[str, Any]] = []
+    changed = False
+    for name, raw_rule in sorted(rules.items()):
+        if not isinstance(raw_rule, Mapping):
+            raise CorrectnessError(f"metric rule {name!r} must be an object")
+        if name not in baseline or name not in candidate:
+            regressions.append({"metric": name, "reason": "missing"})
+            continue
+        left = float(baseline[name])
+        right = float(candidate[name])
+        changed = changed or left != right
+        direction = raw_rule.get("direction", "higher")
+        if direction not in {"higher", "lower"}:
+            raise CorrectnessError(f"metric rule {name!r} has invalid direction")
+        degradation = left - right if direction == "higher" else right - left
+        relative = degradation / abs(left) if left != 0 else (
+            math.inf if degradation > 0 else 0.0
+        )
+        max_absolute = float(raw_rule.get("max_absolute_regression", 0.0))
+        max_relative = float(raw_rule.get("max_relative_regression", 0.0))
+        if degradation > max_absolute or relative > max_relative:
+            regressions.append(
+                {
+                    "metric": name,
+                    "baseline": left,
+                    "candidate": right,
+                    "absolute_regression": degradation,
+                    "relative_regression": relative,
+                    "allowed_absolute": max_absolute,
+                    "allowed_relative": max_relative,
+                }
+            )
+    return regressions, changed
+
+
+def compare_case(
+    case_config: Mapping[str, Any],
+    baseline: Mapping[str, Any] | None,
+    candidate: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    case_id = case_config["id"]
+    if baseline is None or candidate is None:
+        return {
+            "id": case_id,
+            "classification": "infrastructure_failure",
+            "details": {"reason": "case result missing from baseline or candidate"},
+        }
+    statuses = {baseline.get("status"), candidate.get("status")}
+    if "error" in statuses:
+        return {
+            "id": case_id,
+            "classification": "infrastructure_failure",
+            "details": {
+                "baseline_error": baseline.get("error"),
+                "candidate_error": candidate.get("error"),
+            },
+        }
+    if "unsupported" in statuses:
+        return {
+            "id": case_id,
+            "classification": "unsupported_combination",
+            "details": {
+                "baseline_status": baseline.get("status"),
+                "candidate_status": candidate.get("status"),
+            },
+        }
+    comparison_config = case_config.get("comparison", {})
+    metric_rules = comparison_config.get("metric_rules", {})
+    metric_regressions, metrics_changed = _compare_metrics(
+        baseline.get("metrics", {}),
+        candidate.get("metrics", {}),
+        metric_rules,
+    )
+    if metric_regressions:
+        return {
+            "id": case_id,
+            "classification": "task_metric_regression",
+            "details": {"metric_regressions": metric_regressions},
+        }
+    if case_config.get("mode") == "aisbench":
+        return {
+            "id": case_id,
+            "classification": (
+                "numerical_difference_within_tolerance"
+                if metrics_changed
+                else "exact_match"
+            ),
+            "details": {
+                "evidence": "task-metrics",
+                "baseline_metrics": baseline.get("metrics", {}),
+                "candidate_metrics": candidate.get("metrics", {}),
+            },
+        }
+    baseline_outputs = baseline.get("outputs", [])
+    candidate_outputs = candidate.get("outputs", [])
+    if not _is_stable(baseline_outputs) or not _is_stable(candidate_outputs):
+        return {
+            "id": case_id,
+            "classification": "flaky_or_nondeterministic",
+            "details": {
+                "baseline_repeats": len(baseline_outputs),
+                "candidate_repeats": len(candidate_outputs),
+            },
+        }
+    if not baseline_outputs or not candidate_outputs:
+        return {
+            "id": case_id,
+            "classification": "infrastructure_failure",
+            "details": {"reason": "no normalized outputs"},
+        }
+
+    left_output = baseline_outputs[0]
+    right_output = candidate_outputs[0]
+    left_signature = _output_signature(left_output)
+    right_signature = _output_signature(right_output)
+    if left_signature is None or right_signature is None:
+        return {
+            "id": case_id,
+            "classification": "infrastructure_failure",
+            "details": {"reason": "no comparable token, token-id, or text field"},
+        }
+    if left_signature != right_signature:
+        return {
+            "id": case_id,
+            "classification": "token_divergence",
+            "details": {
+                "baseline_signature_type": left_signature[0],
+                "candidate_signature_type": right_signature[0],
+                "baseline": left_signature[1],
+                "candidate": right_signature[1],
+            },
+        }
+
+    left_numeric = left_output.get("numerics", {})
+    right_numeric = right_output.get("numerics", {})
+    if not isinstance(left_numeric, Mapping) or not isinstance(right_numeric, Mapping):
+        raise CorrectnessError(f"{case_id}: numerics must be objects")
+    atol = float(comparison_config.get("atol", 0.0))
+    rtol = float(comparison_config.get("rtol", 0.0))
+    numeric_differences: list[dict[str, Any]] = []
+    numeric_within_tolerance = False
+    for name in sorted(set(left_numeric) | set(right_numeric)):
+        if name not in left_numeric or name not in right_numeric:
+            numeric_differences.append({"field": name, "reason": "missing"})
+            continue
+        left_values = _flatten_numbers(left_numeric[name], label=f"baseline.{name}")
+        right_values = _flatten_numbers(right_numeric[name], label=f"candidate.{name}")
+        if len(left_values) != len(right_values):
+            numeric_differences.append(
+                {
+                    "field": name,
+                    "reason": "length-mismatch",
+                    "baseline_length": len(left_values),
+                    "candidate_length": len(right_values),
+                }
+            )
+            continue
+        for index, (left_value, right_value) in enumerate(
+            zip(left_values, right_values)
+        ):
+            if left_value != right_value:
+                if _close(left_value, right_value, atol=atol, rtol=rtol):
+                    numeric_within_tolerance = True
+                else:
+                    numeric_differences.append(
+                        {
+                            "field": name,
+                            "reason": "numeric-divergence",
+                            "index": index,
+                            "baseline": left_value,
+                            "candidate": right_value,
+                        }
+                    )
+                    break
+    if numeric_differences:
+        return {
+            "id": case_id,
+            "classification": "numerical_regression",
+            "details": {"numeric_differences": numeric_differences},
+        }
+    if numeric_within_tolerance:
+        return {
+            "id": case_id,
+            "classification": "numerical_difference_within_tolerance",
+            "details": {"atol": atol, "rtol": rtol},
+        }
+    return {
+        "id": case_id,
+        "classification": "exact_match",
+        "details": {"signature_type": left_signature[0]},
+    }
+
+
+def compare_documents(
+    cases_document: Mapping[str, Any],
+    baseline_document: Mapping[str, Any],
+    candidate_document: Mapping[str, Any],
+) -> dict[str, Any]:
+    validate_cases_document(cases_document)
+    validate_result_document(baseline_document, label="baseline")
+    validate_result_document(candidate_document, label="candidate")
+    baseline_cases = {case["id"]: case for case in baseline_document["cases"]}
+    candidate_cases = {case["id"]: case for case in candidate_document["cases"]}
+    rows = [
+        compare_case(case, baseline_cases.get(case["id"]), candidate_cases.get(case["id"]))
+        for case in cases_document["cases"]
+    ]
+    counts: dict[str, int] = {}
+    for row in rows:
+        counts[row["classification"]] = counts.get(row["classification"], 0) + 1
+    primary = min(
+        (row["classification"] for row in rows),
+        key=lambda classification: CLASS_PRIORITY[classification],
+    )
+    if any(row["classification"] in INCONCLUSIVE_CLASSES for row in rows):
+        status = "inconclusive"
+    elif any(row["classification"] in FAIL_CLASSES for row in rows):
+        status = "failed"
+    else:
+        status = "passed"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "primary_classification": primary,
+        "counts": counts,
+        "cases": rows,
+    }
+
+
+def render_report(
+    comparison: Mapping[str, Any], *, baseline_label: str, candidate_label: str
+) -> str:
+    lines = [
+        "# Correctness validation report",
+        "",
+        f"- Baseline: `{baseline_label}`",
+        f"- Candidate: `{candidate_label}`",
+        f"- Status: **{comparison['status']}**",
+        f"- Primary classification: `{comparison['primary_classification']}`",
+        "",
+        "| Case | Classification |",
+        "|---|---|",
+    ]
+    for row in comparison["cases"]:
+        lines.append(f"| `{row['id']}` | `{row['classification']}` |")
+    lines.extend(["", "## Details", ""])
+    for row in comparison["cases"]:
+        lines.extend(
+            [
+                f"### {row['id']}",
+                "",
+                f"Classification: `{row['classification']}`",
+                "",
+                "```json",
+                json.dumps(row["details"], ensure_ascii=False, indent=2, sort_keys=True),
+                "```",
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def compare_run(
+    run_dir: Path,
+    *,
+    baseline_path: Path,
+    candidate_path: Path,
+    updated_at: str | None = None,
+) -> dict[str, Any]:
+    run_state = _load_json(run_dir / "run.json", "run state")
+    if run_state.get("status") != "planned":
+        raise CorrectnessError(f"run is already {run_state.get('status')}")
+    cases = _load_json(run_dir / "cases.json", "cases")
+    baseline = _load_json(baseline_path, "baseline result")
+    candidate = _load_json(candidate_path, "candidate result")
+    emit_progress("compare", cases=len(cases.get("cases", [])))
+    comparison = compare_documents(cases, baseline, candidate)
+    raw_dir = run_dir / "raw_outputs"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(baseline_path, raw_dir / "baseline.json")
+    shutil.copy2(candidate_path, raw_dir / "candidate.json")
+    _atomic_write_json(run_dir / "comparison.json", comparison)
+    _atomic_write_text(
+        run_dir / "report.md",
+        render_report(
+            comparison,
+            baseline_label=run_state["baseline_label"],
+            candidate_label=run_state["candidate_label"],
+        ),
+    )
+    timestamp = updated_at or utc_now()
+    run_state["status"] = comparison["status"]
+    run_state["updated_at"] = timestamp
+    _atomic_write_json(run_dir / "run.json", run_state)
+
+    manifest = load_manifest(run_dir / "manifest.json")
+    manifest = transition_status(manifest, "running", updated_at=timestamp)
+    for name, kind, uri in (
+        ("baseline-output", "raw-output", "raw_outputs/baseline.json"),
+        ("candidate-output", "raw-output", "raw_outputs/candidate.json"),
+        ("comparison", "comparison", "comparison.json"),
+        ("report", "report", "report.md"),
+    ):
+        manifest = add_artifact(
+            manifest, name=name, kind=kind, uri=uri, updated_at=timestamp
+        )
+    manifest = transition_status(manifest, comparison["status"], updated_at=timestamp)
+    write_manifest(run_dir / "manifest.json", manifest)
+    return comparison
+
+
+def _json_object(raw: str, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise CorrectnessError(f"{label} must be valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise CorrectnessError(f"{label} must be a JSON object")
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+    init = subparsers.add_parser("init", help="initialize a correctness run")
+    init.add_argument("--run-dir", required=True, type=Path)
+    init.add_argument("--run-id", required=True)
+    init.add_argument("--cases", required=True, type=Path)
+    init.add_argument("--baseline-label", required=True)
+    init.add_argument("--candidate-label", required=True)
+    init.add_argument("--workspace-snapshot", default="{}")
+    init.add_argument("--environment", default="{}")
+    init.add_argument("--model", default="{}")
+    init.add_argument("--topology", default="{}")
+    init.add_argument("--baseline-command", action="append", default=[])
+    init.add_argument("--candidate-command", action="append", default=[])
+
+    compare = subparsers.add_parser("compare", help="compare normalized outputs")
+    compare.add_argument("--run-dir", required=True, type=Path)
+    compare.add_argument("--baseline", required=True, type=Path)
+    compare.add_argument("--candidate", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.action == "init":
+            emit_progress("initialize", run_dir=str(args.run_dir))
+            run_state = init_run(
+                args.run_dir,
+                run_id=args.run_id,
+                cases_path=args.cases,
+                baseline_label=args.baseline_label,
+                candidate_label=args.candidate_label,
+                workspace_snapshot=_json_object(
+                    args.workspace_snapshot, "workspace-snapshot"
+                ),
+                environment=_json_object(args.environment, "environment"),
+                model=_json_object(args.model, "model"),
+                topology=_json_object(args.topology, "topology"),
+                baseline_command=args.baseline_command,
+                candidate_command=args.candidate_command,
+            )
+            payload = {
+                "status": "created",
+                "run_id": run_state["run_id"],
+                "run_dir": str(args.run_dir.resolve()),
+            }
+        else:
+            comparison = compare_run(
+                args.run_dir,
+                baseline_path=args.baseline,
+                candidate_path=args.candidate,
+            )
+            payload = {
+                "status": comparison["status"],
+                "primary_classification": comparison["primary_classification"],
+                "comparison": str((args.run_dir / "comparison.json").resolve()),
+                "report": str((args.run_dir / "report.md").resolve()),
+            }
+    except (CorrectnessError, RunManifestError) as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/vllm-ascend-correctness-validation/scripts/remote_correctness_harness.py
+++ b/.agents/skills/vllm-ascend-correctness-validation/scripts/remote_correctness_harness.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Run normalized offline or online vLLM correctness cases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA_VERSION = 1
+SUPPORTED_MODES = frozenset({"offline-generate", "offline-chat", "online-chat"})
+
+
+class HarnessError(ValueError):
+    """Raised when the harness config or response is invalid."""
+
+
+def _prioritize_workspace_python_packages(
+    workspace_root: Path | None = None,
+) -> None:
+    """Keep outer repository directories from shadowing editable packages."""
+    root = workspace_root or Path(__file__).resolve().parents[4]
+    source_roots = (root / "vllm", root / "vllm-ascend")
+    source_values = [str(path) for path in source_roots if path.is_dir()]
+    for source_root in reversed(source_roots):
+        if not source_root.is_dir():
+            continue
+        value = str(source_root)
+        while value in sys.path:
+            sys.path.remove(value)
+        sys.path.insert(0, value)
+    inherited = [
+        value
+        for value in os.environ.get("PYTHONPATH", "").split(os.pathsep)
+        if value and value not in source_values
+    ]
+    os.environ["PYTHONPATH"] = os.pathsep.join([*source_values, *inherited])
+
+
+def emit_progress(phase: str, **details: Any) -> None:
+    print(json.dumps({"phase": phase, **details}, ensure_ascii=False), file=sys.stderr)
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise HarnessError(f"cannot read harness config {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise HarnessError("harness config root must be an object")
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise HarnessError(f"schema_version must be {SCHEMA_VERSION}")
+    if not isinstance(payload.get("cases"), list) or not payload["cases"]:
+        raise HarnessError("cases must be a non-empty array")
+    return payload
+
+
+def _normalize_vllm_output(request_output: Any) -> dict[str, Any]:
+    outputs = getattr(request_output, "outputs", None)
+    if not outputs:
+        raise HarnessError("vLLM request output has no candidates")
+    output = outputs[0]
+    token_ids = list(getattr(output, "token_ids", []) or [])
+    return {
+        "text": str(getattr(output, "text", "")),
+        "token_ids": token_ids,
+    }
+
+
+def normalize_online_response(payload: Mapping[str, Any]) -> dict[str, Any]:
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise HarnessError("online response has no choices")
+    choice = choices[0]
+    if not isinstance(choice, Mapping):
+        raise HarnessError("online response choice must be an object")
+    message = choice.get("message", {})
+    text = message.get("content", "") if isinstance(message, Mapping) else ""
+    normalized: dict[str, Any] = {"text": str(text)}
+    logprobs = choice.get("logprobs")
+    if isinstance(logprobs, Mapping) and isinstance(logprobs.get("content"), list):
+        tokens = [
+            item.get("token")
+            for item in logprobs["content"]
+            if isinstance(item, Mapping) and isinstance(item.get("token"), str)
+        ]
+        if tokens:
+            normalized["tokens"] = tokens
+            numeric_logprobs = [
+                item.get("logprob")
+                for item in logprobs["content"]
+                if isinstance(item, Mapping)
+                and isinstance(item.get("logprob"), (int, float))
+                and not isinstance(item.get("logprob"), bool)
+            ]
+            if numeric_logprobs:
+                normalized["numerics"] = {"logprobs": numeric_logprobs}
+    return normalized
+
+
+def _online_request(
+    *, base_url: str, model: str, request: Mapping[str, Any], sampling: Mapping[str, Any]
+) -> dict[str, Any]:
+    payload = {
+        "model": model,
+        "messages": request.get("messages"),
+        **dict(sampling),
+    }
+    if payload["messages"] is None:
+        raise HarnessError("online-chat request.messages is required")
+    payload.setdefault("logprobs", True)
+    data = json.dumps(payload).encode("utf-8")
+    target = base_url.rstrip("/") + "/v1/chat/completions"
+    http_request = urllib.request.Request(
+        target,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(http_request, timeout=120) as response:
+            response_payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        raise HarnessError(f"online request failed: {exc}") from exc
+    if not isinstance(response_payload, Mapping):
+        raise HarnessError("online response root must be an object")
+    return normalize_online_response(response_payload)
+
+
+def _build_offline_engine(config: Mapping[str, Any]):
+    _prioritize_workspace_python_packages()
+    try:
+        from vllm import LLM, SamplingParams
+    except ImportError as exc:
+        raise HarnessError("vLLM is unavailable in this runtime") from exc
+    model = config.get("model")
+    if not isinstance(model, str) or not model:
+        raise HarnessError("offline config.model is required")
+    engine_args = config.get("engine_args", {})
+    if not isinstance(engine_args, Mapping):
+        raise HarnessError("engine_args must be an object")
+    return LLM(model=model, **dict(engine_args)), SamplingParams
+
+
+def execute_config(config: Mapping[str, Any]) -> dict[str, Any]:
+    label = str(config.get("label", "unnamed"))
+    offline_cases = [
+        case
+        for case in config["cases"]
+        if isinstance(case, Mapping)
+        and case.get("mode") in {"offline-generate", "offline-chat"}
+    ]
+    engine = None
+    sampling_class = None
+    engine_error: str | None = None
+    if offline_cases:
+        try:
+            engine, sampling_class = _build_offline_engine(config)
+        except HarnessError as exc:
+            engine_error = str(exc)
+
+    results: list[dict[str, Any]] = []
+    for raw_case in config["cases"]:
+        if not isinstance(raw_case, Mapping):
+            results.append(
+                {"id": "invalid-case", "status": "error", "error": "case must be an object"}
+            )
+            continue
+        case_id = str(raw_case.get("id", "invalid-case"))
+        mode = raw_case.get("mode")
+        if mode not in SUPPORTED_MODES:
+            results.append(
+                {
+                    "id": case_id,
+                    "status": "unsupported",
+                    "error": f"unsupported harness mode: {mode}",
+                    "outputs": [],
+                    "metrics": {},
+                }
+            )
+            continue
+        repeats = int(raw_case.get("repeats", 1))
+        request = raw_case.get("request", {})
+        sampling = raw_case.get("sampling", {})
+        outputs: list[dict[str, Any]] = []
+        try:
+            if mode.startswith("offline") and engine_error is not None:
+                raise HarnessError(engine_error)
+            for repeat in range(repeats):
+                emit_progress("execute-case", case_id=case_id, repeat=repeat + 1)
+                if mode == "online-chat":
+                    base_url = config.get("base_url")
+                    model = config.get("served_model") or config.get("model")
+                    if not isinstance(base_url, str) or not base_url:
+                        raise HarnessError("online config.base_url is required")
+                    if not isinstance(model, str) or not model:
+                        raise HarnessError("online served_model or model is required")
+                    outputs.append(
+                        _online_request(
+                            base_url=base_url,
+                            model=model,
+                            request=request,
+                            sampling=sampling,
+                        )
+                    )
+                else:
+                    assert engine is not None and sampling_class is not None
+                    sampling_params = sampling_class(**dict(sampling))
+                    if mode == "offline-generate":
+                        prompt = request.get("prompt")
+                        if not isinstance(prompt, str):
+                            raise HarnessError("offline-generate request.prompt is required")
+                        generated = engine.generate(
+                            prompt, sampling_params, use_tqdm=False
+                        )
+                    else:
+                        messages = request.get("messages")
+                        if not isinstance(messages, list):
+                            raise HarnessError("offline-chat request.messages is required")
+                        generated = engine.chat(
+                            messages, sampling_params=sampling_params, use_tqdm=False
+                        )
+                    if not generated:
+                        raise HarnessError("vLLM returned no request outputs")
+                    outputs.append(_normalize_vllm_output(generated[0]))
+        except Exception as exc:  # Runtime boundary must normalize backend failures.
+            results.append(
+                {
+                    "id": case_id,
+                    "status": "error",
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "outputs": outputs,
+                    "metrics": {},
+                }
+            )
+        else:
+            results.append(
+                {
+                    "id": case_id,
+                    "status": "ok",
+                    "outputs": outputs,
+                    "metrics": {},
+                }
+            )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "label": label,
+        "cases": results,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+    try:
+        config = load_config(args.config)
+        result = execute_config(config)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except HarnessError as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))
+        return 1
+    print(
+        json.dumps(
+            {
+                "status": "completed",
+                "output": str(args.output.resolve()),
+                "case_count": len(result["cases"]),
+                "error_count": sum(
+                    case["status"] == "error" for case in result["cases"]
+                ),
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/vllm-ascend-correctness-validation/tests/test_correctness.py
+++ b/.agents/skills/vllm-ascend-correctness-validation/tests/test_correctness.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Tests for correctness comparison and normalized harness behavior."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+SKILL = ROOT / ".agents" / "skills" / "vllm-ascend-correctness-validation"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+correctness = load_module(
+    "_correctness_run_test", SKILL / "scripts" / "correctness_run.py"
+)
+harness = load_module(
+    "_remote_correctness_harness_test",
+    SKILL / "scripts" / "remote_correctness_harness.py",
+)
+aisbench = load_module(
+    "_aisbench_adapter_test", SKILL / "scripts" / "aisbench_adapter.py"
+)
+NOW = "2026-07-25T12:00:00Z"
+
+
+def case(case_id: str = "case-1", **comparison) -> dict:
+    return {
+        "id": case_id,
+        "mode": "offline-generate",
+        "repeats": 1,
+        "sampling": {"temperature": 0, "seed": 7},
+        "request": {"prompt": "hello"},
+        "comparison": comparison,
+    }
+
+
+def result(case_id: str, output: dict, *, metrics: dict | None = None) -> dict:
+    return {
+        "id": case_id,
+        "status": "ok",
+        "outputs": [output],
+        "metrics": metrics or {},
+    }
+
+
+class ComparisonTests(unittest.TestCase):
+    def test_exact_token_match_passes(self) -> None:
+        config = {"schema_version": 1, "cases": [case()]}
+        baseline = {
+            "schema_version": 1,
+            "cases": [result("case-1", {"text": "ok", "token_ids": [1, 2]})],
+        }
+        candidate = json.loads(json.dumps(baseline))
+        comparison = correctness.compare_documents(config, baseline, candidate)
+        self.assertEqual(comparison["status"], "passed")
+        self.assertEqual(comparison["cases"][0]["classification"], "exact_match")
+
+    def test_token_divergence_fails(self) -> None:
+        row = correctness.compare_case(
+            case(),
+            result("case-1", {"token_ids": [1]}),
+            result("case-1", {"token_ids": [2]}),
+        )
+        self.assertEqual(row["classification"], "token_divergence")
+
+    def test_numeric_tolerance_is_distinct_from_exact(self) -> None:
+        config = case(atol=0.01, rtol=0.0)
+        row = correctness.compare_case(
+            config,
+            result("case-1", {"token_ids": [1], "numerics": {"logits": [1.0]}}),
+            result("case-1", {"token_ids": [1], "numerics": {"logits": [1.001]}}),
+        )
+        self.assertEqual(
+            row["classification"], "numerical_difference_within_tolerance"
+        )
+
+    def test_repeat_instability_is_flaky(self) -> None:
+        baseline = result("case-1", {"text": "a"})
+        baseline["outputs"].append({"text": "b"})
+        row = correctness.compare_case(
+            case(), baseline, result("case-1", {"text": "a"})
+        )
+        self.assertEqual(row["classification"], "flaky_or_nondeterministic")
+
+    def test_metric_regression_respects_direction(self) -> None:
+        config = case(
+            metric_rules={
+                "accuracy": {
+                    "direction": "higher",
+                    "max_absolute_regression": 0.01,
+                    "max_relative_regression": 0.02,
+                }
+            }
+        )
+        row = correctness.compare_case(
+            config,
+            result("case-1", {"text": "same"}, metrics={"accuracy": 0.8}),
+            result("case-1", {"text": "same"}, metrics={"accuracy": 0.7}),
+        )
+        self.assertEqual(row["classification"], "task_metric_regression")
+
+    def test_metric_only_aisbench_case_can_pass(self) -> None:
+        config = {
+            **case(
+                metric_rules={
+                    "accuracy": {
+                        "direction": "higher",
+                        "max_absolute_regression": 1.0,
+                        "max_relative_regression": 0.02,
+                    }
+                }
+            ),
+            "mode": "aisbench",
+            "sampling": {},
+            "request": {},
+        }
+        row = correctness.compare_case(
+            config,
+            result("case-1", {}, metrics={"accuracy": 80.0}),
+            result("case-1", {}, metrics={"accuracy": 79.5}),
+        )
+        self.assertEqual(
+            row["classification"], "numerical_difference_within_tolerance"
+        )
+
+    def test_full_run_writes_required_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cases_path = root / "source-cases.json"
+            cases_path.write_text(
+                json.dumps({"schema_version": 1, "cases": [case()]}),
+                encoding="utf-8",
+            )
+            run_dir = root / "run"
+            correctness.init_run(
+                run_dir,
+                run_id="correctness-case-1",
+                cases_path=cases_path,
+                baseline_label="base",
+                candidate_label="candidate",
+                created_at=NOW,
+            )
+            normalized = {
+                "schema_version": 1,
+                "cases": [result("case-1", {"text": "ok"})],
+            }
+            baseline = root / "baseline.json"
+            candidate = root / "candidate.json"
+            baseline.write_text(json.dumps(normalized), encoding="utf-8")
+            candidate.write_text(json.dumps(normalized), encoding="utf-8")
+            comparison = correctness.compare_run(
+                run_dir,
+                baseline_path=baseline,
+                candidate_path=candidate,
+                updated_at=NOW,
+            )
+            self.assertEqual(comparison["status"], "passed")
+            for relative in (
+                "manifest.json",
+                "cases.json",
+                "comparison.json",
+                "report.md",
+                "reproduction.sh",
+                "raw_outputs/baseline.json",
+                "raw_outputs/candidate.json",
+            ):
+                self.assertTrue((run_dir / relative).is_file(), relative)
+
+
+class HarnessTests(unittest.TestCase):
+    def test_workspace_source_roots_precede_outer_repo_namespace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "vllm").mkdir()
+            (root / "vllm-ascend").mkdir()
+            original = list(sys.path)
+            original_pythonpath = os.environ.get("PYTHONPATH")
+            try:
+                sys.path[:] = [str(root), str(root / "vllm"), "sentinel"]
+                os.environ["PYTHONPATH"] = f"existing{os.pathsep}{root / 'vllm'}"
+                harness._prioritize_workspace_python_packages(root)
+                self.assertEqual(
+                    sys.path[:3],
+                    [str(root / "vllm"), str(root / "vllm-ascend"), str(root)],
+                )
+                self.assertEqual(sys.path.count(str(root / "vllm")), 1)
+                self.assertEqual(
+                    os.environ["PYTHONPATH"].split(os.pathsep),
+                    [str(root / "vllm"), str(root / "vllm-ascend"), "existing"],
+                )
+            finally:
+                sys.path[:] = original
+                if original_pythonpath is None:
+                    os.environ.pop("PYTHONPATH", None)
+                else:
+                    os.environ["PYTHONPATH"] = original_pythonpath
+
+    def test_online_logprobs_are_normalized(self) -> None:
+        normalized = harness.normalize_online_response(
+            {
+                "choices": [
+                    {
+                        "message": {"content": "ok"},
+                        "logprobs": {
+                            "content": [
+                                {"token": "o", "logprob": -0.1},
+                                {"token": "k", "logprob": -0.2},
+                            ]
+                        },
+                    }
+                ]
+            }
+        )
+        self.assertEqual(normalized["tokens"], ["o", "k"])
+        self.assertEqual(normalized["numerics"]["logprobs"], [-0.1, -0.2])
+
+    def test_unknown_mode_is_normalized_as_unsupported(self) -> None:
+        result_document = harness.execute_config(
+            {
+                "schema_version": 1,
+                "label": "test",
+                "cases": [{"id": "unsupported-1", "mode": "future-mode"}],
+            }
+        )
+        self.assertEqual(result_document["cases"][0]["status"], "unsupported")
+
+
+class AisbenchAdapterTests(unittest.TestCase):
+    def test_prepare_does_not_modify_benchmark_tree_or_embed_api_key(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            payload = aisbench.prepare(
+                root / "adapter",
+                host="127.0.0.1",
+                port=8000,
+                served_model="example",
+                datasets=["demo_gsm8k_gen_4_shot_cot_chat_prompt"],
+                work_dir=Path("/remote/output"),
+                metric="accuracy",
+                direction="higher",
+                max_absolute_regression=0.5,
+                max_relative_regression=0.01,
+                max_out_len=64,
+                batch_size=1,
+                temperature=0.0,
+                seed=7,
+                num_prompts=8,
+            )
+            model_config = Path(payload["model_config"])
+            self.assertTrue(model_config.is_file())
+            text = model_config.read_text(encoding="utf-8")
+            self.assertIn('api_key=""', text)
+            self.assertNotIn("benchmark/ais_bench/benchmark/configs", str(model_config))
+            ast.parse(text)
+            self.assertEqual(payload["command"][0], "ais_bench")
+            self.assertIn("--config-dir", payload["command"])
+            cases = json.loads(
+                (root / "adapter" / "aisbench-cases.json").read_text(encoding="utf-8")
+            )
+            correctness.validate_cases_document(cases)
+
+    def test_summary_csv_is_normalized(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            summary = Path(tmp) / "summary.csv"
+            summary.write_text(
+                "dataset,version,metric,mode,vaws-correctness\n"
+                "gsm8k,abc123,accuracy,gen,56.7\n",
+                encoding="utf-8",
+            )
+            normalized = aisbench.normalize_summary(summary, label="baseline")
+            self.assertEqual(normalized["cases"][0]["status"], "ok")
+            self.assertEqual(normalized["cases"][0]["metrics"]["accuracy"], 56.7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/vllm-ascend-distributed-debug/SKILL.md
+++ b/.agents/skills/vllm-ascend-distributed-debug/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: vllm-ascend-distributed-debug
+description: Diagnose vLLM Ascend multi-rank and multi-node startup, rank mapping, process-group, collective, HCCL, Ray, scheduler, connector, and distributed hang failures from structured topology and per-rank evidence. Use when a failure depends on rank count, parallel topology, nodes, collectives, or distributed endpoints. Do not use for graph-only divergence, isolated operator failures, performance benchmarking, or profiler analysis.
+---
+
+# vLLM Ascend Distributed Debug
+
+Build a falsifiable diagnosis from rank-aware evidence. Never infer a distributed
+root cause from one rank's log alone.
+
+## Workflow
+
+1. Create a case with `scripts/distributed_debug.py init`.
+2. Capture the exact failing topology, environment, process tree, endpoints, and
+   reproduction command before changing parallelism.
+3. Add structured per-rank events with `ingest`. Keep raw rank logs and stack
+   dumps in the case directories created by `init`.
+4. Run `analyze` to check rank identity, group membership, endpoint collisions,
+   collective order, missing participants, entered-without-exit stalls, and
+   cross-rank phase divergence.
+5. Form one or more falsifiable hypotheses from the report.
+6. Reduce one parallel dimension at a time. Record each reduced case separately.
+7. After a fix, rerun both the smallest reproducer and the original topology.
+
+## Entry point
+
+`scripts/distributed_debug.py` provides:
+
+- `init`: validate the topology contract and create the complete evidence layout;
+- `ingest`: validate and append normalized rank events;
+- `analyze`: produce deterministic findings, per-rank last progress, and a Run
+  Manifest-linked report.
+
+Read only the reference needed for the current phase:
+
+- [Behavior contract](references/behavior.md)
+- [Command recipes](references/command-recipes.md)
+- [Acceptance](references/acceptance.md)
+
+## Boundaries
+
+- This skill owns failures whose explanation requires comparing ranks, groups,
+  nodes, or distributed endpoints.
+- Correct outputs in eager mode with graph-only failure belong to
+  `vllm-ascend-graph-debug`.
+- A failure reduced to one operator call belongs to `ascend-operator-debug`.
+- Kernel timing, throughput, and imbalance quantification belong to profiling or
+  performance skills; do not load them until the distributed failure is stable
+  and the user asks for that evidence.
+
+## Rules
+
+- Preserve raw evidence; normalize into new files rather than rewriting logs.
+- Treat missing ranks as missing evidence, not proof that those ranks crashed.
+- Treat a collective mismatch as confirmed only when group, sequence, operation,
+  and participating ranks are explicit.
+- Redact secrets before storing environment snapshots.
+- Keep cases under `.vaws-local/distributed-debug/`.

--- a/.agents/skills/vllm-ascend-distributed-debug/agents/openai.yaml
+++ b/.agents/skills/vllm-ascend-distributed-debug/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "vLLM Ascend Distributed Debug"
+  short_description: "Diagnose multi-rank and collective failures"
+  default_prompt: "Use $vllm-ascend-distributed-debug to diagnose this multi-rank or multi-node failure from structured topology and rank evidence."

--- a/.agents/skills/vllm-ascend-distributed-debug/references/acceptance.md
+++ b/.agents/skills/vllm-ascend-distributed-debug/references/acceptance.md
@@ -1,0 +1,24 @@
+# Distributed debug acceptance
+
+## Evidence
+
+- [ ] Original world size and every parallel rank coordinate are recorded.
+- [ ] Rank-to-node and rank-to-device mappings are explicit.
+- [ ] Process groups list exact members.
+- [ ] Environment, process tree, endpoints, and reproduction command are saved.
+- [ ] Raw rank logs and stack dumps are preserved.
+- [ ] Every missing rank is reported as an evidence gap.
+
+## Diagnosis
+
+- [ ] Collective findings name group, sequence, operation, and ranks.
+- [ ] Confirmed findings are separated from candidates and evidence gaps.
+- [ ] Each experiment changes one topology or runtime variable.
+- [ ] The smallest reproducer retains the failure signature.
+
+## Fix validation
+
+- [ ] A regression test covers the proved invariant when practical.
+- [ ] The smallest reproducer passes after the fix.
+- [ ] The original topology passes after the fix.
+- [ ] Temporary debug instrumentation is removed or explicitly retained.

--- a/.agents/skills/vllm-ascend-distributed-debug/references/behavior.md
+++ b/.agents/skills/vllm-ascend-distributed-debug/references/behavior.md
@@ -1,0 +1,62 @@
+# Distributed debug behavior contract
+
+## Case config
+
+The config records the original failure topology. Every rank must contain:
+
+```text
+global_rank, node, device, local_rank,
+tp_rank, pp_rank, dp_rank, ep_rank, pcp_rank, dcp_rank
+```
+
+Global ranks must be unique and contiguous. Process groups name their exact rank
+members. Network endpoints declare a name, address, and port. Duplicate bindings
+are rejected before evidence collection.
+
+Environment snapshots must contain no credentials or tokens.
+
+## Normalized rank event
+
+```json
+{
+  "timestamp": "2026-07-25T12:00:00Z",
+  "rank": 3,
+  "phase": "model-execute",
+  "event": "collective_enter",
+  "group": "tp-1",
+  "sequence": 42,
+  "operation": "all_reduce"
+}
+```
+
+All events require timestamp, rank, phase, and event. `collective_enter` and
+`collective_exit` also require group, sequence, and operation.
+
+## Finding confidence
+
+- `confirmed`: explicit structured evidence violates topology, group, operation,
+  participant, or endpoint invariants;
+- `candidate`: evidence localizes a stall or cross-rank phase divergence but does
+  not prove its cause;
+- `incomplete`: required ranks or evidence are absent.
+
+Missing evidence never becomes a confirmed finding.
+
+## Case layout
+
+```text
+case/
+├── manifest.json
+├── case-config.json
+├── topology.json
+├── environment.json
+├── process-tree.json
+├── network-endpoints.json
+├── events.jsonl
+├── rank-logs/
+├── stack-dumps/
+├── metadata-samples/
+├── analysis.json
+├── report.md
+└── reproduction.md
+```

--- a/.agents/skills/vllm-ascend-distributed-debug/references/command-recipes.md
+++ b/.agents/skills/vllm-ascend-distributed-debug/references/command-recipes.md
@@ -1,0 +1,31 @@
+# Distributed debug command recipes
+
+## Initialize
+
+```bash
+python -B .agents/skills/vllm-ascend-distributed-debug/scripts/distributed_debug.py init \
+  --output-dir .vaws-local/distributed-debug/case-001 \
+  --config /path/to/distributed-case.json
+```
+
+Capture raw logs, stack dumps, and metadata samples without rewriting them.
+
+## Ingest normalized events
+
+```bash
+python -B .agents/skills/vllm-ascend-distributed-debug/scripts/distributed_debug.py ingest \
+  --output-dir .vaws-local/distributed-debug/case-001 \
+  --events /path/to/rank-events.jsonl
+```
+
+Append events for all ranks. Keep sequences scoped to their named process group.
+
+## Analyze
+
+```bash
+python -B .agents/skills/vllm-ascend-distributed-debug/scripts/distributed_debug.py analyze \
+  --output-dir .vaws-local/distributed-debug/case-001
+```
+
+Use `analysis.json` to select one controlled topology reduction. Do not change
+multiple parallel dimensions in the same experiment.

--- a/.agents/skills/vllm-ascend-distributed-debug/scripts/distributed_debug.py
+++ b/.agents/skills/vllm-ascend-distributed-debug/scripts/distributed_debug.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+"""Create and analyze structured vLLM Ascend distributed-debug cases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_run_manifest import (  # noqa: E402
+    RunManifestError,
+    add_artifact,
+    load_manifest,
+    new_manifest,
+    transition_status,
+    write_manifest,
+)
+
+SCHEMA_VERSION = 1
+REQUIRED_RANK_FIELDS = (
+    "global_rank",
+    "node",
+    "device",
+    "local_rank",
+    "tp_rank",
+    "pp_rank",
+    "dp_rank",
+    "ep_rank",
+    "pcp_rank",
+    "dcp_rank",
+)
+COLLECTIVE_EVENTS = {"collective_enter", "collective_exit"}
+
+
+class DistributedDebugError(ValueError):
+    """Raised when case evidence violates the distributed-debug contract."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    _atomic_write(
+        path, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DistributedDebugError(f"cannot read {label} {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise DistributedDebugError(f"{label} root must be an object")
+    return payload
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise DistributedDebugError(f"cannot read events {path}: {exc}") from exc
+    for number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise DistributedDebugError(
+                f"events line {number} is invalid JSON: {exc}"
+            ) from exc
+        if not isinstance(row, dict):
+            raise DistributedDebugError(f"events line {number} must be an object")
+        rows.append(row)
+    return rows
+
+
+def validate_config(config: Mapping[str, Any]) -> None:
+    errors: list[str] = []
+    if config.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    if not isinstance(config.get("run_id"), str) or not config["run_id"]:
+        errors.append("run_id must be a non-empty string")
+    world_size = config.get("expected_world_size")
+    if not isinstance(world_size, int) or isinstance(world_size, bool) or world_size < 1:
+        errors.append("expected_world_size must be a positive integer")
+    ranks = config.get("ranks")
+    seen: set[int] = set()
+    if not isinstance(ranks, list) or not ranks:
+        errors.append("ranks must be a non-empty array")
+        ranks = []
+    for index, rank in enumerate(ranks):
+        if not isinstance(rank, Mapping):
+            errors.append(f"ranks[{index}] must be an object")
+            continue
+        for field in REQUIRED_RANK_FIELDS:
+            value = rank.get(field)
+            if field == "node":
+                if not isinstance(value, str) or not value:
+                    errors.append(f"ranks[{index}].node must be a non-empty string")
+            elif not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                errors.append(f"ranks[{index}].{field} must be a non-negative integer")
+        global_rank = rank.get("global_rank")
+        if isinstance(global_rank, int):
+            if global_rank in seen:
+                errors.append(f"global_rank is duplicated: {global_rank}")
+            seen.add(global_rank)
+    if isinstance(world_size, int) and len(ranks) != world_size:
+        errors.append(
+            f"rank count {len(ranks)} does not match expected_world_size {world_size}"
+        )
+    if isinstance(world_size, int) and seen != set(range(world_size)):
+        errors.append("global ranks must be contiguous from 0 to expected_world_size-1")
+    groups = config.get("groups", [])
+    if not isinstance(groups, list):
+        errors.append("groups must be an array")
+        groups = []
+    group_names: set[str] = set()
+    for index, group in enumerate(groups):
+        if not isinstance(group, Mapping):
+            errors.append(f"groups[{index}] must be an object")
+            continue
+        name = group.get("name")
+        members = group.get("ranks")
+        if not isinstance(name, str) or not name:
+            errors.append(f"groups[{index}].name must be a non-empty string")
+        elif name in group_names:
+            errors.append(f"group name is duplicated: {name}")
+        else:
+            group_names.add(name)
+        if (
+            not isinstance(members, list)
+            or not members
+            or any(
+                not isinstance(rank, int) or isinstance(rank, bool) for rank in members
+            )
+        ):
+            errors.append(f"groups[{index}].ranks must be a non-empty integer array")
+        elif len(set(members)) != len(members):
+            errors.append(f"groups[{index}].ranks contains duplicates")
+        elif not set(members).issubset(seen):
+            errors.append(f"groups[{index}].ranks contains unknown ranks")
+    endpoints = config.get("network_endpoints", [])
+    if not isinstance(endpoints, list):
+        errors.append("network_endpoints must be an array")
+        endpoints = []
+    endpoint_keys: set[tuple[str, int]] = set()
+    for index, endpoint in enumerate(endpoints):
+        if not isinstance(endpoint, Mapping):
+            errors.append(f"network_endpoints[{index}] must be an object")
+            continue
+        address = endpoint.get("address")
+        port = endpoint.get("port")
+        if not isinstance(address, str) or not address:
+            errors.append(
+                f"network_endpoints[{index}].address must be a non-empty string"
+            )
+        if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
+            errors.append(f"network_endpoints[{index}].port must be 1..65535")
+        if isinstance(address, str) and isinstance(port, int):
+            key = (address, port)
+            if key in endpoint_keys:
+                errors.append(f"network endpoint is duplicated: {address}:{port}")
+            endpoint_keys.add(key)
+    if errors:
+        raise DistributedDebugError("; ".join(errors))
+
+
+def validate_event(event: Mapping[str, Any], known_ranks: set[int]) -> None:
+    errors: list[str] = []
+    rank = event.get("rank")
+    if not isinstance(rank, int) or isinstance(rank, bool) or rank not in known_ranks:
+        errors.append("rank must identify a topology rank")
+    if not isinstance(event.get("timestamp"), str) or not event["timestamp"]:
+        errors.append("timestamp must be a non-empty string")
+    if not isinstance(event.get("phase"), str) or not event["phase"]:
+        errors.append("phase must be a non-empty string")
+    kind = event.get("event")
+    if not isinstance(kind, str) or not kind:
+        errors.append("event must be a non-empty string")
+    if kind in COLLECTIVE_EVENTS:
+        if not isinstance(event.get("group"), str) or not event["group"]:
+            errors.append("collective event requires group")
+        if (
+            not isinstance(event.get("sequence"), int)
+            or isinstance(event.get("sequence"), bool)
+            or event["sequence"] < 0
+        ):
+            errors.append("collective event requires a non-negative sequence")
+        if not isinstance(event.get("operation"), str) or not event["operation"]:
+            errors.append("collective event requires operation")
+    if errors:
+        raise DistributedDebugError("; ".join(errors))
+
+
+def init_case(
+    output_dir: Path, *, config_path: Path, created_at: str | None = None
+) -> dict[str, Any]:
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise DistributedDebugError(f"output directory is not empty: {output_dir}")
+    config = _load_json(config_path, "case config")
+    validate_config(config)
+    timestamp = created_at or utc_now()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for directory in ("rank-logs", "stack-dumps", "metadata-samples"):
+        (output_dir / directory).mkdir()
+    topology = {
+        "schema_version": SCHEMA_VERSION,
+        "expected_world_size": config["expected_world_size"],
+        "ranks": config["ranks"],
+        "groups": config.get("groups", []),
+    }
+    _write_json(output_dir / "case-config.json", config)
+    _write_json(output_dir / "topology.json", topology)
+    _write_json(output_dir / "environment.json", config.get("environment", {}))
+    _write_json(output_dir / "process-tree.json", config.get("process_tree", {}))
+    _write_json(
+        output_dir / "network-endpoints.json", config.get("network_endpoints", [])
+    )
+    _atomic_write(output_dir / "events.jsonl", "")
+    _atomic_write(
+        output_dir / "reproduction.md",
+        "# Distributed failure reproduction\n\n"
+        f"Command: `{' '.join(config.get('command', []))}`\n\n"
+        "Record the original topology before reducing any parallel dimension.\n",
+    )
+    manifest = new_manifest(
+        run_type="debug",
+        run_id=config["run_id"],
+        workspace_snapshot=config.get("workspace_snapshot", {}),
+        environment=config.get("environment", {}),
+        model=config.get("model", {}),
+        topology=topology,
+        command=config.get("command", []),
+        created_at=timestamp,
+    )
+    for name, kind, uri in (
+        ("topology", "topology", "topology.json"),
+        ("environment", "environment", "environment.json"),
+        ("process-tree", "process-tree", "process-tree.json"),
+        ("network-endpoints", "network-endpoints", "network-endpoints.json"),
+        ("events", "rank-events", "events.jsonl"),
+        ("reproduction", "reproduction", "reproduction.md"),
+    ):
+        manifest = add_artifact(
+            manifest, name=name, kind=kind, uri=uri, updated_at=timestamp
+        )
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {
+        "status": "planned",
+        "run_id": config["run_id"],
+        "world_size": config["expected_world_size"],
+        "output_dir": str(output_dir.resolve()),
+    }
+
+
+def ingest_events(
+    output_dir: Path, *, events_path: Path, updated_at: str | None = None
+) -> dict[str, Any]:
+    topology = _load_json(output_dir / "topology.json", "topology")
+    known_ranks = {rank["global_rank"] for rank in topology["ranks"]}
+    incoming = _load_jsonl(events_path)
+    for event in incoming:
+        validate_event(event, known_ranks)
+    existing = _load_jsonl(output_dir / "events.jsonl")
+    combined = existing + incoming
+    _atomic_write(
+        output_dir / "events.jsonl",
+        "".join(
+            json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n"
+            for row in combined
+        ),
+    )
+    timestamp = updated_at or utc_now()
+    manifest = load_manifest(output_dir / "manifest.json")
+    if manifest["status"] == "planned":
+        manifest = transition_status(manifest, "running", updated_at=timestamp)
+        write_manifest(output_dir / "manifest.json", manifest)
+    return {
+        "status": "ingested",
+        "added": len(incoming),
+        "total": len(combined),
+    }
+
+
+def _finding(
+    code: str, severity: str, summary: str, **evidence: Any
+) -> dict[str, Any]:
+    return {
+        "code": code,
+        "severity": severity,
+        "summary": summary,
+        "evidence": evidence,
+    }
+
+
+def analyze_evidence(
+    topology: Mapping[str, Any],
+    endpoints: Iterable[Mapping[str, Any]],
+    events: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    ranks = {rank["global_rank"] for rank in topology["ranks"]}
+    groups = {group["name"]: set(group["ranks"]) for group in topology["groups"]}
+    events_by_rank: dict[int, list[Mapping[str, Any]]] = defaultdict(list)
+    findings: list[dict[str, Any]] = []
+    unknown_groups: set[str] = set()
+    collective_rows: dict[tuple[str, int], list[Mapping[str, Any]]] = defaultdict(list)
+    for event in events:
+        rank = event["rank"]
+        events_by_rank[rank].append(event)
+        if event["event"] in COLLECTIVE_EVENTS:
+            group = event["group"]
+            if group not in groups:
+                unknown_groups.add(group)
+            collective_rows[(group, event["sequence"])].append(event)
+    missing_ranks = sorted(ranks - set(events_by_rank))
+    if missing_ranks:
+        findings.append(
+            _finding(
+                "missing-rank-evidence",
+                "incomplete",
+                "No normalized events were captured for some ranks.",
+                ranks=missing_ranks,
+            )
+        )
+    if unknown_groups:
+        findings.append(
+            _finding(
+                "unknown-process-group",
+                "confirmed",
+                "Collective events reference groups absent from topology.",
+                groups=sorted(unknown_groups),
+            )
+        )
+    for (group, sequence), rows in sorted(collective_rows.items()):
+        if group not in groups:
+            continue
+        expected = groups[group]
+        operations = sorted({row["operation"] for row in rows})
+        entered = {
+            row["rank"] for row in rows if row["event"] == "collective_enter"
+        }
+        exited = {row["rank"] for row in rows if row["event"] == "collective_exit"}
+        if len(operations) > 1:
+            findings.append(
+                _finding(
+                    "collective-operation-mismatch",
+                    "confirmed",
+                    "Ranks disagree on the operation at one collective sequence.",
+                    group=group,
+                    sequence=sequence,
+                    operations=operations,
+                )
+            )
+        if entered != expected:
+            findings.append(
+                _finding(
+                    "collective-participant-mismatch",
+                    "confirmed",
+                    "The collective entry set does not match group membership.",
+                    group=group,
+                    sequence=sequence,
+                    expected=sorted(expected),
+                    entered=sorted(entered),
+                    missing=sorted(expected - entered),
+                    unexpected=sorted(entered - expected),
+                )
+            )
+        stalled = sorted(entered - exited)
+        if stalled:
+            findings.append(
+                _finding(
+                    "collective-enter-without-exit",
+                    "candidate",
+                    "Ranks entered a collective without a matching exit event.",
+                    group=group,
+                    sequence=sequence,
+                    ranks=stalled,
+                )
+            )
+    endpoint_keys: dict[tuple[str, int], list[Mapping[str, Any]]] = defaultdict(list)
+    for endpoint in endpoints:
+        endpoint_keys[(endpoint["address"], endpoint["port"])].append(endpoint)
+    for (address, port), rows in endpoint_keys.items():
+        if len(rows) > 1:
+            findings.append(
+                _finding(
+                    "endpoint-collision",
+                    "confirmed",
+                    "Multiple declared endpoints bind the same address and port.",
+                    address=address,
+                    port=port,
+                    endpoints=rows,
+                )
+            )
+    last_progress = {
+        str(rank): {
+            "timestamp": rows[-1]["timestamp"],
+            "phase": rows[-1]["phase"],
+            "event": rows[-1]["event"],
+        }
+        for rank, rows in sorted(events_by_rank.items())
+    }
+    last_phases = {row["phase"] for row in last_progress.values()}
+    if len(last_phases) > 1:
+        findings.append(
+            _finding(
+                "rank-phase-divergence",
+                "candidate",
+                "Ranks stopped in different phases.",
+                phases={
+                    phase: sorted(
+                        int(rank)
+                        for rank, row in last_progress.items()
+                        if row["phase"] == phase
+                    )
+                    for phase in sorted(last_phases)
+                },
+            )
+        )
+    confirmed = [row["code"] for row in findings if row["severity"] == "confirmed"]
+    incomplete = [row["code"] for row in findings if row["severity"] == "incomplete"]
+    if confirmed:
+        status = "diagnosed"
+    elif incomplete or not events_by_rank:
+        status = "inconclusive"
+    elif findings:
+        status = "hypothesis"
+    else:
+        status = "no-mismatch-detected"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "world_size": len(ranks),
+        "event_count": sum(len(rows) for rows in events_by_rank.values()),
+        "last_progress": last_progress,
+        "findings": findings,
+        "confirmed_findings": confirmed,
+        "evidence_gaps": incomplete,
+    }
+
+
+def render_report(analysis: Mapping[str, Any]) -> str:
+    lines = [
+        "# Distributed debug report",
+        "",
+        f"- Status: **{analysis['status']}**",
+        f"- World size: `{analysis['world_size']}`",
+        f"- Normalized events: `{analysis['event_count']}`",
+        "",
+        "## Findings",
+        "",
+    ]
+    if not analysis["findings"]:
+        lines.append("No structured rank, group, endpoint, or collective mismatch was detected.")
+    for row in analysis["findings"]:
+        lines.extend(
+            [
+                f"### `{row['code']}` ({row['severity']})",
+                "",
+                row["summary"],
+                "",
+                "```json",
+                json.dumps(row["evidence"], ensure_ascii=False, indent=2, sort_keys=True),
+                "```",
+                "",
+            ]
+        )
+    lines.extend(["## Last progress by rank", "", "```json"])
+    lines.append(
+        json.dumps(analysis["last_progress"], ensure_ascii=False, indent=2, sort_keys=True)
+    )
+    lines.extend(["```", ""])
+    return "\n".join(lines)
+
+
+def analyze_case(
+    output_dir: Path, *, updated_at: str | None = None
+) -> dict[str, Any]:
+    topology = _load_json(output_dir / "topology.json", "topology")
+    endpoints_payload = json.loads(
+        (output_dir / "network-endpoints.json").read_text(encoding="utf-8")
+    )
+    if not isinstance(endpoints_payload, list):
+        raise DistributedDebugError("network-endpoints root must be an array")
+    events = _load_jsonl(output_dir / "events.jsonl")
+    analysis = analyze_evidence(topology, endpoints_payload, events)
+    _write_json(output_dir / "analysis.json", analysis)
+    _atomic_write(output_dir / "report.md", render_report(analysis))
+    timestamp = updated_at or utc_now()
+    manifest = load_manifest(output_dir / "manifest.json")
+    if manifest["status"] == "planned":
+        manifest = transition_status(manifest, "running", updated_at=timestamp)
+    for name, kind, uri in (
+        ("analysis", "analysis", "analysis.json"),
+        ("report", "report", "report.md"),
+    ):
+        manifest = add_artifact(
+            manifest, name=name, kind=kind, uri=uri, updated_at=timestamp
+        )
+    terminal = "failed" if analysis["status"] == "diagnosed" else "inconclusive"
+    manifest = transition_status(manifest, terminal, updated_at=timestamp)
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {
+        "status": analysis["status"],
+        "confirmed_findings": analysis["confirmed_findings"],
+        "evidence_gaps": analysis["evidence_gaps"],
+        "analysis": str((output_dir / "analysis.json").resolve()),
+        "report": str((output_dir / "report.md").resolve()),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+    init_parser = subparsers.add_parser("init", help="create a debug case")
+    init_parser.add_argument("--output-dir", required=True, type=Path)
+    init_parser.add_argument("--config", required=True, type=Path)
+    ingest_parser = subparsers.add_parser("ingest", help="append normalized events")
+    ingest_parser.add_argument("--output-dir", required=True, type=Path)
+    ingest_parser.add_argument("--events", required=True, type=Path)
+    analyze_parser = subparsers.add_parser("analyze", help="analyze case evidence")
+    analyze_parser.add_argument("--output-dir", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.action == "init":
+            payload = init_case(args.output_dir, config_path=args.config)
+        elif args.action == "ingest":
+            payload = ingest_events(args.output_dir, events_path=args.events)
+        else:
+            payload = analyze_case(args.output_dir)
+    except (DistributedDebugError, RunManifestError) as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/vllm-ascend-distributed-debug/tests/test_distributed_debug.py
+++ b/.agents/skills/vllm-ascend-distributed-debug/tests/test_distributed_debug.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Tests for structured distributed-debug evidence analysis."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+SKILL = ROOT / ".agents" / "skills" / "vllm-ascend-distributed-debug"
+
+
+def load_module():
+    name = "_distributed_debug_test"
+    spec = importlib.util.spec_from_file_location(
+        name, SKILL / "scripts" / "distributed_debug.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+distributed = load_module()
+NOW = "2026-07-25T12:00:00Z"
+
+
+def config() -> dict:
+    ranks = []
+    for rank in range(2):
+        ranks.append(
+            {
+                "global_rank": rank,
+                "node": "host-a",
+                "device": rank,
+                "local_rank": rank,
+                "tp_rank": rank,
+                "pp_rank": 0,
+                "dp_rank": 0,
+                "ep_rank": 0,
+                "pcp_rank": 0,
+                "dcp_rank": 0,
+            }
+        )
+    return {
+        "schema_version": 1,
+        "run_id": "distributed-case-1",
+        "expected_world_size": 2,
+        "ranks": ranks,
+        "groups": [{"name": "tp-0", "type": "tp", "ranks": [0, 1]}],
+        "network_endpoints": [
+            {"name": "master", "address": "10.0.0.1", "port": 29500}
+        ],
+        "environment": {"HCCL_BUFFSIZE": "1024"},
+        "process_tree": {},
+        "command": ["python", "repro.py"],
+    }
+
+
+def event(
+    rank: int,
+    kind: str,
+    *,
+    operation: str = "all_reduce",
+    phase: str = "model-execute",
+) -> dict:
+    return {
+        "timestamp": f"2026-07-25T12:00:0{rank}Z",
+        "rank": rank,
+        "phase": phase,
+        "event": kind,
+        "group": "tp-0",
+        "sequence": 1,
+        "operation": operation,
+    }
+
+
+class DistributedDebugTests(unittest.TestCase):
+    def test_rejects_noncontiguous_rank_map(self) -> None:
+        invalid = config()
+        invalid["ranks"][1]["global_rank"] = 2
+        with self.assertRaisesRegex(distributed.DistributedDebugError, "contiguous"):
+            distributed.validate_config(invalid)
+
+    def test_detects_collective_operation_mismatch(self) -> None:
+        case = config()
+        analysis = distributed.analyze_evidence(
+            {
+                "ranks": case["ranks"],
+                "groups": case["groups"],
+            },
+            case["network_endpoints"],
+            [
+                event(0, "collective_enter", operation="all_reduce"),
+                event(1, "collective_enter", operation="all_gather"),
+            ],
+        )
+        self.assertEqual(analysis["status"], "diagnosed")
+        self.assertIn(
+            "collective-operation-mismatch", analysis["confirmed_findings"]
+        )
+
+    def test_detects_missing_collective_participant(self) -> None:
+        case = config()
+        analysis = distributed.analyze_evidence(
+            {"ranks": case["ranks"], "groups": case["groups"]},
+            case["network_endpoints"],
+            [event(0, "collective_enter")],
+        )
+        self.assertIn(
+            "collective-participant-mismatch", analysis["confirmed_findings"]
+        )
+        finding = next(
+            row
+            for row in analysis["findings"]
+            if row["code"] == "collective-participant-mismatch"
+        )
+        self.assertEqual(finding["evidence"]["missing"], [1])
+
+    def test_missing_rank_events_are_evidence_gap(self) -> None:
+        case = config()
+        analysis = distributed.analyze_evidence(
+            {"ranks": case["ranks"], "groups": case["groups"]},
+            case["network_endpoints"],
+            [
+                {
+                    "timestamp": NOW,
+                    "rank": 0,
+                    "phase": "startup",
+                    "event": "checkpoint",
+                }
+            ],
+        )
+        self.assertEqual(analysis["status"], "inconclusive")
+        self.assertEqual(analysis["evidence_gaps"], ["missing-rank-evidence"])
+
+    def test_full_lifecycle_writes_manifest_and_report(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(config()), encoding="utf-8")
+            output = root / "case"
+            distributed.init_case(output, config_path=config_path, created_at=NOW)
+            events_path = root / "events.jsonl"
+            rows = []
+            for kind in ("collective_enter", "collective_exit"):
+                rows.extend([event(0, kind), event(1, kind)])
+            events_path.write_text(
+                "".join(json.dumps(row) + "\n" for row in rows),
+                encoding="utf-8",
+            )
+            distributed.ingest_events(
+                output, events_path=events_path, updated_at=NOW
+            )
+            result = distributed.analyze_case(output, updated_at=NOW)
+            self.assertEqual(result["status"], "no-mismatch-detected")
+            self.assertTrue((output / "report.md").is_file())
+            manifest = json.loads(
+                (output / "manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(manifest["status"], "inconclusive")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/vllm-ascend-graph-debug/SKILL.md
+++ b/.agents/skills/vllm-ascend-graph-debug/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: vllm-ascend-graph-debug
+description: Diagnose vLLM Ascend cudagraph and ACL Graph compile, capture, replay, hang, and graph-versus-eager correctness problems. Use when eager passes but graph mode fails, hangs, or diverges, or when graph/eager intermediate tensors must be aligned. Do not use to plan a correctness matrix, after the failure is reduced to one operator, when eager itself fails, or for performance profiling or HBM attribution.
+---
+
+# NPU Graph Debug
+
+用于排查 vLLM Ascend 图模式下的编译、捕获、重放和精度问题。核心方法是：记录已知信息，先定性问题阶段，再控制变量缩小范围；只有范围足够小时，才插入预分配 buffer，通过图内 `copy_` 和图外落盘对比 graph/eager 的中间状态。
+
+## 结构化入口
+
+从仓库根目录使用 `scripts/graph_debug_case.py`：
+
+1. `init` 创建 `.vaws-local/graph-debug/<case-id>/case.json` 和 Run Manifest v1。
+2. 每轮单变量实验后立即用 `record` 追加假设、预期、观测、结论和下一步。
+3. 需要中间状态对拍时，用 `compare` 对齐 eager/graph JSONL snapshot 并找到首个分叉。
+4. 修复后用 `finalize` 同时记录最小复现、原始复现和 instrumentation 清理状态。
+
+按需读取：
+
+- [Behavior contract](references/behavior.md)：case 生命周期、snapshot schema、比较语义和 Run Manifest 集成。
+- [Command recipes](references/command-recipes.md)：可复制的 init、record、compare、finalize 命令。
+- [Acceptance](references/acceptance.md)：结案前必须逐项满足的验收条件。
+
+## 工作原则
+
+1. 每轮实验只改变一个变量，实验前写明假设，实验后记录结论。
+2. 优先证明“已经排除什么”和“问题首次出现在哪里”，避免重复回到已验证路径。
+3. Eager 模式必须先正常；如果 Eager 本身失败，先修 Eager，不进入图模式排查。
+4. 精度排查优先固定随机性和输入；性能、吞吐、并发压力只在问题需要时引入。
+5. 图内只做设备侧、可 capture 的操作；同步、CPU 读回、文件写入统一放到图外。
+
+## 记录要求
+
+不要使用散落的临时笔记作为唯一事实来源。以 case 目录中的 `case.json` 为结构化记录；issue 或 PR comment 可以引用它的摘要。每次实验完成后立即运行 `record`，并保持“已知事实 / 已排除 / 当前嫌疑 / 下一步”与 case 内容一致。
+
+## 总流程
+
+1. 建立基线：同输入、同 seed、同采样参数分别跑 Eager 和 Graph。
+2. 固定确定性：启动环境设置 `HCCL_DETERMINISTIC=true`；model runner 初始化时调用 `torch.use_deterministic_algorithms(True)`。
+3. 阶段定性：先判断问题发生在 compile、capture、replay 还是 accuracy。
+4. 控制变量缩小范围：模型规模、并行策略、请求 shape、capture size、特性开关、部署方式逐项收敛。
+5. 静态审计：检查 graph replay 依赖的 metadata、padding、dummy run 与真实请求路径、自定义算子 capture/replay 约束。
+6. 动态打点：在候选模块插入预分配 debug buffer，图内 `copy_`，图外 flush。
+7. 对齐比较：按 step/layer/rank/tag 先比统计量，再比局部样本，定位首个分叉点。
+8. 修复验证：关闭 debug 代码和同步逻辑，重跑最小复现和原始复现，更新记录。
+
+## 阶段定性
+
+| 阶段 | 典型现象 | 先问什么 | 下一步 |
+|------|----------|----------|--------|
+| Compile | 启动、加载或 `torch.compile` 阶段报错/卡住 | 是否是 Python/Dynamo/FX/算子前端问题 | 看堆栈；缩小到具体模块或算子；必要时图外打印 |
+| Capture | dummy run、capture model 阶段报错/卡住 | 编译后静态图是否能在固定 shape 下执行 | 隔离 compile backend 与 graph capture；查同步、CPU 读回、自定义算子 |
+| Replay | capture 成功，真实请求时报错/卡住 | 真实请求和捕获 shape/metadata/通信序列是否一致 | 查 padding、固定地址 metadata、event 配对、rank 间状态 |
+| Accuracy | graph 输出与 Eager 非预期差异 | 是良性数值差异还是功能性错误 | 无 padding 对照；静态审计；中间 tensor 对比 |
+
+如果阶段不清楚，先用最小请求复现，并记录最后一个成功阶段。不要一开始就改多处代码。
+
+## 范围收敛
+
+按从外到内、从便宜到昂贵的顺序缩小范围：
+
+1. 环境：确认驱动、CANN、torch、torch_npu、vLLM、vLLM Ascend 版本一致且被记录。
+2. 输入：固定 prompt 或 token ids、采样参数、seed、max tokens、batch、并发。
+3. 模型：从原模型缩到同结构小模型；必要时屏蔽或替换可疑模块。
+4. 并行：多机到单机，多卡到单卡，逐步恢复 TP/DP/EP/PP 等策略。
+5. Shape：构造无 padding、少 padding、大 padding 的请求，观察差异是否跟 capture size 相关。
+6. 特性：逐个关闭可选优化、特殊 decode 路径、自定义 kernel 或高级调度。
+7. 部署：从在线服务缩到离线脚本，排除服务层、调度层和并发干扰。
+
+每一步只改变一个变量。若实验结果不改变结论，记录为“已排除”，后续不要重复尝试。
+
+## 精度排查
+
+先判断差异性质：
+
+| 类型 | 表现 | 判断方式 | 处理 |
+|------|------|----------|------|
+| 良性数值差异 | 数值有小幅偏移，输出整体合理 | 无 padding 或固定 shape 后差异明显缩小；任务级指标可接受 | 记录结论，通常不修 |
+| 功能性错误 | 乱码、重复、答案坍缩、首个分叉后快速扩散 | Eager 正常，Graph 稳定异常；中间状态出现明确首个分叉 | 继续缩小到模块、rank、token、算子 |
+
+常见嫌疑按优先级审计：
+
+1. Graph replay 读取的 tensor 地址是否固定：input、position、slot/block、attention metadata、长度信息等都应预分配并复用。
+2. Dummy run 与真实请求是否走同一逻辑：shape、分支、metadata、mask、cache 索引、空 tensor 情况是否一致。
+3. Padding 是否被正确处理：算子是否读取 padding 区，统计是否包含无效 token，索引是否越界或错位。
+4. Rank 间状态是否一致：每个 rank 的请求数、token 数、通信序列、metadata 更新顺序是否对齐。
+5. 自定义算子是否支持 capture/replay：是否在图内分配内存、同步、读回 CPU 或依赖变化的 host 状态。
+
+## 快照打点
+
+当静态审计无法定位时，使用预分配 buffer 快照。原则：
+
+1. Buffer 在初始化阶段创建并注册；不要在 forward 中惰性创建。
+2. Forward 中只做 `copy_(..., non_blocking=True)` 和设备侧统计。
+3. 图外统一 `synchronize`、CPU 读回和写文件。
+4. 打点尽量少：先输入/输出，再在首个分叉窗口内增加更细 tag。
+5. 每次新增 tag 都记录目的，定位后删除。
+
+### 最小模板
+
+按代码结构改名即可，不要照搬固定 rank、shape 或 tag；它们应由当前最小复现决定。
+
+```python
+DEBUG_ENABLE = True
+DEBUG_MAX_LAYERS = 2
+DEBUG_RANKS = None  # None 表示所有 rank；也可设置为 {0, 1}
+_DEBUG_IMPLS = []
+
+def flush_debug_buffers() -> None:
+    if not _DEBUG_IMPLS:
+        return
+    if torch.npu.is_current_stream_capturing():
+        return
+    torch.npu.synchronize()
+    lines = []
+    for impl in _DEBUG_IMPLS:
+        impl.flush_debug(lines)
+    if lines:
+        with open(debug_log_path(), "a") as f:
+            f.write("\n".join(lines) + "\n")
+```
+
+```python
+class DebuggableImpl:
+    def __init__(self, ...):
+        self.debug_rank = current_rank()
+        self.debug_enabled = (
+            DEBUG_ENABLE
+            and (DEBUG_RANKS is None or self.debug_rank in DEBUG_RANKS)
+        )
+        if self.debug_enabled:
+            self.debug_step = 0
+            self.debug_layer = -1
+            self.debug_shapes = {
+                "IN": (max_rows, max_cols),
+                "OUT": (max_rows, max_cols),
+            }
+            self.debug_buffers = {
+                tag: torch.zeros(shape, dtype=torch.bfloat16, device=current_device())
+                for tag, shape in self.debug_shapes.items()
+            }
+            self.debug_stats = {
+                tag: torch.zeros(4, dtype=torch.float32, device=current_device())
+                for tag in self.debug_shapes
+            }
+            _DEBUG_IMPLS.append(self)
+
+    def snapshot(self, tag: str, tensor: torch.Tensor) -> None:
+        if not self.debug_enabled or tensor.numel() == 0:
+            return
+        buf = self.debug_buffers.get(tag)
+        if buf is None:
+            return
+        sample = select_representative_slice(tensor).to(buf.dtype).contiguous()
+        rows = min(sample.shape[0], buf.shape[0])
+        cols = min(sample.shape[1], buf.shape[1])
+        buf[:rows, :cols].copy_(sample[:rows, :cols], non_blocking=True)
+
+        values = tensor.float()
+        stat = self.debug_stats[tag]
+        stat[0].copy_(values.min(), non_blocking=True)
+        stat[1].copy_(values.max(), non_blocking=True)
+        stat[2].copy_(values.mean(), non_blocking=True)
+        stat[3].copy_(values.var(), non_blocking=True)
+
+    def flush_debug(self, lines: list[str]) -> None:
+        if not self.debug_enabled or not (0 <= self.debug_layer < DEBUG_MAX_LAYERS):
+            return
+        for tag, buf in self.debug_buffers.items():
+            stat = self.debug_stats[tag].cpu().tolist()
+            sample = buf.cpu().tolist()
+            lines.append(format_debug_record(
+                step=self.debug_step,
+                layer=self.debug_layer,
+                rank=self.debug_rank,
+                tag=tag,
+                stat=stat,
+                sample=sample,
+            ))
+        self.debug_step += 1
+```
+
+在 model runner 或等价调度位置：
+
+```python
+def __init__(self, ...):
+    torch.use_deterministic_algorithms(True)
+    ...
+
+def execute_model(self, ...):
+    output = run_model(...)
+    flush_debug_buffers()
+    return output
+```
+
+启动脚本或服务环境：
+
+```bash
+export HCCL_DETERMINISTIC=true
+```
+
+## 对比方法
+
+1. 两轮运行必须使用同一最小复现：一次 graph，一次 Eager。
+2. 日志 key 至少包含 `step/layer/rank/tag`，确保能机械对齐。
+3. 先比统计量：`min/max/mean/var` 一致时，通常不需要扩大样本。
+4. 统计量首次不一致时，记录首个分叉窗口，再在该窗口内增加 tag 或扩大样本。
+5. 若所有 rank 同时分叉，优先查共享输入、shape、padding、公共算子。
+6. 若单个或少数 rank 分叉，优先查 rank-local metadata、通信顺序、分片索引。
+7. 若只有特定 shape 分叉，优先查 capture size、padding、空 tensor、边界索引。
+8. 每轮对比结束后更新“已知事实 / 已排除 / 当前嫌疑 / 下一步”。
+
+## 工具选择
+
+| 工具 | 适用阶段 | 注意 |
+|------|----------|------|
+| Python `print` | 构图、capture 前后 Python 逻辑 | Replay 不会重新执行 Python，不能证明 replay 内状态 |
+| 图外设备打印 | Compile 卡住、Eager 调试 | 可能引入同步，不要放进 capture/replay 路径 |
+| `copy_` 到预分配 buffer | Capture、Replay、精度对比 | 首选；只做设备侧 copy，图外落盘 |
+| 图模式专用打印工具 | Capture、Replay 阻塞点 | 放在其支持的位置，避免破坏 compile |
+| plog/运行日志 | Capture、Replay 报错或卡住 | 结合最后成功阶段和 rank 对齐信息看 |
+| GDB/线程栈 | 卡死 | 用于确认底层等待、通信或事件阻塞 |
+
+## 收尾
+
+定位完成后：
+
+1. 删除或关闭 debug buffer、同步、落盘、确定性调试开关。
+2. 用最小复现验证修复。
+3. 用原始复现验证问题不再出现。
+4. 运行 `finalize`，写清根因、修复点、已验证场景和仍未覆盖的风险。
+5. 对照 [Acceptance](references/acceptance.md) 验证 `case.json`、comparison artifacts 和 Run Manifest。

--- a/.agents/skills/vllm-ascend-graph-debug/agents/openai.yaml
+++ b/.agents/skills/vllm-ascend-graph-debug/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "vLLM Ascend Graph Debug"
+  short_description: "Diagnose Ascend graph capture and replay failures"
+  default_prompt: "Use $vllm-ascend-graph-debug to classify and diagnose this graph-mode failure with a structured evidence trail."

--- a/.agents/skills/vllm-ascend-graph-debug/references/acceptance.md
+++ b/.agents/skills/vllm-ascend-graph-debug/references/acceptance.md
@@ -1,0 +1,34 @@
+# Graph debug acceptance
+
+Do not mark a graph-debug case resolved until every required item passes.
+
+## Baseline and classification
+
+- [ ] The exact workspace snapshot, environment, model, topology, input, seed, and sampling parameters are recorded.
+- [ ] Eager passes under the same functional inputs, or the issue has been routed away from graph debug.
+- [ ] The failure is classified as compile, capture, replay, accuracy, or explicitly unknown.
+- [ ] The smallest current reproduction is recorded.
+
+## Controlled experiments
+
+- [ ] Each experiment changes one named variable.
+- [ ] Each experiment records a falsifiable hypothesis and expected observation before execution.
+- [ ] Actual observation, conclusion, and next step are recorded.
+- [ ] Previously excluded paths are not repeated without new evidence.
+
+## Snapshot comparison
+
+- [ ] Graph and eager snapshots use identical `step/layer/rank/tag` keys.
+- [ ] Snapshot buffers are allocated before capture.
+- [ ] No CPU read, synchronization, or file I/O occurs inside captured execution.
+- [ ] Tolerances are explicit and justified.
+- [ ] The first divergent key is recorded and used to narrow subsequent instrumentation.
+
+## Resolution
+
+- [ ] Root cause and fix are recorded.
+- [ ] The minimal reproduction passes after the fix.
+- [ ] The original reproduction passes after the fix.
+- [ ] Temporary buffers, logging, synchronization, deterministic overrides, and workarounds are removed or intentionally disabled.
+- [ ] `case.json`, comparison artifacts, and Run Manifest v1 validate.
+- [ ] Remaining untested combinations are listed as risks rather than implied supported.

--- a/.agents/skills/vllm-ascend-graph-debug/references/behavior.md
+++ b/.agents/skills/vllm-ascend-graph-debug/references/behavior.md
@@ -1,0 +1,103 @@
+# Graph debug behavior contract
+
+## Contents
+
+- [Case lifecycle](#case-lifecycle)
+- [Snapshot contract](#snapshot-contract)
+- [Comparison semantics](#comparison-semantics)
+- [Run Manifest integration](#run-manifest-integration)
+- [Failure boundaries](#failure-boundaries)
+
+## Case lifecycle
+
+Use `scripts/graph_debug_case.py` to keep one structured case directory:
+
+```text
+case-dir/
+├── case.json
+├── manifest.json
+└── comparisons/
+    └── comparison-001.json
+```
+
+The lifecycle is:
+
+1. `init`: record environment, workspace snapshot, topology, reproduction, eager result, graph result, and the classified failure stage.
+2. `record`: append one single-variable experiment with its hypothesis, expected observation, actual observation, conclusion, and next step.
+3. `compare`: align eager and graph snapshots by `step/layer/rank/tag`, compare statistics and optional samples, then record the first divergence.
+4. `finalize`: record the root cause, fix, minimal-reproduction result, original-reproduction result, and debug-instrumentation cleanup.
+
+A case is resolved only when both reproductions pass and instrumentation is removed or disabled. Other final results are `inconclusive`.
+
+## Snapshot contract
+
+Write UTF-8 JSON Lines. Each non-empty line is one object with this key:
+
+```json
+{
+  "step": 0,
+  "layer": 1,
+  "rank": 0,
+  "tag": "attention-output",
+  "shape": [16, 4096],
+  "dtype": "bfloat16",
+  "stats": {
+    "min": -1.25,
+    "max": 2.5,
+    "mean": 0.03125,
+    "var": 0.75
+  },
+  "sample": [0.5, 0.25, -0.125]
+}
+```
+
+Required fields:
+
+- `step`, `layer`, and `rank`: integers;
+- `tag`: non-empty string;
+- `stats`: object when numeric statistics are captured.
+
+Optional `sample` may contain nested numeric arrays. Duplicate alignment keys are invalid.
+
+Graph capture constraints:
+
+- allocate snapshot buffers before capture;
+- perform only device-side `copy_` and supported device-side statistics inside captured execution;
+- synchronize, read to CPU, and write JSONL outside capture;
+- use identical tags and representative-slice logic in eager and graph runs.
+
+## Comparison semantics
+
+The comparator:
+
+- aligns records by `step/layer/rank/tag`;
+- sorts aligned keys deterministically;
+- reports missing records as divergence;
+- compares all shared statistic fields and optional samples;
+- accepts independent absolute and relative tolerances;
+- reports the earliest divergent key as `first_divergence`;
+- does not decide whether a tolerance is acceptable for a model or dtype.
+
+Default tolerances are zero. Choose non-zero tolerances explicitly and record why.
+
+## Run Manifest integration
+
+`init` creates Run Manifest v1 with `run_type=debug`. The first experiment or comparison moves it to `running`. Each comparison becomes a linked artifact. `finalize` links `case.json` and moves the manifest to:
+
+- `passed` for a resolved case;
+- `inconclusive` otherwise.
+
+Do not store passwords, tokens, credentials, or secret environment variables in case inputs.
+
+## Failure boundaries
+
+The script manages evidence and comparison; it does not:
+
+- launch a vLLM service;
+- synchronize local code to a remote machine;
+- collect device logs or stack dumps;
+- insert instrumentation into vLLM or vllm-ascend automatically;
+- decide task-level accuracy acceptance;
+- diagnose eager failures.
+
+Use `remote-code-parity` before remote execution and the appropriate Serving or distributed-debug workflow for runtime control.

--- a/.agents/skills/vllm-ascend-graph-debug/references/command-recipes.md
+++ b/.agents/skills/vllm-ascend-graph-debug/references/command-recipes.md
@@ -1,0 +1,59 @@
+# Graph debug command recipes
+
+Run commands from the workspace root.
+
+## Initialize a case
+
+```bash
+python -B .agents/skills/vllm-ascend-graph-debug/scripts/graph_debug_case.py init \
+  --case-dir .vaws-local/graph-debug/graph-case-001 \
+  --case-id graph-case-001 \
+  --stage accuracy \
+  --eager-result pass \
+  --graph-result fail \
+  --reproduction "fixed prompt, seed 7, temperature 0, max_tokens 32" \
+  --workspace-snapshot '{"workspace":"<commit-or-snapshot>","dirty":false}' \
+  --environment '{"machine":"<alias>","cann":"<version>","torch_npu":"<version>"}' \
+  --model '{"path":"<remote-model-path>"}' \
+  --topology '{"tp":2,"devices":[0,1]}'
+```
+
+Never place secrets in JSON arguments.
+
+## Record one controlled experiment
+
+```bash
+python -B .agents/skills/vllm-ascend-graph-debug/scripts/graph_debug_case.py record \
+  --case-dir .vaws-local/graph-debug/graph-case-001 \
+  --variable "capture size: 128 -> 64" \
+  --hypothesis "divergence follows padding introduced by capture size 128" \
+  --expected "capture size 64 removes the first divergence" \
+  --observed "first divergence remains at step 0 layer 3 rank 1" \
+  --conclusion "capture size alone is excluded" \
+  --next-step "compare rank-local attention metadata before layer 3"
+```
+
+## Compare eager and graph snapshots
+
+```bash
+python -B .agents/skills/vllm-ascend-graph-debug/scripts/graph_debug_case.py compare \
+  --case-dir .vaws-local/graph-debug/graph-case-001 \
+  --eager /path/to/eager.jsonl \
+  --graph /path/to/graph.jsonl \
+  --atol 1e-5 \
+  --rtol 1e-4
+```
+
+Inspect `first_divergence` in stdout first. Load the saved comparison artifact only when more detail is needed.
+
+## Finalize
+
+```bash
+python -B .agents/skills/vllm-ascend-graph-debug/scripts/graph_debug_case.py finalize \
+  --case-dir .vaws-local/graph-debug/graph-case-001 \
+  --root-cause "rank-local slot mapping was not refreshed before replay" \
+  --fix "copy slot mapping into the fixed graph input buffer before replay" \
+  --minimal-result pass \
+  --original-result pass \
+  --cleanup-status removed
+```

--- a/.agents/skills/vllm-ascend-graph-debug/scripts/graph_debug_case.py
+++ b/.agents/skills/vllm-ascend-graph-debug/scripts/graph_debug_case.py
@@ -1,0 +1,646 @@
+#!/usr/bin/env python3
+"""Manage graph-debug cases and compare graph/eager JSONL snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_run_manifest import (  # noqa: E402
+    RunManifestError,
+    add_artifact,
+    load_manifest,
+    new_manifest,
+    transition_status,
+    write_manifest,
+)
+
+CASE_SCHEMA_VERSION = 1
+SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+STAGES = ("compile", "capture", "replay", "accuracy", "unknown")
+BASELINE_RESULTS = ("pass", "fail", "not-run")
+SNAPSHOT_KEY_FIELDS = ("step", "layer", "rank", "tag")
+
+
+class GraphDebugError(ValueError):
+    """Raised when a graph-debug case or snapshot is invalid."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def emit_progress(phase: str, **details: Any) -> None:
+    print(json.dumps({"phase": phase, **details}, ensure_ascii=False), file=sys.stderr)
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _json_object(raw: str, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise GraphDebugError(f"{label} must be valid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise GraphDebugError(f"{label} must be a JSON object")
+    return value
+
+
+def _case_path(case_dir: Path) -> Path:
+    return case_dir / "case.json"
+
+
+def _manifest_path(case_dir: Path) -> Path:
+    return case_dir / "manifest.json"
+
+
+def _validate_case(case: Mapping[str, Any]) -> None:
+    errors: list[str] = []
+    if case.get("schema_version") != CASE_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {CASE_SCHEMA_VERSION}")
+    case_id = case.get("case_id")
+    if not isinstance(case_id, str) or not SAFE_ID_RE.fullmatch(case_id):
+        errors.append("case_id must be a lowercase safe identifier")
+    if case.get("stage") not in STAGES:
+        errors.append(f"stage must be one of: {', '.join(STAGES)}")
+    baselines = case.get("baselines")
+    if not isinstance(baselines, Mapping):
+        errors.append("baselines must be an object")
+    else:
+        for mode in ("eager", "graph"):
+            if baselines.get(mode) not in BASELINE_RESULTS:
+                errors.append(
+                    f"baselines.{mode} must be one of: {', '.join(BASELINE_RESULTS)}"
+                )
+    for field in ("environment", "workspace_snapshot", "model", "topology"):
+        if not isinstance(case.get(field), Mapping):
+            errors.append(f"{field} must be an object")
+    if not isinstance(case.get("reproduction"), str) or not case["reproduction"].strip():
+        errors.append("reproduction must be a non-empty string")
+    for field in ("experiments", "comparisons"):
+        if not isinstance(case.get(field), list):
+            errors.append(f"{field} must be an array")
+    if case.get("status") not in {"active", "resolved", "inconclusive"}:
+        errors.append("status must be active, resolved, or inconclusive")
+    if errors:
+        raise GraphDebugError("; ".join(errors))
+
+
+def load_case(case_dir: Path) -> dict[str, Any]:
+    path = _case_path(case_dir)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GraphDebugError(f"cannot read graph-debug case {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise GraphDebugError("case root must be an object")
+    _validate_case(payload)
+    return payload
+
+
+def init_case(
+    case_dir: Path,
+    *,
+    case_id: str,
+    stage: str,
+    eager_result: str,
+    graph_result: str,
+    reproduction: str,
+    environment: Mapping[str, Any] | None = None,
+    workspace_snapshot: Mapping[str, Any] | None = None,
+    model: Mapping[str, Any] | None = None,
+    topology: Mapping[str, Any] | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    if case_dir.exists() and any(case_dir.iterdir()):
+        raise GraphDebugError(f"case directory is not empty: {case_dir}")
+    timestamp = created_at or utc_now()
+    case: dict[str, Any] = {
+        "schema_version": CASE_SCHEMA_VERSION,
+        "case_id": case_id,
+        "stage": stage,
+        "baselines": {"eager": eager_result, "graph": graph_result},
+        "environment": dict(environment or {}),
+        "workspace_snapshot": dict(workspace_snapshot or {}),
+        "model": dict(model or {}),
+        "topology": dict(topology or {}),
+        "reproduction": reproduction,
+        "known_facts": [],
+        "excluded": [],
+        "current_suspects": [],
+        "experiments": [],
+        "comparisons": [],
+        "resolution": None,
+        "status": "active",
+        "created_at": timestamp,
+        "updated_at": timestamp,
+    }
+    _validate_case(case)
+    manifest = new_manifest(
+        run_type="debug",
+        run_id=case_id,
+        workspace_snapshot=workspace_snapshot,
+        environment=environment,
+        model=model,
+        topology=topology,
+        command=[],
+        created_at=timestamp,
+    )
+    case_dir.mkdir(parents=True, exist_ok=True)
+    _atomic_write_json(_case_path(case_dir), case)
+    write_manifest(_manifest_path(case_dir), manifest)
+    return case
+
+
+def _ensure_manifest_running(case_dir: Path, *, updated_at: str | None = None) -> dict[str, Any]:
+    manifest = load_manifest(_manifest_path(case_dir))
+    if manifest["status"] == "planned":
+        manifest = transition_status(manifest, "running", updated_at=updated_at)
+        write_manifest(_manifest_path(case_dir), manifest)
+    if manifest["status"] != "running":
+        raise GraphDebugError(
+            f"case manifest is already terminal: {manifest['status']}"
+        )
+    return manifest
+
+
+def record_experiment(
+    case_dir: Path,
+    *,
+    variable: str,
+    hypothesis: str,
+    expected: str,
+    observed: str,
+    conclusion: str,
+    next_step: str,
+    updated_at: str | None = None,
+) -> dict[str, Any]:
+    case = load_case(case_dir)
+    if case["status"] != "active":
+        raise GraphDebugError(f"cannot record experiment on {case['status']} case")
+    values = {
+        "variable": variable,
+        "hypothesis": hypothesis,
+        "expected": expected,
+        "observed": observed,
+        "conclusion": conclusion,
+        "next_step": next_step,
+    }
+    for field, value in values.items():
+        if not value.strip():
+            raise GraphDebugError(f"{field} must be non-empty")
+    timestamp = updated_at or utc_now()
+    experiment = {
+        "index": len(case["experiments"]) + 1,
+        **values,
+        "recorded_at": timestamp,
+    }
+    case["experiments"].append(experiment)
+    case["updated_at"] = timestamp
+    _validate_case(case)
+    _ensure_manifest_running(case_dir, updated_at=timestamp)
+    _atomic_write_json(_case_path(case_dir), case)
+    return experiment
+
+
+def _snapshot_key(record: Mapping[str, Any], *, path: Path, line_number: int) -> tuple:
+    values: list[Any] = []
+    for field in SNAPSHOT_KEY_FIELDS:
+        if field not in record:
+            raise GraphDebugError(f"{path}:{line_number}: missing snapshot key {field}")
+        value = record[field]
+        if field == "tag":
+            if not isinstance(value, str) or not value:
+                raise GraphDebugError(f"{path}:{line_number}: tag must be non-empty")
+        elif not isinstance(value, int) or isinstance(value, bool):
+            raise GraphDebugError(f"{path}:{line_number}: {field} must be an integer")
+        values.append(value)
+    return tuple(values)
+
+
+def load_snapshots(path: Path) -> dict[tuple, dict[str, Any]]:
+    records: dict[tuple, dict[str, Any]] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise GraphDebugError(f"cannot read snapshot file {path}: {exc}") from exc
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise GraphDebugError(f"{path}:{line_number}: invalid JSON: {exc}") from exc
+        if not isinstance(record, dict):
+            raise GraphDebugError(f"{path}:{line_number}: snapshot must be an object")
+        key = _snapshot_key(record, path=path, line_number=line_number)
+        if key in records:
+            raise GraphDebugError(f"{path}:{line_number}: duplicate snapshot key {key}")
+        records[key] = record
+    if not records:
+        raise GraphDebugError(f"snapshot file has no records: {path}")
+    return records
+
+
+def _flatten_numbers(value: Any, *, label: str) -> list[float]:
+    if isinstance(value, bool):
+        raise GraphDebugError(f"{label} contains a boolean instead of a number")
+    if isinstance(value, (int, float)):
+        return [float(value)]
+    if isinstance(value, list):
+        flattened: list[float] = []
+        for index, item in enumerate(value):
+            flattened.extend(_flatten_numbers(item, label=f"{label}[{index}]"))
+        return flattened
+    raise GraphDebugError(f"{label} must contain only numbers or nested arrays")
+
+
+def _numbers_close(left: float, right: float, *, atol: float, rtol: float) -> bool:
+    if math.isnan(left) or math.isnan(right):
+        return math.isnan(left) and math.isnan(right)
+    if math.isinf(left) or math.isinf(right):
+        return left == right
+    return math.isclose(left, right, abs_tol=atol, rel_tol=rtol)
+
+
+def _compare_record(
+    eager: Mapping[str, Any],
+    graph: Mapping[str, Any],
+    *,
+    atol: float,
+    rtol: float,
+) -> list[dict[str, Any]]:
+    differences: list[dict[str, Any]] = []
+    eager_stats = eager.get("stats", {})
+    graph_stats = graph.get("stats", {})
+    if not isinstance(eager_stats, Mapping) or not isinstance(graph_stats, Mapping):
+        raise GraphDebugError("snapshot stats must be objects")
+    for name in sorted(set(eager_stats) | set(graph_stats)):
+        if name not in eager_stats or name not in graph_stats:
+            differences.append({"field": f"stats.{name}", "reason": "missing"})
+            continue
+        left = _flatten_numbers(eager_stats[name], label=f"eager.stats.{name}")
+        right = _flatten_numbers(graph_stats[name], label=f"graph.stats.{name}")
+        if len(left) != len(right):
+            differences.append(
+                {
+                    "field": f"stats.{name}",
+                    "reason": "length-mismatch",
+                    "eager_length": len(left),
+                    "graph_length": len(right),
+                }
+            )
+            continue
+        mismatches = [
+            index
+            for index, (left_value, right_value) in enumerate(zip(left, right))
+            if not _numbers_close(left_value, right_value, atol=atol, rtol=rtol)
+        ]
+        if mismatches:
+            index = mismatches[0]
+            differences.append(
+                {
+                    "field": f"stats.{name}",
+                    "reason": "numeric-divergence",
+                    "first_index": index,
+                    "eager": left[index],
+                    "graph": right[index],
+                    "mismatch_count": len(mismatches),
+                }
+            )
+
+    if "sample" in eager or "sample" in graph:
+        if "sample" not in eager or "sample" not in graph:
+            differences.append({"field": "sample", "reason": "missing"})
+        else:
+            left = _flatten_numbers(eager["sample"], label="eager.sample")
+            right = _flatten_numbers(graph["sample"], label="graph.sample")
+            if len(left) != len(right):
+                differences.append(
+                    {
+                        "field": "sample",
+                        "reason": "length-mismatch",
+                        "eager_length": len(left),
+                        "graph_length": len(right),
+                    }
+                )
+            else:
+                mismatches = [
+                    index
+                    for index, (left_value, right_value) in enumerate(zip(left, right))
+                    if not _numbers_close(left_value, right_value, atol=atol, rtol=rtol)
+                ]
+                if mismatches:
+                    index = mismatches[0]
+                    differences.append(
+                        {
+                            "field": "sample",
+                            "reason": "numeric-divergence",
+                            "first_index": index,
+                            "eager": left[index],
+                            "graph": right[index],
+                            "mismatch_count": len(mismatches),
+                        }
+                    )
+    return differences
+
+
+def compare_snapshots(
+    eager_path: Path,
+    graph_path: Path,
+    *,
+    atol: float,
+    rtol: float,
+) -> dict[str, Any]:
+    if atol < 0 or rtol < 0:
+        raise GraphDebugError("atol and rtol must be non-negative")
+    eager = load_snapshots(eager_path)
+    graph = load_snapshots(graph_path)
+    eager_keys = set(eager)
+    graph_keys = set(graph)
+    missing_in_graph = sorted(eager_keys - graph_keys)
+    missing_in_eager = sorted(graph_keys - eager_keys)
+    divergences: list[dict[str, Any]] = []
+    for key in sorted(eager_keys & graph_keys):
+        differences = _compare_record(eager[key], graph[key], atol=atol, rtol=rtol)
+        if differences:
+            divergences.append(
+                {
+                    "key": dict(zip(SNAPSHOT_KEY_FIELDS, key)),
+                    "differences": differences,
+                }
+            )
+    for key in missing_in_graph:
+        divergences.append(
+            {
+                "key": dict(zip(SNAPSHOT_KEY_FIELDS, key)),
+                "differences": [{"field": "record", "reason": "missing-in-graph"}],
+            }
+        )
+    for key in missing_in_eager:
+        divergences.append(
+            {
+                "key": dict(zip(SNAPSHOT_KEY_FIELDS, key)),
+                "differences": [{"field": "record", "reason": "missing-in-eager"}],
+            }
+        )
+    divergences.sort(
+        key=lambda row: tuple(row["key"][field] for field in SNAPSHOT_KEY_FIELDS)
+    )
+    return {
+        "schema_version": 1,
+        "status": "exact-match" if not divergences else "diverged",
+        "eager_snapshot": str(eager_path.resolve()),
+        "graph_snapshot": str(graph_path.resolve()),
+        "atol": atol,
+        "rtol": rtol,
+        "eager_count": len(eager),
+        "graph_count": len(graph),
+        "aligned_count": len(eager_keys & graph_keys),
+        "divergence_count": len(divergences),
+        "first_divergence": divergences[0] if divergences else None,
+        "divergences": divergences,
+    }
+
+
+def compare_case(
+    case_dir: Path,
+    *,
+    eager_path: Path,
+    graph_path: Path,
+    atol: float,
+    rtol: float,
+    updated_at: str | None = None,
+) -> tuple[dict[str, Any], Path]:
+    case = load_case(case_dir)
+    if case["status"] != "active":
+        raise GraphDebugError(f"cannot compare snapshots on {case['status']} case")
+    emit_progress("load-snapshots", eager=str(eager_path), graph=str(graph_path))
+    comparison = compare_snapshots(eager_path, graph_path, atol=atol, rtol=rtol)
+    index = len(case["comparisons"]) + 1
+    output = case_dir / "comparisons" / f"comparison-{index:03d}.json"
+    _atomic_write_json(output, comparison)
+    timestamp = updated_at or utc_now()
+    case["comparisons"].append(
+        {
+            "index": index,
+            "path": output.relative_to(case_dir).as_posix(),
+            "status": comparison["status"],
+            "first_divergence": comparison["first_divergence"],
+            "recorded_at": timestamp,
+        }
+    )
+    case["updated_at"] = timestamp
+    _atomic_write_json(_case_path(case_dir), case)
+
+    manifest = _ensure_manifest_running(case_dir, updated_at=timestamp)
+    manifest = add_artifact(
+        manifest,
+        name=f"comparison-{index:03d}",
+        kind="graph-eager-comparison",
+        uri=output.relative_to(case_dir).as_posix(),
+        updated_at=timestamp,
+    )
+    write_manifest(_manifest_path(case_dir), manifest)
+    return comparison, output
+
+
+def finalize_case(
+    case_dir: Path,
+    *,
+    root_cause: str,
+    fix: str,
+    minimal_result: str,
+    original_result: str,
+    cleanup_status: str,
+    updated_at: str | None = None,
+) -> dict[str, Any]:
+    case = load_case(case_dir)
+    if case["status"] != "active":
+        raise GraphDebugError(f"case is already {case['status']}")
+    if minimal_result not in {"pass", "fail"} or original_result not in {"pass", "fail"}:
+        raise GraphDebugError("minimal-result and original-result must be pass or fail")
+    if cleanup_status not in {"removed", "disabled", "pending"}:
+        raise GraphDebugError("cleanup-status must be removed, disabled, or pending")
+    if not root_cause.strip() or not fix.strip():
+        raise GraphDebugError("root-cause and fix must be non-empty")
+    resolved = (
+        minimal_result == "pass"
+        and original_result == "pass"
+        and cleanup_status in {"removed", "disabled"}
+    )
+    timestamp = updated_at or utc_now()
+    case["resolution"] = {
+        "root_cause": root_cause,
+        "fix": fix,
+        "minimal_reproduction": minimal_result,
+        "original_reproduction": original_result,
+        "debug_instrumentation": cleanup_status,
+        "resolved_at": timestamp,
+    }
+    case["status"] = "resolved" if resolved else "inconclusive"
+    case["updated_at"] = timestamp
+    _validate_case(case)
+    _atomic_write_json(_case_path(case_dir), case)
+
+    manifest = _ensure_manifest_running(case_dir, updated_at=timestamp)
+    manifest = add_artifact(
+        manifest,
+        name="graph-debug-case",
+        kind="debug-record",
+        uri="case.json",
+        updated_at=timestamp,
+    )
+    manifest = transition_status(
+        manifest, "passed" if resolved else "inconclusive", updated_at=timestamp
+    )
+    write_manifest(_manifest_path(case_dir), manifest)
+    return case
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+
+    init = subparsers.add_parser("init", help="initialize a graph-debug case")
+    init.add_argument("--case-dir", required=True, type=Path)
+    init.add_argument("--case-id", required=True)
+    init.add_argument("--stage", required=True, choices=STAGES)
+    init.add_argument("--eager-result", required=True, choices=BASELINE_RESULTS)
+    init.add_argument("--graph-result", required=True, choices=BASELINE_RESULTS)
+    init.add_argument("--reproduction", required=True)
+    init.add_argument("--environment", default="{}")
+    init.add_argument("--workspace-snapshot", default="{}")
+    init.add_argument("--model", default="{}")
+    init.add_argument("--topology", default="{}")
+
+    record = subparsers.add_parser("record", help="append one controlled experiment")
+    record.add_argument("--case-dir", required=True, type=Path)
+    record.add_argument("--variable", required=True)
+    record.add_argument("--hypothesis", required=True)
+    record.add_argument("--expected", required=True)
+    record.add_argument("--observed", required=True)
+    record.add_argument("--conclusion", required=True)
+    record.add_argument("--next-step", required=True)
+
+    compare = subparsers.add_parser("compare", help="compare eager and graph JSONL snapshots")
+    compare.add_argument("--case-dir", required=True, type=Path)
+    compare.add_argument("--eager", required=True, type=Path)
+    compare.add_argument("--graph", required=True, type=Path)
+    compare.add_argument("--atol", type=float, default=0.0)
+    compare.add_argument("--rtol", type=float, default=0.0)
+
+    finalize = subparsers.add_parser("finalize", help="finalize validation and cleanup")
+    finalize.add_argument("--case-dir", required=True, type=Path)
+    finalize.add_argument("--root-cause", required=True)
+    finalize.add_argument("--fix", required=True)
+    finalize.add_argument("--minimal-result", required=True, choices=("pass", "fail"))
+    finalize.add_argument("--original-result", required=True, choices=("pass", "fail"))
+    finalize.add_argument(
+        "--cleanup-status", required=True, choices=("removed", "disabled", "pending")
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.action == "init":
+            emit_progress("initialize", case_dir=str(args.case_dir))
+            case = init_case(
+                args.case_dir,
+                case_id=args.case_id,
+                stage=args.stage,
+                eager_result=args.eager_result,
+                graph_result=args.graph_result,
+                reproduction=args.reproduction,
+                environment=_json_object(args.environment, "environment"),
+                workspace_snapshot=_json_object(
+                    args.workspace_snapshot, "workspace-snapshot"
+                ),
+                model=_json_object(args.model, "model"),
+                topology=_json_object(args.topology, "topology"),
+            )
+            payload = {
+                "status": "created",
+                "case_id": case["case_id"],
+                "case_dir": str(args.case_dir.resolve()),
+            }
+        elif args.action == "record":
+            emit_progress("record-experiment", case_dir=str(args.case_dir))
+            experiment = record_experiment(
+                args.case_dir,
+                variable=args.variable,
+                hypothesis=args.hypothesis,
+                expected=args.expected,
+                observed=args.observed,
+                conclusion=args.conclusion,
+                next_step=args.next_step,
+            )
+            payload = {"status": "recorded", "experiment": experiment}
+        elif args.action == "compare":
+            comparison, output = compare_case(
+                args.case_dir,
+                eager_path=args.eager,
+                graph_path=args.graph,
+                atol=args.atol,
+                rtol=args.rtol,
+            )
+            payload = {
+                "status": comparison["status"],
+                "comparison": str(output.resolve()),
+                "first_divergence": comparison["first_divergence"],
+            }
+        else:
+            emit_progress("finalize", case_dir=str(args.case_dir))
+            case = finalize_case(
+                args.case_dir,
+                root_cause=args.root_cause,
+                fix=args.fix,
+                minimal_result=args.minimal_result,
+                original_result=args.original_result,
+                cleanup_status=args.cleanup_status,
+            )
+            payload = {
+                "status": case["status"],
+                "case_id": case["case_id"],
+                "case": str(_case_path(args.case_dir).resolve()),
+            }
+    except (GraphDebugError, RunManifestError) as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/vllm-ascend-graph-debug/tests/test_graph_debug_case.py
+++ b/.agents/skills/vllm-ascend-graph-debug/tests/test_graph_debug_case.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Tests for the graph-debug case controller."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+SCRIPT = (
+    ROOT
+    / ".agents"
+    / "skills"
+    / "vllm-ascend-graph-debug"
+    / "scripts"
+    / "graph_debug_case.py"
+)
+
+
+def load_module():
+    module_name = "_graph_debug_case_test"
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+graph_debug = load_module()
+NOW = "2026-07-25T12:00:00Z"
+
+
+def write_snapshot(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def record(*, layer: int, sample: list[float]) -> dict:
+    return {
+        "step": 0,
+        "layer": layer,
+        "rank": 0,
+        "tag": "out",
+        "stats": {"mean": sum(sample) / len(sample)},
+        "sample": sample,
+    }
+
+
+class GraphDebugCaseTests(unittest.TestCase):
+    def test_case_lifecycle_resolves_only_after_both_reproductions_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            case_dir = Path(tmp) / "case"
+            graph_debug.init_case(
+                case_dir,
+                case_id="graph-case-1",
+                stage="accuracy",
+                eager_result="pass",
+                graph_result="fail",
+                reproduction="fixed input",
+                created_at=NOW,
+            )
+            graph_debug.record_experiment(
+                case_dir,
+                variable="capture size",
+                hypothesis="padding causes divergence",
+                expected="smaller capture removes divergence",
+                observed="divergence remains",
+                conclusion="capture size excluded",
+                next_step="inspect metadata",
+                updated_at=NOW,
+            )
+            case = graph_debug.finalize_case(
+                case_dir,
+                root_cause="stale metadata",
+                fix="refresh fixed buffer",
+                minimal_result="pass",
+                original_result="pass",
+                cleanup_status="removed",
+                updated_at=NOW,
+            )
+            self.assertEqual(case["status"], "resolved")
+            manifest = json.loads((case_dir / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["status"], "passed")
+            self.assertEqual(manifest["artifacts"][0]["name"], "graph-debug-case")
+
+    def test_pending_cleanup_is_inconclusive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            case_dir = Path(tmp) / "case"
+            graph_debug.init_case(
+                case_dir,
+                case_id="graph-case-2",
+                stage="replay",
+                eager_result="pass",
+                graph_result="fail",
+                reproduction="fixed input",
+                created_at=NOW,
+            )
+            case = graph_debug.finalize_case(
+                case_dir,
+                root_cause="event mismatch",
+                fix="pair replay events",
+                minimal_result="pass",
+                original_result="pass",
+                cleanup_status="pending",
+                updated_at=NOW,
+            )
+            self.assertEqual(case["status"], "inconclusive")
+
+    def test_snapshot_comparison_reports_first_sorted_divergence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eager = root / "eager.jsonl"
+            graph = root / "graph.jsonl"
+            write_snapshot(
+                eager,
+                [record(layer=2, sample=[1.0]), record(layer=1, sample=[1.0])],
+            )
+            write_snapshot(
+                graph,
+                [record(layer=2, sample=[3.0]), record(layer=1, sample=[2.0])],
+            )
+            comparison = graph_debug.compare_snapshots(
+                eager, graph, atol=0.0, rtol=0.0
+            )
+            self.assertEqual(comparison["status"], "diverged")
+            self.assertEqual(comparison["first_divergence"]["key"]["layer"], 1)
+            self.assertEqual(comparison["divergence_count"], 2)
+
+    def test_tolerance_can_accept_small_numeric_difference(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eager = root / "eager.jsonl"
+            graph = root / "graph.jsonl"
+            write_snapshot(eager, [record(layer=0, sample=[1.0])])
+            write_snapshot(graph, [record(layer=0, sample=[1.00001])])
+            comparison = graph_debug.compare_snapshots(
+                eager, graph, atol=1e-4, rtol=0.0
+            )
+            self.assertEqual(comparison["status"], "exact-match")
+
+    def test_duplicate_snapshot_key_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "duplicate.jsonl"
+            write_snapshot(
+                path,
+                [record(layer=0, sample=[1.0]), record(layer=0, sample=[2.0])],
+            )
+            with self.assertRaisesRegex(graph_debug.GraphDebugError, "duplicate"):
+                graph_debug.load_snapshots(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/vllm-ascend-pd-serving/SKILL.md
+++ b/.agents/skills/vllm-ascend-pd-serving/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: vllm-ascend-pd-serving
+description: Plan, start, inspect, smoke-test, and stop a multi-session vLLM Ascend prefill/decode deployment with explicit connector configuration, role ordering, proxy endpoint health, rollback, and KV-transfer request evidence. Use for PD disaggregation with NIXL, Mooncake, or another KV connector. Do not use for one colocated service, generic Ray clusters, correctness matrices, performance regression decisions, or distributed root-cause diagnosis.
+---
+
+# vLLM Ascend PD Serving
+
+Operate one prefill/decode deployment across an existing Session Group whose
+members have distinct session IDs. Reuse
+single-node Serving for each vLLM process; this Skill owns only cross-service
+role configuration, ordering, proxy health, rollback, and end-to-end smoke.
+
+## Preconditions
+
+- Every service has its own ready session.
+- `session-management` has grouped those sessions and proved an identical code
+  plus submodule snapshot.
+- Connector type and options are explicit in the config.
+- The proxy or load balancer already has a stable URL. Proxy process lifecycle
+  remains outside this MVP; its health and request path are verified here.
+
+## Workflow
+
+1. Run `scripts/pd_serving.py plan` with a PD config and Session Group file.
+2. Review generated commands. Connector options must already be present in each
+   role's vLLM arguments; the controller never invents connector metadata.
+3. Run `start`. Services launch in declared order through the existing
+   single-node Serving entry point.
+4. If any role fails, the controller stops already-started roles in reverse
+   order and returns a failed state.
+5. Run `status` to inspect every member and the proxy health endpoint.
+6. Run `smoke` to send the configured request through the proxy and preserve the
+   response as KV-transfer path evidence.
+7. Run `stop`; roles stop in reverse startup order.
+
+## Entry point
+
+`scripts/pd_serving.py` provides `plan`, `start`, `status`, `smoke`, and `stop`.
+
+Read only the reference needed for the active phase:
+
+- [Behavior contract](references/behavior.md)
+- [Command recipes](references/command-recipes.md)
+- [Acceptance](references/acceptance.md)
+
+## Boundaries
+
+- Single-node start/status/stop belongs to `vllm-ascend-serving`.
+- Session creation, leases, and group teardown belong to `session-management`.
+- A working PD deployment's accuracy or performance belongs to the corresponding
+  validation workflow.
+- Hangs, rank divergence, endpoint mismatch, or connector diagnosis after a
+  stable reproduction belongs to `vllm-ascend-distributed-debug`.
+
+## Rules
+
+- Never mix code snapshots inside one deployment.
+- Never start a role outside the declared order.
+- Always rollback already-started roles after a partial failure.
+- Do not report KV transfer as proven from health checks alone; require a proxy
+  request response and retain raw service logs for deeper confirmation.
+- Keep state under `.vaws-local/pd-serving/`.

--- a/.agents/skills/vllm-ascend-pd-serving/agents/openai.yaml
+++ b/.agents/skills/vllm-ascend-pd-serving/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "vLLM Ascend PD Serving"
+  short_description: "Orchestrate prefill/decode services and KV-transfer smoke"
+  default_prompt: "Use $vllm-ascend-pd-serving to plan and operate this multi-session prefill/decode deployment with connector and proxy health evidence."

--- a/.agents/skills/vllm-ascend-pd-serving/references/acceptance.md
+++ b/.agents/skills/vllm-ascend-pd-serving/references/acceptance.md
@@ -1,0 +1,25 @@
+# PD Serving acceptance
+
+## Preconditions
+
+- [ ] Session Group is ready and all members share one code/submodule snapshot.
+- [ ] Missing member names, session IDs, or snapshots fail validation before lifecycle files are created.
+- [ ] Distinct group members cannot alias the same session ID.
+- [ ] Every service uses a unique group member.
+- [ ] Prefill and decode roles both exist.
+- [ ] Connector type, options, role-specific CLI JSON, endpoints, and ports are explicit.
+
+## Lifecycle
+
+- [ ] Startup follows the declared order.
+- [ ] Partial startup failure rolls back started roles in reverse.
+- [ ] Status covers every vLLM service and the proxy health endpoint.
+- [ ] Stop covers every role in reverse startup order.
+- [ ] State and Run Manifest retain all lifecycle results.
+
+## Smoke
+
+- [ ] Request enters through the proxy rather than a role's direct endpoint.
+- [ ] HTTP status and response body are preserved.
+- [ ] Service logs or connector metrics corroborate KV transfer before making that claim.
+- [ ] Correctness and performance conclusions are produced by their own workflows.

--- a/.agents/skills/vllm-ascend-pd-serving/references/behavior.md
+++ b/.agents/skills/vllm-ascend-pd-serving/references/behavior.md
@@ -1,0 +1,41 @@
+# PD Serving behavior contract
+
+## Config
+
+The deployment references one ready Session Group. Each group member hosts at
+most one vLLM service and each service declares:
+
+- stable name and `prefill` or `decode` role;
+- Session Group member;
+- model, TP/DP, optional port and health timeout;
+- environment and exact vLLM arguments.
+
+At least one service of each role is required. `startup_order` contains every
+service exactly once. Shutdown and rollback use the reverse order.
+
+Planning validates every group member's name, session ID, and non-empty code
+snapshot before creating lifecycle state. All member snapshots must match; a
+malformed or mixed-snapshot group is rejected as input instead of failing later
+while constructing the Run Manifest.
+
+Connector type is `nixl`, `mooncake`, or `custom`. Connector options are recorded
+for traceability, but the controller never synthesizes version-sensitive vLLM
+arguments from them; exact connector CLI JSON remains explicit in each service.
+
+## Proxy boundary
+
+The MVP accepts an externally managed proxy or load-balancer URL. It verifies the
+health endpoint and sends smoke requests through it, but does not own the proxy
+process. This prevents generic process supervision from being duplicated inside
+the Skill.
+
+## Lifecycle
+
+- `plan`: immutable config, group snapshot, lifecycle, state, and Run Manifest;
+- `start`: ordered single-node Serving calls with reverse rollback;
+- `status`: every member service plus proxy health;
+- `smoke`: one configured proxy request and raw response;
+- `stop`: reverse-order member stop.
+
+A successful proxy request proves the routed request path. Connector-level KV
+transfer requires corroborating service logs or connector metrics.

--- a/.agents/skills/vllm-ascend-pd-serving/references/command-recipes.md
+++ b/.agents/skills/vllm-ascend-pd-serving/references/command-recipes.md
@@ -1,0 +1,37 @@
+# PD Serving command recipes
+
+## Plan
+
+```bash
+python -B .agents/skills/vllm-ascend-pd-serving/scripts/pd_serving.py plan \
+  --output-dir .vaws-local/pd-serving/case-001 \
+  --config /path/to/pd-config.json \
+  --group-file .vaws-local/sessions/groups/pd-group/group.json
+```
+
+## Start and inspect
+
+```bash
+python -B .agents/skills/vllm-ascend-pd-serving/scripts/pd_serving.py start \
+  --output-dir .vaws-local/pd-serving/case-001
+
+python -B .agents/skills/vllm-ascend-pd-serving/scripts/pd_serving.py status \
+  --output-dir .vaws-local/pd-serving/case-001
+```
+
+## KV request-path smoke
+
+```bash
+python -B .agents/skills/vllm-ascend-pd-serving/scripts/pd_serving.py smoke \
+  --output-dir .vaws-local/pd-serving/case-001
+```
+
+Inspect both role logs before claiming connector-level KV transfer.
+
+## Stop
+
+```bash
+python -B .agents/skills/vllm-ascend-pd-serving/scripts/pd_serving.py stop \
+  --output-dir .vaws-local/pd-serving/case-001 \
+  --force
+```

--- a/.agents/skills/vllm-ascend-pd-serving/scripts/pd_serving.py
+++ b/.agents/skills/vllm-ascend-pd-serving/scripts/pd_serving.py
@@ -1,0 +1,615 @@
+#!/usr/bin/env python3
+"""Operate a Session Group as a vLLM Ascend prefill/decode deployment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_run_manifest import (  # noqa: E402
+    RunManifestError,
+    add_artifact,
+    load_manifest,
+    new_manifest,
+    transition_status,
+    write_manifest,
+)
+
+SCHEMA_VERSION = 1
+ROLES = {"prefill", "decode"}
+
+
+class PdServingError(ValueError):
+    """Raised when a PD deployment config or lifecycle result is invalid."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def _atomic_write(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PdServingError(f"cannot read {label} {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise PdServingError(f"{label} root must be an object")
+    return payload
+
+
+def validate_config(config: Mapping[str, Any], group: Mapping[str, Any]) -> None:
+    errors: list[str] = []
+    if config.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    for field in ("run_id", "group_id"):
+        if not isinstance(config.get(field), str) or not config[field]:
+            errors.append(f"{field} must be a non-empty string")
+    if config.get("group_id") != group.get("group_id"):
+        errors.append("config group_id does not match Session Group")
+    if group.get("status") != "ready":
+        errors.append(f"Session Group must be ready, got {group.get('status')}")
+    raw_group_members = group.get("members")
+    group_members: dict[str, Mapping[str, Any]] = {}
+    session_ids: set[str] = set()
+    snapshot_keys: set[str] = set()
+    if not isinstance(raw_group_members, list) or not raw_group_members:
+        errors.append("Session Group members must be a non-empty array")
+        raw_group_members = []
+    for index, member in enumerate(raw_group_members):
+        path = f"Session Group members[{index}]"
+        if not isinstance(member, Mapping):
+            errors.append(f"{path} must be an object")
+            continue
+        name = member.get("name")
+        session_id = member.get("session_id")
+        snapshot = member.get("snapshot")
+        if not isinstance(name, str) or not name:
+            errors.append(f"{path}.name must be a non-empty string")
+        elif name in group_members:
+            errors.append(f"Session Group member name is duplicated: {name}")
+        else:
+            group_members[name] = member
+        if not isinstance(session_id, str) or not session_id:
+            errors.append(f"{path}.session_id must be a non-empty string")
+        elif session_id in session_ids:
+            errors.append(
+                f"Session Group session_id is duplicated: {session_id}"
+            )
+        else:
+            session_ids.add(session_id)
+        if not isinstance(snapshot, Mapping) or not snapshot:
+            errors.append(f"{path}.snapshot must be a non-empty object")
+        else:
+            snapshot_keys.add(
+                json.dumps(
+                    snapshot,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            )
+    if len(snapshot_keys) > 1:
+        errors.append("Session Group members must share one code snapshot")
+    services = config.get("services")
+    if not isinstance(services, list) or len(services) < 2:
+        errors.append("services must contain at least one prefill and one decode")
+        services = []
+    names: set[str] = set()
+    members: set[str] = set()
+    roles: set[str] = set()
+    for index, service in enumerate(services):
+        path = f"services[{index}]"
+        if not isinstance(service, Mapping):
+            errors.append(f"{path} must be an object")
+            continue
+        name = service.get("name")
+        member = service.get("member")
+        role = service.get("role")
+        if not isinstance(name, str) or not name:
+            errors.append(f"{path}.name must be a non-empty string")
+        elif name in names:
+            errors.append(f"service name is duplicated: {name}")
+        else:
+            names.add(name)
+        if not isinstance(member, str) or member not in group_members:
+            errors.append(f"{path}.member must name a Session Group member")
+        elif member in members:
+            errors.append(f"Session Group member is reused by multiple services: {member}")
+        else:
+            members.add(member)
+        if role not in ROLES:
+            errors.append(f"{path}.role must be prefill or decode")
+        else:
+            roles.add(role)
+        if not isinstance(service.get("model"), str) or not service["model"]:
+            errors.append(f"{path}.model must be a non-empty string")
+        for field in ("tp", "dp", "port", "health_timeout"):
+            value = service.get(field)
+            if value is not None and (
+                not isinstance(value, int) or isinstance(value, bool) or value < 1
+            ):
+                errors.append(f"{path}.{field} must be a positive integer")
+        if not isinstance(service.get("env", {}), Mapping):
+            errors.append(f"{path}.env must be an object")
+        if not isinstance(service.get("args", []), list) or any(
+            not isinstance(value, str) for value in service.get("args", [])
+        ):
+            errors.append(f"{path}.args must be an array of strings")
+    if roles != ROLES:
+        errors.append("services must include both prefill and decode roles")
+    order = config.get("startup_order")
+    if (
+        not isinstance(order, list)
+        or any(not isinstance(value, str) for value in order)
+        or len(order) != len(set(order))
+        or set(order) != names
+    ):
+        errors.append("startup_order must contain every service name exactly once")
+    connector = config.get("connector")
+    if not isinstance(connector, Mapping):
+        errors.append("connector must be an object")
+    else:
+        if connector.get("type") not in {"nixl", "mooncake", "custom"}:
+            errors.append("connector.type must be nixl, mooncake, or custom")
+        if not isinstance(connector.get("options"), Mapping):
+            errors.append("connector.options must be an object")
+    proxy = config.get("proxy")
+    if not isinstance(proxy, Mapping):
+        errors.append("proxy must be an object")
+    else:
+        if not isinstance(proxy.get("base_url"), str) or not proxy["base_url"]:
+            errors.append("proxy.base_url must be a non-empty string")
+        if not isinstance(proxy.get("health_path", "/health"), str):
+            errors.append("proxy.health_path must be a string")
+    smoke = config.get("smoke")
+    if not isinstance(smoke, Mapping):
+        errors.append("smoke must be an object")
+    else:
+        if not isinstance(smoke.get("path"), str) or not smoke["path"]:
+            errors.append("smoke.path must be a non-empty string")
+        if not isinstance(smoke.get("request"), Mapping):
+            errors.append("smoke.request must be an object")
+    if errors:
+        raise PdServingError("; ".join(errors))
+
+
+def service_command(
+    service: Mapping[str, Any],
+    member: Mapping[str, Any],
+    *,
+    action: str,
+    force: bool = False,
+) -> list[str]:
+    serving = ROOT / ".agents" / "skills" / "vllm-ascend-serving" / "scripts"
+    if action == "start":
+        command = [
+            sys.executable,
+            str(serving / "serve_start.py"),
+            "--session-id",
+            member["session_id"],
+            "--model",
+            service["model"],
+        ]
+        for field, option in (
+            ("tp", "--tp"),
+            ("dp", "--dp"),
+            ("port", "--port"),
+            ("health_timeout", "--health-timeout"),
+        ):
+            if service.get(field) is not None:
+                command.extend([option, str(service[field])])
+        for key, value in sorted(service.get("env", {}).items()):
+            command.extend(["--extra-env", f"{key}={value}"])
+        if service.get("args"):
+            command.append("--")
+            command.extend(service["args"])
+        return command
+    command = [
+        sys.executable,
+        str(serving / f"serve_{action}.py"),
+        "--session-id",
+        member["session_id"],
+    ]
+    if action == "stop" and force:
+        command.append("--force")
+    return command
+
+
+def _run_json(
+    command: Sequence[str],
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> dict[str, Any]:
+    completed = runner(
+        list(command),
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    try:
+        payload = json.loads(completed.stdout) if completed.stdout.strip() else {}
+    except json.JSONDecodeError:
+        payload = {"stdout_tail": completed.stdout[-1000:]}
+    return {
+        "returncode": completed.returncode,
+        "payload": payload,
+        "stderr_tail": completed.stderr[-1000:],
+        "command": list(command),
+    }
+
+
+def plan(
+    output_dir: Path,
+    *,
+    config_path: Path,
+    group_path: Path,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise PdServingError(f"output directory is not empty: {output_dir}")
+    config = _load_json(config_path, "PD config")
+    group = _load_json(group_path, "Session Group")
+    validate_config(config, group)
+    members = {member["name"]: member for member in group["members"]}
+    services = {service["name"]: service for service in config["services"]}
+    lifecycle = []
+    for name in config["startup_order"]:
+        service = services[name]
+        lifecycle.append(
+            {
+                "name": name,
+                "role": service["role"],
+                "member": service["member"],
+                "session_id": members[service["member"]]["session_id"],
+                "start_command": service_command(
+                    service, members[service["member"]], action="start"
+                ),
+            }
+        )
+    timestamp = created_at or utc_now()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _atomic_write(output_dir / "pd-config.json", config)
+    _atomic_write(output_dir / "session-group.json", group)
+    _atomic_write(
+        output_dir / "lifecycle.json",
+        {
+            "schema_version": SCHEMA_VERSION,
+            "startup": lifecycle,
+            "shutdown": list(reversed([row["name"] for row in lifecycle])),
+        },
+    )
+    _atomic_write(
+        output_dir / "state.json",
+        {
+            "schema_version": SCHEMA_VERSION,
+            "run_id": config["run_id"],
+            "status": "planned",
+            "started": [],
+            "updated_at": timestamp,
+        },
+    )
+    manifest = new_manifest(
+        run_type="debug",
+        run_id=config["run_id"],
+        workspace_snapshot=group["members"][0]["snapshot"],
+        topology={
+            "session_group": group["group_id"],
+            "services": [
+                {
+                    "name": service["name"],
+                    "role": service["role"],
+                    "member": service["member"],
+                }
+                for service in config["services"]
+            ],
+        },
+        model={"paths": sorted({service["model"] for service in config["services"]})},
+        created_at=timestamp,
+    )
+    for name, kind, uri in (
+        ("pd-config", "pd-config", "pd-config.json"),
+        ("session-group", "session-group", "session-group.json"),
+        ("lifecycle", "lifecycle", "lifecycle.json"),
+        ("state", "state", "state.json"),
+    ):
+        manifest = add_artifact(
+            manifest, name=name, kind=kind, uri=uri, updated_at=timestamp
+        )
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {
+        "status": "planned",
+        "run_id": config["run_id"],
+        "service_count": len(config["services"]),
+        "startup_order": config["startup_order"],
+    }
+
+
+def start(
+    output_dir: Path,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    updated_at: str | None = None,
+) -> dict[str, Any]:
+    config = _load_json(output_dir / "pd-config.json", "PD config")
+    group = _load_json(output_dir / "session-group.json", "Session Group")
+    state = _load_json(output_dir / "state.json", "PD state")
+    if state["status"] != "planned":
+        raise PdServingError(f"deployment must be planned, got {state['status']}")
+    members = {member["name"]: member for member in group["members"]}
+    services = {service["name"]: service for service in config["services"]}
+    results: list[dict[str, Any]] = []
+    started: list[str] = []
+    failed: str | None = None
+    for name in config["startup_order"]:
+        service = services[name]
+        member = members[service["member"]]
+        result = _run_json(
+            service_command(service, member, action="start"),
+            runner=runner,
+        )
+        results.append({"name": name, **result})
+        if result["returncode"] != 0 or result["payload"].get("status") != "ready":
+            failed = name
+            break
+        started.append(name)
+    rollback: list[dict[str, Any]] = []
+    if failed:
+        for name in reversed(started):
+            service = services[name]
+            member = members[service["member"]]
+            rollback.append(
+                {
+                    "name": name,
+                    **_run_json(
+                        service_command(service, member, action="stop", force=True),
+                        runner=runner,
+                    ),
+                }
+            )
+    timestamp = updated_at or utc_now()
+    state.update(
+        {
+            "status": "failed" if failed else "running",
+            "started": started,
+            "failed_service": failed,
+            "start_results": results,
+            "rollback_results": rollback,
+            "updated_at": timestamp,
+        }
+    )
+    _atomic_write(output_dir / "state.json", state)
+    manifest = load_manifest(output_dir / "manifest.json")
+    manifest = transition_status(manifest, "running", updated_at=timestamp)
+    if failed:
+        manifest = transition_status(manifest, "failed", updated_at=timestamp)
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {
+        "status": state["status"],
+        "started": started,
+        "failed_service": failed,
+        "rollback": [row["name"] for row in rollback],
+    }
+
+
+def status(
+    output_dir: Path,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    urlopen: Callable[..., Any] = urllib.request.urlopen,
+) -> dict[str, Any]:
+    config = _load_json(output_dir / "pd-config.json", "PD config")
+    group = _load_json(output_dir / "session-group.json", "Session Group")
+    members = {member["name"]: member for member in group["members"]}
+    rows = []
+    for service in config["services"]:
+        rows.append(
+            {
+                "name": service["name"],
+                **_run_json(
+                    service_command(
+                        service, members[service["member"]], action="status"
+                    ),
+                    runner=runner,
+                ),
+            }
+        )
+    health_url = (
+        config["proxy"]["base_url"].rstrip("/")
+        + "/"
+        + config["proxy"].get("health_path", "/health").lstrip("/")
+    )
+    proxy: dict[str, Any]
+    try:
+        with urlopen(health_url, timeout=5) as response:
+            proxy = {"ok": 200 <= response.status < 300, "status_code": response.status}
+    except (OSError, urllib.error.URLError) as exc:
+        proxy = {"ok": False, "error": str(exc)}
+    ready = all(
+        row["returncode"] == 0
+        and row["payload"].get("status") in {"ready", "alive_healthy"}
+        for row in rows
+    ) and proxy["ok"]
+    return {
+        "status": "ready" if ready else "needs_repair",
+        "services": rows,
+        "proxy": {"url": health_url, **proxy},
+    }
+
+
+def smoke(
+    output_dir: Path,
+    *,
+    urlopen: Callable[..., Any] = urllib.request.urlopen,
+    updated_at: str | None = None,
+) -> dict[str, Any]:
+    config = _load_json(output_dir / "pd-config.json", "PD config")
+    url = (
+        config["proxy"]["base_url"].rstrip("/")
+        + "/"
+        + config["smoke"]["path"].lstrip("/")
+    )
+    request_body = json.dumps(config["smoke"]["request"]).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=request_body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=config["smoke"].get("timeout", 120)) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            status_code = response.status
+    except (OSError, urllib.error.URLError) as exc:
+        result = {"status": "failed", "url": url, "error": str(exc)}
+        _atomic_write(output_dir / "smoke.json", result)
+        return result
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        payload = {"raw_body": body[:4000]}
+    result = {
+        "status": "passed" if 200 <= status_code < 300 else "failed",
+        "url": url,
+        "status_code": status_code,
+        "response": payload,
+        "completed_at": updated_at or utc_now(),
+        "claim": "proxy request path passed; inspect service logs to confirm connector-level KV transfer",
+    }
+    _atomic_write(output_dir / "smoke.json", result)
+    manifest = load_manifest(output_dir / "manifest.json")
+    manifest = add_artifact(
+        manifest,
+        name="smoke",
+        kind="pd-smoke",
+        uri="smoke.json",
+        updated_at=result["completed_at"],
+    )
+    write_manifest(output_dir / "manifest.json", manifest)
+    return result
+
+
+def stop(
+    output_dir: Path,
+    *,
+    force: bool,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    updated_at: str | None = None,
+) -> dict[str, Any]:
+    config = _load_json(output_dir / "pd-config.json", "PD config")
+    group = _load_json(output_dir / "session-group.json", "Session Group")
+    state = _load_json(output_dir / "state.json", "PD state")
+    members = {member["name"]: member for member in group["members"]}
+    services = {service["name"]: service for service in config["services"]}
+    results = []
+    for name in reversed(config["startup_order"]):
+        service = services[name]
+        results.append(
+            {
+                "name": name,
+                **_run_json(
+                    service_command(
+                        service,
+                        members[service["member"]],
+                        action="stop",
+                        force=force,
+                    ),
+                    runner=runner,
+                ),
+            }
+        )
+    success = all(
+        row["returncode"] == 0
+        and row["payload"].get("status") in {"stopped", "not_found"}
+        for row in results
+    )
+    timestamp = updated_at or utc_now()
+    state["status"] = "stopped" if success else "needs_repair"
+    state["stop_results"] = results
+    state["updated_at"] = timestamp
+    _atomic_write(output_dir / "state.json", state)
+    manifest = load_manifest(output_dir / "manifest.json")
+    if manifest["status"] == "running":
+        manifest = transition_status(
+            manifest, "passed" if success else "inconclusive", updated_at=timestamp
+        )
+        write_manifest(output_dir / "manifest.json", manifest)
+    return {"status": state["status"], "stopped": [row["name"] for row in results]}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+    plan_parser = subparsers.add_parser("plan")
+    plan_parser.add_argument("--output-dir", required=True, type=Path)
+    plan_parser.add_argument("--config", required=True, type=Path)
+    plan_parser.add_argument("--group-file", required=True, type=Path)
+    for name in ("start", "status", "smoke"):
+        subparser = subparsers.add_parser(name)
+        subparser.add_argument("--output-dir", required=True, type=Path)
+    stop_parser = subparsers.add_parser("stop")
+    stop_parser.add_argument("--output-dir", required=True, type=Path)
+    stop_parser.add_argument("--force", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.action == "plan":
+            payload = plan(
+                args.output_dir,
+                config_path=args.config,
+                group_path=args.group_file,
+            )
+        elif args.action == "start":
+            payload = start(args.output_dir)
+        elif args.action == "status":
+            payload = status(args.output_dir)
+        elif args.action == "smoke":
+            payload = smoke(args.output_dir)
+        else:
+            payload = stop(args.output_dir, force=args.force)
+    except (PdServingError, RunManifestError) as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/vllm-ascend-pd-serving/tests/test_pd_serving.py
+++ b/.agents/skills/vllm-ascend-pd-serving/tests/test_pd_serving.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Tests for multi-session prefill/decode lifecycle orchestration."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+SKILL = ROOT / ".agents" / "skills" / "vllm-ascend-pd-serving"
+
+
+def load_module():
+    name = "_pd_serving_test"
+    spec = importlib.util.spec_from_file_location(
+        name, SKILL / "scripts" / "pd_serving.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pd = load_module()
+NOW = "2026-07-25T12:00:00Z"
+
+
+def group() -> dict:
+    snapshot = {"workspace_head": "abc", "submodules": [], "dirty": False}
+    return {
+        "schema_version": 1,
+        "group_id": "pd-group",
+        "status": "ready",
+        "members": [
+            {
+                "name": "prefill-member",
+                "session_id": "prefill-session",
+                "snapshot": snapshot,
+            },
+            {
+                "name": "decode-member",
+                "session_id": "decode-session",
+                "snapshot": snapshot,
+            },
+        ],
+    }
+
+
+def config() -> dict:
+    return {
+        "schema_version": 1,
+        "run_id": "pd-run-1",
+        "group_id": "pd-group",
+        "connector": {"type": "mooncake", "options": {"port": 5000}},
+        "services": [
+            {
+                "name": "decode",
+                "member": "decode-member",
+                "role": "decode",
+                "model": "/models/example",
+                "tp": 1,
+                "args": ["--kv-transfer-config", '{"kv_role":"kv_consumer"}'],
+            },
+            {
+                "name": "prefill",
+                "member": "prefill-member",
+                "role": "prefill",
+                "model": "/models/example",
+                "tp": 1,
+                "args": ["--kv-transfer-config", '{"kv_role":"kv_producer"}'],
+            },
+        ],
+        "startup_order": ["decode", "prefill"],
+        "proxy": {"base_url": "http://proxy:9000", "health_path": "/health"},
+        "smoke": {
+            "path": "/v1/chat/completions",
+            "request": {
+                "model": "example",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        },
+    }
+
+
+class PdServingTests(unittest.TestCase):
+    def test_rejects_group_member_without_snapshot(self) -> None:
+        invalid_group = group()
+        invalid_group["members"][0].pop("snapshot")
+
+        with self.assertRaisesRegex(
+            pd.PdServingError,
+            "snapshot must be a non-empty object",
+        ):
+            pd.validate_config(config(), invalid_group)
+
+    def test_rejects_mixed_group_snapshots(self) -> None:
+        invalid_group = group()
+        invalid_group["members"][1]["snapshot"] = {
+            "workspace_head": "different",
+            "submodules": [],
+            "dirty": False,
+        }
+
+        with self.assertRaisesRegex(
+            pd.PdServingError,
+            "share one code snapshot",
+        ):
+            pd.validate_config(config(), invalid_group)
+
+    def test_rejects_members_that_alias_one_session(self) -> None:
+        invalid_group = group()
+        invalid_group["members"][1]["session_id"] = invalid_group["members"][0][
+            "session_id"
+        ]
+
+        with self.assertRaisesRegex(pd.PdServingError, "session_id is duplicated"):
+            pd.validate_config(config(), invalid_group)
+
+    def test_requires_both_roles(self) -> None:
+        invalid = config()
+        invalid["services"][1]["role"] = "decode"
+        with self.assertRaisesRegex(pd.PdServingError, "both prefill and decode"):
+            pd.validate_config(invalid, group())
+
+    def test_plan_preserves_declared_order(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config_path = root / "config.json"
+            group_path = root / "group.json"
+            config_path.write_text(json.dumps(config()), encoding="utf-8")
+            group_path.write_text(json.dumps(group()), encoding="utf-8")
+            output = root / "run"
+            result = pd.plan(
+                output,
+                config_path=config_path,
+                group_path=group_path,
+                created_at=NOW,
+            )
+            self.assertEqual(result["startup_order"], ["decode", "prefill"])
+            lifecycle = json.loads(
+                (output / "lifecycle.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(lifecycle["shutdown"], ["prefill", "decode"])
+
+    def test_partial_start_rolls_back_in_reverse(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config_path = root / "config.json"
+            group_path = root / "group.json"
+            config_path.write_text(json.dumps(config()), encoding="utf-8")
+            group_path.write_text(json.dumps(group()), encoding="utf-8")
+            output = root / "run"
+            pd.plan(
+                output,
+                config_path=config_path,
+                group_path=group_path,
+                created_at=NOW,
+            )
+            calls = []
+
+            def runner(command, **_kwargs):
+                calls.append(command)
+                if "serve_start.py" in command[1] and "--session-id" in command:
+                    session_id = command[command.index("--session-id") + 1]
+                    if session_id == "prefill-session":
+                        return subprocess.CompletedProcess(
+                            command, 1, '{"status":"failed"}', ""
+                        )
+                    return subprocess.CompletedProcess(
+                        command, 0, '{"status":"ready"}', ""
+                    )
+                return subprocess.CompletedProcess(
+                    command, 0, '{"status":"stopped"}', ""
+                )
+
+            result = pd.start(output, runner=runner, updated_at=NOW)
+            self.assertEqual(result["status"], "failed")
+            self.assertEqual(result["rollback"], ["decode"])
+            self.assertIn("serve_stop.py", calls[-1][1])
+
+    def test_service_command_forwards_role_args(self) -> None:
+        service = config()["services"][0]
+        member = group()["members"][1]
+        command = pd.service_command(service, member, action="start")
+        self.assertIn("--kv-transfer-config", command)
+        self.assertEqual(
+            command[command.index("--session-id") + 1], "decode-session"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/vllm-ascend-performance-regression/SKILL.md
+++ b/.agents/skills/vllm-ascend-performance-regression/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: vllm-ascend-performance-regression
+description: Plan, record, and analyze controlled baseline-versus-candidate vLLM Ascend serving performance experiments with isolated sessions, identical non-code configuration, alternating A/B order, warmup exclusion, variance and outlier reporting, and metric-specific regression thresholds. Use for throughput, TTFT, TPOT, ITL, acceptance-rate, startup-time, or HBM regression checks. Do not use for correctness, single-state measurement, HBM component attribution, or profiling root-cause analysis.
+---
+
+# vLLM Ascend Performance Regression
+
+Wrap `vllm-ascend-benchmark` with a controlled two-state experiment.
+
+## Workflow
+
+1. Create independent baseline and candidate worktrees and `session-management` sessions.
+2. Use the same machine allocation policy, NPU count, model and weight hash, environment, topology, Serving arguments, Benchmark arguments, dataset, request rate, and concurrency.
+3. Put all non-code conditions in the experiment `shared` object.
+4. Run `scripts/performance_regression.py plan`.
+5. Follow `schedule.json` exactly. Before each state executes, establish `remote-code-parity`, start or confirm its service, then call `vllm-ascend-benchmark`.
+6. Normalize each raw Benchmark result with `normalize`, then call `record`.
+7. Run `analyze` only after the schedule is complete.
+8. If the result is failed or inconclusive and operator timing is needed, recommend profiling collection; do not collect heavy profiles automatically.
+
+For three measurements the alternating sequence is:
+
+```text
+baseline warmup
+candidate warmup
+baseline 1
+candidate 1
+candidate 2
+baseline 2
+baseline 3
+candidate 3
+```
+
+## Entry point
+
+`scripts/performance_regression.py` provides:
+
+- `plan`: validate experiment parity, generate the alternating schedule, and create Run Manifest v1;
+- `normalize`: convert one single-run or aggregated Benchmark result into the measurement contract;
+- `record`: accept the next normalized measurement only when its state, phase, ordinal, and config hash match the schedule;
+- `analyze`: exclude warmups, report mean, sample deviation, coefficient of variation, outliers, relative change, and threshold verdict.
+
+Read:
+
+- [Behavior contract](references/behavior.md) for config, schedule, measurement, statistics, and status semantics.
+- [Command recipes](references/command-recipes.md) for the full lifecycle.
+- [Acceptance](references/acceptance.md) before claiming a regression or pass.
+
+## Rules
+
+- Never compare measurements with different config hashes.
+- Never run all baseline measurements before all candidate measurements.
+- Do not include warmups in statistics.
+- Preserve raw values even when configured to exclude detected outliers from the decision set.
+- Return `inconclusive` when required metrics are missing, too few decision values remain, or observed variation exceeds `max_cv`.
+- Use metric direction explicitly: higher is better or lower is better.
+- Keep experiment state under `.vaws-local/performance-regression/`.

--- a/.agents/skills/vllm-ascend-performance-regression/agents/openai.yaml
+++ b/.agents/skills/vllm-ascend-performance-regression/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "vLLM Ascend Performance Regression"
+  short_description: "Run controlled baseline and candidate performance comparisons"
+  default_prompt: "Use $vllm-ascend-performance-regression to plan a controlled alternating A/B benchmark and assess regressions."

--- a/.agents/skills/vllm-ascend-performance-regression/references/acceptance.md
+++ b/.agents/skills/vllm-ascend-performance-regression/references/acceptance.md
@@ -1,0 +1,28 @@
+# Performance regression acceptance
+
+## Parity
+
+- [ ] Baseline and candidate use distinct worktrees and sessions.
+- [ ] Machine policy, devices, model and weight hash, environment, topology, Serving arguments, Benchmark arguments, dataset, request rate, and concurrency are identical.
+- [ ] Every measurement uses the planned config hash.
+
+## Execution
+
+- [ ] Warmups ran for both states and are excluded.
+- [ ] Measurements followed the alternating schedule exactly.
+- [ ] Raw Benchmark output was normalized by the controller rather than manually rewritten.
+- [ ] Each result links to its raw Benchmark artifact.
+- [ ] Temperature, background load, and cache drift were considered.
+
+## Analysis
+
+- [ ] Every threshold declares higher-is-better or lower-is-better.
+- [ ] Raw values, mean, sample deviation, CV, and outlier indices are reported.
+- [ ] Outlier exclusion policy was fixed before analysis.
+- [ ] No metric exceeds `max_cv` for a pass or fail conclusion.
+- [ ] Missing or insufficient values yield inconclusive.
+
+## Delivery
+
+- [ ] Config, parity check, schedule, measurements, comparison, report, reproduction, and Run Manifest exist.
+- [ ] A profiling recommendation is explicit and does not imply profiling was already collected.

--- a/.agents/skills/vllm-ascend-performance-regression/references/behavior.md
+++ b/.agents/skills/vllm-ascend-performance-regression/references/behavior.md
@@ -1,0 +1,115 @@
+# Performance regression behavior contract
+
+## Experiment config
+
+```json
+{
+  "schema_version": 1,
+  "run_id": "performance-change-001",
+  "baseline": {
+    "label": "baseline",
+    "code_snapshot": "abc123",
+    "session_id": "perf-base"
+  },
+  "candidate": {
+    "label": "candidate",
+    "code_snapshot": "def456",
+    "session_id": "perf-candidate"
+  },
+  "shared": {
+    "machine": "npu-host",
+    "npu_devices": [0, 1],
+    "model": {
+      "path": "/models/example",
+      "weight_manifest_hash": "..."
+    },
+    "environment": {
+      "cann": "...",
+      "torch_npu": "..."
+    },
+    "topology": {
+      "tp": 2
+    },
+    "serve_args": [],
+    "bench_args": [],
+    "dataset": "sharegpt"
+  },
+  "warmups": 1,
+  "runs": 3,
+  "max_cv": 0.1,
+  "exclude_outliers": false,
+  "thresholds": {
+    "throughput": {
+      "direction": "higher",
+      "max_relative_regression": 0.03
+    },
+    "ttft": {
+      "direction": "lower",
+      "max_relative_regression": 0.05
+    }
+  }
+}
+```
+
+All conditions except code snapshot, session ID, and display label belong in `shared`. Its canonical SHA256 is the required `config_hash`.
+
+## Benchmark normalization
+
+`normalize` reads either the Benchmark skill's single-run `metrics` object or
+the `mean` values from its multi-run `aggregated` object. The default mapping is:
+
+| Measurement | Benchmark field |
+|---|---|
+| `throughput` | `output_throughput` |
+| `ttft` | `mean_ttft_ms` |
+| `tpot` | `mean_tpot_ms` |
+| `itl` | `mean_itl_ms` |
+| `acceptance_rate` | `acceptance_rate` |
+
+Add or replace mappings with `--metric-map TARGET=SOURCE`. Missing source fields
+are omitted, so the analysis will mark a configured-but-missing metric
+inconclusive.
+
+## Measurement contract
+
+Normalize one Benchmark result at a time:
+
+```json
+{
+  "schema_version": 1,
+  "state": "baseline",
+  "phase": "measure",
+  "ordinal": 1,
+  "config_hash": "<64 lowercase hex>",
+  "metrics": {
+    "throughput": 1234.5,
+    "ttft": 18.2,
+    "tpot": 4.3,
+    "itl": 4.2,
+    "acceptance_rate": 0.91,
+    "service_start_time": 42.0,
+    "hbm": 61234
+  },
+  "source": "/path/to/benchmark-result.json"
+}
+```
+
+The controller rejects out-of-order state, phase, ordinal, or config hash.
+
+## Statistics
+
+- exclude warmups;
+- preserve all raw values;
+- detect outliers with modified z-score based on median absolute deviation;
+- exclude detected outliers from the decision only when `exclude_outliers=true`;
+- compute arithmetic mean, sample standard deviation, and absolute coefficient of variation;
+- compute relative change as `(candidate_mean - baseline_mean) / abs(baseline_mean)`;
+- apply direction-specific degradation thresholds.
+
+## Status
+
+- `passed`: every required metric has at least two decision values per state, CV is within limit, and no threshold is exceeded;
+- `failed`: measurement quality passes and at least one metric regresses;
+- `inconclusive`: schedule incomplete, metrics missing or insufficient, or CV exceeds the configured limit.
+
+Heavy profiler collection is a separate explicit action.

--- a/.agents/skills/vllm-ascend-performance-regression/references/command-recipes.md
+++ b/.agents/skills/vllm-ascend-performance-regression/references/command-recipes.md
@@ -1,0 +1,40 @@
+# Performance regression command recipes
+
+## Plan
+
+```bash
+python -B .agents/skills/vllm-ascend-performance-regression/scripts/performance_regression.py plan \
+  --output-dir .vaws-local/performance-regression/change-001 \
+  --config /path/to/experiment-config.json
+```
+
+Read the returned config hash and `schedule.json`.
+
+## Normalize and record
+
+After executing the next scheduled Benchmark:
+
+```bash
+python -B .agents/skills/vllm-ascend-performance-regression/scripts/performance_regression.py normalize \
+  --result /path/to/raw-benchmark-result.json \
+  --output /path/to/normalized-measurement.json \
+  --state baseline \
+  --phase measure \
+  --ordinal 1 \
+  --config-hash <hash-from-plan>
+
+python -B .agents/skills/vllm-ascend-performance-regression/scripts/performance_regression.py record \
+  --output-dir .vaws-local/performance-regression/change-001 \
+  --result /path/to/normalized-measurement.json
+```
+
+Do not skip ahead. The script returns the remaining entry count.
+
+## Analyze
+
+```bash
+python -B .agents/skills/vllm-ascend-performance-regression/scripts/performance_regression.py analyze \
+  --output-dir .vaws-local/performance-regression/change-001
+```
+
+Inspect `report.md`, then use the linked raw Benchmark results for deeper review.

--- a/.agents/skills/vllm-ascend-performance-regression/scripts/performance_regression.py
+++ b/.agents/skills/vllm-ascend-performance-regression/scripts/performance_regression.py
@@ -1,0 +1,670 @@
+#!/usr/bin/env python3
+"""Control and analyze alternating vLLM Ascend A/B performance experiments."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import statistics
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_run_manifest import (  # noqa: E402
+    RunManifestError,
+    add_artifact,
+    load_manifest,
+    new_manifest,
+    transition_status,
+    write_manifest,
+)
+
+SCHEMA_VERSION = 1
+STATES = ("baseline", "candidate")
+PHASES = ("warmup", "measure")
+DEFAULT_BENCHMARK_METRICS = {
+    "throughput": "output_throughput",
+    "ttft": "mean_ttft_ms",
+    "tpot": "mean_tpot_ms",
+    "itl": "mean_itl_ms",
+    "acceptance_rate": "acceptance_rate",
+}
+
+
+class PerformanceRegressionError(ValueError):
+    """Raised when experiment parity, schedule, or measurements are invalid."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def emit_progress(phase: str, **details: Any) -> None:
+    print(json.dumps({"phase": phase, **details}, ensure_ascii=False), file=sys.stderr)
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    _atomic_write(
+        path, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PerformanceRegressionError(f"cannot read {label} {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise PerformanceRegressionError(f"{label} root must be an object")
+    return payload
+
+
+def config_hash(shared: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        shared, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def parse_metric_maps(values: Sequence[str]) -> dict[str, str]:
+    mapping = dict(DEFAULT_BENCHMARK_METRICS)
+    for value in values:
+        target, separator, source = value.partition("=")
+        if not separator or not target.strip() or not source.strip():
+            raise PerformanceRegressionError(
+                f"metric map must use TARGET=SOURCE, got: {value}"
+            )
+        mapping[target.strip()] = source.strip()
+    return mapping
+
+
+def normalize_benchmark_result(
+    benchmark: Mapping[str, Any],
+    *,
+    state: str,
+    phase: str,
+    ordinal: int,
+    fingerprint: str,
+    source: str,
+    metric_map: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    if benchmark.get("status") != "ok":
+        raise PerformanceRegressionError("Benchmark result status must be ok")
+    raw_metrics = benchmark.get("metrics")
+    aggregated = False
+    if not isinstance(raw_metrics, Mapping):
+        raw_metrics = benchmark.get("aggregated")
+        aggregated = True
+    if not isinstance(raw_metrics, Mapping):
+        raise PerformanceRegressionError(
+            "Benchmark result must contain metrics or aggregated"
+        )
+    normalized_metrics: dict[str, float] = {}
+    for target, source_name in (metric_map or DEFAULT_BENCHMARK_METRICS).items():
+        raw_value = raw_metrics.get(source_name)
+        if aggregated and isinstance(raw_value, Mapping):
+            raw_value = raw_value.get("mean")
+        if raw_value is None:
+            continue
+        if not isinstance(raw_value, (int, float)) or isinstance(raw_value, bool):
+            raise PerformanceRegressionError(
+                f"Benchmark metric {source_name} must be numeric"
+            )
+        normalized_metrics[target] = float(raw_value)
+    measurement = {
+        "schema_version": SCHEMA_VERSION,
+        "state": state,
+        "phase": phase,
+        "ordinal": ordinal,
+        "config_hash": fingerprint,
+        "metrics": normalized_metrics,
+        "source": source,
+    }
+    validate_measurement(measurement)
+    return measurement
+
+
+def validate_config(config: Mapping[str, Any]) -> None:
+    errors: list[str] = []
+    if config.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    for state in STATES:
+        value = config.get(state)
+        if not isinstance(value, Mapping):
+            errors.append(f"{state} must be an object")
+            continue
+        for field in ("label", "code_snapshot", "session_id"):
+            if not isinstance(value.get(field), str) or not value[field].strip():
+                errors.append(f"{state}.{field} must be a non-empty string")
+    if isinstance(config.get("baseline"), Mapping) and isinstance(
+        config.get("candidate"), Mapping
+    ):
+        if config["baseline"].get("session_id") == config["candidate"].get("session_id"):
+            errors.append("baseline and candidate session_id must be different")
+    shared = config.get("shared")
+    if not isinstance(shared, Mapping) or not shared:
+        errors.append("shared must be a non-empty object")
+    runs = config.get("runs")
+    if not isinstance(runs, int) or isinstance(runs, bool) or runs < 2:
+        errors.append("runs must be an integer of at least 2")
+    warmups = config.get("warmups", 1)
+    if not isinstance(warmups, int) or isinstance(warmups, bool) or warmups < 1:
+        errors.append("warmups must be a positive integer")
+    thresholds = config.get("thresholds")
+    if not isinstance(thresholds, Mapping) or not thresholds:
+        errors.append("thresholds must be a non-empty object")
+        thresholds = {}
+    for metric, rule in thresholds.items():
+        if not isinstance(rule, Mapping):
+            errors.append(f"thresholds.{metric} must be an object")
+            continue
+        if rule.get("direction") not in {"higher", "lower"}:
+            errors.append(f"thresholds.{metric}.direction must be higher or lower")
+        limit = rule.get("max_relative_regression")
+        if not isinstance(limit, (int, float)) or isinstance(limit, bool) or limit < 0:
+            errors.append(
+                f"thresholds.{metric}.max_relative_regression must be non-negative"
+            )
+    max_cv = config.get("max_cv", 0.1)
+    if not isinstance(max_cv, (int, float)) or isinstance(max_cv, bool) or max_cv < 0:
+        errors.append("max_cv must be non-negative")
+    if errors:
+        raise PerformanceRegressionError("; ".join(errors))
+
+
+def build_schedule(*, warmups: int, runs: int) -> list[dict[str, Any]]:
+    schedule: list[dict[str, Any]] = []
+    for ordinal in range(1, warmups + 1):
+        for state in STATES:
+            schedule.append(
+                {
+                    "index": len(schedule) + 1,
+                    "id": f"{state}-warmup-{ordinal}",
+                    "state": state,
+                    "phase": "warmup",
+                    "ordinal": ordinal,
+                    "status": "pending",
+                }
+            )
+    for ordinal in range(1, runs + 1):
+        order = STATES if ordinal % 2 == 1 else tuple(reversed(STATES))
+        for state in order:
+            schedule.append(
+                {
+                    "index": len(schedule) + 1,
+                    "id": f"{state}-measure-{ordinal}",
+                    "state": state,
+                    "phase": "measure",
+                    "ordinal": ordinal,
+                    "status": "pending",
+                }
+            )
+    return schedule
+
+
+def plan(
+    output_dir: Path,
+    *,
+    config_path: Path,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise PerformanceRegressionError(f"output directory is not empty: {output_dir}")
+    config = _load_json(config_path, "experiment config")
+    validate_config(config)
+    run_id = config.get("run_id")
+    if not isinstance(run_id, str) or not run_id:
+        raise PerformanceRegressionError("run_id must be a non-empty string")
+    fingerprint = config_hash(config["shared"])
+    schedule = {
+        "schema_version": SCHEMA_VERSION,
+        "config_hash": fingerprint,
+        "entries": build_schedule(warmups=config.get("warmups", 1), runs=config["runs"]),
+    }
+    timestamp = created_at or utc_now()
+    state = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "status": "planned",
+        "config_hash": fingerprint,
+        "created_at": timestamp,
+        "updated_at": timestamp,
+    }
+    measurements = {
+        "schema_version": SCHEMA_VERSION,
+        "config_hash": fingerprint,
+        "measurements": [],
+    }
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(output_dir / "experiment-config.json", config)
+    _write_json(output_dir / "parity-check.json", {
+        "schema_version": SCHEMA_VERSION,
+        "status": "passed",
+        "config_hash": fingerprint,
+        "shared": config["shared"],
+        "allowed_difference": ["code_snapshot", "session_id", "label"],
+    })
+    _write_json(output_dir / "schedule.json", schedule)
+    _write_json(output_dir / "measurements.json", measurements)
+    _write_json(output_dir / "run.json", state)
+    _atomic_write(
+        output_dir / "reproduction.md",
+        "# Performance regression reproduction\n\n"
+        "Follow `schedule.json` in order. For every entry, establish code parity for "
+        "the named state, run the shared Serving and Benchmark configuration, and "
+        "record a normalized result with the exact `config_hash`.\n",
+    )
+    manifest = new_manifest(
+        run_type="performance",
+        run_id=run_id,
+        workspace_snapshot={
+            "baseline": config["baseline"]["code_snapshot"],
+            "candidate": config["candidate"]["code_snapshot"],
+        },
+        environment=config["shared"].get("environment", {}),
+        model=config["shared"].get("model", {}),
+        topology=config["shared"].get("topology", {}),
+        created_at=timestamp,
+    )
+    for name, kind, uri in (
+        ("experiment-config", "experiment-config", "experiment-config.json"),
+        ("parity-check", "parity-check", "parity-check.json"),
+        ("schedule", "schedule", "schedule.json"),
+        ("measurements", "measurements", "measurements.json"),
+        ("reproduction", "reproduction", "reproduction.md"),
+    ):
+        manifest = add_artifact(
+            manifest, name=name, kind=kind, uri=uri, updated_at=timestamp
+        )
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {
+        "status": "planned",
+        "run_id": run_id,
+        "config_hash": fingerprint,
+        "schedule_entries": len(schedule["entries"]),
+    }
+
+
+def validate_measurement(measurement: Mapping[str, Any]) -> None:
+    errors: list[str] = []
+    if measurement.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    if measurement.get("state") not in STATES:
+        errors.append(f"state must be one of: {', '.join(STATES)}")
+    if measurement.get("phase") not in PHASES:
+        errors.append(f"phase must be one of: {', '.join(PHASES)}")
+    ordinal = measurement.get("ordinal")
+    if not isinstance(ordinal, int) or isinstance(ordinal, bool) or ordinal < 1:
+        errors.append("ordinal must be a positive integer")
+    fingerprint = measurement.get("config_hash")
+    if not isinstance(fingerprint, str) or len(fingerprint) != 64:
+        errors.append("config_hash must be a SHA256 string")
+    metrics = measurement.get("metrics")
+    if not isinstance(metrics, Mapping) or not metrics:
+        errors.append("metrics must be a non-empty object")
+    else:
+        for name, value in metrics.items():
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                errors.append(f"metrics.{name} must be numeric")
+            elif not math.isfinite(float(value)):
+                errors.append(f"metrics.{name} must be finite")
+    if errors:
+        raise PerformanceRegressionError("; ".join(errors))
+
+
+def record(
+    output_dir: Path,
+    *,
+    result_path: Path,
+    recorded_at: str | None = None,
+) -> dict[str, Any]:
+    result = _load_json(result_path, "measurement result")
+    validate_measurement(result)
+    schedule = _load_json(output_dir / "schedule.json", "schedule")
+    measurements = _load_json(output_dir / "measurements.json", "measurements")
+    if result["config_hash"] != schedule["config_hash"]:
+        raise PerformanceRegressionError(
+            "measurement config_hash does not match the planned experiment"
+        )
+    pending = next(
+        (entry for entry in schedule["entries"] if entry["status"] == "pending"),
+        None,
+    )
+    if pending is None:
+        raise PerformanceRegressionError("schedule is already complete")
+    expected = (pending["state"], pending["phase"], pending["ordinal"])
+    actual = (result["state"], result["phase"], result["ordinal"])
+    if actual != expected:
+        raise PerformanceRegressionError(
+            f"out-of-order measurement: expected {expected}, received {actual}"
+        )
+    timestamp = recorded_at or utc_now()
+    normalized = {
+        "schedule_id": pending["id"],
+        "state": result["state"],
+        "phase": result["phase"],
+        "ordinal": result["ordinal"],
+        "config_hash": result["config_hash"],
+        "metrics": {name: float(value) for name, value in result["metrics"].items()},
+        "source": result.get("source"),
+        "recorded_at": timestamp,
+    }
+    measurements["measurements"].append(normalized)
+    pending["status"] = "recorded"
+    _write_json(output_dir / "measurements.json", measurements)
+    _write_json(output_dir / "schedule.json", schedule)
+    state = _load_json(output_dir / "run.json", "run state")
+    if state["status"] == "planned":
+        state["status"] = "running"
+    state["updated_at"] = timestamp
+    _write_json(output_dir / "run.json", state)
+    manifest = load_manifest(output_dir / "manifest.json")
+    if manifest["status"] == "planned":
+        manifest = transition_status(manifest, "running", updated_at=timestamp)
+        write_manifest(output_dir / "manifest.json", manifest)
+    return {
+        "status": "recorded",
+        "schedule_id": pending["id"],
+        "remaining": sum(entry["status"] == "pending" for entry in schedule["entries"]),
+    }
+
+
+def detect_outliers(values: Sequence[float]) -> list[int]:
+    if len(values) < 3:
+        return []
+    median = statistics.median(values)
+    deviations = [abs(value - median) for value in values]
+    mad = statistics.median(deviations)
+    if mad == 0:
+        return [index for index, value in enumerate(values) if value != median]
+    return [
+        index
+        for index, value in enumerate(values)
+        if 0.6745 * abs(value - median) / mad > 3.5
+    ]
+
+
+def summarize_values(
+    values: Sequence[float], *, exclude_outliers: bool
+) -> dict[str, Any]:
+    outliers = detect_outliers(values)
+    decision_values = [
+        value for index, value in enumerate(values) if not exclude_outliers or index not in outliers
+    ]
+    if not decision_values:
+        return {
+            "values": list(values),
+            "outlier_indices": outliers,
+            "decision_values": [],
+            "count": 0,
+            "mean": None,
+            "stdev": None,
+            "cv": None,
+        }
+    mean = statistics.fmean(decision_values)
+    stdev = statistics.stdev(decision_values) if len(decision_values) > 1 else 0.0
+    cv = abs(stdev / mean) if mean != 0 else (math.inf if stdev else 0.0)
+    return {
+        "values": list(values),
+        "outlier_indices": outliers,
+        "decision_values": decision_values,
+        "count": len(decision_values),
+        "mean": mean,
+        "stdev": stdev,
+        "cv": cv,
+    }
+
+
+def analyze_documents(
+    config: Mapping[str, Any],
+    schedule: Mapping[str, Any],
+    measurements: Mapping[str, Any],
+) -> dict[str, Any]:
+    validate_config(config)
+    pending = [entry["id"] for entry in schedule["entries"] if entry["status"] != "recorded"]
+    if pending:
+        raise PerformanceRegressionError(
+            f"schedule is incomplete; pending entries: {', '.join(pending)}"
+        )
+    measured = [
+        row for row in measurements["measurements"] if row["phase"] == "measure"
+    ]
+    exclude_outliers = bool(config.get("exclude_outliers", False))
+    max_cv = float(config.get("max_cv", 0.1))
+    metrics: dict[str, Any] = {}
+    missing_metrics: list[str] = []
+    noisy_metrics: list[str] = []
+    regressions: list[str] = []
+    for metric, rule in sorted(config["thresholds"].items()):
+        state_values: dict[str, list[float]] = {}
+        for state in STATES:
+            rows = [row for row in measured if row["state"] == state]
+            if any(metric not in row["metrics"] for row in rows):
+                missing_metrics.append(metric)
+                state_values[state] = []
+            else:
+                state_values[state] = [float(row["metrics"][metric]) for row in rows]
+        baseline_summary = summarize_values(
+            state_values["baseline"], exclude_outliers=exclude_outliers
+        )
+        candidate_summary = summarize_values(
+            state_values["candidate"], exclude_outliers=exclude_outliers
+        )
+        metric_result: dict[str, Any] = {
+            "direction": rule["direction"],
+            "max_relative_regression": float(rule["max_relative_regression"]),
+            "baseline": baseline_summary,
+            "candidate": candidate_summary,
+            "relative_change": None,
+            "regression": None,
+        }
+        if baseline_summary["count"] < 2 or candidate_summary["count"] < 2:
+            if metric not in missing_metrics:
+                missing_metrics.append(metric)
+        else:
+            baseline_mean = baseline_summary["mean"]
+            candidate_mean = candidate_summary["mean"]
+            relative_change = (
+                (candidate_mean - baseline_mean) / abs(baseline_mean)
+                if baseline_mean != 0
+                else math.inf
+                if candidate_mean != 0
+                else 0.0
+            )
+            direction = rule["direction"]
+            degradation = -relative_change if direction == "higher" else relative_change
+            regression = degradation > float(rule["max_relative_regression"])
+            metric_result["relative_change"] = relative_change
+            metric_result["regression"] = regression
+            if regression:
+                regressions.append(metric)
+            if baseline_summary["cv"] > max_cv or candidate_summary["cv"] > max_cv:
+                noisy_metrics.append(metric)
+        metrics[metric] = metric_result
+    if missing_metrics or noisy_metrics:
+        status = "inconclusive"
+    elif regressions:
+        status = "failed"
+    else:
+        status = "passed"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "config_hash": schedule["config_hash"],
+        "exclude_outliers": exclude_outliers,
+        "max_cv": max_cv,
+        "missing_metrics": sorted(set(missing_metrics)),
+        "noisy_metrics": sorted(set(noisy_metrics)),
+        "regressions": sorted(set(regressions)),
+        "metrics": metrics,
+    }
+
+
+def render_report(comparison: Mapping[str, Any]) -> str:
+    lines = [
+        "# Performance regression report",
+        "",
+        f"- Status: **{comparison['status']}**",
+        f"- Config hash: `{comparison['config_hash']}`",
+        f"- Outliers excluded from decision: `{comparison['exclude_outliers']}`",
+        f"- Maximum accepted CV: `{comparison['max_cv']}`",
+        "",
+        "| Metric | Baseline mean | Candidate mean | Relative change | Regression |",
+        "|---|---:|---:|---:|---|",
+    ]
+    for name, row in comparison["metrics"].items():
+        baseline = row["baseline"]["mean"]
+        candidate = row["candidate"]["mean"]
+        change = row["relative_change"]
+        lines.append(
+            f"| `{name}` | {baseline if baseline is not None else 'N/A'} | "
+            f"{candidate if candidate is not None else 'N/A'} | "
+            f"{change if change is not None else 'N/A'} | {row['regression']} |"
+        )
+    lines.extend(["", "## Measurement quality", ""])
+    lines.append(
+        "- Missing or insufficient metrics: "
+        + (", ".join(comparison["missing_metrics"]) or "none")
+    )
+    lines.append(
+        "- Metrics above CV limit: "
+        + (", ".join(comparison["noisy_metrics"]) or "none")
+    )
+    lines.append(
+        "- Regressions: " + (", ".join(comparison["regressions"]) or "none")
+    )
+    lines.extend(["", "## Full statistics", "", "```json"])
+    lines.append(json.dumps(comparison["metrics"], ensure_ascii=False, indent=2, sort_keys=True))
+    lines.extend(["```", ""])
+    return "\n".join(lines)
+
+
+def analyze(output_dir: Path, *, updated_at: str | None = None) -> dict[str, Any]:
+    state = _load_json(output_dir / "run.json", "run state")
+    if state["status"] != "running":
+        raise PerformanceRegressionError(f"run must be running, got {state['status']}")
+    config = _load_json(output_dir / "experiment-config.json", "experiment config")
+    schedule = _load_json(output_dir / "schedule.json", "schedule")
+    measurements = _load_json(output_dir / "measurements.json", "measurements")
+    comparison = analyze_documents(config, schedule, measurements)
+    _write_json(output_dir / "comparison.json", comparison)
+    _atomic_write(output_dir / "report.md", render_report(comparison))
+    timestamp = updated_at or utc_now()
+    state["status"] = comparison["status"]
+    state["updated_at"] = timestamp
+    _write_json(output_dir / "run.json", state)
+    manifest = load_manifest(output_dir / "manifest.json")
+    for name, kind, uri in (
+        ("comparison", "comparison", "comparison.json"),
+        ("report", "report", "report.md"),
+    ):
+        manifest = add_artifact(
+            manifest, name=name, kind=kind, uri=uri, updated_at=timestamp
+        )
+    manifest = transition_status(manifest, comparison["status"], updated_at=timestamp)
+    write_manifest(output_dir / "manifest.json", manifest)
+    return {
+        "status": comparison["status"],
+        "regressions": comparison["regressions"],
+        "noisy_metrics": comparison["noisy_metrics"],
+        "comparison": str((output_dir / "comparison.json").resolve()),
+        "report": str((output_dir / "report.md").resolve()),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+    plan_parser = subparsers.add_parser("plan", help="validate and schedule an experiment")
+    plan_parser.add_argument("--output-dir", required=True, type=Path)
+    plan_parser.add_argument("--config", required=True, type=Path)
+    record_parser = subparsers.add_parser("record", help="record the next measurement")
+    record_parser.add_argument("--output-dir", required=True, type=Path)
+    record_parser.add_argument("--result", required=True, type=Path)
+    normalize_parser = subparsers.add_parser(
+        "normalize", help="normalize one Benchmark result"
+    )
+    normalize_parser.add_argument("--result", required=True, type=Path)
+    normalize_parser.add_argument("--output", required=True, type=Path)
+    normalize_parser.add_argument("--state", required=True, choices=STATES)
+    normalize_parser.add_argument("--phase", required=True, choices=PHASES)
+    normalize_parser.add_argument("--ordinal", required=True, type=int)
+    normalize_parser.add_argument("--config-hash", required=True)
+    normalize_parser.add_argument(
+        "--metric-map",
+        action="append",
+        default=[],
+        metavar="TARGET=SOURCE",
+        help="add or override a Benchmark-to-measurement metric mapping",
+    )
+    analyze_parser = subparsers.add_parser("analyze", help="analyze completed measurements")
+    analyze_parser.add_argument("--output-dir", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.action == "plan":
+            emit_progress("plan", output_dir=str(args.output_dir))
+            payload = plan(args.output_dir, config_path=args.config)
+        elif args.action == "normalize":
+            emit_progress("normalize", result=str(args.result))
+            benchmark = _load_json(args.result, "Benchmark result")
+            normalized = normalize_benchmark_result(
+                benchmark,
+                state=args.state,
+                phase=args.phase,
+                ordinal=args.ordinal,
+                fingerprint=args.config_hash,
+                source=str(args.result.resolve()),
+                metric_map=parse_metric_maps(args.metric_map),
+            )
+            _write_json(args.output, normalized)
+            payload = {
+                "status": "normalized",
+                "output": str(args.output.resolve()),
+                "metrics": sorted(normalized["metrics"]),
+            }
+        elif args.action == "record":
+            emit_progress("record", result=str(args.result))
+            payload = record(args.output_dir, result_path=args.result)
+        else:
+            emit_progress("analyze", output_dir=str(args.output_dir))
+            payload = analyze(args.output_dir)
+    except (PerformanceRegressionError, RunManifestError) as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/vllm-ascend-performance-regression/tests/test_performance_regression.py
+++ b/.agents/skills/vllm-ascend-performance-regression/tests/test_performance_regression.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Tests for controlled A/B performance regression analysis."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+SKILL = ROOT / ".agents" / "skills" / "vllm-ascend-performance-regression"
+
+
+def load_module():
+    name = "_performance_regression_test"
+    spec = importlib.util.spec_from_file_location(
+        name, SKILL / "scripts" / "performance_regression.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+performance = load_module()
+NOW = "2026-07-25T12:00:00Z"
+
+
+def config() -> dict:
+    return {
+        "schema_version": 1,
+        "run_id": "performance-case-1",
+        "baseline": {
+            "label": "baseline",
+            "code_snapshot": "abc",
+            "session_id": "base-session",
+        },
+        "candidate": {
+            "label": "candidate",
+            "code_snapshot": "def",
+            "session_id": "candidate-session",
+        },
+        "shared": {
+            "machine": "host",
+            "npu_devices": [0, 1],
+            "model": {"path": "/models/example"},
+            "environment": {"cann": "test"},
+            "topology": {"tp": 2},
+            "serve_args": [],
+            "bench_args": [],
+            "dataset": "test",
+        },
+        "warmups": 1,
+        "runs": 3,
+        "max_cv": 0.1,
+        "exclude_outliers": False,
+        "thresholds": {
+            "throughput": {
+                "direction": "higher",
+                "max_relative_regression": 0.03,
+            },
+            "ttft": {
+                "direction": "lower",
+                "max_relative_regression": 0.05,
+            },
+        },
+    }
+
+
+def measurement(
+    entry: dict, fingerprint: str, *, throughput: float, ttft: float
+) -> dict:
+    return {
+        "schema_version": 1,
+        "state": entry["state"],
+        "phase": entry["phase"],
+        "ordinal": entry["ordinal"],
+        "config_hash": fingerprint,
+        "metrics": {"throughput": throughput, "ttft": ttft},
+    }
+
+
+class PerformanceRegressionTests(unittest.TestCase):
+    def test_normalizes_single_run_benchmark_result(self) -> None:
+        result = performance.normalize_benchmark_result(
+            {
+                "status": "ok",
+                "metrics": {
+                    "output_throughput": 123.0,
+                    "mean_ttft_ms": 45.0,
+                    "ignored": "value",
+                },
+            },
+            state="baseline",
+            phase="measure",
+            ordinal=1,
+            fingerprint="a" * 64,
+            source="/tmp/bench.json",
+        )
+        self.assertEqual(result["metrics"], {"throughput": 123.0, "ttft": 45.0})
+
+    def test_normalizes_aggregated_benchmark_result(self) -> None:
+        result = performance.normalize_benchmark_result(
+            {
+                "status": "ok",
+                "aggregated": {
+                    "output_throughput": {"mean": 120.0, "stddev": 2.0},
+                    "mean_tpot_ms": {"mean": 4.5, "stddev": 0.1},
+                },
+            },
+            state="candidate",
+            phase="warmup",
+            ordinal=1,
+            fingerprint="b" * 64,
+            source="/tmp/bench.json",
+        )
+        self.assertEqual(result["metrics"], {"throughput": 120.0, "tpot": 4.5})
+
+    def test_three_run_schedule_alternates(self) -> None:
+        schedule = performance.build_schedule(warmups=1, runs=3)
+        self.assertEqual(
+            [entry["id"] for entry in schedule],
+            [
+                "baseline-warmup-1",
+                "candidate-warmup-1",
+                "baseline-measure-1",
+                "candidate-measure-1",
+                "candidate-measure-2",
+                "baseline-measure-2",
+                "baseline-measure-3",
+                "candidate-measure-3",
+            ],
+        )
+
+    def test_same_session_is_rejected(self) -> None:
+        invalid = config()
+        invalid["candidate"]["session_id"] = invalid["baseline"]["session_id"]
+        with self.assertRaisesRegex(performance.PerformanceRegressionError, "different"):
+            performance.validate_config(invalid)
+
+    def test_regression_is_detected(self) -> None:
+        experiment = config()
+        schedule = {
+            "config_hash": performance.config_hash(experiment["shared"]),
+            "entries": performance.build_schedule(warmups=1, runs=3),
+        }
+        for entry in schedule["entries"]:
+            entry["status"] = "recorded"
+        rows = []
+        for entry in schedule["entries"]:
+            rows.append(
+                {
+                    **measurement(
+                        entry,
+                        schedule["config_hash"],
+                        throughput=100.0 if entry["state"] == "baseline" else 90.0,
+                        ttft=10.0 if entry["state"] == "baseline" else 11.0,
+                    ),
+                    "schedule_id": entry["id"],
+                }
+            )
+        comparison = performance.analyze_documents(
+            experiment,
+            schedule,
+            {"measurements": rows},
+        )
+        self.assertEqual(comparison["status"], "failed")
+        self.assertEqual(comparison["regressions"], ["throughput", "ttft"])
+
+    def test_high_variation_is_inconclusive(self) -> None:
+        experiment = config()
+        schedule = {
+            "config_hash": performance.config_hash(experiment["shared"]),
+            "entries": performance.build_schedule(warmups=1, runs=3),
+        }
+        for entry in schedule["entries"]:
+            entry["status"] = "recorded"
+        values = {
+            ("baseline", 1): 100.0,
+            ("baseline", 2): 50.0,
+            ("baseline", 3): 150.0,
+            ("candidate", 1): 100.0,
+            ("candidate", 2): 100.0,
+            ("candidate", 3): 100.0,
+        }
+        rows = []
+        for entry in schedule["entries"]:
+            value = values.get((entry["state"], entry["ordinal"]), 100.0)
+            rows.append(
+                {
+                    **measurement(
+                        entry,
+                        schedule["config_hash"],
+                        throughput=value,
+                        ttft=10.0,
+                    ),
+                    "schedule_id": entry["id"],
+                }
+            )
+        comparison = performance.analyze_documents(
+            experiment, schedule, {"measurements": rows}
+        )
+        self.assertEqual(comparison["status"], "inconclusive")
+        self.assertIn("throughput", comparison["noisy_metrics"])
+
+    def test_full_lifecycle_records_in_schedule_order(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(config()), encoding="utf-8")
+            output = root / "run"
+            planned = performance.plan(output, config_path=config_path, created_at=NOW)
+            schedule = json.loads(
+                (output / "schedule.json").read_text(encoding="utf-8")
+            )
+            for entry in schedule["entries"]:
+                result_path = root / f"{entry['id']}.json"
+                result_path.write_text(
+                    json.dumps(
+                        measurement(
+                            entry,
+                            planned["config_hash"],
+                            throughput=100.0,
+                            ttft=10.0,
+                        )
+                    ),
+                    encoding="utf-8",
+                )
+                performance.record(output, result_path=result_path, recorded_at=NOW)
+            result = performance.analyze(output, updated_at=NOW)
+            self.assertEqual(result["status"], "passed")
+            self.assertTrue((output / "report.md").is_file())
+
+    def test_wrong_config_hash_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(config()), encoding="utf-8")
+            output = root / "run"
+            performance.plan(output, config_path=config_path, created_at=NOW)
+            entry = json.loads(
+                (output / "schedule.json").read_text(encoding="utf-8")
+            )["entries"][0]
+            result_path = root / "wrong.json"
+            result_path.write_text(
+                json.dumps(measurement(entry, "0" * 64, throughput=1.0, ttft=1.0)),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                performance.PerformanceRegressionError, "config_hash"
+            ):
+                performance.record(output, result_path=result_path, recorded_at=NOW)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_skill_catalog.py
+++ b/.agents/tests/test_skill_catalog.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Tests for the repository-local skill catalog validator."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / ".agents" / "scripts" / "skill_catalog.py"
+
+
+def load_catalog_module():
+    module_name = "_skill_catalog_test"
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+catalog = load_catalog_module()
+
+
+def write_minimal_repo(root: Path, *, docs_include: str = "example-skill") -> None:
+    skill = root / ".agents" / "skills" / "example-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\n"
+        "name: example-skill\n"
+        "description: Use for deterministic catalog tests.\n"
+        "---\n\n"
+        "# Example\n",
+        encoding="utf-8",
+    )
+    (root / "README.md").write_text(
+        f"| **{docs_include}** | purpose | when |\n", encoding="utf-8"
+    )
+    (root / "README.en.md").write_text(
+        f"| **{docs_include}** | purpose | when |\n", encoding="utf-8"
+    )
+    (root / "AGENTS.md").write_text(
+        f"| `{docs_include}` | purpose |\n", encoding="utf-8"
+    )
+    agents_readme = root / ".agents" / "README.md"
+    agents_readme.parent.mkdir(exist_ok=True)
+    agents_readme.write_text(
+        f"- `.agents/skills/{docs_include}/` is canonical.\n", encoding="utf-8"
+    )
+
+
+class SkillCatalogTests(unittest.TestCase):
+    def test_current_repository_catalog_is_complete(self) -> None:
+        records, findings = catalog.validate_repo(ROOT)
+        self.assertGreater(len(records), 0)
+        self.assertEqual(findings, [])
+
+    def test_directory_and_frontmatter_name_must_match(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_minimal_repo(root)
+            skill_file = root / ".agents" / "skills" / "example-skill" / "SKILL.md"
+            skill_file.write_text(
+                skill_file.read_text(encoding="utf-8").replace(
+                    "name: example-skill", "name: another-skill"
+                ),
+                encoding="utf-8",
+            )
+            _records, findings = catalog.validate_repo(root)
+            self.assertIn("name-mismatch", {finding.code for finding in findings})
+
+    def test_document_catalog_drift_is_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_minimal_repo(root, docs_include="stale-skill")
+            _records, findings = catalog.validate_repo(root)
+            codes = {finding.code for finding in findings}
+            self.assertIn("catalog-entry-missing", codes)
+            self.assertIn("catalog-entry-unknown", codes)
+
+    def test_missing_relative_markdown_link_is_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_minimal_repo(root)
+            skill_file = root / ".agents" / "skills" / "example-skill" / "SKILL.md"
+            skill_file.write_text(
+                skill_file.read_text(encoding="utf-8")
+                + "\nSee [acceptance](references/acceptance.md).\n",
+                encoding="utf-8",
+            )
+            _records, findings = catalog.validate_repo(root)
+            self.assertIn("link-missing", {finding.code for finding in findings})
+
+    def test_description_with_angle_brackets_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_minimal_repo(root)
+            skill_file = root / ".agents" / "skills" / "example-skill" / "SKILL.md"
+            skill_file.write_text(
+                skill_file.read_text(encoding="utf-8").replace(
+                    "Use for deterministic catalog tests.",
+                    "Use when a local -> remote copy is required.",
+                ),
+                encoding="utf-8",
+            )
+            _records, findings = catalog.validate_repo(root)
+            self.assertIn("description-invalid", {finding.code for finding in findings})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/ascend-operator-debug/SKILL.md
+++ b/.claude/skills/ascend-operator-debug/SKILL.md
@@ -1,0 +1,18 @@
+<!-- Generated Claude Code shim from .agents/skills/ascend-operator-debug/SKILL.md. Do not edit. -->
+---
+name: ascend-operator-debug
+description: Reduce an Ascend model-level failure to one torch_npu, ACLNN, or custom operator call, then validate explicit dtype, shape, layout, and eager/compile/graph cases against a reference implementation. Use for operator crashes, unsupported dtype or layout errors, shape-dependent numerical mismatches, or workspace API faults. Do not use for whole-model graph localization, multi-rank failures, performance benchmarking, or profiler analysis.
+---
+
+# Ascend Operator Debug
+
+Canonical skill source:
+
+`.agents/skills/ascend-operator-debug/SKILL.md`
+
+Before using this skill:
+
+1. Read the canonical skill file above.
+2. Follow its routing rules, entrypoints, guardrails, and acceptance criteria.
+3. Use `.remote-dev` companion tools for ordinary remote endpoint read/edit/bash/search/patch work.
+4. Use this Claude project skill only for the domain workflow described by the canonical source.

--- a/.claude/skills/vllm-ascend-change-validation/SKILL.md
+++ b/.claude/skills/vllm-ascend-change-validation/SKILL.md
@@ -1,0 +1,18 @@
+<!-- Generated Claude Code shim from .agents/skills/vllm-ascend-change-validation/SKILL.md. Do not edit. -->
+---
+name: vllm-ascend-change-validation
+description: Analyze vLLM and vllm-ascend diffs, map affected components to the minimum sufficient correctness, build, performance, graph, operator, distributed, and profiling evidence, link downstream Run Manifest results, and produce a PR-ready validation report. Use for PR validation, workspace-diff risk analysis, deciding what tests a change requires, or documenting untested combinations. Do not use as a replacement for the downstream execution skills or for a change with no accessible diff.
+---
+
+# vLLM Ascend Change Validation
+
+Canonical skill source:
+
+`.agents/skills/vllm-ascend-change-validation/SKILL.md`
+
+Before using this skill:
+
+1. Read the canonical skill file above.
+2. Follow its routing rules, entrypoints, guardrails, and acceptance criteria.
+3. Use `.remote-dev` companion tools for ordinary remote endpoint read/edit/bash/search/patch work.
+4. Use this Claude project skill only for the domain workflow described by the canonical source.

--- a/.claude/skills/vllm-ascend-correctness-validation/SKILL.md
+++ b/.claude/skills/vllm-ascend-correctness-validation/SKILL.md
@@ -1,0 +1,18 @@
+<!-- Generated Claude Code shim from .agents/skills/vllm-ascend-correctness-validation/SKILL.md. Do not edit. -->
+---
+name: vllm-ascend-correctness-validation
+description: Plan, execute, normalize, and compare vLLM Ascend inference correctness across baseline and candidate code states, eager and graph modes, offline generate or chat, online chat completions, and AISBench task metrics. Use for accuracy validation, token-output comparison, graph-versus-eager checks, deterministic regression testing, or failure classification. Do not use to root-cause an already reproduced graph-only or isolated-operator failure, or for throughput benchmarking, HBM attribution, or profiling-only analysis.
+---
+
+# vLLM Ascend Correctness Validation
+
+Canonical skill source:
+
+`.agents/skills/vllm-ascend-correctness-validation/SKILL.md`
+
+Before using this skill:
+
+1. Read the canonical skill file above.
+2. Follow its routing rules, entrypoints, guardrails, and acceptance criteria.
+3. Use `.remote-dev` companion tools for ordinary remote endpoint read/edit/bash/search/patch work.
+4. Use this Claude project skill only for the domain workflow described by the canonical source.

--- a/.claude/skills/vllm-ascend-distributed-debug/SKILL.md
+++ b/.claude/skills/vllm-ascend-distributed-debug/SKILL.md
@@ -1,0 +1,18 @@
+<!-- Generated Claude Code shim from .agents/skills/vllm-ascend-distributed-debug/SKILL.md. Do not edit. -->
+---
+name: vllm-ascend-distributed-debug
+description: Diagnose vLLM Ascend multi-rank and multi-node startup, rank mapping, process-group, collective, HCCL, Ray, scheduler, connector, and distributed hang failures from structured topology and per-rank evidence. Use when a failure depends on rank count, parallel topology, nodes, collectives, or distributed endpoints. Do not use for graph-only divergence, isolated operator failures, performance benchmarking, or profiler analysis.
+---
+
+# vLLM Ascend Distributed Debug
+
+Canonical skill source:
+
+`.agents/skills/vllm-ascend-distributed-debug/SKILL.md`
+
+Before using this skill:
+
+1. Read the canonical skill file above.
+2. Follow its routing rules, entrypoints, guardrails, and acceptance criteria.
+3. Use `.remote-dev` companion tools for ordinary remote endpoint read/edit/bash/search/patch work.
+4. Use this Claude project skill only for the domain workflow described by the canonical source.

--- a/.claude/skills/vllm-ascend-graph-debug/SKILL.md
+++ b/.claude/skills/vllm-ascend-graph-debug/SKILL.md
@@ -1,0 +1,18 @@
+<!-- Generated Claude Code shim from .agents/skills/vllm-ascend-graph-debug/SKILL.md. Do not edit. -->
+---
+name: vllm-ascend-graph-debug
+description: Diagnose vLLM Ascend cudagraph and ACL Graph compile, capture, replay, hang, and graph-versus-eager correctness problems. Use when eager passes but graph mode fails, hangs, or diverges, or when graph/eager intermediate tensors must be aligned. Do not use to plan a correctness matrix, after the failure is reduced to one operator, when eager itself fails, or for performance profiling or HBM attribution.
+---
+
+# NPU Graph Debug
+
+Canonical skill source:
+
+`.agents/skills/vllm-ascend-graph-debug/SKILL.md`
+
+Before using this skill:
+
+1. Read the canonical skill file above.
+2. Follow its routing rules, entrypoints, guardrails, and acceptance criteria.
+3. Use `.remote-dev` companion tools for ordinary remote endpoint read/edit/bash/search/patch work.
+4. Use this Claude project skill only for the domain workflow described by the canonical source.

--- a/.claude/skills/vllm-ascend-pd-serving/SKILL.md
+++ b/.claude/skills/vllm-ascend-pd-serving/SKILL.md
@@ -1,0 +1,18 @@
+<!-- Generated Claude Code shim from .agents/skills/vllm-ascend-pd-serving/SKILL.md. Do not edit. -->
+---
+name: vllm-ascend-pd-serving
+description: Plan, start, inspect, smoke-test, and stop a multi-session vLLM Ascend prefill/decode deployment with explicit connector configuration, role ordering, proxy endpoint health, rollback, and KV-transfer request evidence. Use for PD disaggregation with NIXL, Mooncake, or another KV connector. Do not use for one colocated service, generic Ray clusters, correctness matrices, performance regression decisions, or distributed root-cause diagnosis.
+---
+
+# vLLM Ascend PD Serving
+
+Canonical skill source:
+
+`.agents/skills/vllm-ascend-pd-serving/SKILL.md`
+
+Before using this skill:
+
+1. Read the canonical skill file above.
+2. Follow its routing rules, entrypoints, guardrails, and acceptance criteria.
+3. Use `.remote-dev` companion tools for ordinary remote endpoint read/edit/bash/search/patch work.
+4. Use this Claude project skill only for the domain workflow described by the canonical source.

--- a/.claude/skills/vllm-ascend-performance-regression/SKILL.md
+++ b/.claude/skills/vllm-ascend-performance-regression/SKILL.md
@@ -1,0 +1,18 @@
+<!-- Generated Claude Code shim from .agents/skills/vllm-ascend-performance-regression/SKILL.md. Do not edit. -->
+---
+name: vllm-ascend-performance-regression
+description: Plan, record, and analyze controlled baseline-versus-candidate vLLM Ascend serving performance experiments with isolated sessions, identical non-code configuration, alternating A/B order, warmup exclusion, variance and outlier reporting, and metric-specific regression thresholds. Use for throughput, TTFT, TPOT, ITL, acceptance-rate, startup-time, or HBM regression checks. Do not use for correctness, single-state measurement, HBM component attribution, or profiling root-cause analysis.
+---
+
+# vLLM Ascend Performance Regression
+
+Canonical skill source:
+
+`.agents/skills/vllm-ascend-performance-regression/SKILL.md`
+
+Before using this skill:
+
+1. Read the canonical skill file above.
+2. Follow its routing rules, entrypoints, guardrails, and acceptance criteria.
+3. Use `.remote-dev` companion tools for ordinary remote endpoint read/edit/bash/search/patch work.
+4. Use this Claude project skill only for the domain workflow described by the canonical source.

--- a/.github/workflows/skill-catalog.yml
+++ b/.github/workflows/skill-catalog.yml
@@ -1,0 +1,80 @@
+name: Skill catalog
+
+on:
+  pull_request:
+    paths:
+      - ".agents/**"
+      - "AGENTS.md"
+      - "README.md"
+      - "README.en.md"
+      - ".github/workflows/skill-catalog.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".agents/**"
+      - "AGENTS.md"
+      - "README.md"
+      - "README.en.md"
+      - ".github/workflows/skill-catalog.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate catalog
+        run: python -B .agents/scripts/skill_catalog.py
+      - name: Validate shared knowledge
+        run: python -B .agents/scripts/knowledge_validate.py
+      - name: Run catalog tests
+        run: python -B -m unittest discover -s .agents/tests -p "test_*catalog.py"
+      - name: Run manifest and knowledge tests
+        run: python -B -m unittest discover -s .agents/tests -p "test_run_manifest.py"
+      - name: Run knowledge evidence-chain tests
+        run: python -B -m unittest discover -s .agents/tests -p "test_knowledge*.py"
+      - name: Run knowledge curation tests
+        run: python -B -m unittest discover -s .agents/skills/curate-workspace-knowledge/tests
+      - name: Run graph-debug tests
+        run: python -B -m unittest discover -s .agents/skills/vllm-ascend-graph-debug/tests
+      - name: Run correctness-validation tests
+        run: python -B -m unittest discover -s .agents/skills/vllm-ascend-correctness-validation/tests
+      - name: Run change-validation tests
+        run: python -B -m unittest discover -s .agents/skills/vllm-ascend-change-validation/tests
+      - name: Run performance-regression tests
+        run: python -B -m unittest discover -s .agents/skills/vllm-ascend-performance-regression/tests
+
+      - name: Run session-management tests
+        run: python -B -m unittest discover -s .agents/skills/session-management/tests
+
+      - name: Validate parameterized Ray helpers
+        run: bash -n scripts/ray_head.sh scripts/ray_worker.sh
+
+      - name: Run distributed-debug tests
+        run: python -B -m unittest discover -s .agents/skills/vllm-ascend-distributed-debug/tests
+
+      - name: Run operator-debug tests
+        run: python -B -m unittest discover -s .agents/skills/ascend-operator-debug/tests
+
+      - name: Run Triton development tests
+        run: python -B -m unittest discover -s .agents/skills/ascend-triton-operator-development/tests
+
+      - name: Run Triton validation tests
+        run: python -B -m unittest discover -s .agents/skills/ascend-triton-kernel-validation/tests
+
+      - name: Run Triton optimization tests
+        run: python -B -m unittest discover -s .agents/skills/ascend-triton-kernel-optimization/tests
+
+      - name: Run Triton workflow tests
+        run: python -B -m unittest discover -s .agents/skills/ascend-triton-workflow/tests
+
+      - name: Run PD-serving tests
+        run: python -B -m unittest discover -s .agents/skills/vllm-ascend-pd-serving/tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Repo-local skills live under `.agents/skills/`. Each has its own `SKILL.md` with
 |-------|---------|
 | `repo-init` | Initialize workspace: `gh`, GitHub auth, submodules, fork topology |
 | `machine-management` | Add / verify / repair / remove a remote NPU machine |
-| `session-management` | Create / inspect / remove isolated agent sessions (local worktree + remote container + leases) |
+| `session-management` | Create / inspect / remove / group isolated agent sessions (local worktree + remote container + leases) |
 | `remote-toolbox` | Compatibility backend for managed VAWS target/probe/exec/job/sync/service/artifact/cleanup tools |
 | `remote-code-parity` | Sync local working tree to remote container before execution |
 | `modelscope` | Download / resume / status-check / SHA256-verify ModelScope model weights under explicit local directories |
@@ -59,6 +59,17 @@ Repo-local skills live under `.agents/skills/`. Each has its own `SKILL.md` with
 | `ascend-profiling-collection` | Collect one Ascend torch-profiler case end-to-end (start service, bracket workload with `/start_profile` + `/stop_profile`, run `analyse()`, verify outputs, write manifest) |
 | `ascend-profiling-analysis` | Analyze collected Ascend torch-profiler roots/manifests and generate reports |
 | `curate-workspace-knowledge` | Explicitly review, deduplicate, promote, merge, reject, or deprecate verified knowledge candidates |
+| `vllm-ascend-graph-debug` | Diagnose Ascend graph compile, capture, replay, and graph/eager correctness divergence |
+| `vllm-ascend-correctness-validation` | Plan and compare baseline/candidate, eager/graph, offline/online, and task-metric correctness evidence |
+| `vllm-ascend-change-validation` | Map code diffs to required validation evidence and aggregate downstream runs into PR reports |
+| `vllm-ascend-performance-regression` | Control alternating baseline/candidate experiments and assess performance regressions |
+| `vllm-ascend-distributed-debug` | Diagnose rank topology, process-group, endpoint, collective, and distributed hang failures |
+| `ascend-operator-debug` | Reduce a model symptom to one Ascend operator call and validate an explicit input/mode matrix |
+| `ascend-triton-operator-development` | Convert a PyTorch or GPU Triton contract into a first correct Ascend Triton candidate |
+| `ascend-triton-kernel-validation` | Detect fallback and validate an Ascend Triton kernel over an explicit correctness matrix |
+| `ascend-triton-kernel-optimization` | Run profiler-driven, correctness-gated Ascend Triton optimization experiments |
+| `ascend-triton-workflow` | Orchestrate Ascend Triton development, validation, optimization, and evidence linking |
+| `vllm-ascend-pd-serving` | Orchestrate grouped prefill/decode services, connector configuration, rollback, and smoke tests |
 
 None of these are gates for normal local coding, docs work, or unrelated Git tasks.
 For remote endpoint work, prefer `.remote-dev` tools first and use these skills

--- a/README.en.md
+++ b/README.en.md
@@ -34,7 +34,7 @@ The Agent will detect your environment, install required tools, and configure Gi
 | ---------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
 | **repo-init**          | Install GitHub CLI, authenticate, initialize submodules, configure forks and remote topology | After first clone                                          |
 | **machine-management** | Add, verify, repair, or remove a remote Ascend NPU server and its managed container          | When setting up a remote NPU dev machine                   |
-| **session-management** | Create, inspect, and clean isolated sessions: local worktree, remote container, state namespace, and resource leases | For parallel remote work or multiple agents |
+| **session-management** | Create, inspect, group, and clean isolated sessions: local worktree, remote container, state namespace, and resource leases | For parallel remote work, multiple agents, or PD deployments |
 | **remote-toolbox**    | Structured target/probe/exec/job/sync/service/artifact/cleanup tools for remote containers | When agents need local-tool-like control of a remote session container |
 | **remote-code-parity** | Sync the full local workspace state (including uncommitted changes) to a remote container    | Triggered automatically before remote test or service runs |
 | **modelscope**       | Download, resume, status-check, and SHA256-verify ModelScope model weights                  | When model weights need to be downloaded into an explicit local directory |
@@ -44,6 +44,17 @@ The Agent will detect your environment, install required tools, and configure Gi
 | **ascend-profiling-collection** | Collect Ascend torch-profiler data: start service, bracket profile window, run workload, remote analyse, and write a manifest | When you need kernel_details/trace_view captures |
 | **ascend-profiling-analysis** | Analyze collected profiler roots/manifests and generate step/layer/operator/cross-rank reports | When you need to analyze profiling output |
 | **curate-workspace-knowledge** | Review, deduplicate, promote, merge, reject, or deprecate verified project knowledge candidates | When explicitly curating or maintaining project knowledge |
+| **vllm-ascend-graph-debug** | Diagnose graph compile, capture, replay, and graph/eager correctness divergence | When graph mode fails or diverges from eager mode |
+| **vllm-ascend-correctness-validation** | Compare baseline/candidate, eager/graph, offline/online, and AISBench correctness | When validating accuracy or normalized outputs |
+| **vllm-ascend-change-validation** | Derive validation plans from code diffs and aggregate PR evidence | When validating a workspace change or PR |
+| **vllm-ascend-performance-regression** | Run alternating A/B experiments and assess variance and regression thresholds | When deciding whether throughput or latency regressed |
+| **vllm-ascend-distributed-debug** | Diagnose topology, endpoint, collective, and per-rank distributed failures | When a failure depends on ranks, nodes, or parallel topology |
+| **ascend-operator-debug** | Reduce a model failure to one operator and run an explicit input/mode matrix | When building an isolated operator reproducer |
+| **ascend-triton-operator-development** | Produce a first correct Ascend Triton candidate from PyTorch or GPU Triton semantics | When creating or migrating a Triton operator |
+| **ascend-triton-kernel-validation** | Detect PyTorch fallback and execute an explicit correctness matrix | When validating an Ascend Triton candidate |
+| **ascend-triton-kernel-optimization** | Run profiler-driven optimization after correctness gates pass | When tuning a correct Ascend Triton kernel |
+| **ascend-triton-workflow** | Orchestrate development, validation, optimization, and Run Manifest evidence | When delivering an end-to-end Triton operator workflow |
+| **vllm-ascend-pd-serving** | Orchestrate grouped prefill/decode roles, connectors, rollback, and KV smoke | When deploying disaggregated PD serving |
 
 
 All skills are **optional**. Use any subset, or none at all.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Agent 会自动检测你的环境、安装所需工具、配置 Git 远程仓库
 | ------------------------ | ---------------------------------------------- | ------------------ |
 | **repo-init**            | 安装 GitHub CLI、登录 GitHub、初始化子模块、配置 Fork 和远程仓库拓扑 | 首次 clone 后初始化工作区   |
 | **machine-management**   | 添加、验证、修复或移除远程昇腾 NPU 服务器及其托管容器                  | 需要配置远程 NPU 开发机时    |
-| **session-management**   | 创建/检查/清理隔离 session：本地 worktree、远端容器、状态目录和资源 lease | 多 agent 或多任务并行远端执行时 |
+| **session-management**   | 创建、检查、分组和清理隔离 session：本地 worktree、远端容器、状态目录和资源 lease | 多 agent、多任务或 PD 场景并行远端执行时 |
 | **remote-toolbox**       | 结构化解析/探测/执行/长任务/同步/服务/产物传输/清理远端容器              | Agent 需要像使用本地工具一样操作远端 session container 时 |
 | **remote-code-parity**   | 将本地工作区的完整状态（含未提交的修改）同步到远程容器                    | 在远程机器上运行测试或服务前自动触发 |
 | **modelscope**           | 下载、续传、查看进度并 SHA256 校验 ModelScope 模型权重                  | 需要把模型权重下载到明确目录时 |
@@ -44,6 +44,17 @@ Agent 会自动检测你的环境、安装所需工具、配置 Git 远程仓库
 | **ascend-profiling-collection** | 采集 Ascend torch profiler：起服务、控制 profile 窗口、运行 workload、远端 analyse 并写 manifest | 需要采集 kernel_details/trace_view 时 |
 | **ascend-profiling-analysis** | 分析已采集的 profiler root/manifest，生成 step/layer/operator/cross-rank 诊断报告 | 需要分析 profiling 结果或生成报告时 |
 | **curate-workspace-knowledge** | 审核、去重、提升、合并、拒绝或废弃已验证的项目知识候选 | 显式要求沉淀、整理或维护项目知识时 |
+| **vllm-ascend-graph-debug** | 定位图编译、捕获、重放及 graph/eager 正确性分歧 | 图模式失败或与 eager 结果不一致时 |
+| **vllm-ascend-correctness-validation** | 对比 baseline/candidate、eager/graph、离线/在线和 AISBench 正确性 | 需要精度验证或输出对拍时 |
+| **vllm-ascend-change-validation** | 根据代码 diff 生成验证计划并汇总证据和 PR 报告 | 验证工作区变更或 PR 时 |
+| **vllm-ascend-performance-regression** | 运行交替 A/B 实验并分析波动和回退阈值 | 判断吞吐或延迟是否回退时 |
+| **vllm-ascend-distributed-debug** | 从拓扑、端点、collective 和逐 rank 事件诊断分布式故障 | 故障依赖多卡、多机或 rank 时 |
+| **ascend-operator-debug** | 将模型故障缩减为单算子并运行 dtype/shape/layout/mode 矩阵 | 需要最小化算子复现时 |
+| **ascend-triton-operator-development** | 从 PyTorch 或 GPU Triton 语义生成首个正确的 Ascend Triton 实现 | 新建或迁移 Triton 算子时 |
+| **ascend-triton-kernel-validation** | 检测 PyTorch fallback 并执行显式正确性矩阵 | 验证 Triton 候选实现时 |
+| **ascend-triton-kernel-optimization** | 在正确性门禁后执行 profiler 驱动的优化实验 | 优化已正确的 Triton kernel 时 |
+| **ascend-triton-workflow** | 编排开发、验证、优化和 Run Manifest 证据 | 交付完整 Triton 算子生命周期时 |
+| **vllm-ascend-pd-serving** | 编排 Session Group 上的 prefill/decode、connector、回滚和 KV smoke | 部署 PD 分离服务时 |
 
 
 所有技能都是**可选的**。你可以只用其中的一部分，也可以完全不用。

--- a/scripts/ray_head.sh
+++ b/scripts/ray_head.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 --node-ip <ip> [--port <port>] [--interface <name>] [--stop-existing]"
+}
+
+node_ip=""
+port=6379
+network_interface="eth0"
+stop_existing=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --node-ip)
+            node_ip="${2:?--node-ip requires a value}"
+            shift 2
+            ;;
+        --port)
+            port="${2:?--port requires a value}"
+            shift 2
+            ;;
+        --interface)
+            network_interface="${2:?--interface requires a value}"
+            shift 2
+            ;;
+        --stop-existing)
+            stop_existing=1
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$node_ip" ]]; then
+    echo "--node-ip is required" >&2
+    usage >&2
+    exit 2
+fi
+if ! [[ "$port" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
+    echo "--port must be an integer from 1 to 65535" >&2
+    exit 2
+fi
+
+export NCCL_DEBUG="${NCCL_DEBUG:-INFO}"
+export NCCL_SOCKET_IFNAME="$network_interface"
+export GLOO_SOCKET_IFNAME="$network_interface"
+export NCCL_IB_DISABLE="${NCCL_IB_DISABLE:-0}"
+export NCCL_NET_GDR_LEVEL="${NCCL_NET_GDR_LEVEL:-2}"
+export NCCL_SHM_DISABLE="${NCCL_SHM_DISABLE:-0}"
+
+if (( stop_existing )); then
+    ray stop -f
+fi
+
+ray start \
+    --head \
+    "--node-ip-address=$node_ip" \
+    "--port=$port" \
+    --dashboard-host=0.0.0.0
+
+printf '{"status":"started","role":"head","node_ip":"%s","port":%s,"interface":"%s"}\n' \
+    "$node_ip" "$port" "$network_interface"

--- a/scripts/ray_worker.sh
+++ b/scripts/ray_worker.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 --head-address <ip:port> --node-ip <ip> [--interface <name>] [--stop-existing]"
+}
+
+head_address=""
+node_ip=""
+network_interface="eth0"
+stop_existing=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --head-address)
+            head_address="${2:?--head-address requires a value}"
+            shift 2
+            ;;
+        --node-ip)
+            node_ip="${2:?--node-ip requires a value}"
+            shift 2
+            ;;
+        --interface)
+            network_interface="${2:?--interface requires a value}"
+            shift 2
+            ;;
+        --stop-existing)
+            stop_existing=1
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$head_address" || -z "$node_ip" ]]; then
+    echo "--head-address and --node-ip are required" >&2
+    usage >&2
+    exit 2
+fi
+
+export NCCL_DEBUG="${NCCL_DEBUG:-INFO}"
+export NCCL_SOCKET_IFNAME="$network_interface"
+export GLOO_SOCKET_IFNAME="$network_interface"
+export NCCL_IB_DISABLE="${NCCL_IB_DISABLE:-0}"
+export NCCL_NET_GDR_LEVEL="${NCCL_NET_GDR_LEVEL:-2}"
+
+if (( stop_existing )); then
+    ray stop -f
+fi
+
+ray start \
+    "--address=$head_address" \
+    "--node-ip-address=$node_ip"
+
+printf '{"status":"started","role":"worker","node_ip":"%s","head_address":"%s","interface":"%s"}\n' \
+    "$node_ip" "$head_address" "$network_interface"


### PR DESCRIPTION
## Summary

Extract eleven reusable validation, debugging, Ascend Triton, and PD-serving skills onto a branch based directly on `upstream/main`.

Each requested skill is introduced by its own commit so reviewers can inspect or cherry-pick the packages independently:

- `vllm-ascend-graph-debug`
- `vllm-ascend-correctness-validation`
- `vllm-ascend-change-validation`
- `vllm-ascend-performance-regression`
- `vllm-ascend-distributed-debug`
- `ascend-operator-debug`
- `ascend-triton-operator-development`
- `ascend-triton-kernel-validation`
- `ascend-triton-kernel-optimization`
- `ascend-triton-workflow`
- `vllm-ascend-pd-serving`

## Supporting changes

- Add shared Run Manifest v1 and compact knowledge query/candidate infrastructure used by the execution skills.
- Add Session Group lifecycle and Ray launch helpers required by grouped PD serving.
- Register the extracted packages in AGENTS.md and the Chinese/English README files.
- Add a dynamic skill-catalog validation workflow.
- Replace one pre-existing angle-bracket-like description token so the new catalog check also passes on the upstream skill set.

The supporting commits are intentionally separate from the eleven skill commits. Skill commits contain only their owning package and, where applicable, the Claude compatibility shim.

## Validation

- `git diff --check upstream/main..HEAD`
- Shared Run Manifest tests
- Shared knowledge-memory tests
- Skill catalog tests
- Session Group/remove/visibility tests
- Unit tests for all eleven extracted skill packages

All 90 selected pure-Python tests pass. Hardware-dependent `torch_npu` execution was not run locally.
