### PR TITLE
feat(machine): select latest local vllm-ascend image

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -70,7 +70,7 @@ When a workflow has deterministic shell, SSH, Git, or local-state mechanics, pre
 
 Wrapper-style helpers should stream bounded phase progress on `stderr` and keep one final machine-readable JSON payload on `stdout`.
 
-For machine-management specifically, image selection is an explicit user decision gate: choose `rc`, `main`, `stable`, or a concrete custom image reference. `rc` is the recommended developer track. Do not silently fall back to `auto`, `latest`, or another moving tag.
+For machine-management specifically, image selection is an explicit user decision gate: choose `local-latest`, `rc`, `main`, `stable`, or a concrete custom image reference. `local-latest` scans the target host's Docker images and deploys the newest machine-compatible `vllm-ascend` image without pulling; `rc` remains the recommended registry-backed developer track. Do not silently fall back to `auto`, `latest`, or another moving tag.
 
 When you add or revise a helper script, keep the CLI alias-tolerant and give safe defaults for metadata that can be inferred. The goal is to reduce agent parameter brittleness, not to force one exact flag spelling.
 

--- a/.agents/skills/machine-management/SKILL.md
+++ b/.agents/skills/machine-management/SKILL.md
@@ -39,11 +39,12 @@ Ready does **not** imply code sync, rebuild, serving, or benchmark readiness.
 - Never write passwords or tokens into tracked files or `.vaws-local/`.
 - Never use `scp`, `sftp`, `sshpass`, or `expect` in this workflow.
 - Never default the container image silently. Ask the user to choose one of:
+  - `local-latest`: inspect every image in the target host Docker daemon, keep repositories whose basename contains `vllm-ascend` (including registry / namespace prefixes and names such as `company-vllm-ascend` or `vllm-ascend-dev`), filter them for the detected A2 / A3 / 310P machine type, and deploy the newest compatible image by Docker image creation time; this never pulls
   - `rc`: resolve the newest official prerelease `vllm-ascend` tag, then try `quay.nju.edu.cn/ascend/vllm-ascend:<tag>` first and `quay.io/ascend/vllm-ascend:<tag>` second; this is the recommended developer track
   - `main`: `quay.nju.edu.cn/ascend/vllm-ascend:main`, then `quay.io/ascend/vllm-ascend:main`
   - `stable`: resolve the latest official non-prerelease `vllm-ascend` release tag, then try NJU first and `quay.io` second
   - `custom`: a full image reference with a concrete non-`latest` tag or digest
-- Treat `auto`, `*:latest`, and bare repositories without a tag as forbidden defaults for managed-machine bootstrap.
+- Treat `auto`, direct `*:latest`, and bare repositories without a tag as forbidden defaults for managed-machine bootstrap; `local-latest` is the explicit bounded discovery policy, not a moving registry tag.
 - Report and persist the **actual selected image** for the managed container, not only the requested image policy.
 - Resolve hardware-specific image tags from the detected machine type whenever the user chose `rc`, `main`, or `stable`: A2 uses the base tag, A3 appends `-a3`, and 310P appends `-310p`.
 - Detect the machine type from `npu-smi info` / SoC output when possible; when detection is inconclusive, stop and ask for an explicit machine type override instead of guessing.
@@ -68,9 +69,9 @@ The primary bootstrap path must not depend on `ssh-copy-id`, `expect`, or any ot
 
 Use these task-oriented wrappers for normal agent work. They keep the parameter surface narrow and return structured JSON statuses such as `ready`, `needs_input`, `needs_repair`, `blocked`, `removed`, or `unmanaged`. They also stream phase progress on `stderr` as `__VAWS_PROGRESS__=<json>` while reserving `stdout` for one final machine-readable JSON payload.
 
-- `python3 .agents/skills/machine-management/scripts/machine_add.py --host <ip> --image <rc|main|stable|custom-ref> [--machine-type <A2|A3|310P>] [--machine-username <letters-or-digits> | --generate-machine-username] [--password-env NAME | --password-stdin | --password ...]`
+- `python3 .agents/skills/machine-management/scripts/machine_add.py --host <ip> --image <local-latest|rc|main|stable|custom-ref> [--machine-type <A2|A3|310P>] [--machine-username <letters-or-digits> | --generate-machine-username] [--password-env NAME | --password-stdin | --password ...]`
 - `python3 .agents/skills/machine-management/scripts/machine_verify.py --machine <alias-or-ip>`
-- `python3 .agents/skills/machine-management/scripts/machine_repair.py --machine <alias-or-ip> [--image <rc|main|stable|custom-ref>] [--machine-type <A2|A3|310P>] [--password-env NAME | --password-stdin | --password ...]`
+- `python3 .agents/skills/machine-management/scripts/machine_repair.py --machine <alias-or-ip> [--image <local-latest|rc|main|stable|custom-ref>] [--machine-type <A2|A3|310P>] [--password-env NAME | --password-stdin | --password ...]`
 - `python3 .agents/skills/machine-management/scripts/machine_remove.py --machine <alias-or-ip>`
 
 Design intent:
@@ -173,7 +174,7 @@ When password bootstrap is required:
 `machine_add.py` should own this order:
 
 1. ensure or reuse the local machine profile
-2. ask for or reuse an explicit image choice; never fall back to `auto` or `latest`
+2. ask for or reuse an explicit image choice; `local-latest` performs bounded host-local discovery, while the other selectors keep their existing registry / custom-reference behavior
 3. if an existing record still points at a legacy or moving image tag, stop for re-selection before any `already-ready` shortcut
 4. ensure a local public key exists
 5. if needed, establish host key auth
@@ -221,6 +222,7 @@ Do not remove host firewall rules or host-level `authorized_keys` entries.
 - Quote remote-script arguments that may contain spaces, especially SSH public keys and mesh peer keys, before sending them through `ssh`.
 - Ensure `/run/sshd` exists before starting the dedicated `sshd`.
 - Image pulls should follow the selected mirror order and emit heartbeat-style progress so long `docker pull`, `apt-get update`, and `apt-get install` phases remain attributable. Persist the actually selected image in inventory, not only the selector.
