### PR TITLE
feat: share machine inventory across Git worktrees

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -162,7 +162,7 @@ Untracked workspace-local state lives under `.vaws-local/`:
 
 - `.vaws-local/workspace-identity.json`
 - `.vaws-local/machine-profile.json`
-- `.vaws-local/machine-inventory.json`
+- `<primary-worktree>/.vaws-local/machine-inventory.json` (shared by linked Git worktrees)
 - `.vaws-local/remote-code-parity/install-consents.json`
 - `.vaws-local/remote-code-parity/runtime-state.json`
 - `.vaws-local/serving/<machine-alias>.json`
@@ -201,7 +201,7 @@ streaming plus hash manifests, and performs dry-run-capable cleanup.
 
 Remote-code-parity transport is container-only after machine attach: use machine inventory to resolve the target, then push synthetic refs directly into the container-local cache root. Synthetic mirrors should also publish an advertised branch ref for the current snapshot so nested repos can be materialized without brittle submodule fetch behavior. Runtime installs should use the single A3-tested HuaweiCloud pip index, stream progress for long package steps, and keep consent/runtime-state writes atomic.
 
-The legacy repo-root `.machine-inventory.json` is compatibility input only and should not be reintroduced as the primary path.
+The legacy repo-root `.machine-inventory.json` and any pre-existing linked-worktree `.vaws-local/machine-inventory.json` are compatibility inputs only. New writes use the primary worktree inventory; session, serving, benchmark, profiling, log, and artifact state stays isolated under the current worktree's `.vaws-local/`.
 
 Key guardrail:
 

--- a/.agents/lib/vaws_local_state.py
+++ b/.agents/lib/vaws_local_state.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Local untracked state helpers for vllm-ascend-workspace.
 
-This module centralizes repo-local runtime state that should never be tracked.
+Machine inventory is shared through the primary Git worktree. Execution state
+remains local to the current worktree and should never be tracked.
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ import os
 import re
 import secrets
 import string
+import subprocess
 import tempfile
 import uuid
 from datetime import datetime, timezone
@@ -36,9 +38,44 @@ ROOT = Path(__file__).resolve().parents[2]
 STATE_DIR = ROOT / STATE_DIRNAME
 PROFILE_PATH = STATE_DIR / PROFILE_FILENAME
 IDENTITY_PATH = STATE_DIR / IDENTITY_FILENAME
-INVENTORY_PATH = STATE_DIR / INVENTORY_FILENAME
 SESSIONS_DIR = STATE_DIR / SESSIONS_DIRNAME
-LEGACY_INVENTORY_PATH = ROOT / LEGACY_INVENTORY_FILENAME
+
+
+def shared_workspace_root(repo_root: Path = ROOT) -> Path:
+    """Return the primary worktree that owns cross-worktree machine inventory."""
+    repo_root = repo_root.expanduser().resolve()
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--git-common-dir"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return repo_root
+    if result.returncode != 0 or not result.stdout.strip():
+        return repo_root
+    common_dir = Path(result.stdout.strip()).expanduser()
+    if not common_dir.is_absolute():
+        common_dir = repo_root / common_dir
+    common_dir = common_dir.resolve()
+    if common_dir.name.lower() == ".git" and common_dir.is_dir():
+        return common_dir.parent
+    return repo_root
+
+
+def shared_inventory_path(repo_root: Path = ROOT) -> Path:
+    return shared_workspace_root(repo_root) / STATE_DIRNAME / INVENTORY_FILENAME
+
+
+SHARED_WORKSPACE_ROOT = shared_workspace_root(ROOT)
+LOCAL_INVENTORY_PATH = STATE_DIR / INVENTORY_FILENAME
+INVENTORY_PATH = shared_inventory_path(ROOT)
+LEGACY_INVENTORY_PATH = SHARED_WORKSPACE_ROOT / LEGACY_INVENTORY_FILENAME
+LOCAL_LEGACY_INVENTORY_PATH = ROOT / LEGACY_INVENTORY_FILENAME
 
 
 class WorkspaceStateError(RuntimeError):
