### PR TITLE
fix: make remote-dev MCP portable across coding clients

### DIFF
--- a/.codex/config.example.toml
+++ b/.codex/config.example.toml
@@ -1,15 +1,26 @@
+# Copy to config.toml and replace the absolute checkout path below.
+# Interactive MCP confirmation must remain available; headless runs need
+# explicit, invocation-scoped approvals for the exact tools they will use.
+approval_policy = "on-request"
+
 [mcp_servers.remote_dev]
 command = "python3"
-args = [".remote-dev/mcp/server.py"]
+args = ["/absolute/path/to/vllm-ascend-workspace/.remote-dev/mcp/server.py"]
+cwd = "/absolute/path/to/vllm-ascend-workspace"
 startup_timeout_sec = 20
 tool_timeout_sec = 600
 enabled = true
+
+[mcp_servers.remote_dev.env]
+REMOTE_DEV_DEFAULT_USER = "root"
+REMOTE_DEV_DEFAULT_ROOT = "/vllm-workspace"
+REMOTE_DEV_DEFAULT_CWD = "/vllm-workspace"
 
 [features]
 hooks = true
 
 [[hooks.PreToolUse]]
-matcher = "^Bash$|^apply_patch$|^mcp__remote-dev__.*"
+matcher = "^Bash$|^apply_patch$|^mcp__(remote-dev|remote_dev)__.*"
 
 [[hooks.PreToolUse.hooks]]
 type = "command"

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -3,7 +3,7 @@
     "remote-dev": {
       "type": "stdio",
       "command": "python3",
-      "args": ["${workspaceFolder}/.remote-dev/mcp/server.py"],
+      "args": [".remote-dev/mcp/server.py"],
       "env": {
         "REMOTE_DEV_DEFAULT_USER": "root",
         "REMOTE_DEV_DEFAULT_ROOT": "/vllm-workspace",

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "remote-dev": {
+      "type": "stdio",
+      "command": "python3",
+      "args": ["${workspaceFolder}/.remote-dev/mcp/server.py"],
+      "env": {
+        "REMOTE_DEV_DEFAULT_USER": "root",
+        "REMOTE_DEV_DEFAULT_ROOT": "/vllm-workspace",
+        "REMOTE_DEV_DEFAULT_CWD": "/vllm-workspace"
+      }
+    }
+  }
+}