+- `local-latest` should enumerate the target host's Docker images, report the filtered candidates and selected image ID, choose the newest compatible `vllm-ascend` image by `Created`, and fail clearly when no compatible local candidate exists. Recheck at bootstrap time and compare immutable image IDs when deciding whether an existing container matches.
 - Container bootstrap should leave behind `/etc/vaws/host-info.json`, `/etc/vaws/container-info.json`, and `/etc/profile.d/vaws-ascend-env.sh` so later verify / repair runs can see the recorded machine type, container type, and SoC quickly.
 - Container bootstrap should determine ATB C++ ABI once from the runtime Python when possible, write `VAWS_ATB_CXX_ABI`, source ATB with `--cxx_abi=<0|1>`, and patch common image startup files such as `/etc/profile` and `/root/.bashrc` when they source ATB without an explicit ABI.
 - Session-management may opt into the shared bootstrap helper's prepared image cache for short-lived session containers. Normal `machine_add.py` / `machine_repair.py` managed-base-container flows keep raw selected-image bootstrap behavior unless explicitly wired otherwise.

--- a/.agents/skills/machine-management/references/acceptance.md
+++ b/.agents/skills/machine-management/references/acceptance.md
@@ -80,8 +80,11 @@ These should not trigger `machine-management` unless machine readiness is the ob
 - `machine_add.py` persists final alias, namespace, host identity, container name, image, and SSH port into inventory without the agent having to call `inventory.py put`
 - the recorded inventory image is the actual selected image after mirror resolution and pull / cache fallback
 - selector-based image resolution is hardware-aware: A2 keeps the base tag, A3 appends `-a3`, and 310P appends `-310p`
+- `local-latest` scans the target host Docker daemon, accepts repository basenames containing `vllm-ascend` (including registry / namespace prefixes and repository-name prefixes or suffixes), filters by machine type, and selects the newest compatible image by Docker creation time without pulling
+- probe and bootstrap payloads expose `local_image_discovery`, the selected reference, and `selected_image_id`; an empty compatible set fails in the image-discovery phase
+- an existing container selected through `local-latest` is compared by immutable source image ID, so a reused tag that now points at a newer image triggers replacement when replacement consent is present
 - inventory persists `host.machine_type`, `host.soc`, and `container.machine_type`
-- `rc`, `main`, and `stable` remain first-class selectors, while `auto`, `*:latest`, and bare repositories without a tag are rejected as defaults
+- `local-latest`, `rc`, `main`, and `stable` remain first-class selectors, while `auto`, direct `*:latest`, and bare repositories without a tag are rejected as defaults
 - long-running bootstrap phases keep emitting attributable progress for image pull and package-install steps instead of going silent behind one global timeout
 - container-side apt bootstrap rewrites sources to the fixed A3-tested NJU mirror (`mirrors.nju.edu.cn`) before `apt-get update` / `apt-get install`
 - container bootstrap writes `/etc/pip.conf` with the single A3-tested HuaweiCloud pip source and no default extra indexes

--- a/.agents/skills/machine-management/references/behavior.md
+++ b/.agents/skills/machine-management/references/behavior.md
@@ -249,13 +249,16 @@ Do **not**:
 
 Image selection is an explicit decision gate, not an implicit default:
 
-1. ask the user to choose `rc`, `main`, `stable`, or a custom image reference before new-machine bootstrap
-2. `rc` resolves the newest official prerelease `vllm-ascend` tag at execution time, then tries `quay.nju.edu.cn/ascend/vllm-ascend:<tag>` first and `quay.io/ascend/vllm-ascend:<tag>` second; this is the recommended developer track
-3. `main` resolves to `quay.nju.edu.cn/ascend/vllm-ascend:main`, then `quay.io/ascend/vllm-ascend:main`
-4. `stable` resolves the latest official non-prerelease `vllm-ascend` release tag at execution time, then tries NJU first and `quay.io` second
-5. custom references must include a concrete non-`latest` tag or digest; `auto`, `*:latest`, and bare repositories without a tag are forbidden defaults
-6. if fresh pulls fail but one of the explicit candidate refs is already cached locally, reuse that cached image as a bounded fallback
-7. for non-destructive attach / repair, a recorded explicit non-`latest` image may be reused; ambiguous legacy images require another user choice
+1. ask the user to choose `local-latest`, `rc`, `main`, `stable`, or a custom image reference before new-machine bootstrap
+2. `local-latest` enumerates every image in the target host Docker daemon, keeps references whose repository basename contains `vllm-ascend` (so registry / namespace prefixes and repository-name prefixes or suffixes are supported), filters by the detected A2 / A3 / 310P tag suffix, and selects the newest compatible image by Docker `Created`; it does not pull
+3. host probe reports the filtered local image set, selected reference, selected immutable image ID, and creation time; bootstrap repeats discovery so deployment uses current host state
+4. an existing container satisfies `local-latest` only when its source image ID matches the newly selected image ID; matching tag text alone is insufficient
+5. `rc` resolves the newest official prerelease `vllm-ascend` tag at execution time, then tries `quay.nju.edu.cn/ascend/vllm-ascend:<tag>` first and `quay.io/ascend/vllm-ascend:<tag>` second; this is the recommended developer track
+6. `main` resolves to `quay.nju.edu.cn/ascend/vllm-ascend:main`, then `quay.io/ascend/vllm-ascend:main`
+7. `stable` resolves the latest official non-prerelease `vllm-ascend` release tag at execution time, then tries NJU first and `quay.io` second
+8. custom references must include a concrete non-`latest` tag or digest; `auto`, direct `*:latest`, and bare repositories without a tag are forbidden defaults
+9. if fresh pulls fail but one of the explicit candidate refs is already cached locally, reuse that cached image as a bounded fallback
+10. for non-destructive attach / repair, a recorded explicit non-`latest` image may be reused; ambiguous legacy images require another user choice
 
 Inventory should record the actual selected image, not only the requested selector string.
 

--- a/.agents/skills/machine-management/references/command-recipes.md
+++ b/.agents/skills/machine-management/references/command-recipes.md
@@ -40,6 +40,16 @@ python3 .agents/skills/machine-management/scripts/machine_add.py \
 
 The wrapper will detect A2 / A3 / 310P from `npu-smi` when possible and append `-a3` or `-310p` automatically for selector-based images.
 