@@ -389,6 +426,8 @@ def profile_summary(path: Path = PROFILE_PATH) -> dict[str, Any]:
         "state_dir": str(path.parent),
         "profile_path": str(path),
         "inventory_path": str(INVENTORY_PATH),
+        "inventory_scope": "git-common-worktree",
+        "shared_workspace_root": str(SHARED_WORKSPACE_ROOT),
         "sessions_path": str(SESSIONS_DIR),
         "legacy_inventory_path": str(LEGACY_INVENTORY_PATH),
         "exists": path.exists(),
@@ -418,8 +457,22 @@ def profile_summary(path: Path = PROFILE_PATH) -> dict[str, Any]:
     return summary
 
 
-def resolve_inventory_read_path(preferred_path: Path = INVENTORY_PATH) -> Path:
+def resolve_inventory_read_path(
+    preferred_path: Path = INVENTORY_PATH,
+    *,
+    repo_root: Path = ROOT,
+) -> Path:
     preferred_path = preferred_path.expanduser().resolve()
-    if same_path(preferred_path, INVENTORY_PATH) and not preferred_path.exists() and LEGACY_INVENTORY_PATH.exists():
-        return LEGACY_INVENTORY_PATH.expanduser().resolve()
+    canonical_path = shared_inventory_path(repo_root).expanduser().resolve()
+    if same_path(preferred_path, canonical_path) and not preferred_path.exists():
+        repo_root = repo_root.expanduser().resolve()
+        fallbacks = (
+            repo_root / STATE_DIRNAME / INVENTORY_FILENAME,
+            shared_workspace_root(repo_root) / LEGACY_INVENTORY_FILENAME,
+            repo_root / LEGACY_INVENTORY_FILENAME,
+        )
+        for fallback in fallbacks:
+            fallback = fallback.expanduser().resolve()
+            if not same_path(fallback, preferred_path) and fallback.exists():
+                return fallback
     return preferred_path

