### PR TITLE
fix(machine): harden Ascend SoC detection

### DIFF
--- a/.agents/skills/machine-management/SKILL.md
+++ b/.agents/skills/machine-management/SKILL.md
@@ -39,15 +39,17 @@ Ready does **not** imply code sync, rebuild, serving, or benchmark readiness.
 - Never write passwords or tokens into tracked files or `.vaws-local/`.
 - Never use `scp`, `sftp`, `sshpass`, or `expect` in this workflow.
 - Never default the container image silently. Ask the user to choose one of:
-  - `local-latest`: inspect every image in the target host Docker daemon, keep repositories whose basename contains `vllm-ascend` (including registry / namespace prefixes and names such as `company-vllm-ascend` or `vllm-ascend-dev`), filter them for the detected A2 / A3 / 310P machine type, and deploy the newest compatible image by Docker image creation time; this never pulls
+  - `local-latest`: inspect every image in the target host Docker daemon, keep repositories whose basename contains `vllm-ascend` (including registry / namespace prefixes and names such as `company-vllm-ascend` or `vllm-ascend-dev`), filter them for the detected A2 / A3 / A5 / 310P machine type, and deploy the newest compatible image by Docker image creation time; this never pulls
   - `rc`: resolve the newest official prerelease `vllm-ascend` tag, then try `quay.nju.edu.cn/ascend/vllm-ascend:<tag>` first and `quay.io/ascend/vllm-ascend:<tag>` second; this is the recommended developer track
   - `main`: `quay.nju.edu.cn/ascend/vllm-ascend:main`, then `quay.io/ascend/vllm-ascend:main`
   - `stable`: resolve the latest official non-prerelease `vllm-ascend` release tag, then try NJU first and `quay.io` second
   - `custom`: a full image reference with a concrete non-`latest` tag or digest
 - Treat `auto`, direct `*:latest`, and bare repositories without a tag as forbidden defaults for managed-machine bootstrap; `local-latest` is the explicit bounded discovery policy, not a moving registry tag.
 - Report and persist the **actual selected image** for the managed container, not only the requested image policy.
-- Resolve hardware-specific image tags from the detected machine type whenever the user chose `rc`, `main`, or `stable`: A2 uses the base tag, A3 appends `-a3`, and 310P appends `-310p`.
-- Detect the machine type from `npu-smi info` / SoC output when possible; when detection is inconclusive, stop and ask for an explicit machine type override instead of guessing.
+- Resolve hardware-specific image tags from the detected machine type whenever the user chose `rc`, `main`, or `stable`: A2 uses the base tag, A3 appends `-a3`, A5 appends `-a5`, and 310P appends `-310p`.
+- Prefer a fresh detailed `npu-smi` board query over the bare `Ascend910` label. Query an NPU ID with `npu-smi info -l`, query both board forms (`-t board -i <id>` and `-t board -i <id> -c <chip-id>`), and construct the SoC from `Chip Type` / `Chip Name` / `NPU Name` as applicable. In particular, `Chip Name: Ascend910` plus `NPU Name: 9362` means `ascend910_9362` / A3. If detailed queries are unavailable, accept an exact bare `Ascend910` token as an A3 compatibility fallback.
+- Treat `/etc/profile.d/vaws-ascend-env.sh`, `SOC_VERSION`, `VAWS_NPU_SOC`, inventory, and image-name inference as fallbacks or consistency hints only. A successful fresh detailed hardware query wins when old persisted metadata disagrees.
+- When detection remains inconclusive, stop and ask for an explicit machine type override instead of guessing.
 - Persist `host.machine_type`, `host.soc`, and `container.machine_type` into inventory, and write matching metadata under `/etc/vaws/` plus `/etc/profile.d/vaws-ascend-env.sh` on the host and inside the managed container.
 - Before running `apt-get update` / `apt-get install` inside the container, rewrite apt sources to the fixed A3-tested NJU mirror (`mirrors.nju.edu.cn`). Do not spend bootstrap time probing alternate mirrors.
 - Prepend `/usr/local/Ascend/driver/lib64/common`, `/usr/local/Ascend/driver/lib64/driver`, and `/usr/local/Ascend/driver/lib64` before calling `npu-smi` or the smoke test; source `/etc/profile.d/vaws-ascend-env.sh` when it exists.
@@ -69,9 +71,9 @@ The primary bootstrap path must not depend on `ssh-copy-id`, `expect`, or any ot
 
 Use these task-oriented wrappers for normal agent work. They keep the parameter surface narrow and return structured JSON statuses such as `ready`, `needs_input`, `needs_repair`, `blocked`, `removed`, or `unmanaged`. They also stream phase progress on `stderr` as `__VAWS_PROGRESS__=<json>` while reserving `stdout` for one final machine-readable JSON payload.
 
