### PR TITLE
feat: add local NPU fleet monitor deployment workflow

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -25,6 +25,7 @@ compatibility backend for managed sessions, sync, service adapters, and cleanup.
 
 - `.agents/skills/repo-init/` is the source-of-truth skill package for repository initialization.
 - `.agents/skills/machine-management/` is the source-of-truth skill package for remote machine attach, verify, repair, and removal workflows.
+- `.agents/skills/npu-fleet-monitor/` is the local deployment and lifecycle package for the standalone NPU fleet monitoring worktree and user service.
 - `.agents/skills/session-management/` is the source-of-truth skill package for isolated parallel agent sessions.
 - `.agents/skills/remote-toolbox/` is the compatibility skill package for managed VAWS target/probe/exec/job/sync/service/artifact/cleanup tools.
 - `.agents/skills/remote-code-parity/` is the source-of-truth skill package for remote code parity before remote execution.
@@ -82,6 +83,7 @@ Current primary helpers:
 - `machine-management/scripts/machine_verify.py`
 - `machine-management/scripts/machine_repair.py`
 - `machine-management/scripts/machine_remove.py`
+- `npu-fleet-monitor/scripts/manage_monitor.py`
 - `session-management/scripts/session_create.py`
 - `session-management/scripts/session_list.py`
 - `session-management/scripts/session_status.py`

--- a/.agents/skills/npu-fleet-monitor/SKILL.md
+++ b/.agents/skills/npu-fleet-monitor/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: npu-fleet-monitor
+description: Create or reuse the dedicated vaws-top worktree, build the dashboard, install or restart its loopback-only user service, and report local health. Use for requests to deploy, start, inspect, restart, or stop the workspace NPU fleet monitor. Do not use to launch workloads or manage remote development containers.
+---
+
+# NPU Fleet Monitor
+
+Operate the local monitoring dashboard without mixing its standalone project history into `main`.
+
+## Invariants
+
+- Keep application source on the standalone `vaws-top` branch; retain its independent project history.
+- Reuse an existing clean worktree attached to that branch. The helper creates the default independent worktree only when none exists.
+- Run the public helper outside the filesystem sandbox from its first call. It invokes the user systemd manager and starts a service that uses OpenSSH to probe managed hosts.
+- Keep the web and API listeners on `127.0.0.1`. This service has no web login and is intended only for the local machine.
+- Preserve the worktree's ignored `data/` directory across rebuilds. It contains historical SQLite data, a monitor-specific SSH key, and `known_hosts`; never print, stage, or copy those secrets into tracked files.
+- Reuse the workspace machine inventory and device-management utilities. Use `machine-management` separately when the inventory itself needs to change.
+- Do not use this workflow to start remote jobs, replace containers, or reserve NPUs.
+
+## Commands
+
+Deploy or reconcile the service:
+
+```bash
+python3 .agents/skills/npu-fleet-monitor/scripts/manage_monitor.py ensure
+```
+
+The helper fetches `vaws-top` from a configured remote when needed, finds or creates its worktree, validates a clean source tree, runs the locked build and backend tests when the commit changed, installs the user unit, restarts it, and waits for `/api/health`.
+
+Inspect, restart, or stop it:
+
+```bash
+python3 .agents/skills/npu-fleet-monitor/scripts/manage_monitor.py status
+python3 .agents/skills/npu-fleet-monitor/scripts/manage_monitor.py restart
+python3 .agents/skills/npu-fleet-monitor/scripts/manage_monitor.py stop
+```
+
+Pass `--worktree /absolute/path` only when the default or discovered worktree is unsuitable. Pass `--branch` only for an intentional alternate monitor branch.
+
+Read [references/acceptance.md](references/acceptance.md) when validating a deployment or diagnosing a failed health check. User-facing setup and operating notes are in [`docs/npu-fleet-monitor.md`](../../../docs/npu-fleet-monitor.md).
+
+## Result
+
+Report the source branch and commit, worktree path, unit state, local URL, health result, and whether a build ran. On success the enabled user unit survives terminal closure; browser activity controls 1/5/10/30-second sampling, while no active page returns the collector to its low-frequency interval.