+To scan all images already present in the target host Docker daemon, filter the machine-compatible `vllm-ascend` images, and deploy the newest by image creation time without pulling:
+
+```bash
+python3 .agents/skills/machine-management/scripts/machine_add.py \
+  --host 173.125.1.2 \
+  --image local-latest
+```
+
+The structured probe and bootstrap output records the filtered candidates, selected reference, image ID, and creation time. If no compatible local image exists, the workflow stops in `image-discovery` instead of falling back to a registry.
+
 If `npu-smi` cannot identify the hardware cleanly, pass an explicit override:
 
 ```bash

--- a/.agents/skills/machine-management/scripts/_workflow_common.py
+++ b/.agents/skills/machine-management/scripts/_workflow_common.py
@@ -161,6 +161,13 @@ def image_selection_needs_input_payload(
             "required": True,
             "choices": [
                 {
+                    "value": machine_ops.IMAGE_SELECTOR_LOCAL_LATEST,
+                    "label": "newest local vllm-ascend image",
+                    "recommended": False,
+                    "resolution": "scan every image in the target host Docker daemon, keep machine-compatible repository basenames containing vllm-ascend, and choose the newest by image creation time",
+                    "use_when": "the target host already contains the desired vllm-ascend image and deployment should not pull from a registry",
+                },
+                {
                     "value": machine_ops.IMAGE_SELECTOR_RC,
                     "label": "latest official rc image",
                     "recommended": True,
@@ -226,7 +233,7 @@ def resolve_workflow_image(
     if existing_record is None:
         return None, image_selection_needs_input_payload(
             reason=(
-                f"{action} requires an explicit image choice; ask the user to choose `rc`, `main`, `stable`, or a custom non-latest image reference before continuing"
+                f"{action} requires an explicit image choice; ask the user to choose `local-latest`, `rc`, `main`, `stable`, or a custom non-latest image reference before continuing"
             )
         )
 
@@ -234,7 +241,7 @@ def resolve_workflow_image(
     if image_requires_explicit_reselection(current_image):
         return None, image_selection_needs_input_payload(
             reason=(
-                f"{action} cannot reuse the recorded image automatically because it is missing, ambiguous, or points at a forbidden moving tag; ask the user to choose `rc`, `main`, `stable`, or a custom non-latest image reference"
+                f"{action} cannot reuse the recorded image automatically because it is missing, ambiguous, or points at a forbidden moving tag; ask the user to choose `local-latest`, `rc`, `main`, `stable`, or a custom non-latest image reference"
             ),
             machine=existing_record["alias"],
             current_image=current_image,
@@ -505,6 +512,23 @@ def probe_host(
     if result.progress_events:
         payload["progress_events"] = result.progress_events
     return payload
+
+
+def local_image_discovery_blocker(probe: dict[str, Any]) -> dict[str, Any] | None:
+    image = probe.get("image")
+    if not isinstance(image, dict) or image.get("policy") != machine_ops.IMAGE_POLICY_LOCAL_LATEST:
+        return None
+    discovery = image.get("local_discovery")
+    if isinstance(discovery, dict) and discovery.get("selected_reference"):
+        return None
+    return status_payload(
+        "blocked",
+        success=False,
+        action="image-discovery",
+        message="no machine-compatible local vllm-ascend image was found on the target host",
+        local_image_discovery=discovery,
+        probe=probe,
+    )
 
 
 def bootstrap_container(

--- a/.agents/skills/machine-management/scripts/machine_add.py
+++ b/.agents/skills/machine-management/scripts/machine_add.py
@@ -23,6 +23,7 @@ from _workflow_common import (  # noqa: E402
     host_target,
     image_request_matches_record,
     list_records,
+    local_image_discovery_blocker,
     load_or_create_profile,
     machine_summary,
     print_json,
@@ -60,7 +61,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--image",
         help=(
-            "explicit image selector: `rc`, `main`, `stable`, or a full non-latest image reference; "
+            "explicit image selector: `local-latest`, `rc`, `main`, `stable`, or a full non-latest image reference; "
             "this workflow does not default implicitly"
         ),
     )
@@ -199,6 +200,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if probe.get("status") == "blocked":
             print_json(probe)
+            return 0
+        image_discovery_blocker = local_image_discovery_blocker(probe)
+        if image_discovery_blocker is not None:
+            print_json(image_discovery_blocker)
             return 0
         free_port = probe.get("free_port")
         if not isinstance(free_port, int) and existing is None:

--- a/.agents/skills/machine-management/scripts/machine_repair.py
+++ b/.agents/skills/machine-management/scripts/machine_repair.py
@@ -23,6 +23,7 @@ from _workflow_common import (  # noqa: E402
     host_target,
     image_request_matches_record,
     list_records,
+    local_image_discovery_blocker,
     machine_summary,
     print_json,
     probe_host,
@@ -41,7 +42,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--image",
         help=(
-            "explicit replacement image selector: `rc`, `main`, `stable`, or a full non-latest image reference; "
+            "explicit replacement image selector: `local-latest`, `rc`, `main`, `stable`, or a full non-latest image reference; "
             "omit only when the recorded image is already explicit and acceptable"
         ),
     )
@@ -161,6 +162,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if probe.get("status") == "blocked":
             print_json(probe)
+            return 0
+        image_discovery_blocker = local_image_discovery_blocker(probe)
+        if image_discovery_blocker is not None:
+            print_json(image_discovery_blocker)
             return 0
 
         probed_machine_type = (

--- a/.agents/skills/machine-management/scripts/manage_machine.py
+++ b/.agents/skills/machine-management/scripts/manage_machine.py
@@ -36,6 +36,8 @@ IMAGE_REGISTRY_MIRRORS = (IMAGE_REGISTRY_NJU, IMAGE_REGISTRY_OFFICIAL)
 IMAGE_SELECTOR_RC = "rc"
 IMAGE_SELECTOR_MAIN = "main"
 IMAGE_SELECTOR_STABLE = "stable"
+IMAGE_SELECTOR_LOCAL_LATEST = "local-latest"
+IMAGE_POLICY_LOCAL_LATEST = "latest-local-vllm-ascend"
 IMAGE_SELECTOR_ALIASES = {
     IMAGE_SELECTOR_RC: IMAGE_SELECTOR_RC,
     "release-candidate": IMAGE_SELECTOR_RC,
@@ -51,6 +53,7 @@ IMAGE_SELECTOR_ALIASES = {
     "release": IMAGE_SELECTOR_STABLE,
     "latest-release": IMAGE_SELECTOR_STABLE,
     "latest-official": IMAGE_SELECTOR_STABLE,
+    IMAGE_SELECTOR_LOCAL_LATEST: IMAGE_SELECTOR_LOCAL_LATEST,
 }
 LEGACY_IMAGE_SELECTORS = {"auto"}
 FORBIDDEN_IMAGE_TAGS = {"latest"}
@@ -115,6 +118,96 @@ SOC_TO_MACHINE_TYPE = {
     "ascend310p3vir08": "310P",
 }
 SOC_MATCH_ORDER = sorted(SOC_TO_MACHINE_TYPE, key=len, reverse=True)
+
+
+LOCAL_IMAGE_DISCOVERY_PY = r'''
+def _vaws_image_ref_repo(ref):
+    without_digest = ref.split("@", 1)[0]
+    last_slash = without_digest.rfind("/")
+    last_colon = without_digest.rfind(":")
+    if last_colon > last_slash:
+        return without_digest[:last_colon]
+    return without_digest
+
+
+def _vaws_image_ref_machine_type(ref):
+    if "@" in ref:
+        return None
+    last_slash = ref.rfind("/")
+    last_colon = ref.rfind(":")
+    if last_colon <= last_slash:
+        return None
+    tag = ref[last_colon + 1:].lower()
+    if "-310p" in tag:
+        return "310P"
+    if "-a3" in tag:
+        return "A3"
+    return "A2"
+
+
+def _vaws_local_ref_rank(ref):
+    is_digest = "@" in ref
+    tag = ""
+    if not is_digest:
+        last_slash = ref.rfind("/")
+        last_colon = ref.rfind(":")
+        if last_colon > last_slash:
+            tag = ref[last_colon + 1:].lower()
+    return (1 if is_digest else 0, 1 if tag == "latest" else 0, ref)
+
+
+def select_latest_local_vllm_ascend_image(image_inspects, machine_type=None):
+    matched_images = []
+    eligible_images = []
+    for image in image_inspects:
+        if not isinstance(image, dict):
+            continue
+        references = []
+        for ref in list(image.get("RepoTags") or []) + list(image.get("RepoDigests") or []):
+            if not isinstance(ref, str) or not ref.strip():
+                continue
+            repo = _vaws_image_ref_repo(ref.strip())
+            if "vllm-ascend" not in repo.rsplit("/", 1)[-1].lower():
+                continue
+            references.append(ref.strip())
+        references = sorted(set(references), key=_vaws_local_ref_rank)
+        if not references:
+            continue
+        compatible_references = [
+            ref
+            for ref in references
+            if machine_type is None or _vaws_image_ref_machine_type(ref) == machine_type
+        ]
+        entry = {
+            "image_id": str(image.get("Id") or ""),
+            "created": str(image.get("Created") or ""),
+            "references": references,
+            "compatible_references": compatible_references,
+            "compatible": bool(compatible_references),
+        }
+        matched_images.append(entry)
+        if compatible_references:
+            eligible = dict(entry)
+            eligible["selected_reference"] = compatible_references[0]
+            eligible_images.append(eligible)
+
+    matched_images.sort(
+        key=lambda item: (item["created"], item["image_id"]), reverse=True
+    )
+    eligible_images.sort(
+        key=lambda item: (item["created"], item["image_id"]), reverse=True
+    )
+    selected = eligible_images[0] if eligible_images else None
+    return {
+        "machine_type": machine_type,
+        "matched_count": len(matched_images),
+        "eligible_count": len(eligible_images),
+        "matched_images": matched_images,
+        "selected_reference": selected.get("selected_reference") if selected else None,
+        "selected_image_id": selected.get("image_id") if selected else None,
+        "selected_created": selected.get("created") if selected else None,
+    }
+'''
 
 
 class MachineManagementError(RuntimeError):
@@ -250,12 +343,12 @@ def require_explicit_image_ref(ref: str) -> str:
     candidate = ref.strip()
     if not candidate:
         raise MachineManagementError(
-            "image reference is empty; choose `rc`, `main`, `stable`, or an explicit non-latest image reference"
+            "image reference is empty; choose `local-latest`, `rc`, `main`, `stable`, or an explicit non-latest image reference"
         )
     normalized = candidate.lower()
     if normalized in LEGACY_IMAGE_SELECTORS:
         raise MachineManagementError(
-            "legacy image selector `auto` is no longer allowed; ask the user to choose `rc`, `main`, `stable`, or a concrete image reference"
+            "legacy image selector `auto` is no longer allowed; ask the user to choose `local-latest`, `rc`, `main`, `stable`, or a concrete image reference"
         )
     if normalized in IMAGE_SELECTOR_ALIASES:
         raise MachineManagementError(
@@ -270,7 +363,7 @@ def require_explicit_image_ref(ref: str) -> str:
         )
     if tag.lower() in FORBIDDEN_IMAGE_TAGS:
         raise MachineManagementError(
-            "the moving `latest` tag is not allowed for managed machine bootstrap; choose `rc`, `main`, `stable`, or a concrete version tag"
+            "the moving `latest` tag is not allowed as a direct image choice; choose `local-latest`, `rc`, `main`, `stable`, or a concrete version tag"
         )
     return candidate
 
@@ -455,7 +548,7 @@ def resolve_image_request(
     requested = spec.strip()
     if not requested:
         raise MachineManagementError(
-            "image selector is missing; choose `rc`, `main`, `stable`, or an explicit non-latest image reference"
+            "image selector is missing; choose `local-latest`, `rc`, `main`, `stable`, or an explicit non-latest image reference"
         )
     normalized_machine_type = normalize_machine_type(machine_type)
     normalized = requested.lower()
@@ -493,6 +586,15 @@ def resolve_image_request(
             resolved_tag=image_tag_for_machine(release_tag, normalized_machine_type),
             machine_type=normalized_machine_type,
         )
+    if selector == IMAGE_SELECTOR_LOCAL_LATEST:
+        return ImageResolution(
+            selector=IMAGE_SELECTOR_LOCAL_LATEST,
+            requested=requested,
+            policy=IMAGE_POLICY_LOCAL_LATEST,
+            candidates=(),
+            mirror_order=(),
+            machine_type=normalized_machine_type,
+        )
 
     candidates = tuple(
         validate_explicit_image_for_machine(item, normalized_machine_type)
@@ -501,7 +603,7 @@ def resolve_image_request(
     )
     if not candidates:
         raise MachineManagementError(
-            "image selector is empty; choose `rc`, `main`, `stable`, or an explicit non-latest image reference"
+            "image selector is empty; choose `local-latest`, `rc`, `main`, `stable`, or an explicit non-latest image reference"
         )
     return ImageResolution(
         selector="explicit",
@@ -1045,7 +1147,11 @@ def run(cmd: list[str], *, env: Optional[dict[str, str]] = None) -> tuple[int, s
     return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
 
 
+__LOCAL_IMAGE_DISCOVERY_PY__
+
+
 candidates = list(image.get("candidates") or [])
+local_image_inspects: list[dict[str, object]] = []
 result: dict[str, object] = {
     "success": True,
     "hostname": socket.gethostname(),
@@ -1123,6 +1229,18 @@ if result["docker"]["present"]:
         result["docker"]["version"] = out
     rc, _, _ = run(["docker", "info"])
     result["docker"]["info_ok"] = rc == 0
+    if image.get("policy") == "__LOCAL_IMAGE_DISCOVERY_POLICY__":
+        rc, out, _ = run(["docker", "image", "ls", "--no-trunc", "--quiet"])
+        image_ids = sorted(set(out.splitlines())) if rc == 0 else []
+        if image_ids:
+            rc, out, _ = run(["docker", "image", "inspect", *image_ids])
+            if rc == 0:
+                try:
+                    inspected = json.loads(out)
+                    if isinstance(inspected, list):
+                        local_image_inspects = [item for item in inspected if isinstance(item, dict)]
+                except json.JSONDecodeError:
+                    local_image_inspects = []
     present_local_candidates: list[str] = []
     for candidate in candidates:
         rc, _, _ = run(["docker", "image", "inspect", candidate])
@@ -1189,6 +1307,22 @@ result["warnings"] = []
 if result["machine_type"] is None:
     result["warnings"].append("machine type could not be inferred from npu-smi output; pass an explicit override if needed")
 
+if image.get("policy") == "__LOCAL_IMAGE_DISCOVERY_POLICY__":
+    discovery_machine_type = image.get("machine_type") or result["machine_type"]
+    local_discovery = select_latest_local_vllm_ascend_image(
+        local_image_inspects,
+        discovery_machine_type,
+    )
+    selected_reference = local_discovery.get("selected_reference")
+    result["image"]["local_discovery"] = local_discovery
+    result["image"]["candidates"] = [selected_reference] if selected_reference else []
+    result["image"]["present_local_candidates"] = [selected_reference] if selected_reference else []
+    result["image"]["present_local"] = bool(selected_reference)
+    if not selected_reference:
+        result["warnings"].append(
+            "no machine-compatible local vllm-ascend image was discovered"
+        )
+
 rc, out, _ = run(["ss", "-ltnH"])
 used: set[int] = set()
 if rc == 0:
@@ -1211,8 +1345,11 @@ for port in range(start, end + 1):
 print("__SENTINEL__" + json.dumps(result, ensure_ascii=False))
 PY
 """
-    return template.replace("__SENTINEL__", SENTINEL).replace(
-        "__SOC_TO_MACHINE_TYPE__", json.dumps(SOC_TO_MACHINE_TYPE, ensure_ascii=False)
+    return (
+        template.replace("__SENTINEL__", SENTINEL)
+        .replace("__SOC_TO_MACHINE_TYPE__", json.dumps(SOC_TO_MACHINE_TYPE, ensure_ascii=False))
+        .replace("__LOCAL_IMAGE_DISCOVERY_PY__", LOCAL_IMAGE_DISCOVERY_PY)
+        .replace("__LOCAL_IMAGE_DISCOVERY_POLICY__", IMAGE_POLICY_LOCAL_LATEST)
     )
 
 
@@ -1280,6 +1417,52 @@ import sys
 payload = json.loads(sys.argv[1])
 for item in payload.get("candidates") or []:
     print(item)
+PY
+}
+
+discover_local_vllm_ascend_images() {
+  local requested_machine_type="$1"
+  local inspect_file
+  local discovery
+  local -a image_ids=()
+  mapfile -t image_ids < <(docker image ls --no-trunc --quiet | sort -u)
+  if [ "${#image_ids[@]}" -eq 0 ]; then
+    printf '%s\n' '{"machine_type": null, "matched_count": 0, "eligible_count": 0, "matched_images": [], "selected_reference": null, "selected_image_id": null, "selected_created": null}'
+    return 0
+  fi
+  inspect_file="$(mktemp)"
+  if ! docker image inspect "${image_ids[@]}" >"$inspect_file"; then
+    rm -f "$inspect_file"
+    return 1
+  fi
+  if ! discovery="$(python3 - "$requested_machine_type" "$inspect_file" <<'PY'
+import json
+import sys
+
+machine_type = sys.argv[1] or None
+with open(sys.argv[2], encoding="utf-8") as handle:
+    image_inspects = json.load(handle)
+
+__LOCAL_IMAGE_DISCOVERY_PY__
+
+print(json.dumps(
+    select_latest_local_vllm_ascend_image(image_inspects, machine_type),
+    ensure_ascii=False,
+))
+PY
+)"; then
+    rm -f "$inspect_file"
+    return 1
+  fi
+  rm -f "$inspect_file"
+  printf '%s\n' "$discovery"
+}
+
+json_string_array() {
+  python3 - "$@" <<'PY'
+import json
+import sys
+print(json.dumps(sys.argv[1:], ensure_ascii=False))
 PY
 }
 
@@ -1798,9 +1981,46 @@ machine_type="${machine_type_input:-$(image_field machine_type || true)}"
 soc="${soc_input:-}"
 container_type=""
 previous_image=""
+selected_image_id=""
+local_image_discovery='null'
 mapfile -t image_candidates < <(resolve_image_candidates)
+if [ "$image_policy" = "__LOCAL_IMAGE_DISCOVERY_POLICY__" ]; then
+  emit_progress "image-discovery" "running" "scanning local Docker images for the newest machine-compatible vllm-ascend image" 30
+  if ! local_image_discovery="$(discover_local_vllm_ascend_images "$machine_type")"; then
+    emit_json '{"success": false, "error": "failed to inspect local Docker images", "phase": "image-discovery"}'
+    exit 19
+  fi
+  selected_local_image="$(python3 - "$local_image_discovery" <<'PY'
+import json
+import sys
+print(json.loads(sys.argv[1]).get("selected_reference") or "")
+PY
+)"
+  if [ -n "$selected_local_image" ]; then
+    image_candidates=("$selected_local_image")
+  else
+    image_candidates=()
+  fi
+fi
+runtime_image_candidates_json="$(json_string_array "${image_candidates[@]}")"
 if [ "${#image_candidates[@]}" -eq 0 ]; then
-  emit_json '{"success": false, "error": "image selector resolved to zero candidates", "phase": "image"}'
+  empty_candidates_payload=$(python3 - "$image_request_json" "$local_image_discovery" <<'PY'
+import json
+import sys
+request = json.loads(sys.argv[1])
+discovery = json.loads(sys.argv[2]) if sys.argv[2] != "null" else None
+print(json.dumps({
+    "success": False,
+    "error": "image selector resolved to zero candidates",
+    "phase": "image-discovery" if discovery is not None else "image",
+    "requested_image": request.get("requested"),
+    "requested_selector": request.get("selector"),
+    "image_policy": request.get("policy"),
+    "local_image_discovery": discovery,
+}, ensure_ascii=False))
+PY
+)
+  emit_json "$empty_candidates_payload"
   exit 19
 fi
 
@@ -1814,12 +2034,24 @@ if docker inspect "$container" >/dev/null 2>&1; then
   fi
   previous_image="$current_image"
   image_matches=false
-  for candidate in "${image_candidates[@]}"; do
-    if [ "$candidate" = "$current_image" ] || { [ "$use_prepared_image_cache" = "true" ] && [ "$candidate" = "$current_base_image" ]; }; then
-      image_matches=true
-      break
+  if [ "$image_policy" = "__LOCAL_IMAGE_DISCOVERY_POLICY__" ]; then
+    candidate_image_id="$(docker image inspect -f '{{.Id}}' "${image_candidates[0]}" 2>/dev/null || true)"
+    current_source_image_id="$(docker inspect -f '{{.Image}}' "$container" 2>/dev/null || true)"
+    recorded_base_image_id="$(docker inspect -f '{{ index .Config.Labels "com.vaws.base_image_id" }}' "$container" 2>/dev/null || true)"
+    if [ "$recorded_base_image_id" != "<no value>" ] && [ -n "$recorded_base_image_id" ]; then
+      current_source_image_id="$recorded_base_image_id"
     fi
-  done
+    if [ -n "$candidate_image_id" ] && [ "$candidate_image_id" = "$current_source_image_id" ]; then
+      image_matches=true
+    fi
+  else
+    for candidate in "${image_candidates[@]}"; do
+      if [ "$candidate" = "$current_image" ] || { [ "$use_prepared_image_cache" = "true" ] && [ "$candidate" = "$current_base_image" ]; }; then
+        image_matches=true
+        break
+      fi
+    done
+  fi
   if [ "$image_matches" != "true" ]; then
     if [ "$replace_on_image_change" = "true" ]; then
       emit_progress "image" "running" "existing container image $current_image does not match requested selector; recreating container" 60
@@ -1827,10 +2059,10 @@ if docker inspect "$container" >/dev/null 2>&1; then
       actions+=("removed-container-for-image-change")
       container_exists=false
     else
-      mismatch_payload=$(python3 - <<'PY' "$current_image" "$image_request_json"
+      mismatch_payload=$(python3 - <<'PY' "$current_image" "$image_request_json" "$runtime_image_candidates_json" "$local_image_discovery"
 import json
 import sys
-current_image, image_request_json = sys.argv[1:]
+current_image, image_request_json, runtime_candidates_json, local_discovery_json = sys.argv[1:]
 image_request = json.loads(image_request_json)
 print(json.dumps({
     "success": False,
@@ -1841,7 +2073,8 @@ print(json.dumps({
     "requested_selector": image_request.get("selector"),
     "image_policy": image_request.get("policy"),
     "resolved_tag": image_request.get("resolved_tag"),
-    "image_candidates": list(image_request.get("candidates") or []),
+    "image_candidates": json.loads(runtime_candidates_json),
+    "local_image_discovery": json.loads(local_discovery_json) if local_discovery_json != "null" else None,
     "suggestion": "rerun with explicit container replacement consent or remove the managed container first",
 }, ensure_ascii=False))
 PY
@@ -1870,6 +2103,11 @@ if [ "$container_exists" = "true" ]; then
     fi
     used_prepared_image_cache=true
   fi
+  selected_image_id="$(docker inspect -f '{{.Image}}' "$container" 2>/dev/null || true)"
+  recorded_base_image_id="$(docker inspect -f '{{ index .Config.Labels "com.vaws.base_image_id" }}' "$container" 2>/dev/null || true)"
+  if [ "$recorded_base_image_id" != "<no value>" ] && [ -n "$recorded_base_image_id" ]; then
+    selected_image_id="$recorded_base_image_id"
+  fi
   image_resolution="existing-container"
   if [ "$state" != "running" ]; then
     docker start "$container" >/dev/null
@@ -1882,6 +2120,16 @@ else
   emit_progress "image" "running" "resolved image selector ${requested_image:-unknown} (${image_policy:-unknown})" 30
   for candidate in "${image_candidates[@]}"; do
     emit_progress "image" "running" "trying image candidate $candidate" 600
+    if [ "$image_policy" = "__LOCAL_IMAGE_DISCOVERY_POLICY__" ]; then
+      if docker image inspect "$candidate" >/dev/null 2>&1; then
+        selected_image="$candidate"
+        image_resolution="local-discovery"
+        actions+=("selected-latest-local-vllm-ascend-image")
+        break
+      fi
+      emit_progress "image-discovery" "running" "locally discovered image $candidate disappeared before deployment" 30
+      continue
+    fi
     if [ "$docker_pull_policy" != "always" ] && [ "$image_policy" != "main-branch" ] && docker image inspect "$candidate" >/dev/null 2>&1; then
       selected_image="$candidate"
       image_resolution="local-cache"
@@ -1901,6 +2149,7 @@ else
     emit_json '{"success": false, "error": "no usable image candidate was found", "phase": "image"}'
     exit 20
   fi
+  selected_image_id="$(docker image inspect -f '{{.Id}}' "$selected_image" 2>/dev/null || true)"
   if [ -z "$machine_type" ]; then
     machine_type="$(infer_type_from_image "$selected_image" || true)"
   fi
@@ -1954,6 +2203,7 @@ else
     "${mount_args[@]}" \
     "${visibility_args[@]}" \
     --label com.vaws.base_image="$selected_image" \
+    --label com.vaws.base_image_id="$selected_image_id" \
     --label com.vaws.run_image="$run_image" \
     --label com.vaws.prepared_image="$prepared_image" \
     "$run_image" >/dev/null
@@ -2019,7 +2269,7 @@ elif command -v firewall-cmd >/dev/null 2>&1 && firewall-cmd --state >/dev/null 
   firewall="firewalld"
 fi
 
-payload=$(python3 - <<'PY' "$container" "$port" "$image_request_json" "$selected_image" "$image_resolution" "$workdir" "$namespace" "$created" "$started" "$pulled" "$installed_ssh" "$firewall" "${actions[*]}" "$previous_image" "$replace_on_image_change" "$machine_type" "$container_type" "$soc" "$host_env_file" "$host_metadata_file" "$container_env_file" "$container_metadata_file" "$package_bootstrap" "$run_image" "$prepared_image" "$use_prepared_image_cache" "$used_prepared_image_cache" "$created_prepared_image_cache" "$docker_pull_policy" "$visible_devices"
+payload=$(python3 - <<'PY' "$container" "$port" "$image_request_json" "$selected_image" "$image_resolution" "$workdir" "$namespace" "$created" "$started" "$pulled" "$installed_ssh" "$firewall" "${actions[*]}" "$previous_image" "$replace_on_image_change" "$machine_type" "$container_type" "$soc" "$host_env_file" "$host_metadata_file" "$container_env_file" "$container_metadata_file" "$package_bootstrap" "$run_image" "$prepared_image" "$use_prepared_image_cache" "$used_prepared_image_cache" "$created_prepared_image_cache" "$docker_pull_policy" "$visible_devices" "$selected_image_id" "$runtime_image_candidates_json" "$local_image_discovery"
 import json
 import sys
 (
@@ -2053,6 +2303,9 @@ import sys
     created_prepared_image_cache,
     docker_pull_policy,
     visible_devices,
+    selected_image_id,
+    runtime_image_candidates_json,
+    local_image_discovery_json,
 ) = sys.argv[1:]
 image_request = json.loads(image_request_json)
 print(json.dumps({
@@ -2065,6 +2318,7 @@ print(json.dumps({
     "image_policy": image_request.get("policy"),
     "resolved_tag": image_request.get("resolved_tag"),
     "selected_image": selected_image,
+    "selected_image_id": selected_image_id or None,
     "run_image": run_image or selected_image,
     "prepared_image": prepared_image or None,
     "prepared_image_cache_requested": use_prepared_image_cache == "true",
@@ -2073,8 +2327,9 @@ print(json.dumps({
     "image_resolution": image_resolution,
     "docker_pull_policy": docker_pull_policy,
     "visible_devices": [int(item) for item in visible_devices.split(",") if item] if visible_devices else [],
-    "image_candidates": list(image_request.get("candidates") or []),
+    "image_candidates": json.loads(runtime_image_candidates_json),
     "image_mirror_order": list(image_request.get("mirror_order") or []),
+    "local_image_discovery": json.loads(local_image_discovery_json) if local_image_discovery_json != "null" else None,
     "workdir": workdir,
     "namespace": namespace or None,
     "previous_image": previous_image or None,
@@ -2099,8 +2354,11 @@ PY
 emit_progress "complete" "done" "managed container bootstrap completed" 0
 emit_json "$payload"
 """
-    return template.replace("__SENTINEL__", SENTINEL).replace(
-        "__PROGRESS__", PROGRESS_SENTINEL
+    return (
+        template.replace("__SENTINEL__", SENTINEL)
+        .replace("__PROGRESS__", PROGRESS_SENTINEL)
+        .replace("__LOCAL_IMAGE_DISCOVERY_PY__", LOCAL_IMAGE_DISCOVERY_PY)
+        .replace("__LOCAL_IMAGE_DISCOVERY_POLICY__", IMAGE_POLICY_LOCAL_LATEST)
     )
 
 
@@ -2814,7 +3072,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--image",
         required=True,
         help=(
-            "explicit image selector: `rc`, `main`, `stable`, or a full non-latest image reference; "
+            "explicit image selector: `local-latest`, `rc`, `main`, `stable`, or a full non-latest image reference; "
             f"`rc` resolves the newest official prerelease tag, and `main` tries {DEFAULT_IMAGE_CANDIDATES[0]} then {DEFAULT_IMAGE_CANDIDATES[1]}"
         ),
     )
@@ -2891,7 +3149,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--image",
         required=True,
         help=(
-            "explicit image selector: `rc`, `main`, `stable`, or a full non-latest image reference; "
+            "explicit image selector: `local-latest`, `rc`, `main`, `stable`, or a full non-latest image reference; "
             f"`rc` resolves the newest official prerelease tag, and `main` tries {DEFAULT_IMAGE_CANDIDATES[0]} then {DEFAULT_IMAGE_CANDIDATES[1]}"
         ),
     )

--- a/.agents/skills/machine-management/tests/test_image_selection.py
+++ b/.agents/skills/machine-management/tests/test_image_selection.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB_DIR = ROOT / ".agents" / "lib"
+SCRIPTS = ROOT / ".agents" / "skills" / "machine-management" / "scripts"
+for value in (str(LIB_DIR), str(SCRIPTS)):
+    if value not in sys.path:
+        sys.path.insert(0, value)
+
+import _workflow_common as workflow  # noqa: E402
+import manage_machine as machine_ops  # noqa: E402
+
+
+def discover(images: list[dict[str, object]], machine_type: str | None) -> dict[str, object]:
+    namespace: dict[str, object] = {}
+    exec(machine_ops.LOCAL_IMAGE_DISCOVERY_PY, namespace)  # noqa: S102
+    selector = namespace["select_latest_local_vllm_ascend_image"]
+    assert callable(selector)
+    return selector(images, machine_type)
+
+
+class LocalLatestImageTests(unittest.TestCase):
+    def test_selector_defers_resolution_to_remote_docker_host(self) -> None:
+        resolution = machine_ops.resolve_image_request("local-latest", machine_type="A3")
+
+        self.assertEqual(resolution.selector, machine_ops.IMAGE_SELECTOR_LOCAL_LATEST)
+        self.assertEqual(resolution.policy, machine_ops.IMAGE_POLICY_LOCAL_LATEST)
+        self.assertEqual(resolution.candidates, ())
+        self.assertEqual(resolution.mirror_order, ())
+        self.assertEqual(resolution.machine_type, "A3")
+
+    def test_discovery_filters_repository_and_machine_type_then_uses_created_time(self) -> None:
+        images = [
+            {
+                "Id": "sha256:unrelated",
+                "Created": "2026-08-27T13:00:00Z",
+                "RepoTags": ["example.invalid/other:main-a3"],
+                "RepoDigests": [],
+            },
+            {
+                "Id": "sha256:newer-a2",
+                "Created": "2026-08-27T12:00:00Z",
+                "RepoTags": ["quay.io/ascend/vllm-ascend:v0.12.0"],
+                "RepoDigests": [],
+            },
+            {
+                "Id": "sha256:older-a3",
+                "Created": "2026-08-26T12:00:00Z",
+                "RepoTags": ["quay.io/ascend/vllm-ascend:v0.11.0-a3"],
+                "RepoDigests": [],
+            },
+            {
+                "Id": "sha256:newest-a3",
+                "Created": "2026-08-27T11:00:00Z",
+                "RepoTags": [
+                    "quay.io/ascend/vllm-ascend:latest",
+                    "quay.io/ascend/vllm-ascend:v0.12.0-a3",
+                ],
+                "RepoDigests": ["quay.io/ascend/vllm-ascend@sha256:newest-a3"],
+            },
+            {
+                "Id": "sha256:prefixed-a3",
+                "Created": "2026-08-27T12:30:00Z",
+                "RepoTags": [
+                    "registry.local/team/company-vllm-ascend:v0.13.0-a3",
+                ],
+                "RepoDigests": [],
+            },
+            {
+                "Id": "sha256:suffixed-a3",
+                "Created": "2026-08-25T12:00:00Z",
+                "RepoTags": [
+                    "registry.local/team/vllm-ascend-dev:v0.10.0-a3",
+                ],
+                "RepoDigests": [],
+            },
+        ]
+
+        result = discover(images, "A3")
+
+        self.assertEqual(result["matched_count"], 5)
+        self.assertEqual(result["eligible_count"], 4)
+        self.assertEqual(result["selected_image_id"], "sha256:prefixed-a3")
+        self.assertEqual(
+            result["selected_reference"],
+            "registry.local/team/company-vllm-ascend:v0.13.0-a3",
+        )
+
+    def test_image_choice_payload_exposes_local_latest_option(self) -> None:
+        with (
+            mock.patch.object(machine_ops, "fetch_latest_prerelease_tag", return_value="v0.12.0rc1"),
+            mock.patch.object(machine_ops, "fetch_latest_release_tag", return_value="v0.11.0"),
+        ):
+            payload = workflow.image_selection_needs_input_payload(reason="choose")
+
+        choices = payload["missing"]["choices"]
+        local_choice = next(
+            item for item in choices if item["value"] == machine_ops.IMAGE_SELECTOR_LOCAL_LATEST
+        )
+        self.assertIn("Docker daemon", local_choice["resolution"])
+
+    def test_probe_without_compatible_local_image_blocks_before_bootstrap(self) -> None:
+        probe = {
+            "image": {
+                "policy": machine_ops.IMAGE_POLICY_LOCAL_LATEST,
+                "local_discovery": {
+                    "matched_count": 2,
+                    "eligible_count": 0,
+                    "selected_reference": None,
+                },
+            }
+        }
+
+        blocker = workflow.local_image_discovery_blocker(probe)
+
+        assert blocker is not None
+        self.assertEqual(blocker["status"], "blocked")
+        self.assertEqual(blocker["action"], "image-discovery")
+
+    def test_probe_with_selected_local_image_continues(self) -> None:
+        probe = {
+            "image": {
+                "policy": machine_ops.IMAGE_POLICY_LOCAL_LATEST,
+                "local_discovery": {
+                    "selected_reference": "quay.io/ascend/vllm-ascend:v0.12.0-a3",
+                },
+            }
+        }
+
+        self.assertIsNone(workflow.local_image_discovery_blocker(probe))
+
+    def test_generated_remote_scripts_are_valid_bash_without_placeholders(self) -> None:
+        for script in (
+            machine_ops.render_host_probe_script(),
+            machine_ops.render_bootstrap_host_script(),
+        ):
+            self.assertNotIn("__LOCAL_IMAGE_DISCOVERY", script)
+            checked = subprocess.run(
+                ["bash", "-n"],
+                input=script,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(checked.returncode, 0, checked.stderr)
+
+        bootstrap = machine_ops.render_bootstrap_host_script()
+        self.assertIn("com.vaws.base_image_id", bootstrap)
+        self.assertIn("selected-latest-local-vllm-ascend-image", bootstrap)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a `local-latest` image selector to managed-machine add and repair workflows
- inspect target-host Docker images, match repository basenames containing `vllm-ascend`, filter for A2/A3/310P compatibility, and select the newest image by Docker creation time
- keep the selector host-local, report discovery evidence, and compare immutable source image IDs when deciding whether an existing container matches
- document the workflow and add regression coverage for prefixed and suffixed repository names

## Testing

- `python3 -m unittest discover -s .agents/skills/machine-management/tests -p 'test_*.py' -v`
- `python3 -m py_compile .agents/skills/machine-management/scripts/manage_machine.py .agents/skills/machine-management/scripts/_workflow_common.py .agents/skills/machine-management/scripts/machine_add.py .agents/skills/machine-management/scripts/machine_repair.py .agents/skills/machine-management/tests/test_image_selection.py`
- generated remote scripts pass `bash -n` through the regression suite