### PR TITLE
feat(parity): add incremental Git transport

### DIFF
--- a/.agents/skills/remote-code-parity/SKILL.md
+++ b/.agents/skills/remote-code-parity/SKILL.md
@@ -35,8 +35,15 @@ Keep a **ready** remote runtime in exact code parity with the local `vllm-ascend
 - Preserve runtime-private paths under `/vllm-workspace`, in particular `Mooncake/` (image-provided runtime) and `.vaws-runtime/` (workspace-managed runtime artifacts such as profiler dumps consumed by downstream skills). The exact list lives in `DEFAULT_ROOT_PRESERVE_PATHS` in `scripts/remote_code_parity.py`.
 - Container locks should record owner metadata and recover stale lock directories after the bounded stale interval; failed mirror hydration should best-effort clean any matching legacy `git-receive-pack` process trees and discard that repo's partial mirror before retry.
 - Keep `stdout` reserved for one final JSON summary and stream phase progress on `stderr` as `__VAWS_PARITY_PROGRESS__=<json>`.
+- Prefer incremental Git `receive-pack` directly into the container-local bare
+  mirrors. In `auto` mode, fall back to the self-contained full-bundle transfer
+  when Git push is unavailable.
 - Runtime install progress should be attributable at the package-step level: uninstall, `vllm`, `vllm-ascend` requirements, `vllm-ascend`, import smoke, and marker write.
-- Publish each synthetic snapshot to both the parity ref and an advertised branch ref inside the container-local mirror. Use Git bundles imported inside the container so parentless transport snapshots do not depend on remote receive-pack negotiation or remote base objects.
+- Publish each synthetic snapshot to both the parity ref and an advertised branch ref inside the container-local mirror. Git push reuses objects already present in that mirror; the bundle fallback remains self-contained and does not require remote base objects.
+- Keep deterministic parentless snapshot commits as the runtime identity. Maintain
+  a separate endpoint-scoped transport-carrier ref whose commits form a chain
+  over the same trees; this gives receive-pack a common ancestor without making
+  snapshot ids target-dependent or pulling upstream history into first sync.
 - Materialize child repos explicitly; do not rely on `git submodule update` to fetch synthetic child commits.
 - Synthetic commits are deterministic parentless tree snapshots. Keep each repo's real `HEAD` separately as `source_head` for reinstall drift detection instead of using it as the transport parent.
 - If a clean child repo only differs from the parent through the parentless transport commit id, suppress that transport-only child gitlink path from the parent repo's `changed_paths`.
@@ -113,6 +120,14 @@ Low-level helper:
 
 - POSIX: `python3 .agents/skills/remote-code-parity/scripts/remote_code_parity.py sync ...`
 
+Transport selection:
+
+- `--transport auto` (default): incremental Git push first, full bundle fallback.
+- `--transport git`: require incremental Git push and fail closed on transport failure.
+- `--transport bundle`: force the legacy self-contained full-bundle path.
+- `scripts/transport_benchmark.py` compares full-bundle payloads with
+  incremental receive-pack payloads in isolated temporary repositories.
+
 Optional cache cleanup helper:
 
 - POSIX: `python3 .agents/skills/remote-code-parity/scripts/gc_runtime_cache.py ...`
@@ -175,7 +190,11 @@ Ignored files stay ignored. The snapshot source of truth is tracked + untracked 
 For each repo in scope:
 
 - ensure the container-local bare mirror repo exists under the cache root
-- create a local Git bundle for the synthetic ref, stream it to the container over SSH, and fetch that bundle into the container-local bare mirror
+- push the synthetic ref over SSH directly into the container-local bare mirror,
+  together with the endpoint-scoped transport-carrier ref, allowing Git to omit
+  objects already reachable from the previous carrier
+- in `auto` mode, if `git-receive-pack` cannot complete, create a self-contained
+  local Git bundle, stream it to the remote, and fetch it into the same mirror
 - update `refs/parity/<workspace_id>/current` and an advertised branch ref inside that same mirror
 - write a compact manifest for this sync attempt under `manifests/`
 - use a **container-local** lock while mutating cache or runtime state

--- a/.agents/skills/remote-code-parity/references/acceptance.md
+++ b/.agents/skills/remote-code-parity/references/acceptance.md
@@ -48,7 +48,13 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 - synthetic snapshots can represent dirty working trees without forcing a real commit
 - when `vllm` or `vllm-ascend` changed locally, the workspace-root synthetic snapshot also changes because the gitlinks are rewritten to the synthetic child commits
 - synthetic snapshot commits are parentless, so first mirror hydration transfers the snapshot tree instead of the full upstream history
-- parentless snapshot mirror hydration uses Git bundle import, so it does not depend on remote receive-pack negotiation or remote base history that may not exist
+- parentless snapshots pushed to an existing mirror reuse unchanged Git objects;
+  first hydration still sends only the snapshot tree rather than upstream history
+- a target-scoped transport carrier advances over the same snapshot trees so a
+  small repeated edit produces a small receive-pack payload while runtime and
+  manifest commit ids remain the deterministic parentless snapshot ids
+- `auto` transport falls back to self-contained Git bundle import when
+  receive-pack is unavailable, without requiring remote base history
 - repeated snapshots of the same workspace tree produce the same synthetic commit ids, enabling the no-change fast path
 - when a nested child repo has no logical changes, the parent repo does not report a reinstall-relevant `changed_paths` entry just because the child was represented by a parentless transport commit
 - ignored files are not added to the snapshot by default
@@ -58,7 +64,11 @@ These should not trigger `remote-code-parity` unless remote code parity is the o
 ### Container-only cache path
 
 - the normal sync path does not require host storage, host lock directories, or `docker inspect`
-- container-local bare mirrors are populated by SSH-streamed Git bundles, without requiring GitHub credentials or host storage
+- container-local bare mirrors are populated by direct SSH Git push when
+  available, without requiring GitHub credentials or host storage
+- `--transport git` fails closed instead of silently using a bundle;
+  `--transport bundle` bypasses receive-pack; `--transport auto` records a
+  progress event before falling back
 - advertised branch refs are published inside the mirror so synthetic child commits are fetchable through ordinary Git paths
 - stale container lock directories are eventually recovered instead of permanently blocking later parity attempts
 - failed or timed-out mirror hydration does not leave matching legacy `git-receive-pack` process trees or partial repo mirrors blocking later retries

--- a/.agents/skills/remote-code-parity/references/behavior.md
+++ b/.agents/skills/remote-code-parity/references/behavior.md
@@ -109,9 +109,17 @@ Per-workspace layout:
 Required behavior:
 
 - create bare mirror repos inside the container cache root
-- stream Git bundles directly from local -> container SSH, then fetch them into the container-local bare mirrors
+- prefer direct SSH Git push into the container-local bare mirrors so repeated
+  snapshots transfer only objects missing from the current mirror ref
+- preserve deterministic parentless snapshot ids, but publish a separate
+  endpoint-scoped carrier chain over the same trees to provide receive-pack
+  with a common ancestor for object negotiation
+- support `auto`, `git`, and `bundle` transport selection; `auto` falls back to
+  the existing self-contained bundle import if receive-pack is unavailable
 - publish deterministic parentless tree snapshot commits so first use of an empty container mirror does not require shipping the full upstream history of large repos such as `vllm`
-- avoid remote receive-pack negotiation for those parentless transport commits so the remote mirror does not need to fix up deltas against absent base history
+- keep the parentless snapshots so first hydration sends only the current tree,
+  not upstream history; direct push may negotiate against an existing mirror,
+  while the bundle fallback remains independent of remote base history
 - also publish an advertised branch ref inside each mirror so ordinary fetch paths can see the latest synthetic snapshot
 - use a container-local lock while mutating cache or runtime state; locks carry owner metadata and stale lock directories are recovered after the bounded stale interval
 - after failed or timed-out mirror hydration, best-effort terminate any matching legacy `git-receive-pack` process trees for that mirror and discard that repo's partial mirror before surfacing the failure

--- a/.agents/skills/remote-code-parity/references/command-recipes.md
+++ b/.agents/skills/remote-code-parity/references/command-recipes.md
@@ -137,6 +137,30 @@ python3 .agents/skills/remote-code-parity/scripts/parity_sync.py \
 
 This syncs the session worktree to the session container and uses `workspace_id=pr123` unless explicitly overridden.
 
+## Select or benchmark mirror transport
+
+The default prefers incremental Git push and retains the full-bundle fallback:
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/parity_sync.py \
+  --machine blue-a \
+  --transport auto
+```
+
+Require Git receive-pack, or force the compatibility transport:
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/parity_sync.py --machine blue-a --transport git
+python3 .agents/skills/remote-code-parity/scripts/parity_sync.py --machine blue-a --transport bundle
+```
+
+Run the isolated transport benchmark without a remote machine:
+
+```bash
+python3 .agents/skills/remote-code-parity/scripts/transport_benchmark.py \
+  --files 256 --bytes-per-file 4096 --changed-bytes 4096 --repeats 3
+```
+
 The runtime-install path sources Ascend env scripts under a `set +u` / `set -u` guard, so first-install parity does not depend on predefining shell-specific variables.
 It also scans versioned CANN paths such as `/usr/local/Ascend/cann-9.0.0/set_env.sh`, so A3 images that do not expose only `/usr/local/Ascend/ascend-toolkit/set_env.sh` still get HCCL/CANN libraries.
 Package installation is pip-only and uses the single A3-tested HuaweiCloud index. Do not install or invoke `uv`, probe mirror candidates, or configure default extra indexes in the parity path.

--- a/.agents/skills/remote-code-parity/scripts/parity_sync.py
+++ b/.agents/skills/remote-code-parity/scripts/parity_sync.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from common import WORKSPACE_ID_PATTERN, json_dump, repo_root_from
 from install_consent import load_consent_state, resolve_sync_mode
-from remote_code_parity import DEFAULT_CONTAINER_CACHE_ROOT
+from remote_code_parity import DEFAULT_CONTAINER_CACHE_ROOT, TRANSFER_MODES
 
 ROOT = Path(__file__).resolve().parents[4]
 LIB_DIR = ROOT / '.agents' / 'lib'
@@ -162,6 +162,9 @@ def build_low_level_command(derived: dict[str, Any], args: argparse.Namespace) -
         cmd.append('--dry-run')
     if args.apply_mode:
         cmd.extend(['--apply-mode', args.apply_mode])
+    transport = getattr(args, 'transport', 'auto')
+    if transport:
+        cmd.extend(['--transport', transport])
     return cmd
 
 
@@ -180,6 +183,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument('--print-manifest', action='store_true')
     parser.add_argument('--force-reinstall', action='store_true', help='Force reinstall of vllm and vllm-ascend regardless of what changed.')
     parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument(
+        '--transport',
+        choices=TRANSFER_MODES,
+        default='auto',
+        help='auto prefers incremental Git push and falls back to the full-bundle transport.',
+    )
     parser.add_argument(
         '--apply-mode',
         choices=('source-only', 'materialize', 'install'),

--- a/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
+++ b/.agents/skills/remote-code-parity/scripts/remote_code_parity.py
@@ -2,16 +2,19 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
+import shlex
 import sys
 import tempfile
+import time
 import uuid
 from dataclasses import asdict, dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import quote, urlsplit, urlunsplit
 
 from common import (
     DEFAULT_DENYLIST,
@@ -163,6 +166,7 @@ DEFAULT_ROOT_PRESERVE_PATHS = ('Mooncake', '.vaws-runtime')
 STATE_FILENAME = 'runtime-state.json'
 CONSENT_FILENAME = 'install-consents.json'
 PARITY_BRANCH_NAME = 'parity-current'
+TRANSFER_MODES = ('auto', 'git', 'bundle')
 
 REMOTE_RUNTIME_ENV_PASSTHROUGH = (
     'XDG_CACHE_HOME',
@@ -537,6 +541,111 @@ def bundle_path_for(container_cache_root: str, workspace_id: str, record: Snapsh
     return str(root / f'{record.repo_id}-{record.commit}.bundle')
 
 
+def git_remote_url(container: SshEndpoint, mirror_path: str) -> str:
+    host = container.host
+    if ':' in host and not host.startswith('['):
+        host = f'[{host}]'
+    user = quote(container.user, safe='')
+    path = quote(validate_absolute_posix_path(mirror_path, label='mirror path'), safe='/')
+    return f'ssh://{user}@{host}:{container.port}{path}'
+
+
+def git_ssh_environment(container: SshEndpoint) -> dict[str, str]:
+    env = os.environ.copy()
+    env['GIT_TERMINAL_PROMPT'] = '0'
+    env['GIT_SSH_COMMAND'] = shlex.join(
+        [
+            'ssh',
+            '-T',
+            '-o',
+            'BatchMode=yes',
+            '-o',
+            'StrictHostKeyChecking=accept-new',
+            '-o',
+            'LogLevel=ERROR',
+            '-p',
+            str(container.port),
+        ]
+    )
+    return env
+
+
+def transport_carrier_ref(
+    container: SshEndpoint,
+    mirror_path: str,
+    workspace_id: str,
+    record: SnapshotRecord,
+) -> str:
+    target = f'{container.user}@{container.host}:{container.port}:{mirror_path}'
+    token = hashlib.sha256(target.encode('utf-8')).hexdigest()[:16]
+    return f'refs/parity-transport/{workspace_id}/{token}/{record.repo_id}'
+
+
+def build_transport_carrier(
+    repo: Path,
+    *,
+    container: SshEndpoint,
+    mirror_path: str,
+    workspace_id: str,
+    record: SnapshotRecord,
+    remote_carrier_commit: str | None = None,
+) -> tuple[str, str]:
+    ref = transport_carrier_ref(container, mirror_path, workspace_id, record)
+    previous_result = git(repo, ['rev-parse', '--verify', ref], check=False)
+    previous = previous_result.stdout.strip() if previous_result.returncode == 0 else None
+    if not previous or previous != remote_carrier_commit:
+        carrier = record.commit
+    elif git_tree_for_commit(repo, previous) == record.tree:
+        carrier = previous
+    else:
+        env = os.environ.copy()
+        author_name, author_email = ensure_local_git_identity(repo)
+        env.update(
+            {
+                'GIT_AUTHOR_NAME': author_name or 'remote-code-parity',
+                'GIT_AUTHOR_EMAIL': author_email or 'remote-code-parity@example.invalid',
+                'GIT_AUTHOR_DATE': '1970-01-01T00:00:00Z',
+                'GIT_COMMITTER_NAME': author_name or 'remote-code-parity',
+                'GIT_COMMITTER_EMAIL': author_email or 'remote-code-parity@example.invalid',
+                'GIT_COMMITTER_DATE': '1970-01-01T00:00:00Z',
+            }
+        )
+        carrier = git(
+            repo,
+            [
+                'commit-tree',
+                record.tree,
+                '-p',
+                previous,
+                '-m',
+                f'remote-code-parity transport carrier {workspace_id} {record.repo_id}',
+            ],
+            env=env,
+        ).stdout.strip()
+    git(repo, ['update-ref', ref, carrier])
+    return ref, carrier
+
+
+def remote_ref_commit(
+    repo: Path,
+    *,
+    remote_url: str,
+    remote_ref: str,
+    env: dict[str, str],
+) -> str | None:
+    result = git(
+        repo,
+        ['ls-remote', remote_url, remote_ref],
+        env=env,
+        timeout=DEFAULT_GIT_TRANSPORT_TIMEOUT_SECONDS,
+    )
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) == 2 and fields[1] == remote_ref:
+            return fields[0]
+    return None
+
+
 def manifest_path_for(container_cache_root: str, workspace_id: str, snapshot_id: str) -> str:
     return str(Path(cache_workspace_root(container_cache_root, workspace_id)) / 'manifests' / f'{snapshot_id}.json')
 
@@ -598,7 +707,57 @@ def cleanup_failed_mirror_hydration(container: SshEndpoint, mirror_path: str) ->
         pass
 
 
-def push_snapshot_to_mirror(
+def push_snapshot_via_git(
+    repo: Path,
+    *,
+    container: SshEndpoint,
+    mirror_path: str,
+    record: SnapshotRecord,
+    workspace_id: str,
+) -> dict[str, Any]:
+    started = time.monotonic()
+    target_ref = f'refs/parity/{workspace_id}/current'
+    remote_carrier_ref = f'refs/parity/{workspace_id}/transport-carrier'
+    remote_url = git_remote_url(container, mirror_path)
+    git_env = git_ssh_environment(container)
+    remote_carrier_commit = remote_ref_commit(
+        repo,
+        remote_url=remote_url,
+        remote_ref=remote_carrier_ref,
+        env=git_env,
+    )
+    carrier_ref, carrier_commit = build_transport_carrier(
+        repo,
+        container=container,
+        mirror_path=mirror_path,
+        workspace_id=workspace_id,
+        record=record,
+        remote_carrier_commit=remote_carrier_commit,
+    )
+    result = git(
+        repo,
+        [
+            'push',
+            '--porcelain',
+            '--force',
+            remote_url,
+            f'{record.ref}:{target_ref}',
+            f'{record.ref}:refs/heads/{PARITY_BRANCH_NAME}',
+            f'{carrier_ref}:{remote_carrier_ref}',
+        ],
+        env=git_env,
+        timeout=DEFAULT_GIT_TRANSPORT_TIMEOUT_SECONDS,
+    )
+    return {
+        'repo': record.relpath,
+        'transport': 'git',
+        'elapsed_seconds': round(time.monotonic() - started, 6),
+        'carrier_commit': carrier_commit,
+        'detail': result.stdout.strip(),
+    }
+
+
+def push_snapshot_via_bundle(
     repo: Path,
     *,
     container: SshEndpoint,
@@ -606,18 +765,18 @@ def push_snapshot_to_mirror(
     container_cache_root: str,
     record: SnapshotRecord,
     workspace_id: str,
-    dry_run: bool,
-) -> None:
-    if dry_run:
-        return
+) -> dict[str, Any]:
     target_ref = f'refs/parity/{workspace_id}/current'
     remote_bundle_path = bundle_path_for(container_cache_root, workspace_id, record)
     local_bundle = tempfile.NamedTemporaryFile(prefix='parity-bundle-', suffix='.bundle', delete=False)
     local_bundle.close()
     local_bundle_path = Path(local_bundle.name)
+    started = time.monotonic()
     try:
         git(repo, ['bundle', 'create', str(local_bundle_path), record.ref], timeout=DEFAULT_GIT_TRANSPORT_TIMEOUT_SECONDS)
-        ssh_stream_bytes_to_file(container, remote_bundle_path, local_bundle_path.read_bytes())
+        bundle_payload = local_bundle_path.read_bytes()
+        bundle_bytes = len(bundle_payload)
+        ssh_stream_bytes_to_file(container, remote_bundle_path, bundle_payload)
         script = '\n'.join(
             [
                 'set -eo pipefail',
@@ -632,11 +791,68 @@ def push_snapshot_to_mirror(
             ]
         )
         ssh_exec(container, script)
+        return {
+            'repo': record.relpath,
+            'transport': 'bundle',
+            'elapsed_seconds': round(time.monotonic() - started, 6),
+            'bundle_bytes': bundle_bytes,
+        }
     except Exception:
         cleanup_failed_mirror_hydration(container, mirror_path)
         raise
     finally:
         local_bundle_path.unlink(missing_ok=True)
+
+
+def push_snapshot_to_mirror(
+    repo: Path,
+    *,
+    container: SshEndpoint,
+    mirror_path: str,
+    container_cache_root: str,
+    record: SnapshotRecord,
+    workspace_id: str,
+    dry_run: bool,
+    transport: str = 'auto',
+) -> dict[str, Any]:
+    if transport not in TRANSFER_MODES:
+        raise ValueError(f'unsupported parity transport: {transport}')
+    if dry_run:
+        return {'repo': record.relpath, 'transport': f'{transport}-dry-run'}
+
+    git_error: Exception | None = None
+    if transport in {'auto', 'git'}:
+        try:
+            return push_snapshot_via_git(
+                repo,
+                container=container,
+                mirror_path=mirror_path,
+                record=record,
+                workspace_id=workspace_id,
+            )
+        except Exception as exc:
+            if transport == 'git':
+                raise
+            git_error = exc
+            emit_progress(
+                'push-mirror-fallback',
+                relpath=record.relpath,
+                from_transport='git',
+                to_transport='bundle',
+                reason=str(exc),
+            )
+
+    result = push_snapshot_via_bundle(
+        repo,
+        container=container,
+        mirror_path=mirror_path,
+        container_cache_root=container_cache_root,
+        record=record,
+        workspace_id=workspace_id,
+    )
+    if git_error is not None:
+        result['fallback_from'] = 'git'
+    return result
 
 def acquire_container_lock(
     container: SshEndpoint,
@@ -1393,9 +1609,10 @@ def run_sync(args: argparse.Namespace) -> int:
                     emit_progress(current_phase, repo_count=len(records), apply_mode=args.apply_mode)
                     all_mirror_paths = [mirror_path_for(container_cache_root, workspace_id, r) for r in records]
                     ensure_remote_bare_repos(container, all_mirror_paths, args.dry_run)
+                    transfer_reports: list[dict[str, Any]] = []
                     for record in records:
-                        emit_progress('push-mirror', relpath=record.relpath)
-                        push_snapshot_to_mirror(
+                        emit_progress('push-mirror', relpath=record.relpath, transport=args.transport)
+                        transfer = push_snapshot_to_mirror(
                             repo=workspace_root if record.relpath in ('', '.') else workspace_root / record.relpath,
                             container=container,
                             mirror_path=mirror_path_for(container_cache_root, workspace_id, record),
@@ -1403,7 +1620,11 @@ def run_sync(args: argparse.Namespace) -> int:
                             record=record,
                             workspace_id=workspace_id,
                             dry_run=args.dry_run,
+                            transport=args.transport,
                         )
+                        transfer_reports.append(transfer)
+                        emit_progress('push-mirror-complete', **transfer)
+                    manifest['transfers'] = transfer_reports
 
                     current_phase = 'upload-manifest'
                     emit_progress(current_phase, manifest_path=manifest_path, apply_mode=args.apply_mode)
@@ -1460,6 +1681,7 @@ def run_sync(args: argparse.Namespace) -> int:
                             )
                             summary['apply_mode'] = args.apply_mode
                             summary['manifest_path'] = manifest_path
+                            summary['transfers'] = transfer_reports
                             print(json_dump(summary))
                             return 1
                         status = 'materialized'
@@ -1493,6 +1715,7 @@ def run_sync(args: argparse.Namespace) -> int:
                     )
                     summary['apply_mode'] = args.apply_mode
                     summary['manifest_path'] = manifest_path
+                    summary['transfers'] = transfer_reports
                     print(json_dump(summary))
                     return 0
                 finally:
@@ -1617,9 +1840,10 @@ def run_sync(args: argparse.Namespace) -> int:
                 emit_progress(current_phase, repo_count=len(records))
                 all_mirror_paths = [mirror_path_for(container_cache_root, workspace_id, r) for r in records]
                 ensure_remote_bare_repos(container, all_mirror_paths, args.dry_run)
+                transfer_reports: list[dict[str, Any]] = []
                 for record in records:
-                    emit_progress('push-mirror', relpath=record.relpath)
-                    push_snapshot_to_mirror(
+                    emit_progress('push-mirror', relpath=record.relpath, transport=args.transport)
+                    transfer = push_snapshot_to_mirror(
                         repo=workspace_root if record.relpath in ('', '.') else workspace_root / record.relpath,
                         container=container,
                         mirror_path=mirror_path_for(container_cache_root, workspace_id, record),
@@ -1627,7 +1851,11 @@ def run_sync(args: argparse.Namespace) -> int:
                         record=record,
                         workspace_id=workspace_id,
                         dry_run=args.dry_run,
+                        transport=args.transport,
                     )
+                    transfer_reports.append(transfer)
+                    emit_progress('push-mirror-complete', **transfer)
+                manifest['transfers'] = transfer_reports
 
                 current_phase = 'upload-manifest'
                 emit_progress(current_phase, manifest_path=manifest_path)
@@ -1773,6 +2001,7 @@ def run_sync(args: argparse.Namespace) -> int:
                         runtime_install_env=runtime_install_env,
                         observed_runtime_commits=observed_runtime_commits,
                     )
+                    summary['transfers'] = transfer_reports
                     print(json_dump(summary))
                     return 1
 
@@ -1818,6 +2047,7 @@ def run_sync(args: argparse.Namespace) -> int:
                     runtime_install_env=runtime_install_env,
                     observed_runtime_commits=observed_runtime_commits,
                 )
+                summary['transfers'] = transfer_reports
                 print(json_dump(summary))
                 return 0
             finally:
@@ -1855,6 +2085,12 @@ def build_parser() -> argparse.ArgumentParser:
     sync.add_argument('--force-reinstall', action='store_true', help='Force reinstall of vllm and vllm-ascend regardless of what changed.')
     sync.add_argument('--dry-run', action='store_true')
     sync.add_argument('--print-manifest', action='store_true')
+    sync.add_argument(
+        '--transport',
+        choices=TRANSFER_MODES,
+        default='auto',
+        help='auto prefers incremental Git push and falls back to the full-bundle transport.',
+    )
     sync.add_argument(
         '--apply-mode',
         choices=('source-only', 'materialize', 'install'),

--- a/.agents/skills/remote-code-parity/scripts/transport_benchmark.py
+++ b/.agents/skills/remote-code-parity/scripts/transport_benchmark.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Compare full snapshot bundles with incremental Git receive-pack transport."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+
+def run(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    input_bytes: bytes | None = None,
+    capture_output: bool = True,
+) -> subprocess.CompletedProcess[bytes]:
+    result = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        input=input_bytes,
+        stdout=subprocess.PIPE if capture_output else subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"command failed ({result.returncode}): {' '.join(cmd)}\n"
+            f"stderr:\n{result.stderr.decode('utf-8', errors='replace')}"
+        )
+    return result
+
+
+def git(repo: Path, *args: str, input_bytes: bytes | None = None) -> bytes:
+    return run(['git', '-C', str(repo), *args], input_bytes=input_bytes).stdout
+
+
+def deterministic_bytes(file_index: int, size: int) -> bytes:
+    output = bytearray()
+    block = 0
+    while len(output) < size:
+        output.extend(hashlib.sha256(f'{file_index}:{block}'.encode()).digest())
+        block += 1
+    return bytes(output[:size])
+
+
+def snapshot(repo: Path, ref: str, message: str) -> str:
+    git(repo, 'add', '-A')
+    tree = git(repo, 'write-tree').decode().strip()
+    env = os.environ.copy()
+    env.update(
+        {
+            'GIT_AUTHOR_NAME': 'parity-benchmark',
+            'GIT_AUTHOR_EMAIL': 'parity-benchmark@example.invalid',
+            'GIT_AUTHOR_DATE': '1970-01-01T00:00:00Z',
+            'GIT_COMMITTER_NAME': 'parity-benchmark',
+            'GIT_COMMITTER_EMAIL': 'parity-benchmark@example.invalid',
+            'GIT_COMMITTER_DATE': '1970-01-01T00:00:00Z',
+        }
+    )
+    result = subprocess.run(
+        ['git', '-C', str(repo), 'commit-tree', tree, '-m', message],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    commit = result.stdout.strip()
+    git(repo, 'update-ref', ref, commit)
+    return commit
+
+
+def carrier(repo: Path, ref: str, tree: str, parent: str) -> str:
+    env = os.environ.copy()
+    env.update(
+        {
+            'GIT_AUTHOR_NAME': 'parity-benchmark',
+            'GIT_AUTHOR_EMAIL': 'parity-benchmark@example.invalid',
+            'GIT_AUTHOR_DATE': '1970-01-01T00:00:00Z',
+            'GIT_COMMITTER_NAME': 'parity-benchmark',
+            'GIT_COMMITTER_EMAIL': 'parity-benchmark@example.invalid',
+            'GIT_COMMITTER_DATE': '1970-01-01T00:00:00Z',
+        }
+    )
+    result = subprocess.run(
+        [
+            'git',
+            '-C',
+            str(repo),
+            'commit-tree',
+            tree,
+            '-p',
+            parent,
+            '-m',
+            'transport carrier',
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    commit = result.stdout.strip()
+    git(repo, 'update-ref', ref, commit)
+    return commit
+
+
+def init_bare(path: Path, repo: Path, old_ref: str) -> None:
+    run(['git', 'init', '--bare', str(path)])
+    git(
+        repo,
+        'push',
+        '--force',
+        f'file://{path}',
+        f'{old_ref}:refs/parity/bench/current',
+        f'{old_ref}:refs/heads/parity-current',
+        f'{old_ref}:refs/parity/bench/transport-carrier',
+    )
+
+
+def directory_bytes(path: Path) -> int:
+    return sum(item.stat().st_size for item in path.rglob('*') if item.is_file())
+
+
+def first_sync_round(
+    root: Path,
+    repo: Path,
+    old_ref: str,
+    round_id: int,
+) -> dict[str, float | int]:
+    bundle_mirror = root / f'first-bundle-mirror-{round_id}.git'
+    git_mirror = root / f'first-git-mirror-{round_id}.git'
+    run(['git', 'init', '--bare', str(bundle_mirror)])
+    run(['git', 'init', '--bare', str(git_mirror)])
+
+    bundle = root / f'first-snapshot-{round_id}.bundle'
+    uploaded = root / f'first-uploaded-{round_id}.bundle'
+    started = time.perf_counter()
+    git(repo, 'bundle', 'create', str(bundle), old_ref)
+    shutil.copyfile(bundle, uploaded)
+    run(
+        [
+            'git',
+            '-C',
+            str(bundle_mirror),
+            'fetch',
+            '--force',
+            str(uploaded),
+            f'{old_ref}:refs/parity/bench/current',
+            f'{old_ref}:refs/heads/parity-current',
+        ]
+    )
+    bundle_seconds = time.perf_counter() - started
+
+    started = time.perf_counter()
+    git(
+        repo,
+        'push',
+        '--porcelain',
+        '--force',
+        f'file://{git_mirror}',
+        f'{old_ref}:refs/parity/bench/current',
+        f'{old_ref}:refs/heads/parity-current',
+        f'{old_ref}:refs/parity/bench/transport-carrier',
+    )
+    git_seconds = time.perf_counter() - started
+    bundle_bytes = bundle.stat().st_size
+    return {
+        'bundle_seconds_local_no_rtt': bundle_seconds,
+        'git_push_seconds_local': git_seconds,
+        'full_bundle_bytes': bundle_bytes,
+        'git_remote_bytes': directory_bytes(git_mirror),
+    }
+
+
+def one_round(
+    root: Path,
+    repo: Path,
+    old_ref: str,
+    old_commit: str,
+    new_ref: str,
+    new_commit: str,
+    carrier_ref: str,
+    carrier_commit: str,
+    round_id: int,
+) -> dict[str, float | int]:
+    bundle_mirror = root / f'bundle-mirror-{round_id}.git'
+    git_mirror = root / f'git-mirror-{round_id}.git'
+    init_bare(bundle_mirror, repo, old_ref)
+    init_bare(git_mirror, repo, old_ref)
+
+    bundle = root / f'snapshot-{round_id}.bundle'
+    uploaded = root / f'uploaded-{round_id}.bundle'
+    started = time.perf_counter()
+    git(repo, 'bundle', 'create', str(bundle), new_ref)
+    shutil.copyfile(bundle, uploaded)
+    run(
+        [
+            'git',
+            '-C',
+            str(bundle_mirror),
+            'fetch',
+            '--force',
+            str(uploaded),
+            f'{new_ref}:refs/parity/bench/current',
+            f'{new_ref}:refs/heads/parity-current',
+        ]
+    )
+    bundle_seconds = time.perf_counter() - started
+
+    before = directory_bytes(git_mirror)
+    started = time.perf_counter()
+    git(
+        repo,
+        'push',
+        '--porcelain',
+        '--force',
+        f'file://{git_mirror}',
+        f'{new_ref}:refs/parity/bench/current',
+        f'{new_ref}:refs/heads/parity-current',
+        f'{carrier_ref}:refs/parity/bench/transport-carrier',
+    )
+    git_seconds = time.perf_counter() - started
+    after = directory_bytes(git_mirror)
+
+    incremental_pack = run(
+        [
+            'git',
+            '-C',
+            str(repo),
+            'pack-objects',
+            '--thin',
+            '--stdout',
+            '--revs',
+        ],
+        input_bytes=f'{new_commit}\n{carrier_commit}\n^{old_commit}\n'.encode(),
+    ).stdout
+    bundle_bytes = bundle.stat().st_size
+    return {
+        'bundle_seconds_local_no_rtt': bundle_seconds,
+        'git_push_seconds_local': git_seconds,
+        'full_bundle_bytes': bundle_bytes,
+        'incremental_pack_bytes': len(incremental_pack),
+        'git_remote_disk_growth_bytes': max(0, after - before),
+    }
+
+
+def median(records: list[dict[str, float | int]], key: str) -> float:
+    return statistics.median(float(record[key]) for record in records)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--files', type=int, default=256)
+    parser.add_argument('--bytes-per-file', type=int, default=4096)
+    parser.add_argument('--changed-bytes', type=int, default=4096)
+    parser.add_argument('--repeats', type=int, default=3)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if min(args.files, args.bytes_per_file, args.changed_bytes, args.repeats) <= 0:
+        raise SystemExit('all size and repeat arguments must be positive')
+    with tempfile.TemporaryDirectory(prefix='parity-transport-bench-') as temp:
+        root = Path(temp)
+        repo = root / 'source'
+        run(['git', 'init', str(repo)])
+        data = repo / 'data'
+        data.mkdir()
+        for index in range(args.files):
+            (data / f'{index:05d}.bin').write_bytes(
+                deterministic_bytes(index, args.bytes_per_file)
+            )
+
+        old_ref = 'refs/bench/old'
+        new_ref = 'refs/bench/new'
+        old_commit = snapshot(repo, old_ref, 'old snapshot')
+        (data / '00000.bin').write_bytes(
+            deterministic_bytes(args.files + 1, args.changed_bytes)
+        )
+        new_commit = snapshot(repo, new_ref, 'new snapshot')
+        new_tree = git(repo, 'rev-parse', f'{new_commit}^{{tree}}').decode().strip()
+        carrier_ref = 'refs/bench/carrier'
+        carrier_commit = carrier(repo, carrier_ref, new_tree, old_commit)
+
+        first_sync_records = [
+            first_sync_round(root, repo, old_ref, round_id)
+            for round_id in range(args.repeats)
+        ]
+        records = [
+            one_round(
+                root,
+                repo,
+                old_ref,
+                old_commit,
+                new_ref,
+                new_commit,
+                carrier_ref,
+                carrier_commit,
+                round_id,
+            )
+            for round_id in range(args.repeats)
+        ]
+
+        full_bytes = int(median(records, 'full_bundle_bytes'))
+        incremental_bytes = int(median(records, 'incremental_pack_bytes'))
+        payload_reduction = (
+            full_bytes / incremental_bytes if incremental_bytes else None
+        )
+        payload = {
+            'fixture': {
+                'files': args.files,
+                'bytes_per_file': args.bytes_per_file,
+                'changed_bytes': args.changed_bytes,
+                'snapshot_payload_bytes': args.files * args.bytes_per_file,
+                'repeats': args.repeats,
+            },
+            'first_sync_median': {
+                'bundle_seconds_local_no_rtt': median(
+                    first_sync_records, 'bundle_seconds_local_no_rtt'
+                ),
+                'git_push_seconds_local': median(
+                    first_sync_records, 'git_push_seconds_local'
+                ),
+                'full_bundle_bytes': int(
+                    median(first_sync_records, 'full_bundle_bytes')
+                ),
+            },
+            'incremental_sync_median': {
+                'bundle_seconds_local_no_rtt': median(
+                    records, 'bundle_seconds_local_no_rtt'
+                ),
+                'git_push_seconds_local': median(records, 'git_push_seconds_local'),
+                'full_bundle_bytes': full_bytes,
+                'incremental_pack_bytes': incremental_bytes,
+                'git_remote_disk_growth_bytes': int(
+                    median(records, 'git_remote_disk_growth_bytes')
+                ),
+                'payload_reduction_ratio': payload_reduction,
+            },
+            'first_sync_rounds': first_sync_records,
+            'incremental_sync_rounds': records,
+            'note': (
+                'Local elapsed times exclude network RTT and compare filesystem-local '
+                'bundle import with filesystem-local Git receive-pack.'
+            ),
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/.agents/skills/remote-code-parity/tests/test_git_transport.py
+++ b/.agents/skills/remote-code-parity/tests/test_git_transport.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[4]
+SCRIPTS = ROOT / ".agents" / "skills" / "remote-code-parity" / "scripts"
+LIB = ROOT / ".agents" / "lib"
+for path in (SCRIPTS, LIB):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+common = load_module("common", SCRIPTS / "common.py")
+parity = load_module("_remote_code_parity_git_transport_test", SCRIPTS / "remote_code_parity.py")
+wrapper = load_module("_parity_sync_git_transport_test", SCRIPTS / "parity_sync.py")
+
+
+def snapshot_record(relpath: str = "vllm"):
+    return parity.SnapshotRecord(
+        relpath=relpath,
+        repo_id="workspace" if relpath == "." else relpath,
+        source_head="source",
+        parent="source",
+        commit="snapshot",
+        tree="tree",
+        ref=f"refs/parity/test/snapshot/{relpath}",
+        changed_paths=[],
+        submodules=[],
+    )
+
+
+class GitTransportTests(unittest.TestCase):
+    def test_wrapper_forwards_default_transport(self) -> None:
+        derived = {
+            "workspace_root": "/worktree",
+            "workspace_id": "test",
+            "server_name": "server-a",
+            "runtime_root": "/vllm-workspace",
+            "container_identity": "container@/vllm-workspace",
+            "container_cache_root": "/cache",
+            "container_host": "host-a",
+            "container_port": 46001,
+            "container_user": "root",
+            "preserve_path": [],
+        }
+        args = argparse.Namespace(
+            snapshot_id=None,
+            print_manifest=False,
+            force_reinstall=False,
+            dry_run=False,
+            apply_mode="materialize",
+        )
+
+        command = wrapper.build_low_level_command(derived, args)
+
+        index = command.index("--transport")
+        self.assertEqual(command[index + 1], "auto")
+
+    def test_git_remote_url_supports_ipv4_ipv6_and_escaped_paths(self) -> None:
+        ipv4 = common.SshEndpoint(host="10.0.0.2", port=46001, user="root")
+        ipv6 = common.SshEndpoint(host="2001:db8::2", port=22, user="build user")
+
+        self.assertEqual(
+            parity.git_remote_url(ipv4, "/cache/workspace.git"),
+            "ssh://root@10.0.0.2:46001/cache/workspace.git",
+        )
+        self.assertEqual(
+            parity.git_remote_url(ipv6, "/cache/a repo.git"),
+            "ssh://build%20user@[2001:db8::2]:22/cache/a%20repo.git",
+        )
+
+    def test_git_transport_is_noninteractive_and_uses_endpoint_port(self) -> None:
+        endpoint = common.SshEndpoint(host="host", port=46001, user="root")
+
+        env = parity.git_ssh_environment(endpoint)
+
+        self.assertEqual(env["GIT_TERMINAL_PROMPT"], "0")
+        self.assertIn("BatchMode=yes", env["GIT_SSH_COMMAND"])
+        self.assertIn("46001", env["GIT_SSH_COMMAND"])
+
+    def test_transport_carrier_ref_is_stable_and_target_scoped(self) -> None:
+        first = common.SshEndpoint(host="host-a", port=22, user="root")
+        second = common.SshEndpoint(host="host-b", port=22, user="root")
+        record = snapshot_record()
+
+        first_ref = parity.transport_carrier_ref(first, "/cache/vllm.git", "workspace", record)
+        repeated_ref = parity.transport_carrier_ref(first, "/cache/vllm.git", "workspace", record)
+        second_ref = parity.transport_carrier_ref(second, "/cache/vllm.git", "workspace", record)
+
+        self.assertEqual(first_ref, repeated_ref)
+        self.assertNotEqual(first_ref, second_ref)
+        self.assertTrue(first_ref.startswith("refs/parity-transport/workspace/"))
+
+    def test_git_push_publishes_snapshot_and_transport_carrier(self) -> None:
+        endpoint = common.SshEndpoint(host="host", port=22, user="root")
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="ok\n", stderr="")
+
+        with (
+            mock.patch.object(parity, "remote_ref_commit", return_value=None),
+            mock.patch.object(
+                parity,
+                "build_transport_carrier",
+                return_value=("refs/parity-transport/local", "carrier-commit"),
+            ),
+            mock.patch.object(parity, "git_remote_url", return_value="ssh://remote/mirror.git"),
+            mock.patch.object(parity, "git_ssh_environment", return_value={}) as environment,
+            mock.patch.object(parity, "git", return_value=completed) as execute,
+        ):
+            result = parity.push_snapshot_via_git(
+                Path("/repo"),
+                container=endpoint,
+                mirror_path="/cache/vllm.git",
+                record=snapshot_record(),
+                workspace_id="test",
+            )
+
+        command = execute.call_args.args[1]
+        self.assertIn(
+            "refs/parity-transport/local:refs/parity/test/transport-carrier",
+            command,
+        )
+        self.assertIn(
+            "refs/parity/test/snapshot/vllm:refs/parity/test/current",
+            command,
+        )
+        self.assertEqual(result["carrier_commit"], "carrier-commit")
+        environment.assert_called_once_with(endpoint)
+
+    def test_auto_transport_prefers_git_without_creating_bundle(self) -> None:
+        endpoint = common.SshEndpoint(host="host", port=22, user="root")
+        expected = {"repo": "vllm", "transport": "git"}
+
+        with (
+            mock.patch.object(parity, "push_snapshot_via_git", return_value=expected) as push_git,
+            mock.patch.object(parity, "push_snapshot_via_bundle") as push_bundle,
+        ):
+            result = parity.push_snapshot_to_mirror(
+                Path("/repo"),
+                container=endpoint,
+                mirror_path="/cache/vllm.git",
+                container_cache_root="/cache",
+                record=snapshot_record(),
+                workspace_id="test",
+                dry_run=False,
+                transport="auto",
+            )
+
+        self.assertEqual(result, expected)
+        push_git.assert_called_once()
+        push_bundle.assert_not_called()
+
+    def test_auto_transport_falls_back_to_bundle(self) -> None:
+        endpoint = common.SshEndpoint(host="host", port=22, user="root")
+
+        with (
+            mock.patch.object(parity, "push_snapshot_via_git", side_effect=RuntimeError("receive-pack denied")),
+            mock.patch.object(
+                parity,
+                "push_snapshot_via_bundle",
+                return_value={"repo": "vllm", "transport": "bundle"},
+            ) as push_bundle,
+            mock.patch.object(parity, "emit_progress") as progress,
+        ):
+            result = parity.push_snapshot_to_mirror(
+                Path("/repo"),
+                container=endpoint,
+                mirror_path="/cache/vllm.git",
+                container_cache_root="/cache",
+                record=snapshot_record(),
+                workspace_id="test",
+                dry_run=False,
+                transport="auto",
+            )
+
+        self.assertEqual(result["transport"], "bundle")
+        self.assertEqual(result["fallback_from"], "git")
+        push_bundle.assert_called_once()
+        progress.assert_called_once()
+
+    def test_forced_git_transport_does_not_fallback(self) -> None:
+        endpoint = common.SshEndpoint(host="host", port=22, user="root")
+
+        with (
+            mock.patch.object(parity, "push_snapshot_via_git", side_effect=RuntimeError("denied")),
+            mock.patch.object(parity, "push_snapshot_via_bundle") as push_bundle,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "denied"):
+                parity.push_snapshot_to_mirror(
+                    Path("/repo"),
+                    container=endpoint,
+                    mirror_path="/cache/workspace.git",
+                    container_cache_root="/cache",
+                    record=snapshot_record("."),
+                    workspace_id="test",
+                    dry_run=False,
+                    transport="git",
+                )
+
+        push_bundle.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

- make `remote-code-parity` prefer direct SSH Git receive-pack into the container-local bare mirrors
- retain `--transport auto` bundle fallback and add explicit `git` / `bundle` modes
- keep deterministic parentless snapshot commits while advancing an endpoint-scoped carrier chain for incremental object negotiation
- record per-repository transfer results in the manifest and final JSON
- add an isolated, reproducible bundle-vs-Git transport benchmark and focused unit coverage

## Why

The existing path creates and uploads a self-contained bundle for every snapshot. For large vLLM workspaces, a small source edit therefore retransmits essentially the complete snapshot. Git receive-pack can reuse objects already present in the remote bare mirror and send only the changed object set.

## Performance check

Fixture: 256 files × 64 KiB (16 MiB snapshot), one 4 KiB edit, 3 repetitions.

- first sync median: full bundle 0.585 s; Git push 0.480 s
- incremental sync median: full bundle 16,729,607 B / 0.590 s
- incremental Git pack: 4,466 B / 0.019 s
- incremental payload reduction: about 3,746×

Times are filesystem-local and intentionally exclude network RTT; the byte comparison demonstrates the expected network-transfer advantage after first hydration.

## Checks

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s .agents/skills/remote-code-parity/tests -p 'test_*.py'` (8 passed)
- `git diff --check upstream/main..HEAD`
- `PYTHONDONTWRITEBYTECODE=1 python3 .agents/skills/remote-code-parity/scripts/transport_benchmark.py --files 256 --bytes-per-file 65536 --changed-bytes 4096 --repeats 3`

Live remote source-only transport E2E was completed on an isolated managed A3 container cache: forced Git, forced bundle, default auto, injected receive-pack failure with verified bundle fallback, 5-run stability, and final `git fsck` all passed. See the [full validation data appendix](https://github.com/maoxx241/vllm-ascend-workspace/pull/61#issuecomment-5252427861). No runtime materialization, package install, service restart, or NPU workload was performed.