--- a/.agents/skills/npu-fleet-monitor/agents/openai.yaml
+++ b/.agents/skills/npu-fleet-monitor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "NPU Fleet Monitor"
+  short_description: "Deploy and operate the local NPU monitoring dashboard"
+  default_prompt: "Use $npu-fleet-monitor to create or reuse the monitoring worktree, build it, start the local service, and verify health."

--- a/.agents/skills/npu-fleet-monitor/references/acceptance.md
+++ b/.agents/skills/npu-fleet-monitor/references/acceptance.md
@@ -1,0 +1,21 @@
+# Deployment acceptance
+
+Accept an `ensure` or `restart` only when all of the following are true:
+
+- the selected worktree is attached to the requested branch and tracked files are clean;
+- `package.json`, `scripts/install-user-service.sh`, and the built `dist/client` are present;
+- `npu-fleet-monitor.service` reports `ActiveState=active` and `SubState=running`;
+- `http://127.0.0.1:8789/api/health` returns `status=ok` without using an HTTP proxy;
+- the health payload reports `mode=idle` and the configured idle interval when no browser lease exists;
+- the service unit and dashboard URLs remain bound to loopback.
+
+The overview can initially show `pending` while the first fleet probe completes. A healthy API is sufficient for process readiness; verify `/api/overview` separately when the request requires current fleet coverage.
+
+For failures, inspect the final JSON first, then use:
+
+```bash
+systemctl --user status npu-fleet-monitor.service
+journalctl --user -u npu-fleet-monitor.service -n 100 --no-pager
+```
+
+Run these on the host execution plane. Do not work around OpenSSH configuration failures with `ssh -F /dev/null`, and do not expose passwords or the monitor's `data/keys` contents in diagnostics.