--- a/.agents/lib/vaws_remote_toolbox.py
+++ b/.agents/lib/vaws_remote_toolbox.py
@@ -36,6 +36,7 @@ from vaws_local_state import (  # noqa: E402
     WorkspaceStateError,
     ensure_state_dir,
     resolve_inventory_read_path,
+    shared_inventory_path,
     utc_now_iso,
 )
 from vaws_session_state import (  # noqa: E402
@@ -256,13 +257,10 @@ def derive_workspace_id(repo_root: Path) -> str:
 
 
 def _load_inventory(repo_root: Path = ROOT) -> tuple[dict[str, Any], Path]:
-    preferred = repo_root / ".vaws-local" / "machine-inventory.json"
-    path = resolve_inventory_read_path(preferred)
+    preferred = shared_inventory_path(repo_root)
+    path = resolve_inventory_read_path(preferred, repo_root=repo_root)
     if not path.exists():
-        legacy = repo_root / ".machine-inventory.json"
-        if legacy.exists():
-            path = legacy
-        elif INVENTORY_PATH.exists():
+        if INVENTORY_PATH.exists():
             path = INVENTORY_PATH
         elif LEGACY_INVENTORY_PATH.exists():
             path = LEGACY_INVENTORY_PATH

--- a/.agents/skills/machine-management/SKILL.md
+++ b/.agents/skills/machine-management/SKILL.md
@@ -95,16 +95,18 @@ Keep alias compatibility in the parser layer, not in the main skill narrative.
 
 ## Local state
 
-Local workspace-machine state lives under `.vaws-local/`:
+Local workspace-machine state lives under `.vaws-local/`. Machine inventory is shared by every Git worktree through the primary worktree; execution state remains worktree-local:
 
 - `.vaws-local/workspace-identity.json`
 - `.vaws-local/machine-profile.json`
-- `.vaws-local/machine-inventory.json`
+- `<primary-worktree>/.vaws-local/machine-inventory.json` (shared)
+- `<current-worktree>/.vaws-local/sessions/`, `serving/`, benchmark, profiling, and other execution state (isolated)
 
 Compatibility note:
 
-- the helper still reads legacy repo-root `.machine-inventory.json` when the new path does not exist yet
-- the next successful inventory write migrates state to `.vaws-local/machine-inventory.json`
+- a linked worktree resolves the primary worktree through Git's common directory
+- when the shared inventory is absent, the helper can read a pre-existing worktree-local `.vaws-local/machine-inventory.json` or legacy `.machine-inventory.json`
+- the next successful inventory write migrates fallback data to the primary worktree's shared inventory
 
 ## Workflow
 

--- a/.agents/skills/machine-management/references/acceptance.md
+++ b/.agents/skills/machine-management/references/acceptance.md
@@ -60,6 +60,14 @@ These should not trigger `machine-management` unless machine readiness is the ob
 - `workspace_profile.py ensure` on a missing profile fails unless `--username` or `--generate` is provided
 - new managed container names derive from that namespace instead of a single global fixed name
 
+### Cross-worktree state
+
+- every linked Git worktree resolves the same machine inventory under the primary worktree's `.vaws-local/`
+- inventory reads from machine-management, serving, benchmark, profiling, session creation, and remote-toolbox use that shared path
+- a pre-existing linked-worktree inventory remains readable as a migration fallback only when the shared inventory is absent
+- the next successful inventory mutation writes the primary shared inventory
+- session bindings, leases, serving state, benchmark runs, profiling runs, logs, and artifacts remain under the current worktree's `.vaws-local/`
+
 ### Add / attach
 
 - `machine_add.py` can succeed with `--host --image rc` when the profile and host key SSH are already in place

--- a/.agents/skills/machine-management/references/behavior.md
+++ b/.agents/skills/machine-management/references/behavior.md
@@ -35,16 +35,17 @@ Rules:
 - wrapper scripts stream phase progress on `stderr` as `__VAWS_PROGRESS__=<json>` and keep one final JSON result on `stdout`
 - on a missing profile, `workspace_profile.py ensure` must use either `--username` or `--generate`
 
-Relevant files:
+Relevant files and scopes:
 
 - `.vaws-local/workspace-identity.json`
 - `.vaws-local/machine-profile.json`
-- `.vaws-local/machine-inventory.json`
+- `<primary-worktree>/.vaws-local/machine-inventory.json` — shared by all worktrees discovered through Git common-dir
+- `<current-worktree>/.vaws-local/sessions/`, `serving/`, benchmark, profiling, and other execution records — isolated per worktree
 
 Compatibility rule:
 
-- read legacy repo-root `.machine-inventory.json` when the new path is still absent
-- migrate to `.vaws-local/machine-inventory.json` on the next successful inventory write
+- read an existing worktree-local `.vaws-local/machine-inventory.json` or legacy `.machine-inventory.json` when the primary shared inventory is still absent
+- migrate fallback inventory to the primary worktree's `.vaws-local/machine-inventory.json` on the next successful write
 
 ## Public API surface contract
 

--- a/.agents/skills/machine-management/scripts/inventory.py
+++ b/.agents/skills/machine-management/scripts/inventory.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Low-level local machine inventory helper for vllm-ascend-workspace.
+"""Low-level shared machine inventory helper for vllm-ascend-workspace.
 
-The canonical inventory now lives under `.vaws-local/machine-inventory.json`.
-For compatibility, the helper will read the legacy repo-root
-`.machine-inventory.json` when the new path does not exist yet. Prefer the
-task-oriented wrappers for normal add / verify / repair / remove workflows.
+The canonical inventory lives under the primary Git worktree's
+`.vaws-local/machine-inventory.json`, so linked worktrees see the same fleet.
+Execution state remains isolated in each worktree. Compatibility fallbacks are
+read only until the next successful inventory write migrates them.
 """
 
 from __future__ import annotations
@@ -26,6 +26,9 @@ if str(LIB_DIR) not in sys.path:
 from vaws_local_state import (  # noqa: E402
     INVENTORY_PATH as DEFAULT_PATH,
     LEGACY_INVENTORY_PATH,
+    LOCAL_INVENTORY_PATH,
+    LOCAL_LEGACY_INVENTORY_PATH,
+    SHARED_WORKSPACE_ROOT,
     ensure_state_dir,
     resolve_inventory_read_path,
     same_path,
@@ -274,6 +277,9 @@ def cmd_summary(args: argparse.Namespace) -> int:
         "schema_version": inventory["schema_version"],
         "inventory": str(active_path),
         "preferred_inventory": str(requested_path),
+        "inventory_scope": "git-common-worktree",
+        "shared_workspace_root": str(SHARED_WORKSPACE_ROOT),
+        "worktree_local_inventory": str(LOCAL_INVENTORY_PATH),
         "legacy_inventory": str(LEGACY_INVENTORY_PATH),
         "count": len(inventory["machines"]),
         "machines": [
@@ -401,7 +407,11 @@ def cmd_put(args: argparse.Namespace) -> int:
     }
     if not same_path(active_path, requested_path):
         payload["loaded_from"] = str(active_path)
-        payload["migrated_from_legacy"] = same_path(active_path, LEGACY_INVENTORY_PATH)
+        payload["migrated_from_legacy"] = any(
+            same_path(active_path, candidate)
+            for candidate in (LEGACY_INVENTORY_PATH, LOCAL_LEGACY_INVENTORY_PATH)
+        )
+        payload["migrated_from_worktree_local"] = same_path(active_path, LOCAL_INVENTORY_PATH)
     print(json.dumps(payload, indent=2, ensure_ascii=False))
     return 0
 
@@ -430,7 +440,11 @@ def cmd_remove(args: argparse.Namespace) -> int:
     }
     if not same_path(active_path, requested_path):
         payload["loaded_from"] = str(active_path)
-        payload["migrated_from_legacy"] = same_path(active_path, LEGACY_INVENTORY_PATH)
+        payload["migrated_from_legacy"] = any(
+            same_path(active_path, candidate)
+            for candidate in (LEGACY_INVENTORY_PATH, LOCAL_LEGACY_INVENTORY_PATH)
+        )
+        payload["migrated_from_worktree_local"] = same_path(active_path, LOCAL_INVENTORY_PATH)
     print(json.dumps(payload, indent=2, ensure_ascii=False))
     return 0
 

--- a/.agents/skills/repo-init/references/behavior.md
+++ b/.agents/skills/repo-init/references/behavior.md
@@ -19,7 +19,7 @@ Relevant files:
 
 - `.vaws-local/workspace-identity.json`
 - `.vaws-local/machine-profile.json`
-- `.vaws-local/machine-inventory.json`
+- `<primary-worktree>/.vaws-local/machine-inventory.json` (shared across linked Git worktrees)
 
 Rules:
 

--- a/.agents/tests/test_shared_inventory_state.py
+++ b/.agents/tests/test_shared_inventory_state.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_local_state import resolve_inventory_read_path, shared_inventory_path, shared_workspace_root
+from vaws_remote_toolbox import _load_inventory
+from vaws_session_state import sessions_root
+
+
+class SharedInventoryStateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.primary = Path(self.temp.name) / "primary"
+        self.linked = Path(self.temp.name) / "linked"
+        subprocess.run(["git", "init", str(self.primary)], check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["git", "-C", str(self.primary), "config", "user.email", "test@example.com"], check=True)
+        subprocess.run(["git", "-C", str(self.primary), "config", "user.name", "Test"], check=True)
+        (self.primary / "README.md").write_text("test\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.primary), "add", "README.md"], check=True)
+        subprocess.run(["git", "-C", str(self.primary), "commit", "-m", "init"], check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(
+            ["git", "-C", str(self.primary), "worktree", "add", "--detach", str(self.linked)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_all_worktrees_resolve_one_primary_inventory(self) -> None:
+        expected = self.primary / ".vaws-local" / "machine-inventory.json"
+        self.assertEqual(shared_workspace_root(self.primary), self.primary.resolve())
+        self.assertEqual(shared_workspace_root(self.linked), self.primary.resolve())
+        self.assertEqual(shared_inventory_path(self.primary), expected.resolve())
+        self.assertEqual(shared_inventory_path(self.linked), expected.resolve())
+
+    def test_existing_linked_inventory_is_a_read_fallback_until_central_write(self) -> None:
+        local_inventory = self.linked / ".vaws-local" / "machine-inventory.json"
+        local_inventory.parent.mkdir(parents=True)
+        local_inventory.write_text('{"schema_version":1,"machines":[]}\n', encoding="utf-8")
+        preferred = shared_inventory_path(self.linked)
+        self.assertEqual(
+            resolve_inventory_read_path(preferred, repo_root=self.linked),
+            local_inventory.resolve(),
+        )
+
+        preferred.parent.mkdir(parents=True)
+        preferred.write_text('{"schema_version":1,"machines":[]}\n', encoding="utf-8")
+        self.assertEqual(resolve_inventory_read_path(preferred, repo_root=self.linked), preferred.resolve())
+
+    def test_toolbox_shares_inventory_but_sessions_remain_worktree_local(self) -> None:
+        inventory_path = shared_inventory_path(self.primary)
+        inventory_path.parent.mkdir(parents=True)
+        inventory = {"schema_version": 1, "machines": [{"alias": "a3"}]}
+        inventory_path.write_text(json.dumps(inventory), encoding="utf-8")
+
+        loaded, loaded_path = _load_inventory(self.linked)
+        self.assertEqual(loaded, inventory)
+        self.assertEqual(loaded_path, inventory_path.resolve())
+        self.assertNotEqual(sessions_root(self.primary).resolve(), sessions_root(self.linked).resolve())
+        self.assertEqual(sessions_root(self.linked), self.linked / ".vaws-local" / "sessions")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/npu-fleet-monitor.md
+++ b/docs/npu-fleet-monitor.md
@@ -24,7 +24,7 @@ python3 .agents/skills/npu-fleet-monitor/scripts/manage_monitor.py ensure
 
 监控 worktree 的 `data/` 是忽略目录，保存 SQLite 历史库、专用 Ed25519 密钥和独立 `known_hosts`。重新构建和重启不会删除这些文件。
 
-服务根据 Git common-dir 找到主工作区，读取 `.vaws-local/machine-inventory.json`，复用 `machine-management` 的密钥引导和 Ascend NPU 解析。若 worktree 不属于同一个 Git 公共目录，可在服务环境中设置 `NFM_SOURCE_WORKSPACE=/绝对/主工作区/路径`。
+服务根据 Git common-dir 找到主工作区，读取主 worktree 的共享 `.vaws-local/machine-inventory.json`，复用 `machine-management` 的密钥引导和 Ascend NPU 解析。其他 linked worktree 读取同一库存，但 session、serving、benchmark、profiling 等执行状态仍保存在各自 worktree。若监控 worktree 不属于同一个 Git 公共目录，可在服务环境中设置 `NFM_SOURCE_WORKSPACE=/绝对/主工作区/路径`。
 
 浏览器没有活动页面时，采集器默认每 120 秒执行一次低频巡检；页面打开后由可见页面选择的 1、5、10 或 30 秒频率控制，多个页面采用最快频率。磁盘、挂载点和 Docker 使用独立的低频采集周期，历史数据最短每 30 秒落库一次。
 


### PR DESCRIPTION
## Summary

- resolve the canonical machine inventory from Git common-dir so every linked worktree reads the primary worktree inventory
- keep sessions, serving state, benchmarks, profiling runs, logs, and artifacts isolated under each current worktree
- retain worktree-local and legacy inventory files as read-only migration fallbacks until the next successful central write
- surface the inventory scope and shared root in workspace and inventory summaries

## Validation

- `py -3 -m unittest discover -s .agents/tests -p "test_shared_inventory_state.py" -v` (3 passed)
- `py -3 .agents/skills/repo-init/test_workspace_identity.py` (5 passed)
- `git diff --check upstream/main...HEAD`
- verified from the PR linked worktree that inventory resolves to the primary worktree and reports all 10 managed machines