-- `python3 .agents/skills/machine-management/scripts/machine_add.py --host <ip> --image <local-latest|rc|main|stable|custom-ref> [--machine-type <A2|A3|310P>] [--machine-username <letters-or-digits> | --generate-machine-username] [--password-env NAME | --password-stdin | --password ...]`
+- `python3 .agents/skills/machine-management/scripts/machine_add.py --host <ip> --image <local-latest|rc|main|stable|custom-ref> [--machine-type <A2|A3|A5|310P>] [--machine-username <letters-or-digits> | --generate-machine-username] [--password-env NAME | --password-stdin | --password ...]`
 - `python3 .agents/skills/machine-management/scripts/machine_verify.py --machine <alias-or-ip>`
-- `python3 .agents/skills/machine-management/scripts/machine_repair.py --machine <alias-or-ip> [--image <local-latest|rc|main|stable|custom-ref>] [--machine-type <A2|A3|310P>] [--password-env NAME | --password-stdin | --password ...]`
+- `python3 .agents/skills/machine-management/scripts/machine_repair.py --machine <alias-or-ip> [--image <local-latest|rc|main|stable|custom-ref>] [--machine-type <A2|A3|A5|310P>] [--password-env NAME | --password-stdin | --password ...]`
 - `python3 .agents/skills/machine-management/scripts/machine_remove.py --machine <alias-or-ip>`
 
 Design intent:
@@ -149,7 +151,7 @@ Before any mutation, inspect:
 - whether a local public key already exists
 - whether host SSH by key already works
 - whether Docker and required Ascend/NPU paths exist on the host
-- whether `npu-smi` / SoC output identifies the host as A2, A3, or 310P
+- whether detailed `npu-smi` board output identifies the host as A2, A3, A5, or 310P
 - whether a free high SSH port exists
 - whether a managed container already exists
 

--- a/.agents/skills/machine-management/references/acceptance.md
+++ b/.agents/skills/machine-management/references/acceptance.md
@@ -79,7 +79,10 @@ These should not trigger `machine-management` unless machine readiness is the ob
 - if the user already supplied the host password in the request, the skill prefers scripted bootstrap before asking the user to run a manual command
 - the primary bootstrap path does not depend on `ssh-copy-id`
 - the skill checks Docker and required Ascend/NPU prerequisites before container creation
-- the host probe captures `machine_type` and `soc` from `npu-smi` / SoC output when possible and returns a clear override request when it cannot
+- the host probe captures `machine_type` and `soc` from fresh detailed `npu-smi` board output when possible and returns a clear override request when it cannot
+- `Chip Name: Ascend910` plus `NPU Name: 9362` resolves to `ascend910_9362` / A3; if detailed board fields are unavailable, an exact bare `Ascend910` token remains an A3 compatibility fallback
+- A2 is derived from `Chip Type + Chip Name`, A3 and A5 from `Chip Name + NPU Name`, and any canonical `ascend950*` SoC resolves to A5
+- a successful fresh board query outranks stale `SOC_VERSION`, `VAWS_NPU_SOC`, inventory, and image-name hints; disagreement is surfaced as a warning
 - the managed container uses host networking, required devices, required Ascend mounts, and `/vllm-workspace` as the workdir
 - the skill configures a dedicated container `sshd` on a high port without brittle inline edits to `/etc/ssh/sshd_config`
 - the container bootstrap ensures `/run/sshd` exists
@@ -88,7 +91,7 @@ These should not trigger `machine-management` unless machine readiness is the ob
 - when a caller explicitly requests the prepared-image cache, the helper reports `prepared_image`, `used_prepared_image_cache`, and `created_prepared_image_cache` in the bootstrap payload
 - `machine_add.py` persists final alias, namespace, host identity, container name, image, and SSH port into inventory without the agent having to call `inventory.py put`
 - the recorded inventory image is the actual selected image after mirror resolution and pull / cache fallback
-- selector-based image resolution is hardware-aware: A2 keeps the base tag, A3 appends `-a3`, and 310P appends `-310p`
+- selector-based image resolution is hardware-aware: A2 keeps the base tag, A3 appends `-a3`, A5 appends `-a5`, and 310P appends `-310p`
 - `local-latest` scans the target host Docker daemon, accepts repository basenames containing `vllm-ascend` (including registry / namespace prefixes and repository-name prefixes or suffixes), filters by machine type, and selects the newest compatible image by Docker creation time without pulling
 - probe and bootstrap payloads expose `local_image_discovery`, the selected reference, and `selected_image_id`; an empty compatible set fails in the image-discovery phase
 - an existing container selected through `local-latest` is compared by immutable source image ID, so a reused tag that now points at a newer image triggers replacement when replacement consent is present

--- a/.agents/skills/machine-management/references/behavior.md
+++ b/.agents/skills/machine-management/references/behavior.md
@@ -246,12 +246,44 @@ Do **not**:
 - remove host-level `authorized_keys`
 - guess at unmanaged containers
 