--- a/.agents/skills/npu-fleet-monitor/scripts/manage_monitor.py
+++ b/.agents/skills/npu-fleet-monitor/scripts/manage_monitor.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DEFAULT_BRANCH = "vaws-top"
+DEFAULT_URL = "http://127.0.0.1:8789/api/health"
+
+
+class MonitorError(RuntimeError):
+    pass
+
+
+def progress(message: str) -> None:
+    print(message, file=sys.stderr, flush=True)
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path = REPO_ROOT,
+    check: bool = True,
+    relay: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if relay:
+        if result.stdout:
+            print(result.stdout.rstrip(), file=sys.stderr)
+        if result.stderr:
+            print(result.stderr.rstrip(), file=sys.stderr)
+    if check and result.returncode != 0:
+        detail = (result.stderr or result.stdout or "command failed").strip()[-4000:]
+        raise MonitorError(f"{' '.join(command)}: {detail}")
+    return result
+
+
+def default_worktree() -> Path:
+    return Path.home() / "vaws-worktrees" / REPO_ROOT.name / "npu-fleet-monitor"
+
+
+def parse_worktrees(payload: str) -> list[dict[str, str]]:
+    records: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for line in [*payload.splitlines(), ""]:
+        if not line:
+            if current:
+                records.append(current)
+                current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    return records
+
+
+def discover_worktree(branch: str) -> Path | None:
+    result = run(["git", "worktree", "list", "--porcelain"])
+    expected = f"refs/heads/{branch}"
+    for record in parse_worktrees(result.stdout):
+        if record.get("branch") == expected and record.get("worktree"):
+            return Path(record["worktree"]).resolve()
+    return None
+
+
+def ref_exists(ref: str) -> bool:
+    return run(["git", "show-ref", "--verify", ref], check=False).returncode == 0
+
+
+def ensure_local_branch(branch: str) -> None:
+    local_ref = f"refs/heads/{branch}"
+    if ref_exists(local_ref):
+        return
+
+    remotes = run(["git", "remote"]).stdout.split()
+    ordered = [name for name in ("origin", "upstream") if name in remotes]
+    ordered.extend(name for name in remotes if name not in ordered)
+    for remote in ordered:
+        remote_ref = f"refs/remotes/{remote}/{branch}"
+        if not ref_exists(remote_ref):
+            progress(f"Fetching monitor branch {remote}/{branch}")
+            fetched = run(
+                ["git", "fetch", remote, f"refs/heads/{branch}:{remote_ref}"],
+                check=False,
+                relay=True,
+            )
+            if fetched.returncode != 0:
+                continue
+        if ref_exists(remote_ref):
+            run(["git", "branch", "--track", branch, f"{remote}/{branch}"])
+            return
+    raise MonitorError(f"monitor branch {branch} was not found on any configured remote")
+
+
+def resolve_worktree(branch: str, requested: Path | None, *, create: bool) -> Path:
+    existing = discover_worktree(branch)
+    if existing:
+        if requested and requested.resolve() != existing:
+            raise MonitorError(f"branch {branch} is already checked out at {existing}")
+        return existing
+
+    if create:
+        ensure_local_branch(branch)
+    target = (requested or default_worktree()).expanduser().resolve()
+    if not create:
+        raise MonitorError(f"no worktree is attached to {branch}")
+    run(["git", "show-ref", "--verify", f"refs/heads/{branch}"])
+    if target.exists() and any(target.iterdir()):
+        raise MonitorError(f"target exists and is not an empty monitor worktree: {target}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    progress(f"Creating monitor worktree at {target}")
+    run(["git", "worktree", "add", str(target), branch], relay=True)
+    return target
+
+
+def validate_project(worktree: Path, branch: str) -> str:
+    required = ("package.json", "scripts/install-user-service.sh", "deploy/npu-fleet-monitor.service")
+    missing = [name for name in required if not (worktree / name).is_file()]
+    if missing:
+        raise MonitorError(f"monitor branch is missing required files: {', '.join(missing)}")
+    actual = run(["git", "branch", "--show-current"], cwd=worktree).stdout.strip()
+    if actual != branch:
+        raise MonitorError(f"worktree branch is {actual or 'detached'}, expected {branch}")
+    dirty = run(["git", "status", "--porcelain"], cwd=worktree).stdout.strip()
+    if dirty:
+        raise MonitorError("monitor worktree has source changes; preserve or commit them before deployment")
+    return run(["git", "rev-parse", "HEAD"], cwd=worktree).stdout.strip()
+
+
+def build_if_needed(worktree: Path, commit: str) -> bool:
+    marker = worktree / "data" / ".deployed-commit"
+    current = marker.read_text(encoding="utf-8").strip() if marker.is_file() else ""
+    ready = (worktree / "node_modules").is_dir() and (worktree / "dist/client").is_dir()
+    if current == commit and ready:
+        progress("Locked build already matches the selected commit")
+        return False
+
+    version = run(["node", "--version"]).stdout.strip().lstrip("v")
+    try:
+        major = int(version.split(".", 1)[0])
+    except ValueError as exc:
+        raise MonitorError(f"cannot parse Node.js version: {version}") from exc
+    if major < 22:
+        raise MonitorError(f"Node.js 22+ is required, found {version}")
+
+    progress("Installing locked frontend dependencies")
+    run(["npm", "ci"], cwd=worktree, relay=True)
+    progress("Running backend tests")
+    run(["npm", "run", "test:backend"], cwd=worktree, relay=True)
+    progress("Building the production dashboard")
+    run(["npm", "run", "build"], cwd=worktree, relay=True)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(commit + "\n", encoding="utf-8")
+    return True
+
+
+def systemd_properties() -> dict[str, str]:
+    result = run(
+        ["systemctl", "--user", "show", "npu-fleet-monitor.service", "-p", "ActiveState", "-p", "SubState", "-p", "UnitFileState"],
+        check=False,
+    )
+    values: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        key, separator, value = line.partition("=")
+        if separator:
+            values[key] = value
+    if result.returncode != 0 and not values:
+        values["error"] = (result.stderr or "systemctl query failed").strip()[-1000:]
+    return values
+
+
+def health(wait_seconds: float = 0) -> tuple[bool, dict[str, Any] | None, str | None]:
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    deadline = time.monotonic() + wait_seconds
+    error = "health endpoint unavailable"
+    while True:
+        try:
+            with opener.open(DEFAULT_URL, timeout=3) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            return payload.get("status") == "ok", payload, None
+        except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+            error = str(exc)
+        if time.monotonic() >= deadline:
+            return False, None, error
+        time.sleep(0.5)
+
+
+def install_and_restart(worktree: Path) -> None:
+    progress("Installing and enabling the user service")
+    run([str(worktree / "scripts/install-user-service.sh")], cwd=worktree, relay=True)
+    run(["systemctl", "--user", "restart", "npu-fleet-monitor.service"])
+
+
+def payload_for(action: str, branch: str, worktree: Path | None, commit: str | None, built: bool | None) -> dict[str, Any]:
+    ok, health_payload, health_error = health()
+    return {
+        "ok": ok,
+        "action": action,
+        "branch": branch,
+        "commit": commit,
+        "worktree": str(worktree) if worktree else None,
+        "service": systemd_properties(),
+        "url": "http://127.0.0.1:8788",
+        "health": health_payload,
+        "health_error": health_error,
+        "built": built,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Deploy and operate the local NPU fleet monitor")
+    parser.add_argument("action", choices=("ensure", "status", "restart", "stop"))
+    parser.add_argument("--branch", default=DEFAULT_BRANCH)
+    parser.add_argument("--worktree", type=Path)
+    args = parser.parse_args()
+
+    try:
+        worktree = resolve_worktree(args.branch, args.worktree, create=args.action == "ensure")
+        commit = validate_project(worktree, args.branch)
+        if args.action == "ensure":
+            built = build_if_needed(worktree, commit)
+            install_and_restart(worktree)
+            ok, health_payload, health_error = health(wait_seconds=30)
+            result = {
+                "ok": ok,
+                "action": args.action,
+                "branch": args.branch,
+                "commit": commit,
+                "worktree": str(worktree),
+                "service": systemd_properties(),
+                "url": "http://127.0.0.1:8788",
+                "health": health_payload,
+                "health_error": health_error,
+                "built": built,
+            }
+        elif args.action == "restart":
+            run(["systemctl", "--user", "restart", "npu-fleet-monitor.service"])
+            ok, health_payload, health_error = health(wait_seconds=30)
+            result = payload_for(args.action, args.branch, worktree, commit, None)
+            result.update({"ok": ok, "health": health_payload, "health_error": health_error})
+        elif args.action == "stop":
+            run(["systemctl", "--user", "stop", "npu-fleet-monitor.service"])
+            result = payload_for(args.action, args.branch, worktree, commit, None)
+            result["ok"] = result["service"].get("ActiveState") == "inactive"
+        else:
+            result = payload_for(args.action, args.branch, worktree, commit, None)
+        print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+        return 0 if result["ok"] else 1
+    except (MonitorError, OSError) as exc:
+        print(json.dumps({"ok": False, "action": args.action, "error": str(exc)}, ensure_ascii=False, sort_keys=True))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/npu-fleet-monitor/tests/test_manage_monitor.py
+++ b/.agents/skills/npu-fleet-monitor/tests/test_manage_monitor.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/manage_monitor.py"
+SPEC = importlib.util.spec_from_file_location("npu_fleet_monitor_manager", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class ManageMonitorTests(unittest.TestCase):
+    def test_parse_worktrees_preserves_branch_mapping(self) -> None:
+        records = MODULE.parse_worktrees(
+            "worktree /repo\nHEAD abc\nbranch refs/heads/main\n\n"
+            "worktree /monitor\nHEAD def\nbranch refs/heads/vaws-top\n\n"
+        )
+        self.assertEqual(records[1]["worktree"], "/monitor")
+        self.assertEqual(records[1]["branch"], "refs/heads/vaws-top")
+
+    def test_default_branch_is_standalone_project_branch(self) -> None:
+        self.assertEqual(MODULE.DEFAULT_BRANCH, "vaws-top")
+
+    def test_missing_local_branch_tracks_origin_branch(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(command: list[str], **_: object) -> mock.Mock:
+            calls.append(command)
+            if command == ["git", "remote"]:
+                return mock.Mock(returncode=0, stdout="origin\nupstream\n", stderr="")
+            if command == ["git", "show-ref", "--verify", "refs/heads/vaws-top"]:
+                return mock.Mock(returncode=1, stdout="", stderr="")
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(MODULE, "run", side_effect=fake_run):
+            MODULE.ensure_local_branch("vaws-top")
+
+        self.assertIn(
+            ["git", "branch", "--track", "vaws-top", "origin/vaws-top"],
+            calls,
+        )
+
+    def test_validate_project_rejects_missing_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            with self.assertRaisesRegex(MODULE.MonitorError, "missing required files"):
+                MODULE.validate_project(Path(root), MODULE.DEFAULT_BRANCH)
+
+    def test_default_endpoint_is_loopback(self) -> None:
+        self.assertTrue(MODULE.DEFAULT_URL.startswith("http://127.0.0.1:"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Repo-local skills live under `.agents/skills/`. Each has its own `SKILL.md` with
 |-------|---------|
 | `repo-init` | Initialize workspace: `gh`, GitHub auth, submodules, fork topology |
 | `machine-management` | Add / verify / repair / remove a remote NPU machine |
+| `npu-fleet-monitor` | Deploy, start, inspect, restart, or stop the loopback-only NPU monitoring dashboard from its standalone worktree |
 | `session-management` | Create / inspect / remove / group isolated agent sessions (local worktree + remote container + leases) |
 | `remote-toolbox` | Compatibility backend for managed VAWS target/probe/exec/job/sync/service/artifact/cleanup tools |
 | `remote-code-parity` | Sync local working tree to remote container before execution |

--- a/README.en.md
+++ b/README.en.md
@@ -27,6 +27,16 @@ If you use an Agent-capable IDE (Cursor, Windsurf, etc.) or terminal tool (Claud
 
 The Agent will detect your environment, install required tools, and configure Git remotes and forks.
 
+## Local NPU fleet monitoring
+
+The `npu-fleet-monitor` Skill deploys a persistent NPU fleet monitoring service. The application is maintained on the standalone `vaws-top` branch; the deployment entrypoint fetches that branch, creates a dedicated worktree, builds the frontend, and installs and enables a systemd user service:
+
+```bash
+python3 .agents/skills/npu-fleet-monitor/scripts/manage_monitor.py ensure
+```
+
+After deployment, open <http://127.0.0.1:8788>. The dashboard shows NPU/AICore, HBM, CPU, system memory, disk, mount, and Docker status with historical trends and heatmaps. Active browsers can request 1, 5, 10, or 30-second updates; the collector returns to its low-frequency cadence when no page is active. See [Local NPU Fleet Monitor deployment](docs/npu-fleet-monitor.md) for installation, operations, and data-directory details.
+
 ## Built-in skills
 
 
@@ -34,6 +44,7 @@ The Agent will detect your environment, install required tools, and configure Gi
 | ---------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
 | **repo-init**          | Install GitHub CLI, authenticate, initialize submodules, configure forks and remote topology | After first clone                                          |
 | **machine-management** | Add, verify, repair, or remove a remote Ascend NPU server and its managed container          | When setting up a remote NPU dev machine                   |
+| **npu-fleet-monitor**  | Build, start, inspect, or stop the local NPU dashboard from its standalone project worktree | When continuously monitoring fleet resources and history  |
 | **session-management** | Create, inspect, group, and clean isolated sessions: local worktree, remote container, state namespace, and resource leases | For parallel remote work, multiple agents, or PD deployments |
 | **remote-toolbox**    | Structured target/probe/exec/job/sync/service/artifact/cleanup tools for remote containers | When agents need local-tool-like control of a remote session container |
 | **remote-code-parity** | Sync the full local workspace state (including uncommitted changes) to a remote container    | Triggered automatically before remote test or service runs |
@@ -100,6 +111,7 @@ When talking to an Agent:
 │   ├── skills/
 │   │   ├── repo-init/         # Workspace initialization skill
 │   │   ├── machine-management/    # Remote machine management skill
+│   │   ├── npu-fleet-monitor/     # Local NPU monitor deployment skill
 │   │   ├── session-management/    # Parallel session isolation skill
 │   │   ├── remote-toolbox/        # Structured remote toolbox
 │   │   ├── remote-code-parity/    # Code synchronization skill
@@ -159,6 +171,7 @@ This repository supports mainstream AI coding tools:
 
 - **repo-init** — Workspace initialization: GitHub CLI install, auth, submodules, fork & remote topology
 - **machine-management** — Remote machine management: add, verify, repair, remove Ascend NPU servers and managed containers
+- **npu-fleet-monitor** — Standalone-worktree monitoring service with automatic build, user-systemd startup, and loopback health checks
 - **remote-code-parity** — Code sync: push full local workspace state (including uncommitted changes) to remote containers
 - **vllm-ascend-serving** — Service launch: idle NPU detection, idle port detection, one-click vLLM Ascend inference serving
 - **vllm-ascend-benchmark** — Online performance benchmarking: single-run / multi-run (warm-service) mode, warmup exclusion, statistical aggregation; multi-state regression comparisons orchestrated by the Agent

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ git submodule update --init --recursive
 
 Agent 会自动检测你的环境、安装所需工具、配置 Git 远程仓库和 Fork。
 
+## 本地 NPU 集群监控
+
+仓库提供 `npu-fleet-monitor` Skill，用于部署持续运行的 NPU 集群监控服务。监控应用维护在独立的 `vaws-top` 分支；部署入口会自动获取该分支、创建专用 worktree、构建前端、安装并启用 systemd 用户服务：
+
+```bash
+python3 .agents/skills/npu-fleet-monitor/scripts/manage_monitor.py ensure
+```
+
+部署完成后访问 <http://127.0.0.1:8788>。页面集中展示 NPU/AICore、HBM、CPU、系统内存、磁盘、挂载点和 Docker 状态，并保存历史趋势与热力图。浏览器活跃时可选择 1、5、10 或 30 秒刷新；没有活跃页面时自动恢复低频采集。完整安装、运维和数据目录说明见 [NPU Fleet Monitor 本地部署](docs/npu-fleet-monitor.md)。
+
 ## 内置技能
 
 
@@ -34,6 +44,7 @@ Agent 会自动检测你的环境、安装所需工具、配置 Git 远程仓库
 | ------------------------ | ---------------------------------------------- | ------------------ |
 | **repo-init**            | 安装 GitHub CLI、登录 GitHub、初始化子模块、配置 Fork 和远程仓库拓扑 | 首次 clone 后初始化工作区   |
 | **machine-management**   | 添加、验证、修复或移除远程昇腾 NPU 服务器及其托管容器                  | 需要配置远程 NPU 开发机时    |
+| **npu-fleet-monitor**    | 从独立项目 worktree 构建、拉起、检查或停止本地 NPU 监控页面            | 需要持续查看设备、主机和历史资源状态时 |
 | **session-management**   | 创建、检查、分组和清理隔离 session：本地 worktree、远端容器、状态目录和资源 lease | 多 agent、多任务或 PD 场景并行远端执行时 |
 | **remote-toolbox**       | 结构化解析/探测/执行/长任务/同步/服务/产物传输/清理远端容器              | Agent 需要像使用本地工具一样操作远端 session container 时 |
 | **remote-code-parity**   | 将本地工作区的完整状态（含未提交的修改）同步到远程容器                    | 在远程机器上运行测试或服务前自动触发 |
@@ -101,6 +112,7 @@ Agent 会自动检测你的环境、安装所需工具、配置 Git 远程仓库
 │   ├── skills/
 │   │   ├── repo-init/             # 工作区初始化技能
 │   │   ├── machine-management/    # 远程机器管理技能
+│   │   ├── npu-fleet-monitor/     # 本地 NPU 监控服务部署技能
 │   │   ├── session-management/    # 并行 Session 隔离技能
 │   │   ├── remote-toolbox/        # 远端结构化工具面
 │   │   ├── remote-code-parity/    # 代码同步技能
@@ -162,6 +174,7 @@ Agent 会自动检测你的环境、安装所需工具、配置 Git 远程仓库
 
 - [x] **repo-init** — 工作区初始化：GitHub CLI 安装、认证、子模块、Fork 与远程仓库拓扑配置
 - [x] **machine-management** — 远程机器管理：添加、验证、修复、移除昇腾 NPU 服务器及托管容器
+- [x] **npu-fleet-monitor** — 独立 worktree 监控服务：自动构建、systemd 用户服务拉起和回环健康检查
 - [x] **remote-code-parity** — 代码同步：将本地完整工作区状态（含未提交修改）同步到远程容器
 - [x] **vllm-ascend-serving** — 服务拉起：支持空闲 NPU 检测、空闲端口检测，一键拉起 vLLM Ascend 推理服务
 - [x] **vllm-ascend-benchmark** — 在线性能基准测试：支持单轮/多轮（warm-service）模式、预热轮剔除、统计聚合，多状态回归对比由 Agent 编排

--- a/docs/npu-fleet-monitor.md
+++ b/docs/npu-fleet-monitor.md
@@ -1,0 +1,46 @@
+# NPU Fleet Monitor 本地部署
+
+监控前端和采集后端维护在独立分支 `vaws-top`。该分支的项目文件位于分支根目录，拥有独立的项目历史；`main` 保存部署入口和操作说明。
+
+## 一键拉起
+
+在主工作区执行：
+
+```bash
+python3 .agents/skills/npu-fleet-monitor/scripts/manage_monitor.py ensure
+```
+
+该命令会：
+
+1. 首次使用时从已配置的 Git 远端获取 `vaws-top`，然后复用对应 worktree；若不存在，则创建到 `~/vaws-worktrees/<仓库名>/npu-fleet-monitor`。
+2. 确认监控 worktree 没有未提交的源码修改；被项目忽略的运行时数据不受影响。
+3. 提交变化时执行 `npm ci`、后端测试和生产构建；相同提交和完整构建会直接复用。
+4. 安装、启用并重启 `npu-fleet-monitor.service` 用户服务。
+5. 绕过系统 HTTP 代理检查 `http://127.0.0.1:8789/api/health`，最终只在标准输出打印一条 JSON 结果。
+
+浏览器入口为 <http://127.0.0.1:8788>。Web 和 API 均固定在回环地址，不提供用户登录，也不应通过端口转发或反向代理对外开放。
+
+## 数据与设备发现
+
+监控 worktree 的 `data/` 是忽略目录，保存 SQLite 历史库、专用 Ed25519 密钥和独立 `known_hosts`。重新构建和重启不会删除这些文件。
+
+服务根据 Git common-dir 找到主工作区，读取 `.vaws-local/machine-inventory.json`，复用 `machine-management` 的密钥引导和 Ascend NPU 解析。若 worktree 不属于同一个 Git 公共目录，可在服务环境中设置 `NFM_SOURCE_WORKSPACE=/绝对/主工作区/路径`。
+
+浏览器没有活动页面时，采集器默认每 120 秒执行一次低频巡检；页面打开后由可见页面选择的 1、5、10 或 30 秒频率控制，多个页面采用最快频率。磁盘、挂载点和 Docker 使用独立的低频采集周期，历史数据最短每 30 秒落库一次。
+
+## 日常操作
+
+```bash
+python3 .agents/skills/npu-fleet-monitor/scripts/manage_monitor.py status
+python3 .agents/skills/npu-fleet-monitor/scripts/manage_monitor.py restart
+python3 .agents/skills/npu-fleet-monitor/scripts/manage_monitor.py stop
+```
+
+直接查看服务日志：
+
+```bash
+systemctl --user status npu-fleet-monitor.service
+journalctl --user -u npu-fleet-monitor.service -f
+```
+
+首次执行和涉及 systemd/OpenSSH 的操作应在宿主执行面运行。需要新增、修复或移除远程服务器时使用 `machine-management`，监控服务本身不创建远程容器、不启动任务，也不占用 NPU lease。


### PR DESCRIPTION
## Summary

- add the `npu-fleet-monitor` Skill and lifecycle helper for fetching `vaws-top`, creating a dedicated worktree, running the locked build and tests, installing the systemd user service, and verifying loopback health
- document one-command installation, enablement, service operations, local data handling, and adaptive collection behavior
- add Chinese and English README entries plus the repository Skill catalogs

## Validation

- `quick_validate.py .agents/skills/npu-fleet-monitor`
- `python3 .agents/skills/npu-fleet-monitor/tests/test_manage_monitor.py`
- standalone `vaws-top` branch published at commit `0a0e540` in both workspace repositories