--- a/.github/workflows/remote-dev.yml
+++ b/.github/workflows/remote-dev.yml
@@ -1,0 +1,51 @@
+name: Remote-dev contracts
+
+on:
+  pull_request:
+    paths:
+      - ".remote-dev/**"
+      - ".mcp.json"
+      - ".cursor/mcp.json"
+      - ".codex/config.example.toml"
+      - ".grok/config.example.toml"
+      - ".github/workflows/remote-dev.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".remote-dev/**"
+      - ".mcp.json"
+      - ".cursor/mcp.json"
+      - ".codex/config.example.toml"
+      - ".grok/config.example.toml"
+      - ".github/workflows/remote-dev.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  contracts:
+    name: MCP and remote safety (Python ${{ matrix.python }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.9", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Test portable MCP schemas, dispatch, and remote safety
+        env:
+          PYTHONPATH: .remote-dev/tests
+        # Skill catalog/shim freshness is separate from the MCP contract.
+        # These tests use mocks or temporary local files; no SSH/NPU access.
+        run: >-
+          python -B -m unittest -v
+          test_mcp_schema test_patch_ops test_endpoint test_path_policy
+          test_remote_edit test_remote_write test_remote_read test_artifacts
+          test_hook_guard
+          test_cli_help.CliHelpTests.test_cli_wrappers_have_help
+          test_cli_help.CliHelpTests.test_cli_errors_return_result_contract_without_traceback

--- a/.gitignore
+++ b/.gitignore
@@ -18,13 +18,17 @@ docs/superpowers/
 .codex/*
 !.codex/
 !.codex/config.example.toml
+.grok/*
+!.grok/
+!.grok/config.example.toml
 .vaws-local/
 .remote-dev/state/
 .remote-dev/endpoints.local.json
 .machine-inventory.json
 .worktrees/
 
-# Cursor IDE — ignore all except rules and skills (those are tracked / shared)
+# Cursor IDE — share MCP configuration, rules, and skills only
 .cursor/*
+!.cursor/mcp.json
 !.cursor/rules/
 !.cursor/skills/

--- a/.grok/config.example.toml
+++ b/.grok/config.example.toml
@@ -1,0 +1,13 @@
+# Copy to .grok/config.toml and replace the absolute checkout path below.
+# Native Grok config also works when Claude-compatible MCP import is disabled.
+[mcp_servers.remote-dev]
+command = "python3"
+args = ["/absolute/path/to/vllm-ascend-workspace/.remote-dev/mcp/server.py"]
+enabled = true
+startup_timeout_sec = 20
+tool_timeout_sec = 600
+
+[mcp_servers.remote-dev.env]
+REMOTE_DEV_DEFAULT_USER = "root"
+REMOTE_DEV_DEFAULT_ROOT = "/vllm-workspace"
+REMOTE_DEV_DEFAULT_CWD = "/vllm-workspace"

--- a/.remote-dev/CLIENT_COMPATIBILITY.md
+++ b/.remote-dev/CLIENT_COMPATIBILITY.md
@@ -1,0 +1,109 @@
+# Remote-dev client compatibility
+
+Updated 2026-08-27. One server and one schema set serve every client; model
+credentials and provider settings are separate and are not changed by this setup.
+
+## Configuration
+
+Start each client in this repository. Register the MCP once per client, not once
+per model:
+
+| Client | Project configuration | Server identifier |
+| --- | --- | --- |
+| Kimi Code | `.mcp.json` | `remote-dev` |
+| Claude Code, including DeepSeek V4 | `.mcp.json` | `remote-dev` |
+| Cursor IDE / Cursor Agent | `.cursor/mcp.json` | `remote-dev` |
+| Codex | `.codex/config.toml` | `remote_dev` |
+| Grok Build | `.grok/config.toml` | `remote-dev` |
+
+All entries launch `.remote-dev/mcp/server.py` with Python 3. Copy the Codex/Grok
+`config.example.toml` to the adjacent `config.toml`, then replace the placeholder
+checkout path. Actual machine-specific TOML files are ignored by Git. Do not add
+model credentials to these files. Restart existing sessions after schema/config
+changes so they rediscover tools.
+
+Cursor's checked-in entry uses `${workspaceFolder}` to resolve the shared server
+without a machine-specific path, as supported by its
+[official MCP configuration](https://cursor.com/docs/mcp). Cursor Agent uses
+the same project configuration as the IDE. Use `cursor-agent` explicitly when
+Grok also provides an `agent` command; the shared MCP does not require changing
+either client's shell aliases.
+
+Grok's automatic `.mcp.json` import depends on its Claude-import state; a native
+`.grok/config.toml` avoids that ambiguity. Confirm project trust on first use.
+Check registration with `grok inspect --json` and `grok mcp doctor remote-dev --json`,
+then test `search_tool` in a real session: doctor success alone is insufficient.
+
+Codex uses its native project configuration, following the
+[official MCP documentation](https://learn.chatgpt.com/docs/extend/mcp?surface=cli).
+The project example uses `approval_policy = "on-request"` so interactive MCP
+confirmation is possible. It does **not** automatically approve remote writes.
+In a headless `codex exec` run, a pending MCP confirmation can appear as
+`user cancelled MCP tool call`; that is not a schema rejection. A bounded,
+pre-authorized automation can supply invocation-only approvals for its exact
+tools, for example:
+
+```sh
+codex exec \
+  -c 'mcp_servers.remote_dev.tools.remote_apply_patch.approval_mode="approve"' \
+  -c 'mcp_servers.remote_dev.tools.remote_read.approval_mode="approve"' \
+  '<explicitly authorized task with a bounded remote root>'
+```
+
+Do not put blanket remote-command approvals in shared configuration. Normal
+interactive calls should use the client's confirmation flow.
+
+## Shared compatibility contract
+
+- Advertised tool names use `remote_read`, `remote_apply_patch`, etc. Grok 1.0.5
+  can complete the MCP handshake and list dotted names in doctor, yet fail to
+  register them in a model session. An isolated naming-only comparison confirmed
+  that underscore names expose all 18 tools to `search_tool`.
+- The dispatcher still accepts legacy `remote.read` and `remote.apply_patch`
+  names. Result envelopes retain canonical dotted tool names. Kimi/Claude
+  namespaced names remain `mcp__remote-dev__remote_read`; Grok discovers
+  `remote-dev__remote_read`; Codex registers the same tool under `remote_dev`.
+- Input schemas are ordinary typed objects without `anyOf`, `oneOf`, `allOf`,
+  or `$ref`. Kimi's provider rejects the former root `type` plus `anyOf` shape
+  before the requested tool is executed, including on an ordinary chat prompt.
+- Conditional requirements are documented in schema descriptions and enforced
+  by the existing server: supply `host` + `port`, an alias, or a managed selector;
+  supply non-empty `patch` or legacy `command` for patches. `patch` takes
+  precedence. Missing endpoint/payload is rejected before remote execution.
+- `remote_multi_edit.edits` exposes typed item fields; omitted `new_string`
+  retains the existing empty-string deletion behavior.
+- Path containment, symlink checks, read ledgers, patch atomicity, and SSH
+  execution behavior are unchanged. No client-specific schema fork is needed.
+
+## Verification, 2026-08-27
+
+The smoke tests use only a newly created remote scratch directory. Each model
+must actually invoke MCP patch + read and return the exact marker. A successful
+process exit or a server listed as connected does not count as a passing test.
+
+| Client / model | Version | Final-schema result |
+| --- | --- | --- |
+| Kimi Code / `kimi-for-coding` | 0.38.0 | Patch + read passed, `MCP_KIMI_OK` |
+| Claude Code / `deepseek-v4-flash` | 2.1.143 | Patch + read passed, `MCP_DSV4_OK` |
+| Codex / `gpt-5.6-sol` | 0.147.0 | Patch + read passed in both headless and normal interactive confirmation flows, `MCP_CODEX_OK` |
+| Grok Build / `grok-4.6` | 1.0.5 | Discovery + patch + read passed, `MCP_GROK_OK` |
+
+Grok used `dontAsk` plus invocation-only allow rules for
+`MCPTool(remote-dev__remote_apply_patch)` and `MCPTool(remote-dev__remote_read)`.
+Its model round trips took about 290 seconds; the final MCP calls succeeded.
+No blanket approvals were persisted for any client.
+
+Remote Python 3.9.9 unit validation:
+
+- 60 focused tests pass: MCP schema/framing/aliases, missing arguments,
+  patch atomicity/path guards, endpoints, read/write/edit, artifacts, and hooks.
+- MCP burden validation passes: 18 tools, 18 CLI wrappers, no missing documented
+  endpoint requirements, maximum 3 tool-specific required arguments.
+- Full suite: 81 tests, 8 failures within the two pre-existing Claude skill-shim
+  checks in `test_cli_help.py`. The unchanged HEAD snapshot reproduces the same
+  8 failures. No unrelated skill packages were changed to mask this baseline.
+
+These checks establish this MCP integration at the versions above, not every
+provider feature, arbitrary future versions, or NPU/model-serving correctness.
+No existing containers, NPU workloads, model weights, or runtime checkouts were
+modified by the smoke tests.

--- a/.remote-dev/CLIENT_COMPATIBILITY.md
+++ b/.remote-dev/CLIENT_COMPATIBILITY.md
@@ -22,12 +22,14 @@ checkout path. Actual machine-specific TOML files are ignored by Git. Do not add
 model credentials to these files. Restart existing sessions after schema/config
 changes so they rediscover tools.
 
-Cursor's checked-in entry uses `${workspaceFolder}` to resolve the shared server
-without a machine-specific path, as supported by its
-[official MCP configuration](https://cursor.com/docs/mcp). Cursor Agent uses
-the same project configuration as the IDE. Use `cursor-agent` explicitly when
-Grok also provides an `agent` command; the shared MCP does not require changing
-either client's shell aliases.
+Cursor's checked-in entry uses the same repository-relative server path as
+`.mcp.json`; open the repository as the workspace and run Cursor Agent from its
+root. Its [official MCP configuration](https://cursor.com/docs/mcp) documents
+`${workspaceFolder}` interpolation, but Cursor Agent `2026.08.25-3e8eec8` passed
+that expression literally to Python in a real startup check. The relative path
+avoids that CLI incompatibility. Use `cursor-agent` explicitly when Grok also
+provides an `agent` command; the shared MCP does not require changing either
+client's shell aliases.
 
 Grok's automatic `.mcp.json` import depends on its Claude-import state; a native
 `.grok/config.toml` avoids that ambiguity. Confirm project trust on first use.

--- a/.remote-dev/CLIENT_COMPATIBILITY.md
+++ b/.remote-dev/CLIENT_COMPATIBILITY.md
@@ -31,6 +31,13 @@ avoids that CLI incompatibility. Use `cursor-agent` explicitly when Grok also
 provides an `agent` command; the shared MCP does not require changing either
 client's shell aliases.
 
+If Cursor's model cannot discover the tools, check **Customize > MCPs >
+remote-dev** and enable the repository source. A disabled source can still be
+listed in the UI; it is not evidence that the model can call it. Start a new
+agent after enabling it. Cursor Agent separately requires server approval
+(`cursor-agent mcp enable remote-dev`) and a valid client login; these are not
+MCP schema problems.
+
 Grok's automatic `.mcp.json` import depends on its Claude-import state; a native
 `.grok/config.toml` avoids that ambiguity. Confirm project trust on first use.
 Check registration with `grok inspect --json` and `grok mcp doctor remote-dev --json`,
@@ -79,31 +86,52 @@ interactive calls should use the client's confirmation flow.
 
 ## Verification, 2026-08-27
 
-The smoke tests use only a newly created remote scratch directory. Each model
-must actually invoke MCP patch + read and return the exact marker. A successful
-process exit or a server listed as connected does not count as a passing test.
+PR #64 code/config revision `1f93400` was exercised from the VAWS checkout. Each
+model performed four sequential MCP calls in a newly created remote scratch
+directory: patch a new file, read it, replace its content with `remote_multi_edit`,
+and read it again. Final content and SHA256 were independently checked remotely.
+A successful process exit or a server listed as connected does not count as a
+passing test.
 
-| Client / model | Version | Final-schema result |
+| Client / model | Version | Four-call result |
 | --- | --- | --- |
-| Kimi Code / `kimi-for-coding` | 0.38.0 | Patch + read passed, `MCP_KIMI_OK` |
-| Claude Code / `deepseek-v4-flash` | 2.1.143 | Patch + read passed, `MCP_DSV4_OK` |
-| Codex / `gpt-5.6-sol` | 0.147.0 | Patch + read passed in both headless and normal interactive confirmation flows, `MCP_CODEX_OK` |
-| Grok Build / `grok-4.6` | 1.0.5 | Discovery + patch + read passed, `MCP_GROK_OK` |
+| Kimi Code / `kimi-for-coding` | 0.38.0 | Passed, `VAWS_PR64_kimi_clean_OK` |
+| Claude Code / `deepseek-v4-flash` | 2.1.143 | Passed, `VAWS_PR64_claude_OK` |
+| Codex / `gpt-5.6-sol` | 0.147.0 | Passed, `VAWS_PR64_codex_OK` |
+| Grok Build / `grok-4.6` (`grok-4.6-build` usage ID) | 1.0.5 | Discovery and calls passed, `VAWS_PR64_grok_OK` |
+| Cursor IDE / Cursor Grok 4.6 | 3.17.19 | Discovery and calls passed, `VAWS_PR64_cursor_OK` |
 
-Grok used `dontAsk` plus invocation-only allow rules for
-`MCPTool(remote-dev__remote_apply_patch)` and `MCPTool(remote-dev__remote_read)`.
-Its model round trips took about 290 seconds; the final MCP calls succeeded.
-No blanket approvals were persisted for any client.
+The initial Kimi attempt incorrectly escaped patch newlines; the server rejected
+that payload without writing, and the model corrected it. A fresh-file rerun
+with an explicit multiline patch passed all four calls without a retry.
+
+Cursor Agent `2026.08.25-3e8eec8` loaded all 18 tools with the relative path, but
+its model request failed because its saved login had expired. That CLI model run
+is **not** counted as passing: the completed Cursor row is the native IDE test,
+using its existing authenticated session after enabling the workspace MCP source.
+
+Grok and Codex headless checks used invocation-scoped approvals for only
+`remote_apply_patch`, `remote_read`, and `remote_multi_edit`. No blanket approvals
+were persisted. The same server code also passed a separate Codex patch/read
+test with normal allow-once interactive confirmations.
 
 Remote Python 3.9.9 unit validation:
 
-- 60 focused tests pass: MCP schema/framing/aliases, missing arguments,
-  patch atomicity/path guards, endpoints, read/write/edit, artifacts, and hooks.
+- 63 focused tests pass: MCP schema/framing/aliases, native Cursor entry, missing
+  arguments, patch atomicity/path guards, endpoints, read/write/edit, artifacts,
+  hooks, and CLI wrappers/errors. The same 63 tests pass in GitHub Actions on
+  both Python 3.9 and 3.12.
 - MCP burden validation passes: 18 tools, 18 CLI wrappers, no missing documented
   endpoint requirements, maximum 3 tool-specific required arguments.
-- Full suite: 81 tests, 8 failures within the two pre-existing Claude skill-shim
-  checks in `test_cli_help.py`. The unchanged HEAD snapshot reproduces the same
-  8 failures. No unrelated skill packages were changed to mask this baseline.
+- Full suite: 82 tests, 8 failures within the two pre-existing Claude skill-shim
+  checks in `test_cli_help.py`. Base commit `2176b48` runs 73 tests and reproduces
+  exactly the same 8 failures. No unrelated skill packages were changed to mask
+  this baseline.
+
+The focused CI command is in `.github/workflows/remote-dev.yml`; the full suite
+can be reproduced with `python3 -B -m unittest discover -s .remote-dev/tests` on
+a remote validation host. These unit tests use temporary files and mocked
+transports and do not require NPU access.
 
 These checks establish this MCP integration at the versions above, not every
 provider feature, arbitrary future versions, or NPU/model-serving correctness.

--- a/.remote-dev/README.md
+++ b/.remote-dev/README.md
@@ -40,6 +40,11 @@ field and `remote-dev.result.v1` metadata in `result`. The MCP server supports
 standard stdio `Content-Length` framing and a newline-delimited JSON-RPC fallback
 for simple tests.
 
+The names above are canonical dispatcher/result names. MCP discovery advertises
+portable underscore names such as `remote_read`; dotted calls remain accepted.
+See [client compatibility](CLIENT_COMPATIBILITY.md) for Kimi, Claude, Codex,
+Cursor, and Grok configuration and version-specific verification.
+
 MCP resources expose endpoint state and generated evidence:
 
 - `remote://endpoints`

--- a/.remote-dev/VALIDATION.md
+++ b/.remote-dev/VALIDATION.md
@@ -1,8 +1,21 @@
 # Remote-Dev Scaffold Validation
 
-Last updated: 2026-05-25.
+Last updated: 2026-08-27.
 
-## Current Evidence
+## Current Client Compatibility Evidence (2026-08-27)
+
+See [client compatibility](CLIENT_COMPATIBILITY.md) for client-native config
+locations, common object schemas, portable wire names, approval behavior, and
+version-specific real-client smoke results. Kimi Code, Claude + DeepSeek V4,
+Codex, and Grok all passed real MCP patch-and-read checks. The focused regression set passes
+60 tests. The full 81-test run retains 8 failures in two existing Claude
+skill-shim checks, reproduced on unchanged HEAD; it is not a fully passing suite.
+
+## Historical Evidence (2026-05-25)
+
+The following records describe the earlier validation snapshot, not a rerun on
+the current checkout. Its endpoint `anyOf` representation is superseded by the
+portable schemas documented above; endpoint validation remains server-enforced.
 
 - Local contract gates pass:
   - `python3 -m compileall -q .remote-dev .agents`

--- a/.remote-dev/VALIDATION.md
+++ b/.remote-dev/VALIDATION.md
@@ -7,9 +7,13 @@ Last updated: 2026-08-27.
 See [client compatibility](CLIENT_COMPATIBILITY.md) for client-native config
 locations, common object schemas, portable wire names, approval behavior, and
 version-specific real-client smoke results. Kimi Code, Claude + DeepSeek V4,
-Codex, and Grok all passed real MCP patch-and-read checks. The focused regression set passes
-60 tests. The full 81-test run retains 8 failures in two existing Claude
-skill-shim checks, reproduced on unchanged HEAD; it is not a fully passing suite.
+Codex, Grok, and Cursor IDE all passed real MCP patch/read/multi-edit/read checks
+on code/config revision `1f93400`. Cursor CLI separately loaded all 18 tools but
+its model request needs a fresh login and is not counted as passing. The focused
+regression set passes 63 tests remotely and in Python 3.9/3.12 CI. The full
+82-test run retains 8 failures in two existing Claude skill-shim checks; base
+commit `2176b48` reproduces the same failures in 73 tests. It is not a fully
+passing suite.
 
 ## Historical Evidence (2026-05-25)
 

--- a/.remote-dev/mcp/schemas.py
+++ b/.remote-dev/mcp/schemas.py
@@ -18,23 +18,34 @@ ENDPOINT_PROPS: dict[str, Any] = {
     "machine": {"type": "string"},
 }
 
-ENDPOINT_SELECTOR_ANY_OF: list[dict[str, Any]] = [
-    {"required": ["host", "port"]},
-    {"required": ["alias"]},
-    {"required": ["session_id"]},
-    {"required": ["session_file"]},
-    {"required": ["machine"]},
-]
+ENDPOINT_SELECTOR_DESCRIPTION = (
+    "Provide at least one endpoint selector: host and port together, alias, "
+    "session_id, session_file, or machine. The server validates the selector "
+    "before connecting."
+)
 
-def schema(props: dict[str, Any], required: list[str] | None = None, *, endpoint_selector: bool = True) -> dict[str, Any]:
+
+def schema(
+    props: dict[str, Any],
+    required: list[str] | None = None,
+    *,
+    endpoint_selector: bool = True,
+    description: str = "",
+) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "type": "object",
         "additionalProperties": True,
         "properties": {**ENDPOINT_PROPS, **props},
         "required": required or [],
     }
-    if endpoint_selector:
-        payload["allOf"] = [{"anyOf": ENDPOINT_SELECTOR_ANY_OF}]
+    # Model providers accept different JSON Schema subsets. Keep the wire
+    # schema a plain object; conditional requirements remain enforced by
+    # resolve_endpoint / the tool implementation, not just by the client.
+    constraints = [ENDPOINT_SELECTOR_DESCRIPTION] if endpoint_selector else []
+    if description:
+        constraints.append(description)
+    if constraints:
+        payload["description"] = " ".join(constraints)
     return payload
 
 
@@ -42,16 +53,38 @@ TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
     "remote.read": schema({"file_path": {"type": "string"}, "offset": {"type": "integer", "default": 1}, "limit": {"type": "integer", "default": 200, "maximum": 500}, "client_context_id": {"type": "string"}}, ["file_path"]),
     "remote.write": schema({"file_path": {"type": "string"}, "content": {"type": "string"}, "overwrite": {"type": "boolean"}, "create_dirs": {"type": "boolean"}, "client_context_id": {"type": "string"}}, ["file_path", "content"]),
     "remote.edit": schema({"file_path": {"type": "string"}, "old_string": {"type": "string"}, "new_string": {"type": "string"}, "replace_all": {"type": "boolean"}, "client_context_id": {"type": "string"}}, ["file_path", "old_string", "new_string"]),
-    "remote.multi_edit": schema({"file_path": {"type": "string"}, "edits": {"type": "array", "items": {"type": "object"}}, "client_context_id": {"type": "string"}}, ["file_path", "edits"]),
+    "remote.multi_edit": schema(
+        {
+            "file_path": {"type": "string"},
+            "edits": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "old_string": {"type": "string"},
+                        "new_string": {"type": "string", "default": ""},
+                        "replace_all": {"type": "boolean", "default": False},
+                    },
+                    "required": ["old_string"],
+                },
+            },
+            "client_context_id": {"type": "string"},
+        },
+        ["file_path", "edits"],
+    ),
     "remote.bash": schema({"command": {"type": "string"}, "description": {"type": "string"}, "timeout_ms": {"type": "integer"}, "timeout": {"type": "integer"}, "run_in_background": {"type": "boolean"}, "env": {"type": "object", "additionalProperties": {"type": "string"}}}, ["command"]),
     "remote.glob": schema({"pattern": {"type": "string"}, "path": {"type": "string"}, "limit": {"type": "integer"}, "respect_gitignore": {"type": "boolean", "description": "Currently returns a warning; exact gitignore filtering is not implemented."}}, ["pattern"]),
     "remote.grep": schema({"pattern": {"type": "string"}, "path": {"type": "string"}, "glob": {"type": "string"}, "type": {"type": "string"}, "output_mode": {"type": "string", "enum": ["files_with_matches", "content", "count"]}, "multiline": {"type": "boolean"}, "limit": {"type": "integer", "maximum": 500}}, ["pattern"]),
     "remote.ls": schema({"path": {"type": "string"}, "limit": {"type": "integer"}, "all": {"type": "boolean"}}),
     "remote.monitor": schema({"command": {"type": "string"}, "description": {"type": "string"}, "timeout_ms": {"type": "integer"}, "pattern": {"type": "string"}, "env": {"type": "object", "additionalProperties": {"type": "string"}}}, ["command"]),
-    "remote.apply_patch": {
-        **schema({"patch": {"type": "string"}, "command": {"type": "string"}, "timeout_ms": {"type": "integer"}}),
-        "anyOf": [{"required": ["patch"]}, {"required": ["command"]}],
-    },
+    "remote.apply_patch": schema(
+        {
+            "patch": {"type": "string", "description": "Codex apply_patch payload or unified diff. Prefer this field."},
+            "command": {"type": "string", "description": "Legacy alias for the patch payload, not a shell command."},
+            "timeout_ms": {"type": "integer"},
+        },
+        description="Provide a non-empty patch or command. If both are provided, patch takes precedence. Missing patch content is rejected by the server.",
+    ),
     "remote.job_status": schema({"job_id": {"type": "string"}}, ["job_id"], endpoint_selector=False),
     "remote.job_tail": schema({"job_id": {"type": "string"}, "lines": {"type": "integer", "maximum": 500}, "stream": {"type": "string", "enum": ["stdout", "stderr", "both"]}}, ["job_id"], endpoint_selector=False),
     "remote.job_stop": schema({"job_id": {"type": "string"}, "force": {"type": "boolean"}}, ["job_id"], endpoint_selector=False),

--- a/.remote-dev/mcp/tools.py
+++ b/.remote-dev/mcp/tools.py
@@ -58,9 +58,12 @@ def list_tools() -> list[dict[str, Any]]:
         "remote.context_snapshot": "Write a compact endpoint context snapshot.",
         "remote.probe": "Probe basic endpoint facts.",
     }
+    # Grok's session registry rejects dotted names even when its MCP doctor
+    # successfully lists them. Advertise the portable aliases to every client;
+    # call_tool still accepts canonical dotted names for existing integrations.
     return [
-        {"name": name, "description": descriptions.get(name, name), "inputSchema": TOOL_SCHEMAS[name]}
-        for name in TOOL_SCHEMAS
+        {"name": alias, "description": descriptions.get(name, name), "inputSchema": TOOL_SCHEMAS[name]}
+        for alias, name in ALIASES.items()
     ]
 
 

--- a/.remote-dev/tests/test_mcp_schema.py
+++ b/.remote-dev/tests/test_mcp_schema.py
@@ -8,6 +8,7 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -18,14 +19,15 @@ import core.state_store as state_store  # noqa: E402
 import mcp.tools as mcp_tools  # noqa: E402
 from core.endpoint import Endpoint  # noqa: E402
 from core.ssh_transport import RemoteCompleted  # noqa: E402
-from mcp.schemas import ALIASES, ENDPOINT_SELECTOR_ANY_OF, TOOL_SCHEMAS  # noqa: E402
+from mcp.schemas import ALIASES, ENDPOINT_SELECTOR_DESCRIPTION, TOOL_SCHEMAS  # noqa: E402
 from mcp.tools import list_resources, list_tools, read_resource  # noqa: E402
 
 
 class McpSchemaTests(unittest.TestCase):
     def test_all_expected_tools_are_listed(self) -> None:
         names = {tool["name"] for tool in list_tools()}
-        self.assertEqual(names, set(TOOL_SCHEMAS))
+        self.assertEqual(names, set(ALIASES))
+        self.assertEqual(set(ALIASES.values()), set(TOOL_SCHEMAS))
         for expected in (
             "remote.read",
             "remote.write",
@@ -46,23 +48,101 @@ class McpSchemaTests(unittest.TestCase):
             "remote.context_snapshot",
             "remote.probe",
         ):
-            self.assertIn(expected, names)
-            self.assertIn("inputSchema", next(tool for tool in list_tools() if tool["name"] == expected))
+            wire_name = expected.replace(".", "_")
+            self.assertIn(wire_name, names)
+            self.assertEqual(
+                next(tool for tool in list_tools() if tool["name"] == wire_name)["inputSchema"],
+                TOOL_SCHEMAS[expected],
+            )
+
+    def test_wire_names_are_portable_and_unique(self) -> None:
+        names = [tool["name"] for tool in list_tools()]
+        self.assertEqual(len(names), len(set(names)))
+        for name in names:
+            self.assertRegex(name, r"^[A-Za-z0-9_-]{1,64}$")
+
+    def test_cursor_entry_uses_the_shared_server_and_environment(self) -> None:
+        shared = json.loads((REPO_ROOT / ".mcp.json").read_text())["mcpServers"]["remote-dev"]
+        cursor = json.loads((REPO_ROOT / ".cursor" / "mcp.json").read_text())["mcpServers"]["remote-dev"]
+        self.assertEqual(cursor["type"], "stdio")
+        self.assertEqual(cursor["command"], shared["command"])
+        self.assertEqual(cursor["env"], shared["env"])
+        self.assertEqual(cursor["args"], ["${workspaceFolder}/.remote-dev/mcp/server.py"])
+        self.assertTrue((REPO_ROOT / shared["args"][0]).is_file())
 
     def test_underscore_aliases_map_to_canonical_names(self) -> None:
         self.assertEqual(ALIASES["remote_read"], "remote.read")
         self.assertIn("remote.bash", TOOL_SCHEMAS)
 
-    def test_normal_tools_express_endpoint_selector_anyof(self) -> None:
+    def test_normal_tools_describe_endpoint_selector_requirement(self) -> None:
         job_tools = {"remote.job_status", "remote.job_tail", "remote.job_stop"}
         for name, schema in TOOL_SCHEMAS.items():
             if name in job_tools:
-                self.assertNotIn({"anyOf": ENDPOINT_SELECTOR_ANY_OF}, schema.get("allOf", []))
+                self.assertNotIn(ENDPOINT_SELECTOR_DESCRIPTION, schema.get("description", ""))
             else:
-                self.assertIn({"anyOf": ENDPOINT_SELECTOR_ANY_OF}, schema.get("allOf", []), name)
-        self.assertIn({"required": ["host", "port"]}, ENDPOINT_SELECTOR_ANY_OF)
-        self.assertIn({"required": ["alias"]}, ENDPOINT_SELECTOR_ANY_OF)
-        self.assertIn({"required": ["session_id"]}, ENDPOINT_SELECTOR_ANY_OF)
+                self.assertIn(ENDPOINT_SELECTOR_DESCRIPTION, schema.get("description", ""), name)
+
+    def test_model_facing_schemas_use_portable_object_subset(self) -> None:
+        def check(node: dict, path: str) -> None:
+            for keyword in ("anyOf", "oneOf", "allOf", "$ref"):
+                self.assertNotIn(keyword, node, path)
+            self.assertIsInstance(node.get("type"), str, path)
+            properties = node.get("properties", {})
+            self.assertLessEqual(set(node.get("required", [])), set(properties), path)
+            for key, child in properties.items():
+                check(child, f"{path}.{key}")
+            if node["type"] == "array":
+                self.assertIsInstance(node.get("items"), dict, path)
+                check(node["items"], f"{path}[]")
+            if isinstance(node.get("additionalProperties"), dict):
+                check(node["additionalProperties"], f"{path}.*")
+
+        for tool in list_tools():
+            with self.subTest(tool=tool["name"]):
+                self.assertEqual(tool["inputSchema"]["type"], "object")
+                check(tool["inputSchema"], tool["name"])
+
+    def test_patch_schema_keeps_both_payload_forms(self) -> None:
+        schema = TOOL_SCHEMAS["remote.apply_patch"]
+        self.assertIn("patch or command", schema["description"])
+        self.assertIn("patch takes precedence", schema["description"])
+        for field in ("patch", "command"):
+            self.assertEqual(schema["properties"][field]["type"], "string")
+            self.assertNotIn(field, schema["required"])
+
+    def test_multi_edit_items_expose_fields_to_strict_generators(self) -> None:
+        item = TOOL_SCHEMAS["remote.multi_edit"]["properties"]["edits"]["items"]
+        self.assertEqual(item["required"], ["old_string"])
+        self.assertEqual(item["properties"]["new_string"]["default"], "")
+        self.assertEqual(set(item["properties"]), {"old_string", "new_string", "replace_all"})
+
+    def test_missing_endpoint_is_rejected_before_tool_execution(self) -> None:
+        from core.errors import EndpointError
+
+        with patch.object(mcp_tools, "remote_apply_patch") as execute:
+            with self.assertRaises(EndpointError):
+                mcp_tools.call_tool("remote.apply_patch", {"patch": "test"})
+            execute.assert_not_called()
+
+    def test_missing_patch_is_rejected_before_remote_execution(self) -> None:
+        import core.patch_ops as patch_ops
+
+        endpoint = {"host": "example.invalid", "port": 22, "root": "/tmp", "cwd": "/tmp"}
+        with patch.object(patch_ops, "run_remote_python") as run_python, patch.object(patch_ops, "run_script") as run_shell:
+            for name in ("remote.apply_patch", "remote_apply_patch"):
+                result = mcp_tools.call_tool(name, endpoint)["result"]
+                self.assertEqual(result["status"], "patch_required")
+                self.assertEqual(result["outcome"], "needs_input")
+            run_python.assert_not_called()
+            run_shell.assert_not_called()
+
+    def test_patch_and_legacy_command_are_forwarded_without_renaming(self) -> None:
+        endpoint = {"host": "example.invalid", "port": 22, "root": "/tmp", "cwd": "/tmp"}
+        for name in ("remote.apply_patch", "remote_apply_patch"):
+            for field in ("patch", "command"):
+                with self.subTest(name=name, field=field), patch.object(mcp_tools, "remote_apply_patch", return_value={}) as execute:
+                    mcp_tools.call_tool(name, {**endpoint, field: "payload"})
+                    self.assertEqual(execute.call_args.kwargs[field], "payload")
 
     def test_resources_include_endpoint_index(self) -> None:
         resources = {resource["uri"] for resource in list_resources()}
@@ -164,6 +244,15 @@ class McpSchemaTests(unittest.TestCase):
         response = json.loads(body.decode("utf-8"))
         self.assertEqual(response["id"], 1)
         self.assertIn("tools", response["result"])
+
+    def test_server_json_lines_lists_the_same_portable_schemas(self) -> None:
+        request = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+        proc = subprocess.run(
+            [sys.executable, str(ROOT / "mcp" / "server.py")],
+            input=json.dumps(request) + "\n", capture_output=True, text=True, check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(json.loads(proc.stdout)["result"]["tools"], list_tools())
 
     def test_mcp_server_sets_process_level_ledger_scope(self) -> None:
         from core.state_store import resolve_ledger_scope

--- a/.remote-dev/tests/test_mcp_schema.py
+++ b/.remote-dev/tests/test_mcp_schema.py
@@ -67,7 +67,7 @@ class McpSchemaTests(unittest.TestCase):
         self.assertEqual(cursor["type"], "stdio")
         self.assertEqual(cursor["command"], shared["command"])
         self.assertEqual(cursor["env"], shared["env"])
-        self.assertEqual(cursor["args"], ["${workspaceFolder}/.remote-dev/mcp/server.py"])
+        self.assertEqual(cursor["args"], shared["args"])
         self.assertTrue((REPO_ROOT / shared["args"][0]).is_file())
 
     def test_underscore_aliases_map_to_canonical_names(self) -> None:

--- a/.remote-dev/tools/validate_remote_dev_scaffold.py
+++ b/.remote-dev/tools/validate_remote_dev_scaffold.py
@@ -17,7 +17,7 @@ REPO_ROOT = REMOTE_DEV_ROOT.parent
 if str(REMOTE_DEV_ROOT) not in sys.path:
     sys.path.insert(0, str(REMOTE_DEV_ROOT))
 
-from mcp.schemas import ENDPOINT_PROPS, ENDPOINT_SELECTOR_ANY_OF, TOOL_SCHEMAS  # noqa: E402
+from mcp.schemas import ALIASES, ENDPOINT_PROPS, ENDPOINT_SELECTOR_DESCRIPTION, TOOL_SCHEMAS  # noqa: E402
 from mcp.tools import call_tool, list_resources, list_tools, read_resource  # noqa: E402
 
 
@@ -93,28 +93,28 @@ def mcp_and_burden_checks() -> dict[str, Any]:
     endpoint_selector_tools = {
         name
         for name, schema in TOOL_SCHEMAS.items()
-        if {"anyOf": ENDPOINT_SELECTOR_ANY_OF} in schema.get("allOf", [])
+        if ENDPOINT_SELECTOR_DESCRIPTION in schema.get("description", "")
     }
     endpoint_selector_missing = sorted(set(TOOL_SCHEMAS) - {"remote.job_status", "remote.job_tail", "remote.job_stop"} - endpoint_selector_tools)
     own_required_counts = {
         name: len(required - endpoint_fields)
         for name, required in required_by_tool.items()
     }
-    has_native_shape_names = all(name.startswith("remote.") for name in names)
+    has_native_shape_names = all(name.startswith("remote_") for name in names)
     all_have_schema = all("inputSchema" in tool for tool in tools)
     resources = list_resources()
     status = "ok"
     failures: list[str] = []
-    if set(names) != set(TOOL_SCHEMAS):
-        failures.append("tools/list does not match TOOL_SCHEMAS")
+    if set(names) != set(ALIASES) or len(names) != len(set(names)):
+        failures.append("tools/list does not match unique portable aliases")
     if set(scripts) != expected_scripts:
         failures.append("CLI remote_*.py wrappers do not match TOOL_SCHEMAS")
     if endpoint_required:
         failures.append("endpoint fields should not be top-level required by tool schemas")
     if endpoint_selector_missing:
-        failures.append("remote tools should express endpoint selector anyOf in tool schemas")
+        failures.append("remote tools should describe the server-enforced endpoint selector requirement")
     if not has_native_shape_names:
-        failures.append("tool names should retain remote.<native-tool> shape")
+        failures.append("wire tool names should retain remote_<native-tool> shape")
     if not all_have_schema:
         failures.append("every tool must expose inputSchema")
     if failures:


### PR DESCRIPTION
## Summary

- Advertise portable underscore MCP names while retaining dotted dispatcher aliases and existing result contracts.
- Replace provider-incompatible schema combinators with typed objects, documented conditional requirements, and unchanged server-side validation; describe multi-edit item fields explicitly.
- Share one remote-dev server across Kimi Code, Claude Code (including DeepSeek V4), Codex, Cursor, and Grok using their native project configurations.
- Add Python 3.9 / 3.12 CI for schema, dispatch, endpoint, patch, read/write/edit, artifact, hook, and CLI contracts.

## Real-client validation

Code/config revision: `1f9340032c9613a6bd085607a3e5b35e43537e82`. Subsequent changes only document the results.

All five clients were started in the VAWS checkout and made real MCP calls against distinct files in a fresh, isolated remote scratch directory: `remote_apply_patch` → `remote_read` → `remote_multi_edit` → `remote_read`. Final content and SHA256 were independently checked on the remote host. No NPU jobs, existing containers, serving checkouts, or weights were touched.

| Client | Version / model | Result | Final SHA256 prefix |
| --- | --- | --- | --- |
| Grok Build | 1.0.5 / grok-4.6 (`grok-4.6-build` usage ID) | Discovery + four MCP calls passed | `60a42de5e0048fde` |
| Codex | 0.147.0 / gpt-5.6-sol | Four MCP calls passed | `87c61456f7a79ff86` |
| Cursor IDE | 3.17.19 / Cursor Grok 4.6 | Discovery + four MCP calls passed | `229932286b62964d` |
| Kimi Code | 0.38.0 / kimi-for-coding | Four MCP calls passed on a clean rerun | `94df633681c16dd8` |
| Claude Code | 2.1.143 / deepseek-v4-flash | Four MCP calls passed | `ccb37119640d9656` |

Important distinctions:

- Cursor Agent `2026.08.25-3e8eec8` passes `${workspaceFolder}` literally to Python. The shared Cursor entry now uses the same repository-relative path as `.mcp.json`; both the CLI and IDE loaded all 18 tools. The IDE workspace source also needed enabling in Customize > MCPs. These fixes are documented.
- The Cursor CLI model request encountered an expired saved login. It is not claimed as an end-to-end pass: the completed Cursor test is the authenticated native IDE session. No credentials were extracted or reset.
- The initial Kimi attempt double-escaped newlines; the server rejected it without writing and the model corrected it. An explicit multiline-patch rerun on a fresh file passed all four calls without a retry.
- Headless approvals were temporary and limited to the three tested remote tools. No blanket approvals were persisted. Separate earlier Codex testing also passed with allow-once interactive confirmations on the same server code.

## Regression validation

- **63/63** focused unit/CLI tests pass remotely on Python 3.9.9.
- **63/63** pass in both GitHub Actions Python 3.9 and 3.12 jobs.
- MCP burden validation: **18 tools, 18 CLI wrappers**, no missing documented endpoint requirements, maximum 3 tool-specific required arguments.
- Full suite: **82 tests, 8 failures** in two pre-existing Claude skill-shim freshness checks. Unchanged base `2176b48` runs **73 tests with exactly the same 8 failures**. These unrelated failures are not masked or presented as passing. The new CI explicitly targets MCP and remote safety contracts.
- Git diff whitespace check passes. No model/runtime changes, API keys, host identities, private transcripts, or machine-specific configuration are included.

See `.remote-dev/CLIENT_COMPATIBILITY.md` for setup, version boundaries, and reproduction guidance.