+## Hardware detection contract
+
+The fresh `npu-smi` hardware result is authoritative. Persisted VAWS metadata
+is useful for fallback and drift reporting, but it must never override a
+successful detailed board query.
+
+Probe in this order:
+
+1. run `npu-smi info -l` to obtain an NPU ID
+2. run `npu-smi info -m` to obtain an NPU/chip pair when the driver exposes it
+3. run `npu-smi info -t board -i <npu-id>`; this is the complete form used by Ascend 950/A5
+4. run `npu-smi info -t board -i <npu-id> -c <chip-id>`; this exposes the A2/A3/310P chip fields
+5. construct the canonical SoC:
+   - A2: `Chip Type + Chip Name`, for example `Ascend` + `910B4` -> `ascend910b4`
+   - A3: `Chip Name + "_" + NPU Name`, for example `Ascend910` + `9362` -> `ascend910_9362`
+   - A5: `Chip Name + "_" + NPU Name`; classify any canonical token beginning with `ascend950` as A5
+   - 310P: `Chip Type + Chip Name`, for example `Ascend` + `310P3` -> `ascend310p3`
+
+If detailed board queries fail, exact SoC tokens in fresh `npu-smi` output may
+be used. An exact bare `Ascend910` token is accepted as an A3 compatibility
+fallback, but it must not replace the more precise `Ascend910_<NPU Name>` result
+when that result is available. Only after all fresh hardware paths are
+inconclusive may `SOC_VERSION` / `VAWS_NPU_SOC`, inventory metadata, or image
+suffixes be used as a fallback. Report a warning when fresh and persisted SoC
+values disagree.
+
+Primary references:
+
+- Huawei CANN, [obtaining the SoC version with `npu-smi`](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/910beta2/API/ascendcopapi/atlasascendc_api_07_1039.html)
+- vLLM Ascend, [`setup.py` hardware detection and SoC mapping](https://github.com/vllm-project/vllm-ascend/blob/main/setup.py)
+- vLLM Ascend, [official image-build hardware suffix matrix](https://github.com/vllm-project/vllm-ascend/blob/main/.github/workflows/schedule_image_build_and_push.yaml)
+
 ## Image selection policy
 
 Image selection is an explicit decision gate, not an implicit default:
 
 1. ask the user to choose `local-latest`, `rc`, `main`, `stable`, or a custom image reference before new-machine bootstrap
-2. `local-latest` enumerates every image in the target host Docker daemon, keeps references whose repository basename contains `vllm-ascend` (so registry / namespace prefixes and repository-name prefixes or suffixes are supported), filters by the detected A2 / A3 / 310P tag suffix, and selects the newest compatible image by Docker `Created`; it does not pull
+2. `local-latest` enumerates every image in the target host Docker daemon, keeps references whose repository basename contains `vllm-ascend` (so registry / namespace prefixes and repository-name prefixes or suffixes are supported), filters by the detected A2 / A3 / A5 / 310P tag suffix, and selects the newest compatible image by Docker `Created`; it does not pull
 3. host probe reports the filtered local image set, selected reference, selected immutable image ID, and creation time; bootstrap repeats discovery so deployment uses current host state
 4. an existing container satisfies `local-latest` only when its source image ID matches the newly selected image ID; matching tag text alone is insufficient
 5. `rc` resolves the newest official prerelease `vllm-ascend` tag at execution time, then tries `quay.nju.edu.cn/ascend/vllm-ascend:<tag>` first and `quay.io/ascend/vllm-ascend:<tag>` second; this is the recommended developer track
@@ -260,6 +292,7 @@ Image selection is an explicit decision gate, not an implicit default:
 8. custom references must include a concrete non-`latest` tag or digest; `auto`, direct `*:latest`, and bare repositories without a tag are forbidden defaults
 9. if fresh pulls fail but one of the explicit candidate refs is already cached locally, reuse that cached image as a bounded fallback
 10. for non-destructive attach / repair, a recorded explicit non-`latest` image may be reused; ambiguous legacy images require another user choice
+11. selector-based image tags are hardware-specific: base for A2, `-a3` for A3, `-a5` for A5, and `-310p` for 310P
 
 Inventory should record the actual selected image, not only the requested selector string.
 

--- a/.agents/skills/machine-management/references/command-recipes.md
+++ b/.agents/skills/machine-management/references/command-recipes.md
@@ -38,7 +38,7 @@ python3 .agents/skills/machine-management/scripts/machine_add.py \
   --image rc
 ```
 
-The wrapper will detect A2 / A3 / 310P from `npu-smi` when possible and append `-a3` or `-310p` automatically for selector-based images.
+The wrapper detects A2 / A3 / A5 / 310P from detailed `npu-smi` board fields when possible and appends `-a3`, `-a5`, or `-310p` automatically for selector-based images. For A3 the probe prefers the combined `Chip Name + NPU Name` result (for example `Ascend910_9362`); an exact bare `Ascend910` token is retained only as a compatibility fallback.
 
 To scan all images already present in the target host Docker daemon, filter the machine-compatible `vllm-ascend` images, and deploy the newest by image creation time without pulling:
 

--- a/.agents/skills/machine-management/scripts/inventory.py
+++ b/.agents/skills/machine-management/scripts/inventory.py
@@ -38,7 +38,7 @@ SCHEMA_VERSION = 1
 STATE_LOCK_SUFFIX = ".lock"
 DEFAULT_LOCK_TIMEOUT_SECONDS = 15.0
 DEFAULT_LOCK_POLL_SECONDS = 0.05
-MACHINE_TYPE_CHOICES = ("A2", "A3", "310P")
+MACHINE_TYPE_CHOICES = ("A2", "A3", "A5", "310P")
 
 
 class InventoryError(RuntimeError):
@@ -470,7 +470,7 @@ def build_parser() -> argparse.ArgumentParser:
     put_cmd.add_argument("--host-ip", "--host", dest="host_ip", required=True)
     put_cmd.add_argument("--host-port", "--host-ssh-port", dest="host_port", type=int, default=22)
     put_cmd.add_argument("--host-user", "--user", dest="host_user", default="root")
-    put_cmd.add_argument("--host-machine-type", "--machine-type", dest="host_machine_type", help="host machine type metadata, for example A2, A3, or 310P")
+    put_cmd.add_argument("--host-machine-type", "--machine-type", dest="host_machine_type", help="host machine type metadata, for example A2, A3, A5, or 310P")
     put_cmd.add_argument("--host-soc", "--soc", dest="host_soc", help="host SoC token metadata, for example ascend910b1")
     put_cmd.add_argument("--container-name", "--name", dest="container_name", required=True)
     put_cmd.add_argument(
@@ -490,7 +490,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--container-machine-type",
         "--container-type",
         dest="container_machine_type",
-        help="container hardware type metadata, for example A2, A3, or 310P",
+        help="container hardware type metadata, for example A2, A3, A5, or 310P",
     )
     put_cmd.add_argument(
         "--bootstrap-method",
@@ -521,7 +521,7 @@ def build_parser() -> argparse.ArgumentParser:
     upsert_cmd.add_argument("--host-ip", "--host", dest="host_ip", required=True)
     upsert_cmd.add_argument("--host-port", "--host-ssh-port", dest="host_port", type=int, default=22)
     upsert_cmd.add_argument("--host-user", "--user", dest="host_user", default="root")
-    upsert_cmd.add_argument("--host-machine-type", "--machine-type", dest="host_machine_type", help="host machine type metadata, for example A2, A3, or 310P")
+    upsert_cmd.add_argument("--host-machine-type", "--machine-type", dest="host_machine_type", help="host machine type metadata, for example A2, A3, A5, or 310P")
     upsert_cmd.add_argument("--host-soc", "--soc", dest="host_soc", help="host SoC token metadata, for example ascend910b1")
     upsert_cmd.add_argument("--container-name", "--name", dest="container_name", required=True)
     upsert_cmd.add_argument(
@@ -541,7 +541,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--container-machine-type",
         "--container-type",
         dest="container_machine_type",
-        help="container hardware type metadata, for example A2, A3, or 310P",
+        help="container hardware type metadata, for example A2, A3, A5, or 310P",
     )
     upsert_cmd.add_argument(
         "--bootstrap-method",

--- a/.agents/skills/machine-management/scripts/machine_add.py
+++ b/.agents/skills/machine-management/scripts/machine_add.py
@@ -252,7 +252,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "blocked",
                     success=False,
                     action="detect-machine-type",
-                    message="host probe succeeded but machine type could not be inferred; rerun with --machine-type A2|A3|310P",
+                    message="host probe succeeded but machine type could not be inferred; rerun with --machine-type A2|A3|A5|310P",
                     probe=probe,
                 )
             )

--- a/.agents/skills/machine-management/scripts/machine_repair.py
+++ b/.agents/skills/machine-management/scripts/machine_repair.py
@@ -201,7 +201,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "blocked",
                     success=False,
                     action="detect-machine-type",
-                    message="host probe succeeded but machine type could not be inferred; rerun with --machine-type A2|A3|310P",
+                    message="host probe succeeded but machine type could not be inferred; rerun with --machine-type A2|A3|A5|310P",
                     machine=machine_summary(record),
                     probe=probe,
                 )

--- a/.agents/skills/machine-management/scripts/manage_machine.py
+++ b/.agents/skills/machine-management/scripts/manage_machine.py
@@ -92,10 +92,11 @@ SEMVER_TAG_PATTERN = re.compile(
     r"^v?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:(?P<kind>rc)(?P<kind_number>\d+))?$",
     re.IGNORECASE,
 )
-MACHINE_TYPE_CHOICES = ("A2", "A3", "310P")
+MACHINE_TYPE_CHOICES = ("A2", "A3", "A5", "310P")
 IMAGE_SUFFIX_BY_MACHINE_TYPE = {
     "A2": "",
     "A3": "-a3",
+    "A5": "-a5",
     "310P": "-310p",
 }
 SOC_TO_MACHINE_TYPE = {
@@ -124,6 +125,8 @@ SOC_TO_MACHINE_TYPE = {
     "ascend310p3vir08": "310P",
 }
 SOC_MATCH_ORDER = sorted(SOC_TO_MACHINE_TYPE, key=len, reverse=True)
+ASCEND_950_SOC_PATTERN = re.compile(r"\bascend950[a-z0-9_-]*", re.IGNORECASE)
+BARE_ASCEND_910_PATTERN = re.compile(r"\bascend910\b", re.IGNORECASE)
 
 
 LOCAL_IMAGE_DISCOVERY_PY = r'''
@@ -144,6 +147,8 @@ def _vaws_image_ref_machine_type(ref):
     if last_colon <= last_slash:
         return None
     tag = ref[last_colon + 1:].lower()
+    if any(marker in tag for marker in ("-a5", "-950dt", "-950pr")):
+        return "A5"
     if "-310p" in tag:
         return "310P"
     if "-a3" in tag:
@@ -248,7 +253,7 @@ def normalize_machine_type(value: str | None) -> str | None:
     normalized = value.strip().upper().replace("_", "")
     if normalized == "310P":
         return "310P"
-    if normalized in {"A2", "A3"}:
+    if normalized in {"A2", "A3", "A5"}:
         return normalized
     raise MachineManagementError(
         f"unsupported machine type {value!r}; expected one of: {', '.join(MACHINE_TYPE_CHOICES)}"
@@ -262,13 +267,72 @@ def normalize_soc_token(value: str | None) -> str | None:
     return normalized or None
 
 
+def npu_smi_value(text: str | None, field: str) -> str | None:
+    """Return one labelled value from npu-smi's colon-delimited output."""
+    if not text:
+        return None
+    pattern = re.compile(
+        rf"^\s*{re.escape(field)}\s*:\s*(.*?)\s*$", re.IGNORECASE | re.MULTILINE
+    )
+    match = pattern.search(text)
+    if match is None:
+        return None
+    value = match.group(1).strip()
+    return value or None
+
+
+def canonical_soc_from_board_text(text: str | None) -> str | None:
+    """Build the full SoC token from a detailed ``npu-smi -t board`` result.
+
+    A2/310P report the architecture prefix in ``Chip Type``. A3 and A5 report
+    the distinguishing part in ``NPU Name``. This mirrors the official CANN
+    query contract and vllm-ascend's setup-time chip detection.
+    """
+    chip_name = npu_smi_value(text, "Chip Name")
+    if not chip_name:
+        return None
+    chip_type = npu_smi_value(text, "Chip Type")
+    npu_name = npu_smi_value(text, "NPU Name")
+    normalized_chip_name = re.sub(r"\s+", "", chip_name)
+    normalized_chip_type = re.sub(r"\s+", "", chip_type or "")
+    normalized_npu_name = re.sub(r"\s+", "", npu_name or "")
+    lowered_chip_name = normalized_chip_name.lower()
+
+    if "310" in lowered_chip_name and normalized_chip_type:
+        return normalize_soc_token(normalized_chip_type + normalized_chip_name)
+    if "910" in lowered_chip_name:
+        if normalized_chip_type:
+            return normalize_soc_token(normalized_chip_type + normalized_chip_name)
+        if normalized_npu_name:
+            return normalize_soc_token(
+                f"{normalized_chip_name}_{normalized_npu_name}"
+            )
+    if "950" in lowered_chip_name and normalized_npu_name:
+        return normalize_soc_token(f"{normalized_chip_name}_{normalized_npu_name}")
+    return normalize_soc_token(normalized_chip_name)
+
+
+def machine_type_from_soc(soc: str | None) -> str | None:
+    normalized = normalize_soc_token(soc)
+    if normalized is None:
+        return None
+    if normalized.startswith("ascend950"):
+        return "A5"
+    return SOC_TO_MACHINE_TYPE.get(normalized)
+
+
 def detect_machine_type_from_text(text: str | None) -> tuple[str | None, str | None]:
     if not text:
         return None, None
     normalized = text.lower()
+    ascend_950_match = ASCEND_950_SOC_PATTERN.search(normalized)
+    if ascend_950_match is not None:
+        return ascend_950_match.group(0).lower(), "A5"
     for token in SOC_MATCH_ORDER:
         if token in normalized:
             return token, SOC_TO_MACHINE_TYPE[token]
+    if BARE_ASCEND_910_PATTERN.search(normalized) is not None:
+        return "ascend910", "A3"
     return None, None
 
 
@@ -320,6 +384,8 @@ def infer_machine_type_from_image(ref: str | None) -> str | None:
     if tag is None:
         return None
     lowered = tag.lower()
+    if any(marker in lowered for marker in ("-a5", "-950dt", "-950pr")):
+        return "A5"
     if "-310p" in lowered:
         return "310P"
     if "-a3" in lowered:
@@ -1127,6 +1193,7 @@ fi
 import json
 import os
 import pathlib
+import re
 import shutil
 import socket
 import subprocess
@@ -1177,6 +1244,9 @@ result: dict[str, object] = {
         "commands": [],
         "detected_soc": None,
         "machine_type": None,
+        "detection_source": None,
+        "persisted_soc": None,
+        "persisted_machine_type": None,
         "success": False,
         "sourced_scripts": [line for line in sourced_scripts.splitlines() if line],
         "env": {
@@ -1269,13 +1339,10 @@ if result["docker"]["present"]:
                 rows.append({"name": name, "status": status, "image": actual_image})
         result["managed_containers"] = rows
 
-combined_probe_text: list[str] = []
-for label, cmd in [
-    ("info", ["npu-smi", "info"]),
-    ("info-list", ["npu-smi", "info", "-l"]),
-    ("board-0", ["npu-smi", "info", "-t", "board", "-i", "0"]),
-    ("common-0", ["npu-smi", "info", "-t", "common", "-i", "0"]),
-]:
+fresh_probe_text: list[str] = []
+
+
+def probe_command(label: str, cmd: list[str]) -> str:
     rc, out, err = run(cmd, env=os.environ.copy())
     entry = {
         "label": label,
@@ -1288,20 +1355,142 @@ for label, cmd in [
     if rc == 0:
         result["npu_probe"]["success"] = True
         if out:
-            combined_probe_text.append(out)
+            fresh_probe_text.append(out)
         if err:
-            combined_probe_text.append(err)
+            fresh_probe_text.append(err)
+    return out if rc == 0 else ""
+
+
+def npu_smi_value(text: str, field: str) -> Optional[str]:
+    match = re.search(
+        rf"^\s*{re.escape(field)}\s*:\s*(.*?)\s*$",
+        text,
+        flags=re.IGNORECASE | re.MULTILINE,
+    )
+    if match is None:
+        return None
+    value = match.group(1).strip()
+    return value or None
+
+
+def first_npu_chip_ids(text: str) -> tuple[Optional[int], Optional[int]]:
+    for line in text.splitlines():
+        parts = line.split()
+        if len(parts) < 3 or not parts[0].isdigit() or not parts[1].isdigit():
+            continue
+        if any(part.lower().startswith("ascend") for part in parts[2:]):
+            return int(parts[0]), int(parts[1])
+    return None, None
+
+
+def canonical_soc_from_board_text(text: str) -> Optional[str]:
+    chip_name = npu_smi_value(text, "Chip Name")
+    if not chip_name:
+        return None
+    chip_type = npu_smi_value(text, "Chip Type")
+    npu_name = npu_smi_value(text, "NPU Name")
+    chip_name = re.sub(r"\s+", "", chip_name)
+    chip_type = re.sub(r"\s+", "", chip_type or "")
+    npu_name = re.sub(r"\s+", "", npu_name or "")
+    lowered_chip_name = chip_name.lower()
+    if "310" in lowered_chip_name and chip_type:
+        return (chip_type + chip_name).lower()
+    if "910" in lowered_chip_name:
+        if chip_type:
+            return (chip_type + chip_name).lower()
+        if npu_name:
+            return f"{chip_name}_{npu_name}".lower()
+    if "950" in lowered_chip_name and npu_name:
+        return f"{chip_name}_{npu_name}".lower()
+    return chip_name.lower()
+
+
+def machine_type_from_soc(soc: Optional[str]) -> Optional[str]:
+    if not soc:
+        return None
+    normalized = soc.strip().lower()
+    if normalized.startswith("ascend950"):
+        return "A5"
+    return SOC_TO_MACHINE_TYPE.get(normalized)
+
+
+def detect_from_text(text: str) -> tuple[Optional[str], Optional[str]]:
+    normalized = text.lower()
+    ascend_950_match = re.search(r"\bascend950[a-z0-9_-]*", normalized)
+    if ascend_950_match is not None:
+        return ascend_950_match.group(0), "A5"
+    for token in SOC_MATCH_ORDER:
+        if token in normalized:
+            return token, SOC_TO_MACHINE_TYPE[token]
+    if re.search(r"\bascend910\b", normalized) is not None:
+        return "ascend910", "A3"
+    return None, None
+
+
+probe_command("info", ["npu-smi", "info"])
+info_list = probe_command("info-list", ["npu-smi", "info", "-l"])
+info_map = probe_command("info-map", ["npu-smi", "info", "-m"])
+
+npu_id_text = npu_smi_value(info_list, "NPU ID")
+npu_id = int(npu_id_text) if npu_id_text and npu_id_text.isdigit() else 0
+mapped_npu_id, mapped_chip_id = first_npu_chip_ids(info_map)
+if mapped_npu_id is not None:
+    npu_id = mapped_npu_id
+chip_id = mapped_chip_id if mapped_chip_id is not None else 0
+result["npu_probe"]["query_npu_id"] = npu_id
+result["npu_probe"]["query_chip_id"] = chip_id
+
+board_device = probe_command(
+    "board-device",
+    ["npu-smi", "info", "-t", "board", "-i", str(npu_id)],
+)
+board_chip = probe_command(
+    "board-chip",
+    [
+        "npu-smi",
+        "info",
+        "-t",
+        "board",
+        "-i",
+        str(npu_id),
+        "-c",
+        str(chip_id),
+    ],
+)
+probe_command(
+    "common-device",
+    ["npu-smi", "info", "-t", "common", "-i", str(npu_id)],
+)
+
+board_device_soc = canonical_soc_from_board_text(board_device)
+board_chip_soc = canonical_soc_from_board_text(board_chip)
+precise_candidates = [
+    ("board-device", board_device_soc),
+    ("board-chip", board_chip_soc),
+]
+for source, soc in precise_candidates:
+    machine_type = machine_type_from_soc(soc)
+    if machine_type is not None:
+        result["npu_probe"]["detected_soc"] = soc
+        result["npu_probe"]["machine_type"] = machine_type
+        result["npu_probe"]["detection_source"] = source
+        break
+
+if result["npu_probe"]["machine_type"] is None:
+    soc, machine_type = detect_from_text("\n".join(fresh_probe_text))
+    if machine_type is not None:
+        result["npu_probe"]["detected_soc"] = soc
+        result["npu_probe"]["machine_type"] = machine_type
+        result["npu_probe"]["detection_source"] = "npu-smi-text"
 
 soc_from_env = os.environ.get("SOC_VERSION") or os.environ.get("VAWS_NPU_SOC")
-if soc_from_env:
-    combined_probe_text.append(soc_from_env)
-
-normalized_probe_text = "\n".join(combined_probe_text).lower()
-for token in SOC_MATCH_ORDER:
-    if token in normalized_probe_text:
-        result["npu_probe"]["detected_soc"] = token
-        result["npu_probe"]["machine_type"] = SOC_TO_MACHINE_TYPE[token]
-        break
+persisted_soc, persisted_machine_type = detect_from_text(soc_from_env or "")
+result["npu_probe"]["persisted_soc"] = persisted_soc
+result["npu_probe"]["persisted_machine_type"] = persisted_machine_type
+if result["npu_probe"]["machine_type"] is None and persisted_machine_type is not None:
+    result["npu_probe"]["detected_soc"] = persisted_soc
+    result["npu_probe"]["machine_type"] = persisted_machine_type
+    result["npu_probe"]["detection_source"] = "persisted-env-fallback"
 
 result["detected_soc"] = result["npu_probe"]["detected_soc"]
 result["machine_type"] = result["npu_probe"]["machine_type"]
@@ -1313,6 +1502,15 @@ result["prerequisites_ok"] = bool(
 result["warnings"] = []
 if result["machine_type"] is None:
     result["warnings"].append("machine type could not be inferred from npu-smi output; pass an explicit override if needed")
+if (
+    result["npu_probe"]["detection_source"] != "persisted-env-fallback"
+    and persisted_soc is not None
+    and result["detected_soc"] is not None
+    and persisted_soc != result["detected_soc"]
+):
+    result["warnings"].append(
+        "persisted SOC metadata differs from the fresh npu-smi board query; using the fresh hardware result"
+    )
 
 if image.get("policy") == "__LOCAL_IMAGE_DISCOVERY_POLICY__":
     discovery_machine_type = image.get("machine_type") or result["machine_type"]
@@ -1512,6 +1710,10 @@ infer_type_from_image() {
   image_ref="$1"
   lowered="$(printf '%s' "$image_ref" | tr '[:upper:]' '[:lower:]')"
   case "$lowered" in
+    *-a5*|*-950dt*|*-950pr*)
+      printf 'A5\n'
+      return 0
+      ;;
     *-310p*)
       printf '310P\n'
       return 0

--- a/.agents/skills/machine-management/tests/test_image_selection.py
+++ b/.agents/skills/machine-management/tests/test_image_selection.py
@@ -37,6 +37,30 @@ class LocalLatestImageTests(unittest.TestCase):
         self.assertEqual(resolution.mirror_order, ())
         self.assertEqual(resolution.machine_type, "A3")
 
+    def test_discovery_recognizes_a5_image_suffixes(self) -> None:
+        images = [
+            {
+                "Id": "sha256:a5",
+                "Created": "2026-09-02T12:00:00Z",
+                "RepoTags": [
+                    "quay.io/ascend/vllm-ascend:main-a5",
+                    "quay.io/ascend/vllm-ascend:v0.12.0-950dt",
+                ],
+                "RepoDigests": [],
+            },
+            {
+                "Id": "sha256:a3",
+                "Created": "2026-09-02T13:00:00Z",
+                "RepoTags": ["quay.io/ascend/vllm-ascend:main-a3"],
+                "RepoDigests": [],
+            },
+        ]
+
+        result = discover(images, "A5")
+
+        self.assertEqual(result["eligible_count"], 1)
+        self.assertEqual(result["selected_image_id"], "sha256:a5")
+
     def test_discovery_filters_repository_and_machine_type_then_uses_created_time(self) -> None:
         images = [
             {

--- a/.agents/skills/machine-management/tests/test_machine_type_detection.py
+++ b/.agents/skills/machine-management/tests/test_machine_type_detection.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Focused regression tests for npu-smi hardware detection."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import manage_machine as machine_ops  # noqa: E402
+
+
+class NpuSmiDetectionTests(unittest.TestCase):
+    def test_a3_combines_generic_chip_name_and_npu_name(self) -> None:
+        board = """
+        NPU Name                      : 9362
+        Chip Name                     : Ascend910
+        Chip Version                  : V1
+        """
+        soc = machine_ops.canonical_soc_from_board_text(board)
+        self.assertEqual(soc, "ascend910_9362")
+        self.assertEqual(machine_ops.machine_type_from_soc(soc), "A3")
+
+    def test_a2_combines_chip_type_and_chip_name(self) -> None:
+        board = """
+        Chip Name                     : 910B4
+        Chip Type                     : Ascend
+        """
+        soc = machine_ops.canonical_soc_from_board_text(board)
+        self.assertEqual(soc, "ascend910b4")
+        self.assertEqual(machine_ops.machine_type_from_soc(soc), "A2")
+
+    def test_310p_combines_chip_type_and_chip_name(self) -> None:
+        board = """
+        Chip Name                     : 310P3
+        Chip Type                     : Ascend
+        """
+        soc = machine_ops.canonical_soc_from_board_text(board)
+        self.assertEqual(soc, "ascend310p3")
+        self.assertEqual(machine_ops.machine_type_from_soc(soc), "310P")
+
+    def test_a5_accepts_the_ascend950_soc_family(self) -> None:
+        board = """
+        NPU Name                      : 1910
+        Chip Name                     : Ascend950DT
+        """
+        soc = machine_ops.canonical_soc_from_board_text(board)
+        self.assertEqual(soc, "ascend950dt_1910")
+        self.assertEqual(machine_ops.machine_type_from_soc(soc), "A5")
+        self.assertEqual(
+            machine_ops.detect_machine_type_from_text("SOC_VERSION=Ascend950DT_1910"),
+            ("ascend950dt_1910", "A5"),
+        )
+
+    def test_bare_ascend910_is_an_a3_compatibility_fallback(self) -> None:
+        self.assertEqual(
+            machine_ops.detect_machine_type_from_text("Chip Name: Ascend910"),
+            ("ascend910", "A3"),
+        )
+
+    def test_a5_selector_and_explicit_image_suffixes_are_recognized(self) -> None:
+        self.assertEqual(machine_ops.image_tag_for_machine("main", "A5"), "main-a5")
+        for tag in ("v0.13.0-a5", "v0.13.0-a5-openeuler", "v0.12.0-950dt"):
+            with self.subTest(tag=tag):
+                self.assertEqual(
+                    machine_ops.infer_machine_type_from_image(
+                        f"quay.io/ascend/vllm-ascend:{tag}"
+                    ),
+                    "A5",
+                )
+
+    def test_remote_probe_uses_precise_board_queries_before_env_fallback(self) -> None:
+        rendered = machine_ops.render_host_probe_script()
+        self.assertIn('["npu-smi", "info", "-m"]', rendered)
+        self.assertIn('"board-device"', rendered)
+        self.assertIn('"board-chip"', rendered)
+        self.assertLess(
+            rendered.index('precise_candidates = ['),
+            rendered.index('soc_from_env = os.environ.get("SOC_VERSION")'),
+        )
+        self.assertIn('"persisted-env-fallback"', rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make fresh detailed `npu-smi` board queries authoritative over persisted `SOC_VERSION` / `VAWS_NPU_SOC` metadata
- derive canonical SoC identifiers from `Chip Type`, `Chip Name`, and `NPU Name`, including `Ascend910 + 9362 -> ascend910_9362 / A3`
- retain exact bare `Ascend910` as an A3 compatibility fallback when detailed board fields are unavailable
- add A5 / `ascend950*` detection and `-a5` support for selector and `local-latest` image paths
- report persisted-versus-hardware SoC drift and document the official CANN/vLLM-Ascend detection contract

## Validation

- `pytest -q .agents/skills/machine-management/tests .agents/tests/test_shared_inventory_state.py .agents/tests/test_vaws_scaffold_safety.py` — 36 passed
- machine-management skill package validation passed
- embedded remote Python compiled and generated probe/bootstrap shell passed `bash -n`
- read-only K3 probes on `192.168.13.153`–`156` all resolved to `ascend910_9362 / A3` through `board-chip`
- after rebasing onto current `origin/main`, `192.168.13.153` was rechecked and still resolved to `ascend910_9362 / A3`; stale persisted `ascend910_9391` was surfaced as a warning and did not override hardware

## References

- Huawei CANN SoC query guidance: https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/910beta2/API/ascendcopapi/atlasascendc_api_07_1039.html
- vLLM Ascend setup-time hardware detection: https://github.com/vllm-project/vllm-ascend/blob/main/setup.py
