### PR TITLE
feat: agent feedback contract — Result Envelope v1 with explicit failure-layer attribution

### DIFF
--- a/.agents/lib/vaws_result_envelope.py
+++ b/.agents/lib/vaws_result_envelope.py
@@ -1,0 +1,1456 @@
+#!/usr/bin/env python3
+"""Shared Result Envelope v1: the agent-facing diagnosability contract.
+
+Every workspace entry point should return one envelope on ``stdout``, in
+success and in failure, so that an agent can locate the failing layer
+without re-running the operation.
+
+Design notes live in ``docs/agent-feedback-contract.md``. The machine
+readable contract is ``.agents/schemas/result-envelope-v1.schema.json``;
+this module is the authoritative validator because ``jsonschema`` is not
+guaranteed to be installed on a client machine.
+
+Two serialization modes exist on purpose:
+
+* ``dumps(envelope)`` keeps full runtime fidelity (hosts, ports, absolute
+  paths) and is only ever safe to write under untracked ``.vaws-local/``.
+* ``dumps_publishable(envelope)`` redacts first and refuses to emit if a
+  leak pattern survives redaction. Use it for anything that may end up in
+  a tracked file, a PR body, or a knowledge candidate.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import sys
+import uuid
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping, MutableMapping, Sequence
+
+SCHEMA_VERSION = "vaws.result-envelope.v1"
+SCHEMA_MAJOR = 1
+ACCEPTED_SCHEMA_VERSIONS = frozenset({SCHEMA_VERSION})
+
+PROGRESS_SENTINEL = "__VAWS_PROGRESS__="
+
+# ---------------------------------------------------------------------------
+# Controlled vocabularies
+# ---------------------------------------------------------------------------
+
+OUTCOMES = frozenset({"success", "partial", "failure", "blocked", "cancelled"})
+FAILING_OUTCOMES = frozenset({"partial", "failure", "blocked"})
+
+#: The failure taxonomy. The point of the taxonomy is that a confident wrong
+#: attribution costs more than an honest ``unknown``, so ``unknown`` is a
+#: first-class member and every other member requires stated evidence.
+LAYERS = (
+    "caller",
+    "tool",
+    "transport",
+    "remote_env",
+    "remote_workload",
+    "device",
+    "unknown",
+)
+LAYER_SET = frozenset(LAYERS)
+
+LAYER_DESCRIPTIONS: Mapping[str, str] = {
+    "caller": "the invocation was wrong (bad arguments, missing target, "
+    "unsupported flag combination); nothing was attempted downstream",
+    "tool": "the local wrapper, shared library, or tool service itself "
+    "misbehaved (crash, non-JSON output, instant timeout from the tool "
+    "service rather than from the remote command)",
+    "transport": "SSH, network, port forwarding, or connection multiplexing "
+    "failed before the remote command produced a result",
+    "remote_env": "the remote container environment is wrong (missing path, "
+    "import error, version mismatch, missing hostname mapping)",
+    "remote_workload": "the command under test ran and failed on its own "
+    "terms; this is the only layer that says 'the code under test is guilty'",
+    "device": "NPU or another exclusive resource was unavailable, busy, or "
+    "the lease was denied",
+    "unknown": "the evidence does not identify a layer; say so instead of "
+    "guessing, and state in next_step what would narrow it",
+}
+
+CONFIDENCES = frozenset({"high", "medium", "low"})
+TARGET_KINDS = frozenset(
+    {"local", "host", "container", "session", "fleet", "service", "unknown"}
+)
+ENVIRONMENT_SOURCES = frozenset(
+    {"probe", "manifest", "declared", "cache", "unknown"}
+)
+IDEMPOTENCY_CLASSES = frozenset(
+    {"idempotent", "at_most_once", "unsafe_to_retry", "unknown"}
+)
+PART_OUTCOMES = frozenset({"success", "failure", "blocked", "skipped"})
+
+#: Environment identity at the granularity the knowledge base compares on.
+ENVIRONMENT_FIELDS = (
+    "soc",
+    "cann",
+    "driver",
+    "torch",
+    "torch_npu",
+    "vllm",
+    "vllm_ascend",
+)
+
+#: Well-known reason codes. The validator only enforces the shape, so skills
+#: may add their own; reuse these when they fit so that fingerprints stay
+#: comparable across skills.
+REASON_CODES: Mapping[str, str] = {
+    "bad_arguments": "caller",
+    "missing_target": "caller",
+    "consent_required": "caller",
+    "wrapper_crash": "tool",
+    "non_json_output": "tool",
+    "tool_service_instant_timeout": "tool",
+    "ssh_connect_failed": "transport",
+    "ssh_mux_stream_died": "transport",
+    "remote_timeout": "transport",
+    "import_error": "remote_env",
+    "version_mismatch": "remote_env",
+    "path_missing": "remote_env",
+    "hostname_unresolvable": "remote_env",
+    "workload_nonzero_exit": "remote_workload",
+    "workload_assertion_failed": "remote_workload",
+    "service_not_ready": "remote_workload",
+    "npu_busy": "device",
+    "lease_denied": "device",
+    "unattributed": "unknown",
+}
+
+REASON_CODE_RE = re.compile(r"^[a-z][a-z0-9_]{1,63}$")
+RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
+ENVELOPE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+
+TOP_LEVEL_FIELDS = (
+    "schema_version",
+    "envelope_id",
+    "emitted_at",
+    "operation",
+    "outcome",
+    "exit_code",
+    "summary",
+    "attempt",
+    "failure",
+    "environment",
+    "evidence",
+    "next_step",
+    "parts",
+    "attempts",
+    "children",
+    "warnings",
+    "extensions",
+)
+TOP_LEVEL_SET = frozenset(TOP_LEVEL_FIELDS)
+
+# ---------------------------------------------------------------------------
+# Bounded output (same head/tail preview shape as .remote-dev/core/preview.py)
+# ---------------------------------------------------------------------------
+
+DEFAULT_HEAD_CHARS = 4000
+DEFAULT_TAIL_CHARS = 4000
+MAX_SUMMARY_CHARS = 400
+
+
+class EnvelopeError(ValueError):
+    """Raised when an envelope violates the v1 contract."""
+
+
+class EnvelopeRedactionError(EnvelopeError):
+    """Raised when a publishable serialization would still leak identity."""
+
+
+def utc_now() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def new_envelope_id(prefix: str = "env") -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dt%H%M%Sz")
+    token = re.sub(r"[^a-z0-9]+", "-", prefix.lower()).strip("-") or "env"
+    return f"{token}-{stamp}-{uuid.uuid4().hex[:8]}"
+
+
+def text_preview(
+    value: str,
+    *,
+    ref: str | None = None,
+    head_chars: int = DEFAULT_HEAD_CHARS,
+    tail_chars: int = DEFAULT_TAIL_CHARS,
+) -> dict[str, Any]:
+    """Bounded text preview with a pointer to the full content.
+
+    Field names intentionally match ``.remote-dev/core/preview.py`` so that a
+    remote-dev result can be lifted into an envelope without reshaping. The
+    added ``ref`` is what makes truncation safe: a truncated preview without
+    a ref is rejected by :func:`validate_envelope`.
+    """
+    byte_count = len(value.encode("utf-8", errors="replace"))
+    payload: dict[str, Any] = {
+        "bytes": byte_count,
+        "head_chars": head_chars,
+        "tail_chars": tail_chars,
+        "ref": ref,
+    }
+    if len(value) <= head_chars + tail_chars:
+        payload["text"] = value
+        payload["truncated"] = False
+        return payload
+    payload["head"] = value[:head_chars]
+    payload["tail"] = value[-tail_chars:]
+    payload["truncated"] = True
+    return payload
+
+
+def evidence_ref(
+    *,
+    name: str,
+    kind: str,
+    ref: str,
+    bytes_: int | None = None,
+    sha256: str | None = None,
+    note: str | None = None,
+) -> dict[str, Any]:
+    """One evidence pointer. ``ref`` is a locator, never inlined content."""
+    return {
+        "name": name,
+        "kind": kind,
+        "ref": ref,
+        "bytes": bytes_,
+        "sha256": sha256,
+        "note": note,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+#: Only literals that identify nothing survive redaction. RFC 5737
+#: documentation ranges are deliberately *not* on this list: a redactor that
+#: has to reason about whether an address is "safe" is a redactor that will
+#: eventually be wrong, and loopback is the only address a diagnosis actually
+#: needs to keep.
+_SAFE_IPV4 = (
+    re.compile(r"^127\."),
+    re.compile(r"^0\.0\.0\.0$"),
+    re.compile(r"^255\.255\.255\.255$"),
+)
+_IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+_IPV6_RE = re.compile(r"\b(?:[0-9A-Fa-f]{1,4}:){2,7}[0-9A-Fa-f]{1,4}\b")
+_USER_AT_HOST_RE = re.compile(r"\b[\w.+-]{1,64}@[\w.-]{1,255}\b")
+_HOME_PATH_RE = re.compile(r"(?:/Users|/home)/[^/\s\"']+")
+_WINDOWS_HOME_RE = re.compile(r"[A-Za-z]:\\\\?Users\\\\?[^\\\s\"']+")
+#: Shared data roots that live under ``/home`` on Ascend hosts but name no
+#: user. Model paths are load-bearing diagnostic information — losing them
+#: would make two results incomparable for the sake of hiding nothing.
+_SAFE_HOME_PREFIXES = (
+    "/home/weights",
+    "/home/models",
+    "/home/data",
+    "/home/cache",
+    "/home/shared",
+)
+_SECRET_KEY_RE = re.compile(
+    r"(?:^|_)(?:api_?key|access_?key|auth|credential|pass(?:word)?|secret|token)"
+    r"(?:_|$)",
+    re.IGNORECASE,
+)
+_SECRET_VALUE_RES = (
+    re.compile(r"\b(?:gh[pousr]|github_pat)_[A-Za-z0-9_]{16,}\b"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._\-]{12,}\b", re.IGNORECASE),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+)
+_SAFE_HOST_SUFFIXES = (".invalid", ".example", ".example.com", ".localhost")
+
+REDACTED_HOST = "<redacted-host>"
+REDACTED_USER = "<redacted-user>"
+REDACTED_SECRET = "<redacted-secret>"
+REDACTED_HOME = "<redacted-home>"
+
+
+def _ipv4_is_safe(value: str) -> bool:
+    return any(pattern.search(value) for pattern in _SAFE_IPV4)
+
+
+def _home_path_is_safe(value: str) -> bool:
+    return value.startswith(_SAFE_HOME_PREFIXES)
+
+
+def _host_is_safe(value: str) -> bool:
+    lowered = value.lower()
+    if lowered in {"localhost", "example.invalid"}:
+        return True
+    return any(lowered.endswith(suffix) for suffix in _SAFE_HOST_SUFFIXES)
+
+
+def redact_text(value: str) -> str:
+    """Replace runtime identity with stable placeholders.
+
+    Loopback addresses and ``*.invalid`` / ``*.example`` hostnames survive:
+    they identify nothing and a diagnosis is much harder to read without
+    them. Everything else that looks like an address, a ``user@host`` pair, a
+    home directory or a credential is replaced.
+    """
+    result = value
+    for pattern in _SECRET_VALUE_RES:
+        result = pattern.sub(REDACTED_SECRET, result)
+
+    def _mask_user_at_host(match: re.Match[str]) -> str:
+        text = match.group(0)
+        user, _, host = text.partition("@")
+        if _host_is_safe(host) or (
+            _IPV4_RE.fullmatch(host) and _ipv4_is_safe(host)
+        ):
+            return f"{REDACTED_USER}@{host}"
+        return f"{REDACTED_USER}@{REDACTED_HOST}"
+
+    result = _USER_AT_HOST_RE.sub(_mask_user_at_host, result)
+    result = _IPV4_RE.sub(
+        lambda m: m.group(0) if _ipv4_is_safe(m.group(0)) else REDACTED_HOST,
+        result,
+    )
+    result = _IPV6_RE.sub(
+        lambda m: m.group(0) if m.group(0) in {"::1"} else REDACTED_HOST,
+        result,
+    )
+    result = _HOME_PATH_RE.sub(
+        lambda m: m.group(0) if _home_path_is_safe(m.group(0)) else REDACTED_HOME,
+        result,
+    )
+    result = _WINDOWS_HOME_RE.sub(REDACTED_HOME, result)
+    return result
+
+
+def _redact_value(key: str | None, value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(k): _redact_value(str(k), v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_redact_value(key, item) for item in value]
+    if isinstance(value, str):
+        if key is not None and _SECRET_KEY_RE.search(key):
+            return REDACTED_SECRET
+        return redact_text(value)
+    return value
+
+
+def redact(envelope: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a deep copy with runtime identity replaced by placeholders."""
+    return _redact_value(None, dict(envelope))
+
+
+def leak_findings(payload: Any, *, path: str = "$") -> list[str]:
+    """Report residual identity leaks as ``<json path>: <reason>`` strings."""
+    findings: list[str] = []
+    if isinstance(payload, Mapping):
+        for key, value in payload.items():
+            child = f"{path}.{key}"
+            if isinstance(key, str) and _SECRET_KEY_RE.search(key):
+                if value not in (None, REDACTED_SECRET):
+                    findings.append(f"{child}: secret-like key carries a value")
+            findings.extend(leak_findings(value, path=child))
+        return findings
+    if isinstance(payload, (list, tuple)):
+        for index, value in enumerate(payload):
+            findings.extend(leak_findings(value, path=f"{path}[{index}]"))
+        return findings
+    if isinstance(payload, str):
+        for candidate in _IPV4_RE.findall(payload):
+            if not _ipv4_is_safe(candidate):
+                findings.append(f"{path}: routable IPv4 literal")
+                break
+        for candidate in _IPV6_RE.findall(payload):
+            if candidate != "::1":
+                findings.append(f"{path}: IPv6 literal")
+                break
+        for candidate in _HOME_PATH_RE.findall(payload):
+            if not _home_path_is_safe(candidate):
+                findings.append(f"{path}: absolute user home path")
+                break
+        if _WINDOWS_HOME_RE.search(payload):
+            findings.append(f"{path}: absolute user home path")
+        for pattern in _SECRET_VALUE_RES:
+            if pattern.search(payload):
+                findings.append(f"{path}: secret-like value")
+                break
+        for match in _USER_AT_HOST_RE.finditer(payload):
+            _, _, host = match.group(0).partition("@")
+            if not _host_is_safe(host) and not (
+                _IPV4_RE.fullmatch(host) and _ipv4_is_safe(host)
+            ):
+                findings.append(f"{path}: user@host pair")
+                break
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def make_operation(
+    *,
+    entry_point: str,
+    action: str,
+    skill: str | None = None,
+    target_kind: str = "unknown",
+    target_id: str | None = None,
+    target_ref: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "skill": skill,
+        "entry_point": entry_point,
+        "action": action,
+        "target": {"kind": target_kind, "id": target_id, "ref": target_ref},
+    }
+
+
+def make_command(
+    *,
+    argv: Sequence[str],
+    cwd: str | None = None,
+    env_keys: Sequence[str] | None = None,
+    timeout_seconds: float | None = None,
+    display: str | None = None,
+) -> dict[str, Any]:
+    argv_list = [str(part) for part in argv]
+    return {
+        "argv": argv_list,
+        "display": display or shlex.join(argv_list),
+        "cwd": cwd,
+        "env_keys": sorted({str(key) for key in (env_keys or ())}),
+        "timeout_seconds": timeout_seconds,
+    }
+
+
+def make_remote_command(
+    *,
+    endpoint_kind: str,
+    endpoint_ref: str | None = None,
+    argv: Sequence[str] | None = None,
+    script: str | None = None,
+    script_ref: str | None = None,
+    cwd: str | None = None,
+    env_keys: Sequence[str] | None = None,
+    timeout_seconds: float | None = None,
+) -> dict[str, Any]:
+    """The command as it actually ran on the far side of the transport.
+
+    Local ``argv`` alone is not reproducible for remote work: the agent needs
+    the exact remote script, bounded, plus a ref to the full text.
+    """
+    if endpoint_kind not in TARGET_KINDS:
+        raise EnvelopeError(f"unsupported endpoint kind: {endpoint_kind!r}")
+    return {
+        "endpoint": {"kind": endpoint_kind, "ref": endpoint_ref},
+        "argv": [str(part) for part in argv] if argv is not None else None,
+        "script_preview": (
+            text_preview(script, ref=script_ref) if script is not None else None
+        ),
+        "script_ref": script_ref,
+        "cwd": cwd,
+        "env_keys": sorted({str(key) for key in (env_keys or ())}),
+        "timeout_seconds": timeout_seconds,
+    }
+
+
+def make_attempt(
+    *,
+    command: Mapping[str, Any],
+    reproduce: str,
+    remote_command: Mapping[str, Any] | None = None,
+    started_at: str | None = None,
+    duration_ms: int | None = None,
+) -> dict[str, Any]:
+    return {
+        "command": dict(command),
+        "remote_command": dict(remote_command) if remote_command else None,
+        "reproduce": reproduce,
+        "started_at": started_at or utc_now(),
+        "duration_ms": duration_ms,
+    }
+
+
+def make_failure(
+    *,
+    layer: str,
+    reason_code: str,
+    message: str,
+    attribution_basis: Sequence[str] | None = None,
+    confidence: str = "medium",
+    ruled_out: Sequence[str] | None = None,
+    signals: Sequence[Mapping[str, Any]] | None = None,
+    exception_type: str | None = None,
+) -> dict[str, Any]:
+    """Build the failure block.
+
+    ``attribution_basis`` is mandatory for every layer except ``unknown``:
+    naming a layer is a claim, and the claim must cite the observation that
+    supports it. This is what keeps ``unknown`` honest rather than a dumping
+    ground for whatever the traceback happened to say.
+    """
+    return {
+        "layer": layer,
+        "confidence": confidence,
+        "reason_code": reason_code,
+        "message": message,
+        "attribution_basis": [str(item) for item in (attribution_basis or ())],
+        "ruled_out": [str(item) for item in (ruled_out or ())],
+        "signals": [dict(signal) for signal in (signals or ())],
+        "exception_type": exception_type,
+    }
+
+
+def unknown_failure(
+    *,
+    message: str,
+    reason_code: str = "unattributed",
+    ruled_out: Sequence[str] | None = None,
+    signals: Sequence[Mapping[str, Any]] | None = None,
+    exception_type: str | None = None,
+) -> dict[str, Any]:
+    """An honest unknown: no layer claim, low confidence, nothing invented."""
+    return make_failure(
+        layer="unknown",
+        reason_code=reason_code,
+        message=message,
+        confidence="low",
+        ruled_out=ruled_out,
+        signals=signals,
+        exception_type=exception_type,
+    )
+
+
+def make_environment(
+    *,
+    source: str = "unknown",
+    captured_at: str | None = None,
+    **versions: str | None,
+) -> dict[str, Any]:
+    """Environment identity at knowledge-base granularity.
+
+    All seven fields are always present. An explicit ``null`` means "not
+    captured"; a missing key would be indistinguishable from a producer that
+    never knew the field existed.
+    """
+    if source not in ENVIRONMENT_SOURCES:
+        raise EnvelopeError(f"unsupported environment source: {source!r}")
+    unknown_keys = sorted(set(versions) - set(ENVIRONMENT_FIELDS))
+    if unknown_keys:
+        raise EnvelopeError(
+            f"unsupported environment fields: {', '.join(unknown_keys)}"
+        )
+    payload: dict[str, Any] = {
+        field: versions.get(field) for field in ENVIRONMENT_FIELDS
+    }
+    payload["source"] = source
+    payload["captured_at"] = captured_at
+    payload["unknown_fields"] = sorted(
+        field for field in ENVIRONMENT_FIELDS if payload[field] is None
+    )
+    return payload
+
+
+def make_evidence(
+    *,
+    run_id: str | None = None,
+    parent_run_id: str | None = None,
+    manifest_ref: str | None = None,
+    refs: Sequence[Mapping[str, Any]] | None = None,
+    previews: Mapping[str, Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "parent_run_id": parent_run_id,
+        "manifest_ref": manifest_ref,
+        "refs": [dict(ref) for ref in (refs or ())],
+        "previews": {
+            str(name): dict(preview)
+            for name, preview in (previews or {}).items()
+        },
+    }
+
+
+def make_next_step(
+    *,
+    actions: Sequence[Mapping[str, Any] | str] | None = None,
+    do_not: Sequence[str] | None = None,
+    knowledge: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """What to look at next, and explicitly what not to look at.
+
+    ``do_not`` carries as much value as ``actions``: the recorded gloo
+    ``/etc/hosts`` signature is mostly worth having because it tells you not
+    to start tuning HCCL environment variables.
+    """
+    normalized: list[dict[str, Any]] = []
+    for action in actions or ():
+        if isinstance(action, str):
+            normalized.append({"description": action, "command": None, "ref": None})
+            continue
+        normalized.append(
+            {
+                "description": str(action.get("description", "")),
+                "command": action.get("command"),
+                "ref": action.get("ref"),
+            }
+        )
+    return {
+        "actions": normalized,
+        "do_not": [str(item) for item in (do_not or ())],
+        "knowledge": [dict(item) for item in (knowledge or ())],
+    }
+
+
+def knowledge_reference(
+    *,
+    entry_id: str,
+    summary: str,
+    avoidance: str | None = None,
+    score: int | None = None,
+) -> dict[str, Any]:
+    return {
+        "entry_id": entry_id,
+        "summary": summary,
+        "avoidance": avoidance,
+        "score": score,
+    }
+
+
+def make_part(
+    *,
+    unit: str,
+    outcome: str,
+    unit_kind: str = "node",
+    layer: str | None = None,
+    reason_code: str | None = None,
+    summary: str | None = None,
+    refs: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """One unit of a fan-out operation.
+
+    A four-node operation where three nodes succeeded is not a boolean, and
+    collapsing it to one loses exactly the information needed to decide
+    whether the failure is systemic or node-local.
+    """
+    return {
+        "unit": unit,
+        "unit_kind": unit_kind,
+        "outcome": outcome,
+        "layer": layer,
+        "reason_code": reason_code,
+        "summary": summary,
+        "refs": [dict(ref) for ref in (refs or ())],
+    }
+
+
+def make_attempts(
+    *,
+    count: int = 1,
+    records: Sequence[Mapping[str, Any]] | None = None,
+    idempotency_class: str = "unknown",
+    side_effects: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Retry history plus whether re-running is safe.
+
+    ``retry_safe`` is derived from ``idempotency_class`` rather than set by
+    the caller, so the two can never disagree, and it stays ``null`` unless
+    the producer actually classified the operation.
+    """
+    if idempotency_class not in IDEMPOTENCY_CLASSES:
+        raise EnvelopeError(
+            f"unsupported idempotency class: {idempotency_class!r}"
+        )
+    retry_safe: bool | None = None
+    if idempotency_class == "idempotent":
+        retry_safe = True
+    elif idempotency_class == "unsafe_to_retry":
+        retry_safe = False
+    return {
+        "count": count,
+        "records": [dict(record) for record in (records or ())],
+        "idempotency": {
+            "class": idempotency_class,
+            "retry_safe": retry_safe,
+            "side_effects": [str(item) for item in (side_effects or ())],
+        },
+    }
+
+
+def attempt_record(
+    *,
+    index: int,
+    outcome: str,
+    layer: str | None = None,
+    reason_code: str | None = None,
+    duration_ms: int | None = None,
+    note: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "index": index,
+        "outcome": outcome,
+        "layer": layer,
+        "reason_code": reason_code,
+        "duration_ms": duration_ms,
+        "note": note,
+    }
+
+
+def new_envelope(
+    *,
+    operation: Mapping[str, Any],
+    outcome: str,
+    summary: str,
+    attempt: Mapping[str, Any],
+    environment: Mapping[str, Any] | None = None,
+    evidence: Mapping[str, Any] | None = None,
+    next_step: Mapping[str, Any] | None = None,
+    failure: Mapping[str, Any] | None = None,
+    parts: Sequence[Mapping[str, Any]] | None = None,
+    attempts: Mapping[str, Any] | None = None,
+    children: Sequence[Mapping[str, Any]] | None = None,
+    warnings: Sequence[str] | None = None,
+    extensions: Mapping[str, Any] | None = None,
+    exit_code: int | None = None,
+    envelope_id: str | None = None,
+    emitted_at: str | None = None,
+    validate: bool = True,
+) -> dict[str, Any]:
+    envelope: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "envelope_id": envelope_id or new_envelope_id(
+            str(operation.get("action") or "op")
+        ),
+        "emitted_at": emitted_at or utc_now(),
+        "operation": dict(operation),
+        "outcome": outcome,
+        "exit_code": exit_code if exit_code is not None else default_exit_code(outcome),
+        "summary": summary,
+        "attempt": dict(attempt),
+        "failure": dict(failure) if failure else None,
+        "environment": dict(environment) if environment else make_environment(),
+        "evidence": dict(evidence) if evidence else make_evidence(),
+        "next_step": dict(next_step) if next_step else make_next_step(),
+        "parts": [dict(part) for part in (parts or ())],
+        "attempts": dict(attempts) if attempts else make_attempts(),
+        "children": [dict(child) for child in (children or ())],
+        "warnings": [str(item) for item in (warnings or ())],
+        "extensions": dict(extensions or {}),
+    }
+    if validate:
+        validate_envelope(envelope)
+    return envelope
+
+
+def default_exit_code(outcome: str) -> int:
+    """Map an outcome to the conventional process exit code.
+
+    Distinct codes let a shell caller branch without parsing JSON, while the
+    envelope stays the source of truth for anything finer.
+    """
+    return {
+        "success": 0,
+        "partial": 1,
+        "failure": 1,
+        "blocked": 2,
+        "cancelled": 3,
+    }.get(outcome, 1)
+
+
+# ---------------------------------------------------------------------------
+# Partial success and composition
+# ---------------------------------------------------------------------------
+
+
+def outcome_from_parts(parts: Sequence[Mapping[str, Any]]) -> str:
+    """Derive an aggregate outcome from per-unit results."""
+    if not parts:
+        return "success"
+    outcomes = [str(part.get("outcome")) for part in parts]
+    failed = [item for item in outcomes if item in {"failure", "blocked"}]
+    succeeded = [item for item in outcomes if item == "success"]
+    if not failed:
+        return "success"
+    if not succeeded:
+        return "blocked" if all(item == "blocked" for item in failed) else "failure"
+    return "partial"
+
+
+def failure_from_parts(parts: Sequence[Mapping[str, Any]]) -> dict[str, Any] | None:
+    """Summarize failing units into one top-level failure block.
+
+    A single shared layer across every failing unit is reported with that
+    layer; a mix is reported as ``unknown``, because "some nodes hit the
+    transport and some hit the workload" is genuinely not one diagnosis.
+    """
+    failing = [
+        part
+        for part in parts
+        if str(part.get("outcome")) in {"failure", "blocked"}
+    ]
+    if not failing:
+        return None
+    layers = {part.get("layer") for part in failing}
+    total = len(parts)
+    units = ", ".join(str(part.get("unit")) for part in failing[:8])
+    basis = [f"{len(failing)} of {total} units failed: {units}"]
+    if len(layers) == 1 and None not in layers:
+        layer = next(iter(layers))
+        codes = {
+            part.get("reason_code") for part in failing if part.get("reason_code")
+        }
+        return make_failure(
+            layer=str(layer),
+            reason_code=str(next(iter(codes))) if len(codes) == 1 else "unattributed",
+            message=f"{len(failing)}/{total} units failed in layer {layer}",
+            attribution_basis=basis + [f"all failing units attributed to {layer}"],
+            confidence="medium" if len(failing) < total else "high",
+        )
+    return unknown_failure(
+        message=(
+            f"{len(failing)}/{total} units failed with mixed or missing layer "
+            "attribution"
+        ),
+        signals=[{"kind": "part_layers", "value": sorted(str(x) for x in layers)}],
+    )
+
+
+def child_digest(
+    child: Mapping[str, Any],
+    *,
+    ref: str | None = None,
+    depth: int = 1,
+) -> dict[str, Any]:
+    """Collapse a nested envelope into a bounded digest.
+
+    Nesting whole envelopes would let a three-level call chain crowd out the
+    diagnosis it exists to deliver, so the parent keeps identity, outcome and
+    attribution, and points at the full child through ``ref``.
+    """
+    failure = child.get("failure") or {}
+    operation = child.get("operation") or {}
+    return {
+        "envelope_id": child.get("envelope_id"),
+        "entry_point": operation.get("entry_point"),
+        "action": operation.get("action"),
+        "outcome": child.get("outcome"),
+        "layer": failure.get("layer"),
+        "reason_code": failure.get("reason_code"),
+        "summary": child.get("summary"),
+        "ref": ref,
+        "depth": depth,
+    }
+
+
+def escalate_child_layer(child_layer: str) -> str:
+    """Map a nested call's layer onto the parent's own layer.
+
+    A nested ``caller`` fault does not stay ``caller`` at the parent: the
+    parent *is* the caller, so the parent built bad arguments and the parent's
+    fault is ``tool``. Every other layer propagates unchanged, because the
+    parent adds no information about it.
+    """
+    if child_layer not in LAYER_SET:
+        return "unknown"
+    return "tool" if child_layer == "caller" else child_layer
+
+
+def compose_child(
+    parent: MutableMapping[str, Any],
+    child: Mapping[str, Any],
+    *,
+    ref: str | None = None,
+    adopt_failure: bool = True,
+    validate: bool = True,
+) -> dict[str, Any]:
+    """Attach a nested envelope to its parent and propagate attribution.
+
+    The parent keeps its own summary and command, adopts the child's layer
+    through :func:`escalate_child_layer` when it has no failure of its own,
+    and inherits the child's ``do_not`` guidance so a known signature is not
+    lost one frame up the stack.
+    """
+    composed = deepcopy(dict(parent))
+    depth = 1 + max(
+        (int(item.get("depth") or 1) for item in child.get("children") or ()),
+        default=0,
+    )
+    composed["children"] = list(composed.get("children") or ()) + [
+        child_digest(child, ref=ref, depth=depth)
+    ]
+    child_failure = child.get("failure")
+    if adopt_failure and child_failure and not composed.get("failure"):
+        child_layer = str(child_failure.get("layer") or "unknown")
+        layer = escalate_child_layer(child_layer)
+        basis = [
+            f"nested call {child.get('operation', {}).get('entry_point')} "
+            f"reported layer {child_layer}"
+        ]
+        if layer == "tool" and child_layer == "caller":
+            basis.append(
+                "a nested caller fault is this wrapper's fault: it built the "
+                "arguments"
+            )
+        else:
+            basis.extend(child_failure.get("attribution_basis") or ())
+        composed["failure"] = make_failure(
+            layer=layer,
+            reason_code=str(child_failure.get("reason_code") or "unattributed"),
+            message=str(child_failure.get("message") or "nested call failed"),
+            attribution_basis=basis,
+            confidence=str(child_failure.get("confidence") or "low")
+            if layer != "unknown"
+            else "low",
+            ruled_out=child_failure.get("ruled_out") or (),
+            signals=child_failure.get("signals") or (),
+        )
+        child_outcome = str(child.get("outcome") or "failure")
+        if composed.get("outcome") == "success":
+            composed["outcome"] = (
+                child_outcome if child_outcome in FAILING_OUTCOMES else "failure"
+            )
+            composed["exit_code"] = default_exit_code(composed["outcome"])
+        child_next = child.get("next_step") or {}
+        parent_next = composed.get("next_step") or make_next_step()
+        merged_do_not = list(
+            dict.fromkeys(
+                list(parent_next.get("do_not") or ())
+                + list(child_next.get("do_not") or ())
+            )
+        )
+        parent_next["do_not"] = merged_do_not
+        if not parent_next.get("actions"):
+            parent_next["actions"] = list(child_next.get("actions") or ())
+        if not parent_next.get("knowledge"):
+            parent_next["knowledge"] = list(child_next.get("knowledge") or ())
+        composed["next_step"] = parent_next
+    if validate:
+        validate_envelope(composed)
+    return composed
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _require_str(value: Any, path: str, errors: list[str], *, allow_empty: bool = False) -> None:
+    if not isinstance(value, str) or (not allow_empty and not value.strip()):
+        errors.append(f"{path} must be a non-empty string")
+
+
+def _require_opt_str(value: Any, path: str, errors: list[str]) -> None:
+    if value is not None and not isinstance(value, str):
+        errors.append(f"{path} must be a string or null")
+
+
+def _require_str_list(value: Any, path: str, errors: list[str]) -> None:
+    if not isinstance(value, list) or any(
+        not isinstance(item, str) for item in value
+    ):
+        errors.append(f"{path} must be an array of strings")
+
+
+def _validate_operation(value: Any, errors: list[str]) -> None:
+    if not isinstance(value, Mapping):
+        errors.append("operation must be an object")
+        return
+    _require_str(value.get("entry_point"), "operation.entry_point", errors)
+    entry_point = value.get("entry_point")
+    if isinstance(entry_point, str) and entry_point.startswith("/"):
+        errors.append(
+            "operation.entry_point must be repo-relative, not an absolute path"
+        )
+    _require_str(value.get("action"), "operation.action", errors)
+    _require_opt_str(value.get("skill"), "operation.skill", errors)
+    target = value.get("target")
+    if not isinstance(target, Mapping):
+        errors.append("operation.target must be an object")
+        return
+    if target.get("kind") not in TARGET_KINDS:
+        errors.append(
+            "operation.target.kind must be one of: "
+            + ", ".join(sorted(TARGET_KINDS))
+        )
+    _require_opt_str(target.get("id"), "operation.target.id", errors)
+    _require_opt_str(target.get("ref"), "operation.target.ref", errors)
+
+
+def _validate_command(value: Any, path: str, errors: list[str]) -> None:
+    if not isinstance(value, Mapping):
+        errors.append(f"{path} must be an object")
+        return
+    _require_str_list(value.get("argv"), f"{path}.argv", errors)
+    if isinstance(value.get("argv"), list) and not value["argv"]:
+        errors.append(f"{path}.argv must not be empty")
+    _require_str(value.get("display"), f"{path}.display", errors)
+    _require_opt_str(value.get("cwd"), f"{path}.cwd", errors)
+    _require_str_list(value.get("env_keys"), f"{path}.env_keys", errors)
+
+
+def _validate_preview(value: Any, path: str, errors: list[str]) -> None:
+    if not isinstance(value, Mapping):
+        errors.append(f"{path} must be a preview object")
+        return
+    if not isinstance(value.get("truncated"), bool):
+        errors.append(f"{path}.truncated must be a boolean")
+        return
+    if value["truncated"]:
+        if not isinstance(value.get("ref"), str) or not value["ref"].strip():
+            errors.append(
+                f"{path} is truncated and must carry a ref to the full content"
+            )
+        if "head" not in value or "tail" not in value:
+            errors.append(f"{path} is truncated and must carry head and tail")
+    elif "text" not in value:
+        errors.append(f"{path} is not truncated and must carry text")
+
+
+def _validate_attempt(value: Any, errors: list[str]) -> None:
+    if not isinstance(value, Mapping):
+        errors.append("attempt must be an object")
+        return
+    _validate_command(value.get("command"), "attempt.command", errors)
+    _require_str(value.get("reproduce"), "attempt.reproduce", errors)
+    timestamp = value.get("started_at")
+    if not isinstance(timestamp, str) or not RFC3339_UTC_RE.fullmatch(timestamp):
+        errors.append("attempt.started_at must be an RFC3339 UTC timestamp")
+    duration = value.get("duration_ms")
+    if duration is not None and not isinstance(duration, int):
+        errors.append("attempt.duration_ms must be an integer or null")
+    remote = value.get("remote_command")
+    if remote is None:
+        return
+    if not isinstance(remote, Mapping):
+        errors.append("attempt.remote_command must be an object or null")
+        return
+    endpoint = remote.get("endpoint")
+    if not isinstance(endpoint, Mapping) or endpoint.get("kind") not in TARGET_KINDS:
+        errors.append("attempt.remote_command.endpoint.kind must be a target kind")
+    if remote.get("argv") is None and remote.get("script_preview") is None:
+        errors.append(
+            "attempt.remote_command must carry argv or script_preview so the "
+            "remote step is reproducible by hand"
+        )
+    if remote.get("argv") is not None:
+        _require_str_list(remote.get("argv"), "attempt.remote_command.argv", errors)
+    if remote.get("script_preview") is not None:
+        _validate_preview(
+            remote.get("script_preview"),
+            "attempt.remote_command.script_preview",
+            errors,
+        )
+
+
+def _validate_failure(value: Any, errors: list[str]) -> None:
+    if not isinstance(value, Mapping):
+        errors.append("failure must be an object or null")
+        return
+    layer = value.get("layer")
+    if layer not in LAYER_SET:
+        errors.append("failure.layer must be one of: " + ", ".join(LAYERS))
+    if value.get("confidence") not in CONFIDENCES:
+        errors.append(
+            "failure.confidence must be one of: " + ", ".join(sorted(CONFIDENCES))
+        )
+    reason_code = value.get("reason_code")
+    if not isinstance(reason_code, str) or not REASON_CODE_RE.fullmatch(reason_code):
+        errors.append(f"failure.reason_code must match {REASON_CODE_RE.pattern}")
+    _require_str(value.get("message"), "failure.message", errors)
+    _require_str_list(
+        value.get("attribution_basis"), "failure.attribution_basis", errors
+    )
+    _require_str_list(value.get("ruled_out"), "failure.ruled_out", errors)
+    basis = value.get("attribution_basis")
+    if layer != "unknown" and isinstance(basis, list) and not basis:
+        errors.append(
+            "failure.attribution_basis must be non-empty when a layer is "
+            "claimed; use layer 'unknown' instead of guessing"
+        )
+    if layer == "unknown" and value.get("confidence") == "high":
+        errors.append("failure.confidence cannot be high for layer 'unknown'")
+    ruled_out = value.get("ruled_out")
+    if isinstance(ruled_out, list):
+        unsupported = sorted(set(ruled_out) - LAYER_SET)
+        if unsupported:
+            errors.append(
+                "failure.ruled_out contains unknown layers: "
+                + ", ".join(unsupported)
+            )
+        if layer in ruled_out:
+            errors.append("failure.ruled_out must not contain failure.layer")
+    signals = value.get("signals")
+    if not isinstance(signals, list) or any(
+        not isinstance(item, Mapping) for item in signals
+    ):
+        errors.append("failure.signals must be an array of objects")
+    _require_opt_str(value.get("exception_type"), "failure.exception_type", errors)
+
+
+def _validate_environment(value: Any, errors: list[str]) -> None:
+    if not isinstance(value, Mapping):
+        errors.append("environment must be an object")
+        return
+    for field in ENVIRONMENT_FIELDS:
+        if field not in value:
+            errors.append(
+                f"environment.{field} must be present (explicit null when not "
+                "captured)"
+            )
+            continue
+        _require_opt_str(value.get(field), f"environment.{field}", errors)
+    if value.get("source") not in ENVIRONMENT_SOURCES:
+        errors.append(
+            "environment.source must be one of: "
+            + ", ".join(sorted(ENVIRONMENT_SOURCES))
+        )
+    _require_opt_str(value.get("captured_at"), "environment.captured_at", errors)
+    _require_str_list(
+        value.get("unknown_fields"), "environment.unknown_fields", errors
+    )
+    expected = sorted(
+        field for field in ENVIRONMENT_FIELDS if value.get(field) is None
+    )
+    if isinstance(value.get("unknown_fields"), list) and sorted(
+        value["unknown_fields"]
+    ) != expected:
+        errors.append(
+            "environment.unknown_fields must list exactly the null version "
+            f"fields: {expected}"
+        )
+
+
+def _validate_evidence(value: Any, errors: list[str]) -> None:
+    if not isinstance(value, Mapping):
+        errors.append("evidence must be an object")
+        return
+    for field in ("run_id", "parent_run_id", "manifest_ref"):
+        _require_opt_str(value.get(field), f"evidence.{field}", errors)
+    refs = value.get("refs")
+    if not isinstance(refs, list):
+        errors.append("evidence.refs must be an array")
+    else:
+        for index, ref in enumerate(refs):
+            path = f"evidence.refs[{index}]"
+            if not isinstance(ref, Mapping):
+                errors.append(f"{path} must be an object")
+                continue
+            for field in ("name", "kind", "ref"):
+                _require_str(ref.get(field), f"{path}.{field}", errors)
+    previews = value.get("previews")
+    if not isinstance(previews, Mapping):
+        errors.append("evidence.previews must be an object")
+        return
+    for name, preview in previews.items():
+        _validate_preview(preview, f"evidence.previews.{name}", errors)
+
+
+def _validate_next_step(value: Any, errors: list[str]) -> None:
+    if not isinstance(value, Mapping):
+        errors.append("next_step must be an object")
+        return
+    actions = value.get("actions")
+    if not isinstance(actions, list):
+        errors.append("next_step.actions must be an array")
+    else:
+        for index, action in enumerate(actions):
+            path = f"next_step.actions[{index}]"
+            if not isinstance(action, Mapping):
+                errors.append(f"{path} must be an object")
+                continue
+            _require_str(action.get("description"), f"{path}.description", errors)
+            _require_opt_str(action.get("command"), f"{path}.command", errors)
+            _require_opt_str(action.get("ref"), f"{path}.ref", errors)
+    _require_str_list(value.get("do_not"), "next_step.do_not", errors)
+    knowledge = value.get("knowledge")
+    if not isinstance(knowledge, list):
+        errors.append("next_step.knowledge must be an array")
+        return
+    for index, item in enumerate(knowledge):
+        path = f"next_step.knowledge[{index}]"
+        if not isinstance(item, Mapping):
+            errors.append(f"{path} must be an object")
+            continue
+        _require_str(item.get("entry_id"), f"{path}.entry_id", errors)
+        _require_str(item.get("summary"), f"{path}.summary", errors)
+
+
+def _validate_parts(value: Any, errors: list[str]) -> None:
+    if not isinstance(value, list):
+        errors.append("parts must be an array")
+        return
+    seen: set[str] = set()
+    for index, part in enumerate(value):
+        path = f"parts[{index}]"
+        if not isinstance(part, Mapping):
+            errors.append(f"{path} must be an object")
+            continue
+        _require_str(part.get("unit"), f"{path}.unit", errors)
+        unit = part.get("unit")
+        if isinstance(unit, str):
+            if unit in seen:
+                errors.append(f"{path}.unit is duplicated: {unit!r}")
+            seen.add(unit)
+        if part.get("outcome") not in PART_OUTCOMES:
+            errors.append(
+                f"{path}.outcome must be one of: " + ", ".join(sorted(PART_OUTCOMES))
+            )
+        layer = part.get("layer")
+        if layer is not None and layer not in LAYER_SET:
+            errors.append(f"{path}.layer must be a layer or null")
+        if part.get("outcome") in {"failure", "blocked"} and layer is None:
+            errors.append(
+                f"{path} failed and must carry a layer (use 'unknown' when the "
+                "evidence does not identify one)"
+            )
+
+
+def _validate_attempts(value: Any, errors: list[str]) -> None:
+    if not isinstance(value, Mapping):
+        errors.append("attempts must be an object")
+        return
+    count = value.get("count")
+    if not isinstance(count, int) or count < 1:
+        errors.append("attempts.count must be an integer >= 1")
+    records = value.get("records")
+    if not isinstance(records, list):
+        errors.append("attempts.records must be an array")
+    elif isinstance(count, int) and len(records) > count:
+        errors.append("attempts.records must not be longer than attempts.count")
+    idempotency = value.get("idempotency")
+    if not isinstance(idempotency, Mapping):
+        errors.append("attempts.idempotency must be an object")
+        return
+    klass = idempotency.get("class")
+    if klass not in IDEMPOTENCY_CLASSES:
+        errors.append(
+            "attempts.idempotency.class must be one of: "
+            + ", ".join(sorted(IDEMPOTENCY_CLASSES))
+        )
+    expected = {"idempotent": True, "unsafe_to_retry": False}.get(str(klass))
+    if idempotency.get("retry_safe") != expected:
+        errors.append(
+            "attempts.idempotency.retry_safe must be derived from class "
+            f"(expected {expected!r})"
+        )
+    _require_str_list(
+        idempotency.get("side_effects"),
+        "attempts.idempotency.side_effects",
+        errors,
+    )
+
+
+def _validate_children(value: Any, errors: list[str]) -> None:
+    if not isinstance(value, list):
+        errors.append("children must be an array")
+        return
+    for index, child in enumerate(value):
+        path = f"children[{index}]"
+        if not isinstance(child, Mapping):
+            errors.append(f"{path} must be an object")
+            continue
+        _require_str(child.get("envelope_id"), f"{path}.envelope_id", errors)
+        if child.get("outcome") not in OUTCOMES:
+            errors.append(f"{path}.outcome must be an envelope outcome")
+        layer = child.get("layer")
+        if layer is not None and layer not in LAYER_SET:
+            errors.append(f"{path}.layer must be a layer or null")
+        depth = child.get("depth")
+        if not isinstance(depth, int) or depth < 1:
+            errors.append(f"{path}.depth must be an integer >= 1")
+        if isinstance(child, Mapping) and "children" in child:
+            errors.append(
+                f"{path} must be a digest, not a nested envelope; point at the "
+                "full child through ref"
+            )
+
+
+def validate_envelope(envelope: Mapping[str, Any]) -> None:
+    """Raise :class:`EnvelopeError` describing every contract violation."""
+    errors: list[str] = []
+    if not isinstance(envelope, Mapping):
+        raise EnvelopeError("envelope root must be an object")
+    if envelope.get("schema_version") not in ACCEPTED_SCHEMA_VERSIONS:
+        errors.append(f"schema_version must be {SCHEMA_VERSION!r}")
+    envelope_id = envelope.get("envelope_id")
+    if not isinstance(envelope_id, str) or not ENVELOPE_ID_RE.fullmatch(envelope_id):
+        errors.append(f"envelope_id must match {ENVELOPE_ID_RE.pattern}")
+    emitted_at = envelope.get("emitted_at")
+    if not isinstance(emitted_at, str) or not RFC3339_UTC_RE.fullmatch(emitted_at):
+        errors.append("emitted_at must be an RFC3339 UTC timestamp ending in Z")
+    outcome = envelope.get("outcome")
+    if outcome not in OUTCOMES:
+        errors.append("outcome must be one of: " + ", ".join(sorted(OUTCOMES)))
+    exit_code = envelope.get("exit_code")
+    if exit_code is not None and not isinstance(exit_code, int):
+        errors.append("exit_code must be an integer or null")
+    summary = envelope.get("summary")
+    _require_str(summary, "summary", errors)
+    if isinstance(summary, str) and len(summary) > MAX_SUMMARY_CHARS:
+        errors.append(f"summary must be at most {MAX_SUMMARY_CHARS} characters")
+
+    _validate_operation(envelope.get("operation"), errors)
+    _validate_attempt(envelope.get("attempt"), errors)
+    _validate_environment(envelope.get("environment"), errors)
+    _validate_evidence(envelope.get("evidence"), errors)
+    _validate_next_step(envelope.get("next_step"), errors)
+    _validate_parts(envelope.get("parts"), errors)
+    _validate_attempts(envelope.get("attempts"), errors)
+    _validate_children(envelope.get("children"), errors)
+    _require_str_list(envelope.get("warnings"), "warnings", errors)
+    if not isinstance(envelope.get("extensions"), Mapping):
+        errors.append("extensions must be an object")
+
+    failure = envelope.get("failure")
+    if failure is not None:
+        _validate_failure(failure, errors)
+    if outcome in FAILING_OUTCOMES and failure is None:
+        errors.append(
+            f"outcome {outcome!r} requires a failure block with a layer "
+            "attribution"
+        )
+    if outcome == "success" and failure is not None:
+        errors.append("outcome 'success' must not carry a failure block")
+    next_step = envelope.get("next_step")
+    if (
+        outcome in FAILING_OUTCOMES
+        and isinstance(next_step, Mapping)
+        and not next_step.get("actions")
+    ):
+        errors.append(
+            f"outcome {outcome!r} requires at least one next_step action, even "
+            "if that action is only how to narrow an unknown"
+        )
+    parts = envelope.get("parts")
+    if isinstance(parts, list) and parts:
+        derived = outcome_from_parts(parts)
+        if derived != outcome:
+            errors.append(
+                f"outcome {outcome!r} disagrees with parts (derived {derived!r})"
+            )
+    elif outcome == "partial":
+        errors.append("outcome 'partial' requires parts describing each unit")
+
+    unknown = sorted(set(envelope) - TOP_LEVEL_SET)
+    if unknown:
+        errors.append(
+            "unknown top-level fields (use 'extensions' for additive data): "
+            + ", ".join(unknown)
+        )
+    missing = sorted(TOP_LEVEL_SET - set(envelope))
+    if missing:
+        errors.append("missing top-level fields: " + ", ".join(missing))
+
+    if errors:
+        raise EnvelopeError("; ".join(errors))
+
+
+def read_envelope(
+    payload: Mapping[str, Any],
+    *,
+    accepted_versions: Iterable[str] = ACCEPTED_SCHEMA_VERSIONS,
+) -> dict[str, Any]:
+    """Lag-tolerant read path for consumers.
+
+    Consumers lag producers, so a reader must not crash on a newer producer.
+    An unrecognized ``schema_version`` or an unrecognized enum value is
+    downgraded to ``unknown`` and recorded in ``compat_warnings`` instead of
+    raising, while a same-version envelope is still validated strictly.
+    """
+    if not isinstance(payload, Mapping):
+        raise EnvelopeError("envelope root must be an object")
+    view = deepcopy(dict(payload))
+    warnings: list[str] = []
+    version = view.get("schema_version")
+    if version in set(accepted_versions):
+        validate_envelope(view)
+        view["compat_warnings"] = []
+        return view
+    warnings.append(f"unrecognized schema_version {version!r}; read leniently")
+    if view.get("outcome") not in OUTCOMES:
+        warnings.append(f"unrecognized outcome {view.get('outcome')!r}")
+        view["outcome"] = "failure"
+    failure = view.get("failure")
+    if isinstance(failure, Mapping) and failure.get("layer") not in LAYER_SET:
+        warnings.append(f"unrecognized failure layer {failure.get('layer')!r}")
+        failure = dict(failure)
+        failure["layer"] = "unknown"
+        view["failure"] = failure
+    view["compat_warnings"] = warnings
+    return view
+
+
+# ---------------------------------------------------------------------------
+# Serialization and emission
+# ---------------------------------------------------------------------------
+
+
+def dumps(envelope: Mapping[str, Any]) -> str:
+    """Full-fidelity JSON. Safe only for untracked ``.vaws-local/`` writes."""
+    return json.dumps(dict(envelope), ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def dumps_publishable(envelope: Mapping[str, Any]) -> str:
+    """Redacted JSON, refusing to emit if a leak survives redaction."""
+    redacted = redact(envelope)
+    findings = leak_findings(redacted)
+    if findings:
+        raise EnvelopeRedactionError(
+            "redacted envelope still carries identity: " + "; ".join(findings)
+        )
+    return json.dumps(redacted, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def assert_publishable(envelope: Mapping[str, Any]) -> None:
+    """Raise unless the envelope is already free of runtime identity."""
+    findings = leak_findings(dict(envelope))
+    if findings:
+        raise EnvelopeRedactionError(
+            "envelope carries runtime identity: " + "; ".join(findings)
+        )
+
+
+def emit(
+    envelope: Mapping[str, Any],
+    *,
+    stream: Any = None,
+    validate: bool = True,
+) -> int:
+    """Write exactly one envelope on ``stdout`` and return its exit code."""
+    if validate:
+        validate_envelope(envelope)
+    target = stream if stream is not None else sys.stdout
+    target.write(dumps(envelope) + "\n")
+    target.flush()
+    code = envelope.get("exit_code")
+    return code if isinstance(code, int) else default_exit_code(
+        str(envelope.get("outcome"))
+    )
+
+
+def progress(
+    phase: str,
+    message: str,
+    *,
+    sentinel: str = PROGRESS_SENTINEL,
+    stream: Any = None,
+    **extra: Any,
+) -> None:
+    """Write one bounded progress line on ``stderr``.
+
+    Progress never goes to ``stdout``: a consumer must be able to parse
+    ``stdout`` as exactly one JSON object without filtering.
+    """
+    payload: dict[str, Any] = {"phase": phase, "message": message}
+    payload.update({key: value for key, value in extra.items() if value is not None})
+    target = stream if stream is not None else sys.stderr
+    target.write(sentinel + json.dumps(payload, ensure_ascii=False) + "\n")
+    target.flush()

--- a/.agents/lib/vaws_result_envelope.py
+++ b/.agents/lib/vaws_result_envelope.py
@@ -790,6 +790,10 @@ def failure_from_parts(parts: Sequence[Mapping[str, Any]]) -> dict[str, Any] | N
     A single shared layer across every failing unit is reported with that
     layer; a mix is reported as ``unknown``, because "some nodes hit the
     transport and some hit the workload" is genuinely not one diagnosis.
+
+    Shared ``unknown`` stays low-confidence: counting more unattributed
+    failures never creates an attribution. The validator still rejects
+    ``unknown`` with ``confidence: "high"``.
     """
     failing = [
         part
@@ -803,16 +807,22 @@ def failure_from_parts(parts: Sequence[Mapping[str, Any]]) -> dict[str, Any] | N
     units = ", ".join(str(part.get("unit")) for part in failing[:8])
     basis = [f"{len(failing)} of {total} units failed: {units}"]
     if len(layers) == 1 and None not in layers:
-        layer = next(iter(layers))
+        layer = str(next(iter(layers)))
         codes = {
             part.get("reason_code") for part in failing if part.get("reason_code")
         }
+        if layer == "unknown":
+            confidence = "low"
+        elif len(failing) < total:
+            confidence = "medium"
+        else:
+            confidence = "high"
         return make_failure(
-            layer=str(layer),
+            layer=layer,
             reason_code=str(next(iter(codes))) if len(codes) == 1 else "unattributed",
             message=f"{len(failing)}/{total} units failed in layer {layer}",
             attribution_basis=basis + [f"all failing units attributed to {layer}"],
-            confidence="medium" if len(failing) < total else "high",
+            confidence=confidence,
         )
     return unknown_failure(
         message=(
@@ -863,6 +873,37 @@ def escalate_child_layer(child_layer: str) -> str:
     return "tool" if child_layer == "caller" else child_layer
 
 
+def propagate_child_ruled_out(
+    child_ruled_out: Sequence[Any] | None,
+    *,
+    child_layer: str,
+    parent_layer: str,
+) -> list[str]:
+    """Translate child-frame exclusions into the parent frame.
+
+    ``ruled_out`` is relative to the wrapper that recorded it. Nested
+    ``caller`` becomes the parent's ``tool``, so a child exclusion of
+    ``tool`` is an exclusion of the *child's* wrapper, not the parent's.
+    Drop any exclusion that matches the parent's attributed layer; keep
+    the rest in order so downstream exclusions survive. The child record
+    itself is left unchanged.
+    """
+    attributed = (
+        parent_layer
+        if parent_layer in LAYER_SET
+        else escalate_child_layer(str(child_layer))
+    )
+    excluded: list[str] = []
+    seen: set[str] = set()
+    for item in child_ruled_out or ():
+        layer = str(item)
+        if layer == attributed or layer in seen:
+            continue
+        seen.add(layer)
+        excluded.append(layer)
+    return excluded
+
+
 def compose_child(
     parent: MutableMapping[str, Any],
     child: Mapping[str, Any],
@@ -877,6 +918,12 @@ def compose_child(
     through :func:`escalate_child_layer` when it has no failure of its own,
     and inherits the child's ``do_not`` guidance so a known signature is not
     lost one frame up the stack.
+
+    Child exclusions are remapped through :func:`propagate_child_ruled_out`
+    so a child-frame ``tool`` exclusion is not treated as an exclusion of
+    the parent's wrapper after a ``caller`` → ``tool`` escalation. The
+    supplied child is not mutated; its original fields remain reachable
+    through the digest ``ref``.
     """
     composed = deepcopy(dict(parent))
     depth = 1 + max(
@@ -909,7 +956,11 @@ def compose_child(
             confidence=str(child_failure.get("confidence") or "low")
             if layer != "unknown"
             else "low",
-            ruled_out=child_failure.get("ruled_out") or (),
+            ruled_out=propagate_child_ruled_out(
+                child_failure.get("ruled_out") or (),
+                child_layer=child_layer,
+                parent_layer=layer,
+            ),
             signals=child_failure.get("signals") or (),
         )
         child_outcome = str(child.get("outcome") or "failure")

--- a/.agents/schemas/result-envelope-v1.schema.json
+++ b/.agents/schemas/result-envelope-v1.schema.json
@@ -1,0 +1,535 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vllm-ascend-workspace.local/schemas/result-envelope-v1.schema.json",
+  "title": "vLLM Ascend Workspace Result Envelope v1",
+  "description": "Uniform result envelope returned on stdout by every workspace entry point, in success and in failure. jsonschema is not guaranteed to be installed on a client machine, so .agents/lib/vaws_result_envelope.py is the authoritative validator and enforces the cross-field rules this document can only partially express.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "envelope_id",
+    "emitted_at",
+    "operation",
+    "outcome",
+    "exit_code",
+    "summary",
+    "attempt",
+    "failure",
+    "environment",
+    "evidence",
+    "next_step",
+    "parts",
+    "attempts",
+    "children",
+    "warnings",
+    "extensions"
+  ],
+  "$defs": {
+    "layer": {
+      "description": "Which layer failed. 'unknown' is a first-class outcome: a confident wrong attribution costs more than an honest unknown.",
+      "enum": [
+        "caller",
+        "tool",
+        "transport",
+        "remote_env",
+        "remote_workload",
+        "device",
+        "unknown"
+      ]
+    },
+    "targetKind": {
+      "enum": [
+        "local",
+        "host",
+        "container",
+        "session",
+        "fleet",
+        "service",
+        "unknown"
+      ]
+    },
+    "version": {
+      "type": ["string", "null"]
+    },
+    "preview": {
+      "description": "Bounded text preview. Field names match .remote-dev/core/preview.py; 'ref' is required whenever 'truncated' is true so the full content is always reachable.",
+      "type": "object",
+      "required": ["bytes", "truncated", "head_chars", "tail_chars", "ref"],
+      "properties": {
+        "text": {"type": "string"},
+        "head": {"type": "string"},
+        "tail": {"type": "string"},
+        "bytes": {"type": "integer", "minimum": 0},
+        "truncated": {"type": "boolean"},
+        "head_chars": {"type": "integer", "minimum": 0},
+        "tail_chars": {"type": "integer", "minimum": 0},
+        "ref": {"type": ["string", "null"]}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"truncated": {"const": true}}},
+          "then": {
+            "required": ["head", "tail", "ref"],
+            "properties": {"ref": {"type": "string", "minLength": 1}}
+          },
+          "else": {"required": ["text"]}
+        }
+      ]
+    },
+    "evidenceRef": {
+      "type": "object",
+      "required": ["name", "kind", "ref"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "kind": {"type": "string", "minLength": 1},
+        "ref": {"type": "string", "minLength": 1},
+        "bytes": {"type": ["integer", "null"], "minimum": 0},
+        "sha256": {
+          "oneOf": [
+            {"type": "null"},
+            {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+          ]
+        },
+        "note": {"type": ["string", "null"]}
+      }
+    },
+    "command": {
+      "type": "object",
+      "required": ["argv", "display", "cwd", "env_keys", "timeout_seconds"],
+      "properties": {
+        "argv": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string"}
+        },
+        "display": {
+          "description": "Shell-quoted rendering of argv, reproducible by copy-paste.",
+          "type": "string",
+          "minLength": 1
+        },
+        "cwd": {"type": ["string", "null"]},
+        "env_keys": {
+          "description": "Environment variable names only. Values are never carried, so the envelope cannot become the thing that leaks a credential.",
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "timeout_seconds": {"type": ["number", "null"], "minimum": 0}
+      }
+    }
+  },
+  "properties": {
+    "schema_version": {"const": "vaws.result-envelope.v1"},
+    "envelope_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+    },
+    "emitted_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+    },
+    "operation": {
+      "description": "What was attempted.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["skill", "entry_point", "action", "target"],
+      "properties": {
+        "skill": {"type": ["string", "null"]},
+        "entry_point": {
+          "description": "Repo-relative path of the script that produced this envelope. Absolute paths are rejected: they leak the local user and are not portable between agents.",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[^/]"
+        },
+        "action": {"type": "string", "minLength": 1},
+        "target": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "id", "ref"],
+          "properties": {
+            "kind": {"$ref": "#/$defs/targetKind"},
+            "id": {"type": ["string", "null"]},
+            "ref": {"type": ["string", "null"]}
+          }
+        }
+      }
+    },
+    "outcome": {
+      "enum": ["success", "partial", "failure", "blocked", "cancelled"]
+    },
+    "exit_code": {"type": ["integer", "null"]},
+    "summary": {"type": "string", "minLength": 1, "maxLength": 400},
+    "attempt": {
+      "description": "The exact command that ran, reproducible by hand.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "remote_command",
+        "reproduce",
+        "started_at",
+        "duration_ms"
+      ],
+      "properties": {
+        "command": {"$ref": "#/$defs/command"},
+        "remote_command": {
+          "oneOf": [
+            {"type": "null"},
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "endpoint",
+                "argv",
+                "script_preview",
+                "script_ref",
+                "cwd",
+                "env_keys",
+                "timeout_seconds"
+              ],
+              "properties": {
+                "endpoint": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["kind", "ref"],
+                  "properties": {
+                    "kind": {"$ref": "#/$defs/targetKind"},
+                    "ref": {"type": ["string", "null"]}
+                  }
+                },
+                "argv": {
+                  "oneOf": [
+                    {"type": "null"},
+                    {"type": "array", "items": {"type": "string"}}
+                  ]
+                },
+                "script_preview": {
+                  "oneOf": [{"type": "null"}, {"$ref": "#/$defs/preview"}]
+                },
+                "script_ref": {"type": ["string", "null"]},
+                "cwd": {"type": ["string", "null"]},
+                "env_keys": {"type": "array", "items": {"type": "string"}},
+                "timeout_seconds": {"type": ["number", "null"], "minimum": 0}
+              },
+              "anyOf": [
+                {"properties": {"argv": {"type": "array"}}, "required": ["argv"]},
+                {
+                  "properties": {"script_preview": {"type": "object"}},
+                  "required": ["script_preview"]
+                }
+              ]
+            }
+          ]
+        },
+        "reproduce": {
+          "description": "One copy-pasteable string that re-runs the failing step by hand.",
+          "type": "string",
+          "minLength": 1
+        },
+        "started_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+        },
+        "duration_ms": {"type": ["integer", "null"], "minimum": 0}
+      }
+    },
+    "failure": {
+      "description": "Required for outcome partial, failure and blocked; forbidden for success.",
+      "oneOf": [
+        {"type": "null"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "layer",
+            "confidence",
+            "reason_code",
+            "message",
+            "attribution_basis",
+            "ruled_out",
+            "signals",
+            "exception_type"
+          ],
+          "properties": {
+            "layer": {"$ref": "#/$defs/layer"},
+            "confidence": {"enum": ["high", "medium", "low"]},
+            "reason_code": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]{1,63}$"
+            },
+            "message": {"type": "string", "minLength": 1},
+            "attribution_basis": {
+              "description": "Observations that support the layer claim. Must be non-empty unless layer is 'unknown'.",
+              "type": "array",
+              "items": {"type": "string", "minLength": 1}
+            },
+            "ruled_out": {
+              "description": "Layers explicitly excluded by evidence, so the reader knows where not to look.",
+              "type": "array",
+              "items": {"$ref": "#/$defs/layer"}
+            },
+            "signals": {
+              "type": "array",
+              "items": {"type": "object"}
+            },
+            "exception_type": {"type": ["string", "null"]}
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {"layer": {"not": {"const": "unknown"}}}
+              },
+              "then": {
+                "properties": {"attribution_basis": {"minItems": 1}}
+              }
+            },
+            {
+              "if": {"properties": {"layer": {"const": "unknown"}}},
+              "then": {
+                "properties": {"confidence": {"enum": ["medium", "low"]}}
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "environment": {
+      "description": "The concrete environment the operation ran against, at the granularity the knowledge base compares on. Every version field is always present; explicit null means 'not captured'.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "soc",
+        "cann",
+        "driver",
+        "torch",
+        "torch_npu",
+        "vllm",
+        "vllm_ascend",
+        "source",
+        "captured_at",
+        "unknown_fields"
+      ],
+      "properties": {
+        "soc": {"$ref": "#/$defs/version"},
+        "cann": {"$ref": "#/$defs/version"},
+        "driver": {"$ref": "#/$defs/version"},
+        "torch": {"$ref": "#/$defs/version"},
+        "torch_npu": {"$ref": "#/$defs/version"},
+        "vllm": {"$ref": "#/$defs/version"},
+        "vllm_ascend": {"$ref": "#/$defs/version"},
+        "source": {
+          "enum": ["probe", "manifest", "declared", "cache", "unknown"]
+        },
+        "captured_at": {"type": ["string", "null"]},
+        "unknown_fields": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "evidence": {
+      "description": "Pointers to logs, artifacts and manifests, plus the Run Manifest correlation id where one exists.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "run_id",
+        "parent_run_id",
+        "manifest_ref",
+        "refs",
+        "previews"
+      ],
+      "properties": {
+        "run_id": {"type": ["string", "null"]},
+        "parent_run_id": {"type": ["string", "null"]},
+        "manifest_ref": {"type": ["string", "null"]},
+        "refs": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/evidenceRef"}
+        },
+        "previews": {
+          "type": "object",
+          "additionalProperties": {"$ref": "#/$defs/preview"}
+        }
+      }
+    },
+    "next_step": {
+      "description": "What to look at next, and explicitly what not to look at when a known signature applies.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["actions", "do_not", "knowledge"],
+      "properties": {
+        "actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["description", "command", "ref"],
+            "properties": {
+              "description": {"type": "string", "minLength": 1},
+              "command": {"type": ["string", "null"]},
+              "ref": {"type": ["string", "null"]}
+            }
+          }
+        },
+        "do_not": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        },
+        "knowledge": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["entry_id", "summary"],
+            "properties": {
+              "entry_id": {"type": "string", "minLength": 1},
+              "summary": {"type": "string", "minLength": 1},
+              "avoidance": {"type": ["string", "null"]},
+              "score": {"type": ["integer", "null"]}
+            }
+          }
+        }
+      }
+    },
+    "parts": {
+      "description": "Per-unit results for fan-out operations. Three of four nodes succeeding is not a boolean.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "unit",
+          "unit_kind",
+          "outcome",
+          "layer",
+          "reason_code",
+          "summary",
+          "refs"
+        ],
+        "properties": {
+          "unit": {"type": "string", "minLength": 1},
+          "unit_kind": {"type": "string", "minLength": 1},
+          "outcome": {"enum": ["success", "failure", "blocked", "skipped"]},
+          "layer": {
+            "oneOf": [{"type": "null"}, {"$ref": "#/$defs/layer"}]
+          },
+          "reason_code": {"type": ["string", "null"]},
+          "summary": {"type": ["string", "null"]},
+          "refs": {
+            "type": "array",
+            "items": {"$ref": "#/$defs/evidenceRef"}
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {"outcome": {"enum": ["failure", "blocked"]}}
+            },
+            "then": {"properties": {"layer": {"$ref": "#/$defs/layer"}}}
+          }
+        ]
+      }
+    },
+    "attempts": {
+      "description": "Retry history and whether re-running is safe. retry_safe is derived from class so the two can never disagree.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["count", "records", "idempotency"],
+      "properties": {
+        "count": {"type": "integer", "minimum": 1},
+        "records": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["index", "outcome"],
+            "properties": {
+              "index": {"type": "integer", "minimum": 1},
+              "outcome": {"type": "string", "minLength": 1},
+              "layer": {
+                "oneOf": [{"type": "null"}, {"$ref": "#/$defs/layer"}]
+              },
+              "reason_code": {"type": ["string", "null"]},
+              "duration_ms": {"type": ["integer", "null"], "minimum": 0},
+              "note": {"type": ["string", "null"]}
+            }
+          }
+        },
+        "idempotency": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["class", "retry_safe", "side_effects"],
+          "properties": {
+            "class": {
+              "enum": [
+                "idempotent",
+                "at_most_once",
+                "unsafe_to_retry",
+                "unknown"
+              ]
+            },
+            "retry_safe": {"type": ["boolean", "null"]},
+            "side_effects": {
+              "type": "array",
+              "items": {"type": "string"}
+            }
+          }
+        }
+      }
+    },
+    "children": {
+      "description": "Bounded digests of nested envelopes. A digest never nests another envelope; the full child is reachable through ref.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["envelope_id", "outcome", "depth"],
+        "properties": {
+          "envelope_id": {"type": "string", "minLength": 1},
+          "entry_point": {"type": ["string", "null"]},
+          "action": {"type": ["string", "null"]},
+          "outcome": {
+            "enum": ["success", "partial", "failure", "blocked", "cancelled"]
+          },
+          "layer": {
+            "oneOf": [{"type": "null"}, {"$ref": "#/$defs/layer"}]
+          },
+          "reason_code": {"type": ["string", "null"]},
+          "summary": {"type": ["string", "null"]},
+          "ref": {"type": ["string", "null"]},
+          "depth": {"type": "integer", "minimum": 1}
+        }
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "extensions": {
+      "description": "Additive escape hatch. Producers put experimental data here so that adding a field never needs a version bump, and readers ignore what they do not recognize. A new required field or a new enum value requires v2.",
+      "type": "object"
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"outcome": {"const": "success"}}},
+      "then": {"properties": {"failure": {"type": "null"}}}
+    },
+    {
+      "if": {
+        "properties": {
+          "outcome": {"enum": ["partial", "failure", "blocked"]}
+        }
+      },
+      "then": {
+        "properties": {
+          "failure": {"type": "object"},
+          "next_step": {"properties": {"actions": {"minItems": 1}}}
+        }
+      }
+    },
+    {
+      "if": {"properties": {"outcome": {"const": "partial"}}},
+      "then": {"properties": {"parts": {"minItems": 1}}}
+    }
+  ]
+}

--- a/.agents/scripts/envelope_lint.py
+++ b/.agents/scripts/envelope_lint.py
@@ -1,0 +1,540 @@
+#!/usr/bin/env python3
+"""Check entry points against the Result Envelope v1 contract.
+
+Three modes:
+
+* ``scan``  — static survey of the tree's entry points and the current
+  conformance rate. Heuristic by construction: it reads source, it does not
+  run anything, and every heuristic is named in the output so a reader can
+  discount it.
+* ``check`` — validate an envelope payload from a file or ``stdin``.
+* ``run``   — execute a command and verify the runtime contract: exactly one
+  valid envelope on ``stdout``, progress confined to ``stderr``, and an exit
+  code that agrees with the envelope.
+
+This script follows the convention it enforces: progress on ``stderr``, one
+envelope on ``stdout``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB_DIR = ROOT / ".agents" / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from vaws_result_envelope import (  # noqa: E402
+    EnvelopeError,
+    emit,
+    make_attempt,
+    make_command,
+    make_environment,
+    make_evidence,
+    make_failure,
+    make_next_step,
+    make_operation,
+    new_envelope,
+    progress,
+    utc_now,
+    validate_envelope,
+)
+
+#: Directories that hold shared libraries and data rather than agent-facing
+#: entry points. Excluding them keeps the conformance denominator honest.
+EXCLUDED_DIR_PARTS = frozenset(
+    {"tests", "lib", "knowledge", "schemas", "references", "presets", "agents"}
+)
+ENTRY_POINT_GUARD_RE = re.compile(r"^if\s+__name__\s*==\s*[\"']__main__[\"']", re.M)
+
+#: Static checks. ``required`` members define conformance; the others are
+#: reported so a migration can be sequenced by what is already close.
+CHECKS: tuple[tuple[str, bool, str], ...] = (
+    ("envelope_library", True, "imports .agents/lib/vaws_result_envelope.py"),
+    ("stdout_json", True, "emits a JSON payload on stdout"),
+    ("stderr_progress", True, "writes progress to stderr"),
+    ("layer_attribution", True, "populates a failure layer on failure"),
+    ("reproduce_command", False, "records the exact command for re-running"),
+    ("environment_identity", False, "records soc/cann/driver/torch versions"),
+    ("evidence_refs", False, "points at logs and artifacts by reference"),
+    ("next_step", False, "states the next diagnostic step"),
+    ("run_correlation", False, "carries a Run Manifest correlation id"),
+)
+REQUIRED_CHECKS = tuple(name for name, required, _ in CHECKS if required)
+ALL_CHECKS = tuple(name for name, _, _ in CHECKS)
+
+_ENVELOPE_IMPORT_RE = re.compile(r"\bvaws_result_envelope\b")
+_LAYER_RE = re.compile(
+    r"make_failure|unknown_failure|escalate_child_layer|[\"']layer[\"']\s*:"
+)
+_PROGRESS_RE = re.compile(
+    r"sys\.stderr\.write|file\s*=\s*sys\.stderr|emit_progress\s*\(|progress\s*\("
+)
+_STDOUT_JSON_RE = re.compile(
+    r"print_json\s*\(|print\s*\(\s*json\.dumps|print\s*\(\s*json_dump|"
+    r"sys\.stdout\.write\s*\(\s*json|\bemit\s*\("
+)
+_REPRODUCE_RE = re.compile(r"make_attempt|[\"']reproduce[\"']|make_command")
+_ENV_IDENTITY_RE = re.compile(
+    r"make_environment|[\"']torch_npu[\"']|[\"']vllm_ascend[\"']"
+)
+_EVIDENCE_RE = re.compile(
+    r"make_evidence|evidence_ref|[\"']artifacts[\"']\s*:|[\"']logs[\"']\s*:"
+)
+_NEXT_STEP_RE = re.compile(
+    r"make_next_step|[\"']next_step[\"']|[\"']next_actions[\"']|[\"']do_not[\"']"
+)
+_RUN_ID_RE = re.compile(r"vaws_run_manifest|[\"']run_id[\"']|[\"']parent_run_id[\"']")
+
+
+def repo_relative(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(ROOT))
+    except ValueError:
+        return path.name
+
+
+def discover_entry_points(root: Path) -> list[Path]:
+    """Python files with a ``__main__`` guard, excluding test modules.
+
+    Test modules are excluded because they are invoked by the test runner and
+    are not part of the agent-facing surface.
+    """
+    found: list[Path] = []
+    for path in sorted(root.rglob("*.py")):
+        relative = path.relative_to(root).parts
+        if set(relative[:-1]) & EXCLUDED_DIR_PARTS:
+            continue
+        if path.name.startswith("test_"):
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if ENTRY_POINT_GUARD_RE.search(source):
+            found.append(path)
+    return found
+
+
+def _plain_print_lines(source: str) -> list[int]:
+    """Line numbers of ``print()`` calls that clearly do not emit JSON.
+
+    A bare ``print("phase: starting")`` is the single most common way a script
+    corrupts ``stdout`` for a JSON consumer, so it is worth naming precisely
+    rather than folding into a text heuristic.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    lines: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Name) and func.id == "print"):
+            continue
+        if any(
+            isinstance(keyword.value, ast.Attribute)
+            and keyword.arg == "file"
+            and keyword.value.attr == "stderr"
+            for keyword in node.keywords
+        ):
+            continue
+        if not node.args:
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Call):
+            continue
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            lines.append(node.lineno)
+        elif isinstance(first, ast.JoinedStr):
+            lines.append(node.lineno)
+    return lines
+
+
+def scan_file(path: Path) -> dict[str, Any]:
+    source = path.read_text(encoding="utf-8", errors="replace")
+    checks = {
+        "envelope_library": bool(_ENVELOPE_IMPORT_RE.search(source)),
+        "stdout_json": bool(_STDOUT_JSON_RE.search(source)),
+        "stderr_progress": bool(_PROGRESS_RE.search(source)),
+        "layer_attribution": bool(_LAYER_RE.search(source)),
+        "reproduce_command": bool(_REPRODUCE_RE.search(source)),
+        "environment_identity": bool(_ENV_IDENTITY_RE.search(source)),
+        "evidence_refs": bool(_EVIDENCE_RE.search(source)),
+        "next_step": bool(_NEXT_STEP_RE.search(source)),
+        "run_correlation": bool(_RUN_ID_RE.search(source)),
+    }
+    plain_prints = _plain_print_lines(source)
+    return {
+        "entry_point": repo_relative(path),
+        "checks": checks,
+        "required_passed": sum(1 for name in REQUIRED_CHECKS if checks[name]),
+        "conformant": all(checks[name] for name in REQUIRED_CHECKS),
+        "stdout_purity_risk_lines": plain_prints[:20],
+        "stdout_purity_risk": bool(plain_prints),
+    }
+
+
+def scan_tree(root: Path) -> dict[str, Any]:
+    entry_points = discover_entry_points(root)
+    progress("scan", f"scanning {len(entry_points)} entry points")
+    results = [scan_file(path) for path in entry_points]
+    total = len(results) or 1
+    per_check = {
+        name: sum(1 for item in results if item["checks"][name])
+        for name in ALL_CHECKS
+    }
+    conformant = [item["entry_point"] for item in results if item["conformant"]]
+    near_miss = sorted(
+        (
+            item
+            for item in results
+            if not item["conformant"] and item["required_passed"] >= 2
+        ),
+        key=lambda item: (-item["required_passed"], item["entry_point"]),
+    )
+    return {
+        "root": repo_relative(root),
+        "entry_points": len(results),
+        "conformant": len(conformant),
+        "conformance_rate": round(len(conformant) / total, 4),
+        "conformant_entry_points": conformant,
+        "required_checks": list(REQUIRED_CHECKS),
+        "per_check_passed": per_check,
+        "per_check_rate": {
+            name: round(count / total, 4) for name, count in per_check.items()
+        },
+        "stdout_purity_risk": sum(
+            1 for item in results if item["stdout_purity_risk"]
+        ),
+        "near_miss": [
+            {
+                "entry_point": item["entry_point"],
+                "required_passed": item["required_passed"],
+                "missing": [
+                    name for name in REQUIRED_CHECKS if not item["checks"][name]
+                ],
+            }
+            for item in near_miss[:20]
+        ],
+        "results": results,
+    }
+
+
+def check_payload(text: str) -> dict[str, Any]:
+    """Validate one envelope payload; never raise on bad input."""
+    findings: list[str] = []
+    payload: Any = None
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return {
+            "valid": False,
+            "findings": [f"stdout is not a single JSON document: {exc}"],
+            "envelope_id": None,
+            "outcome": None,
+            "layer": None,
+        }
+    if not isinstance(payload, dict):
+        findings.append("envelope root is not a JSON object")
+    else:
+        try:
+            validate_envelope(payload)
+        except EnvelopeError as exc:
+            findings.extend(str(exc).split("; "))
+    failure = payload.get("failure") if isinstance(payload, dict) else None
+    return {
+        "valid": not findings,
+        "findings": findings,
+        "envelope_id": payload.get("envelope_id") if isinstance(payload, dict) else None,
+        "outcome": payload.get("outcome") if isinstance(payload, dict) else None,
+        "layer": (failure or {}).get("layer") if isinstance(failure, dict) else None,
+    }
+
+
+def run_and_check(argv: Sequence[str], *, timeout: float | None) -> dict[str, Any]:
+    progress("run", f"executing {argv[0]}")
+    started = time.monotonic()
+    try:
+        completed = subprocess.run(
+            list(argv),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            cwd=str(ROOT),
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "valid": False,
+            "findings": [f"command did not finish within {timeout}s"],
+            "exit_code": None,
+            "duration_ms": int((time.monotonic() - started) * 1000),
+            "stdout_bytes": 0,
+            "stderr_bytes": 0,
+        }
+    except OSError as exc:
+        return {
+            "valid": False,
+            "findings": [f"command could not be launched: {exc}"],
+            "exit_code": None,
+            "duration_ms": int((time.monotonic() - started) * 1000),
+            "stdout_bytes": 0,
+            "stderr_bytes": 0,
+        }
+    report = check_payload(completed.stdout)
+    findings = list(report["findings"])
+    if completed.stdout.count("\n") and completed.stdout.strip().count("}\n{"):
+        findings.append("stdout carries more than one JSON document")
+    if "__VAWS_" in completed.stdout:
+        findings.append("progress sentinel found on stdout; progress belongs on stderr")
+    envelope_exit = None
+    try:
+        envelope_exit = json.loads(completed.stdout).get("exit_code")
+    except (json.JSONDecodeError, AttributeError):
+        pass
+    if isinstance(envelope_exit, int) and envelope_exit != completed.returncode:
+        findings.append(
+            f"process exit code {completed.returncode} disagrees with "
+            f"envelope exit_code {envelope_exit}"
+        )
+    return {
+        "valid": not findings,
+        "findings": findings,
+        "exit_code": completed.returncode,
+        "duration_ms": int((time.monotonic() - started) * 1000),
+        "stdout_bytes": len(completed.stdout.encode("utf-8", errors="replace")),
+        "stderr_bytes": len(completed.stderr.encode("utf-8", errors="replace")),
+        "envelope_id": report["envelope_id"],
+        "outcome": report["outcome"],
+        "layer": report["layer"],
+    }
+
+
+def _self_envelope(
+    *,
+    action: str,
+    argv: Sequence[str],
+    report: dict[str, Any],
+    ok: bool,
+    summary: str,
+    findings: Iterable[str],
+    started_at: str,
+    duration_ms: int,
+    next_actions: Sequence[str],
+) -> dict[str, Any]:
+    command = make_command(argv=argv, cwd=".")
+    failure = None
+    outcome = "success"
+    if not ok:
+        finding_list = list(findings)
+        outcome = "failure"
+        reason_code = "envelope_nonconformant"
+        if any("not a single JSON document" in item for item in finding_list):
+            reason_code = "non_json_output"
+        elif action == "scan":
+            reason_code = "conformance_below_gate"
+        failure = make_failure(
+            layer="tool",
+            reason_code=reason_code,
+            message=summary,
+            attribution_basis=[
+                "the linted target is a local wrapper and its output contract "
+                "is what failed",
+                *finding_list[:8],
+            ],
+            confidence="high",
+            ruled_out=["transport", "remote_env", "remote_workload", "device"],
+        )
+    return new_envelope(
+        operation=make_operation(
+            entry_point=".agents/scripts/envelope_lint.py",
+            action=action,
+            skill=None,
+            target_kind="local",
+            target_id=report.get("root") or (list(argv)[-1] if argv else None),
+        ),
+        outcome=outcome,
+        summary=summary,
+        attempt=make_attempt(
+            command=command,
+            reproduce=command["display"],
+            started_at=started_at,
+            duration_ms=duration_ms,
+        ),
+        environment=make_environment(source="unknown"),
+        evidence=make_evidence(),
+        next_step=make_next_step(actions=list(next_actions) or ["no action needed"]),
+        failure=failure,
+        extensions={"report": report},
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, allow_abbrev=False, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    scan = sub.add_parser("scan", help="static conformance survey of a tree")
+    scan.add_argument("--root", default=str(ROOT / ".agents"))
+    scan.add_argument(
+        "--details",
+        action="store_true",
+        help="include the per-entry-point table in extensions.report.results",
+    )
+    scan.add_argument(
+        "--fail-under",
+        type=float,
+        default=None,
+        help="exit non-zero when the conformance rate is below this fraction",
+    )
+
+    check = sub.add_parser("check", help="validate an envelope payload")
+    check.add_argument(
+        "--payload-file",
+        default="-",
+        help="path to a JSON envelope, or '-' for stdin",
+    )
+
+    run = sub.add_parser("run", help="run a command and check its envelope")
+    run.add_argument("--timeout", type=float, default=300.0)
+    run.add_argument("command", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    raw_argv = list(argv) if argv is not None else sys.argv[1:]
+    args = build_parser().parse_args(raw_argv)
+    self_argv = ["python3", ".agents/scripts/envelope_lint.py", *raw_argv]
+    started_at = utc_now()
+    started = time.monotonic()
+
+    if args.mode == "scan":
+        report = scan_tree(Path(args.root).resolve())
+        results = report.pop("results")
+        if args.details:
+            report["results"] = results
+        rate = report["conformance_rate"]
+        ok = args.fail_under is None or rate >= args.fail_under
+        summary = (
+            f"{report['conformant']}/{report['entry_points']} entry points "
+            f"conform to the envelope contract ({rate:.1%})"
+        )
+        progress("scan", summary)
+        return emit(
+            _self_envelope(
+                action="scan",
+                argv=self_argv,
+                report=report,
+                ok=ok,
+                summary=summary,
+                findings=[f"conformance rate {rate} below gate {args.fail_under}"]
+                if not ok
+                else [],
+                started_at=started_at,
+                duration_ms=int((time.monotonic() - started) * 1000),
+                next_actions=[
+                    "migrate the near_miss entry points first: they already "
+                    "keep progress on stderr and JSON on stdout",
+                    "read docs/agent-feedback-contract.md for the migration "
+                    "sequence",
+                ],
+            )
+        )
+
+    if args.mode == "check":
+        if args.payload_file == "-":
+            text = sys.stdin.read()
+            source = "stdin"
+        else:
+            path = Path(args.payload_file)
+            try:
+                text = path.read_text(encoding="utf-8")
+            except OSError as exc:
+                text = ""
+                progress("check", f"cannot read payload: {exc}")
+            source = repo_relative(path)
+        report = check_payload(text)
+        report["source"] = source
+        summary = (
+            f"payload from {source} conforms to Result Envelope v1"
+            if report["valid"]
+            else f"payload from {source} has {len(report['findings'])} violations"
+        )
+        progress("check", summary)
+        return emit(
+            _self_envelope(
+                action="check",
+                argv=self_argv,
+                report=report,
+                ok=bool(report["valid"]),
+                summary=summary,
+                findings=report["findings"],
+                started_at=started_at,
+                duration_ms=int((time.monotonic() - started) * 1000),
+                next_actions=[
+                    "fix the reported fields in the producing entry point",
+                ]
+                if not report["valid"]
+                else [],
+            )
+        )
+
+    command = [part for part in (args.command or []) if part != "--"]
+    if not command:
+        report = {"findings": ["no command given"], "valid": False}
+        progress("run", "no command given")
+        return emit(
+            _self_envelope(
+                action="run",
+                argv=self_argv,
+                report=report,
+                ok=False,
+                summary="no command given to run",
+                findings=report["findings"],
+                started_at=started_at,
+                duration_ms=int((time.monotonic() - started) * 1000),
+                next_actions=["pass the command after 'run --'"],
+            )
+        )
+    report = run_and_check(command, timeout=args.timeout)
+    report["command"] = command
+    summary = (
+        "command satisfies the runtime envelope contract"
+        if report["valid"]
+        else f"command violates the envelope contract ({len(report['findings'])} findings)"
+    )
+    progress("run", summary)
+    return emit(
+        _self_envelope(
+            action="run",
+            argv=self_argv,
+            report=report,
+            ok=bool(report["valid"]),
+            summary=summary,
+            findings=report["findings"],
+            started_at=started_at,
+            duration_ms=int((time.monotonic() - started) * 1000),
+            next_actions=[
+                "adopt .agents/lib/vaws_result_envelope.py in the target script",
+            ]
+            if not report["valid"]
+            else [],
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/envelope_lint.py
+++ b/.agents/scripts/envelope_lint.py
@@ -414,6 +414,21 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def child_command(raw: Sequence[str] | None) -> list[str]:
+    """Build the child argv, consuming only one optional leading ``--``.
+
+    ``envelope_lint.py run -- cmd ...`` uses a single leading separator to
+    end lint options. That token is not part of the child. Every remaining
+    token is left unchanged, in order, including a later ``--`` that the
+    child itself uses as an option delimiter. The returned list is the
+    exact argv used for both execution and the report.
+    """
+    command = list(raw or ())
+    if command and command[0] == "--":
+        return command[1:]
+    return command
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     raw_argv = list(argv) if argv is not None else sys.argv[1:]
     args = build_parser().parse_args(raw_argv)
@@ -492,7 +507,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         )
 
-    command = [part for part in (args.command or []) if part != "--"]
+    command = child_command(args.command)
     if not command:
         report = {"findings": ["no command given"], "valid": False}
         progress("run", "no command given")

--- a/.agents/tests/test_result_envelope.py
+++ b/.agents/tests/test_result_envelope.py
@@ -57,6 +57,7 @@ from vaws_result_envelope import (  # noqa: E402
     new_envelope,
     outcome_from_parts,
     progress,
+    propagate_child_ruled_out,
     read_envelope,
     redact,
     text_preview,
@@ -408,6 +409,165 @@ class PartialSuccessTests(unittest.TestCase):
         ]
         self.assertEqual(outcome_from_parts(parts), "blocked")
 
+    def test_one_unknown_failure_stays_unknown_with_low_confidence(self) -> None:
+        parts = [
+            make_part(
+                unit="node-0",
+                outcome="failure",
+                layer="unknown",
+                reason_code="fixture",
+            )
+        ]
+        failure = failure_from_parts(parts)
+        self.assertEqual(failure["layer"], "unknown")
+        self.assertEqual(failure["confidence"], "low")
+        self.assertIn("node-0", failure["attribution_basis"][0])
+        envelope = base_envelope(
+            outcome="failure",
+            failure=failure,
+            parts=parts,
+            next_step=make_next_step(actions=["inspect fixture log"]),
+        )
+        validate_envelope(envelope)
+        self.assertEqual(envelope["outcome"], "failure")
+
+    def test_several_unknown_failures_do_not_raise_confidence(self) -> None:
+        parts = [
+            make_part(
+                unit="node-0",
+                outcome="failure",
+                layer="unknown",
+                reason_code="fixture",
+            ),
+            make_part(
+                unit="node-1",
+                outcome="failure",
+                layer="unknown",
+                reason_code="fixture",
+            ),
+            make_part(
+                unit="node-2",
+                outcome="failure",
+                layer="unknown",
+                reason_code="fixture",
+            ),
+        ]
+        failure = failure_from_parts(parts)
+        self.assertEqual(failure["layer"], "unknown")
+        self.assertEqual(failure["confidence"], "low")
+        self.assertIn("node-0", failure["attribution_basis"][0])
+        self.assertIn("node-2", failure["attribution_basis"][0])
+        envelope = base_envelope(
+            outcome="failure",
+            failure=failure,
+            parts=parts,
+            next_step=make_next_step(actions=["collect a layer signal"]),
+        )
+        validate_envelope(envelope)
+        self.assertEqual(envelope["outcome"], "failure")
+
+    def test_all_unknown_blocked_parts_stay_blocked_and_low_confidence(self) -> None:
+        parts = [
+            make_part(
+                unit="node-0",
+                outcome="blocked",
+                layer="unknown",
+                reason_code="fixture",
+            ),
+            make_part(
+                unit="node-1",
+                outcome="blocked",
+                layer="unknown",
+                reason_code="fixture",
+            ),
+        ]
+        self.assertEqual(outcome_from_parts(parts), "blocked")
+        failure = failure_from_parts(parts)
+        self.assertEqual(failure["layer"], "unknown")
+        self.assertEqual(failure["confidence"], "low")
+        envelope = base_envelope(
+            outcome="blocked",
+            failure=failure,
+            parts=parts,
+            next_step=make_next_step(actions=["collect a layer signal"]),
+        )
+        validate_envelope(envelope)
+        self.assertEqual(envelope["outcome"], "blocked")
+
+    def test_known_same_layer_failures_keep_high_confidence(self) -> None:
+        parts = [
+            make_part(
+                unit="node-0",
+                outcome="failure",
+                layer="tool",
+                reason_code="fixture",
+            )
+        ]
+        failure = failure_from_parts(parts)
+        self.assertEqual(failure["layer"], "tool")
+        self.assertEqual(failure["confidence"], "high")
+        envelope = base_envelope(
+            outcome="failure",
+            failure=failure,
+            parts=parts,
+            next_step=make_next_step(actions=["inspect fixture log"]),
+        )
+        validate_envelope(envelope)
+        self.assertEqual(envelope["outcome"], "failure")
+
+    def test_mixed_attributed_and_unknown_parts_stay_unknown_and_low(self) -> None:
+        parts = [
+            make_part(
+                unit="node-0",
+                outcome="failure",
+                layer="device",
+                reason_code="npu_busy",
+            ),
+            make_part(
+                unit="node-1",
+                outcome="failure",
+                layer="unknown",
+                reason_code="fixture",
+            ),
+        ]
+        self.assertEqual(outcome_from_parts(parts), "failure")
+        failure = failure_from_parts(parts)
+        self.assertEqual(failure["layer"], "unknown")
+        self.assertEqual(failure["confidence"], "low")
+        envelope = base_envelope(
+            outcome="failure",
+            failure=failure,
+            parts=parts,
+            next_step=make_next_step(
+                actions=["separate the attributed unit from the rest"]
+            ),
+        )
+        validate_envelope(envelope)
+        self.assertEqual(envelope["outcome"], "failure")
+
+    def test_partial_unknown_failures_stay_partial_and_low_confidence(self) -> None:
+        parts = [
+            make_part(unit="node-0", outcome="success"),
+            make_part(
+                unit="node-1",
+                outcome="failure",
+                layer="unknown",
+                reason_code="fixture",
+            ),
+        ]
+        self.assertEqual(outcome_from_parts(parts), "partial")
+        failure = failure_from_parts(parts)
+        self.assertEqual(failure["layer"], "unknown")
+        self.assertEqual(failure["confidence"], "low")
+        envelope = base_envelope(
+            outcome="partial",
+            failure=failure,
+            parts=parts,
+            next_step=make_next_step(actions=["inspect node-1"]),
+        )
+        validate_envelope(envelope)
+        self.assertEqual(envelope["outcome"], "partial")
+
 
 class RetryTests(unittest.TestCase):
     def test_retry_safe_is_derived_from_the_idempotency_class(self) -> None:
@@ -468,7 +628,14 @@ class RetryTests(unittest.TestCase):
 
 
 class CompositionTests(unittest.TestCase):
-    def _child(self, layer: str, reason_code: str) -> dict:
+    def _child(
+        self,
+        layer: str,
+        reason_code: str,
+        *,
+        ruled_out: list[str] | None = None,
+        outcome: str = "failure",
+    ) -> dict:
         command = make_command(
             argv=["python3", ".agents/scripts/remote_exec.py", "--session-id", "demo-1"]
         )
@@ -479,7 +646,7 @@ class CompositionTests(unittest.TestCase):
                 target_kind="container",
                 target_id="demo-1",
             ),
-            outcome="failure",
+            outcome=outcome,
             summary=f"remote_exec failed in layer {layer}",
             attempt=make_attempt(
                 command=command, reproduce=command["display"], started_at=NOW
@@ -489,6 +656,7 @@ class CompositionTests(unittest.TestCase):
                 reason_code=reason_code,
                 message="nested failure",
                 attribution_basis=["nested observation"],
+                ruled_out=ruled_out,
             ),
             next_step=make_next_step(
                 actions=["read the nested log"],
@@ -503,6 +671,28 @@ class CompositionTests(unittest.TestCase):
         self.assertNotIn("children", digest)
         self.assertNotIn("attempt", digest)
         self.assertEqual(digest["layer"], "transport")
+
+    def test_propagate_child_ruled_out_is_frame_aware(self) -> None:
+        self.assertEqual(
+            propagate_child_ruled_out(
+                ["tool", "device"],
+                child_layer="caller",
+                parent_layer="tool",
+            ),
+            ["device"],
+        )
+        self.assertEqual(
+            propagate_child_ruled_out(
+                ["tool", "device"],
+                child_layer="transport",
+                parent_layer="transport",
+            ),
+            ["tool", "device"],
+        )
+        self.assertEqual(
+            escalate_child_layer("caller"),
+            "tool",
+        )
 
     def test_nested_layer_propagates_unchanged(self) -> None:
         parent = base_envelope()
@@ -554,6 +744,97 @@ class CompositionTests(unittest.TestCase):
         parent["children"] = [self._child("transport", "ssh_connect_failed")]
         with self.assertRaisesRegex(EnvelopeError, "must be a digest"):
             validate_envelope(parent)
+
+    def test_nested_caller_without_child_tool_exclusion_composes(self) -> None:
+        parent = base_envelope()
+        child = self._child("caller", "bad_arguments", outcome="blocked")
+        child_snapshot = json.loads(json.dumps(child))
+        validate_envelope(parent)
+        validate_envelope(child)
+        composed = compose_child(parent, child, ref="fixture-child.json")
+        validate_envelope(composed)
+        self.assertEqual(composed["outcome"], "blocked")
+        self.assertEqual(composed["failure"]["layer"], "tool")
+        self.assertEqual(composed["failure"]["ruled_out"], [])
+        self.assertEqual(child, child_snapshot)
+        self.assertEqual(composed["children"][0]["envelope_id"], child["envelope_id"])
+        self.assertEqual(composed["children"][0]["ref"], "fixture-child.json")
+        self.assertEqual(composed["children"][0]["layer"], "caller")
+        self.assertEqual(
+            composed["next_step"]["actions"][0]["description"],
+            "read the nested log",
+        )
+        self.assertIn(
+            "do not retry on the shared mux", composed["next_step"]["do_not"]
+        )
+
+    def test_nested_caller_with_child_tool_exclusion_drops_parent_tool(self) -> None:
+        parent = base_envelope()
+        child = self._child(
+            "caller",
+            "bad_arguments",
+            ruled_out=["tool"],
+            outcome="blocked",
+        )
+        child_snapshot = json.loads(json.dumps(child))
+        validate_envelope(parent)
+        validate_envelope(child)
+        composed = compose_child(parent, child, ref="fixture-child.json")
+        validate_envelope(composed)
+        self.assertEqual(composed["outcome"], "blocked")
+        self.assertEqual(composed["failure"]["layer"], "tool")
+        self.assertNotIn("tool", composed["failure"]["ruled_out"])
+        self.assertEqual(child, child_snapshot)
+        self.assertEqual(child["failure"]["layer"], "caller")
+        self.assertEqual(child["failure"]["ruled_out"], ["tool"])
+        self.assertEqual(composed["children"][0]["envelope_id"], child["envelope_id"])
+        self.assertEqual(composed["children"][0]["ref"], "fixture-child.json")
+        self.assertEqual(composed["children"][0]["layer"], "caller")
+        self.assertEqual(
+            composed["next_step"]["actions"][0]["description"],
+            "read the nested log",
+        )
+        self.assertIn(
+            "do not retry on the shared mux", composed["next_step"]["do_not"]
+        )
+
+    def test_nested_caller_keeps_downstream_exclusions(self) -> None:
+        parent = base_envelope()
+        child = self._child(
+            "caller",
+            "bad_arguments",
+            ruled_out=["tool", "transport", "device"],
+        )
+        child_snapshot = json.loads(json.dumps(child))
+        composed = compose_child(parent, child, ref="fixture-child.json")
+        validate_envelope(composed)
+        self.assertEqual(composed["failure"]["layer"], "tool")
+        self.assertEqual(composed["failure"]["ruled_out"], ["transport", "device"])
+        self.assertEqual(
+            child["failure"]["ruled_out"], ["tool", "transport", "device"]
+        )
+        self.assertEqual(child, child_snapshot)
+        self.assertEqual(composed["children"][0]["layer"], "caller")
+        self.assertEqual(composed["children"][0]["ref"], "fixture-child.json")
+
+    def test_unchanged_layer_keeps_child_exclusions(self) -> None:
+        parent = base_envelope()
+        child = self._child(
+            "transport",
+            "ssh_mux_stream_died",
+            ruled_out=["caller", "tool"],
+        )
+        child_snapshot = json.loads(json.dumps(child))
+        composed = compose_child(parent, child, ref="fixture-child.json")
+        validate_envelope(composed)
+        self.assertEqual(composed["failure"]["layer"], "transport")
+        self.assertEqual(composed["failure"]["ruled_out"], ["caller", "tool"])
+        self.assertEqual(child, child_snapshot)
+        self.assertEqual(composed["children"][0]["layer"], "transport")
+        self.assertEqual(composed["children"][0]["ref"], "fixture-child.json")
+        self.assertIn(
+            "do not retry on the shared mux", composed["next_step"]["do_not"]
+        )
 
 
 class BoundedOutputTests(unittest.TestCase):

--- a/.agents/tests/test_result_envelope.py
+++ b/.agents/tests/test_result_envelope.py
@@ -1,0 +1,963 @@
+#!/usr/bin/env python3
+"""Tests for Result Envelope v1, its taxonomy, redaction, and the lint.
+
+Fixtures use RFC 5737 documentation addresses and ``*.invalid`` hostnames so
+that a realistic-looking failure never puts a real endpoint in a tracked
+file.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+SCRIPTS = ROOT / ".agents" / "scripts"
+for candidate in (LIB, SCRIPTS):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+import envelope_lint  # noqa: E402
+from vaws_result_envelope import (  # noqa: E402
+    ENVIRONMENT_FIELDS,
+    LAYERS,
+    REDACTED_HOME,
+    REDACTED_HOST,
+    REDACTED_SECRET,
+    SCHEMA_VERSION,
+    EnvelopeError,
+    EnvelopeRedactionError,
+    assert_publishable,
+    child_digest,
+    compose_child,
+    default_exit_code,
+    dumps_publishable,
+    emit,
+    escalate_child_layer,
+    evidence_ref,
+    failure_from_parts,
+    knowledge_reference,
+    leak_findings,
+    make_attempt,
+    make_attempts,
+    make_command,
+    make_environment,
+    make_evidence,
+    make_failure,
+    make_next_step,
+    make_operation,
+    make_part,
+    make_remote_command,
+    new_envelope,
+    outcome_from_parts,
+    progress,
+    read_envelope,
+    redact,
+    text_preview,
+    unknown_failure,
+    validate_envelope,
+)
+
+NOW = "2026-09-04T12:00:00Z"
+SCHEMA_PATH = ROOT / ".agents" / "schemas" / "result-envelope-v1.schema.json"
+
+
+def base_command(*extra: str) -> dict:
+    return make_command(
+        argv=[
+            "python3",
+            ".agents/skills/vllm-ascend-serving/scripts/serve_start.py",
+            *extra,
+        ],
+        cwd=".",
+        env_keys=["ASCEND_RT_VISIBLE_DEVICES"],
+        timeout_seconds=900,
+    )
+
+
+def base_envelope(**overrides) -> dict:
+    command = overrides.pop("command", base_command("--session-id", "demo-1"))
+    payload = {
+        "operation": make_operation(
+            entry_point=".agents/skills/vllm-ascend-serving/scripts/serve_start.py",
+            action="serve_start",
+            skill="vllm-ascend-serving",
+            target_kind="session",
+            target_id="demo-1",
+        ),
+        "outcome": "success",
+        "summary": "service reached ready",
+        "attempt": make_attempt(
+            command=command,
+            reproduce=command["display"],
+            started_at=NOW,
+            duration_ms=1234,
+        ),
+        "environment": make_environment(
+            source="probe",
+            captured_at=NOW,
+            soc="ascend910_9391",
+            cann="8.3.RC1",
+            driver="25.2.0",
+            torch="2.7.1",
+            torch_npu="2.7.1.dev20260801",
+            vllm="0.11.0",
+            vllm_ascend="0.11.0rc1",
+        ),
+        "evidence": make_evidence(run_id="debug-20260904-120000-abcd1234"),
+        "next_step": make_next_step(),
+        "emitted_at": NOW,
+        "envelope_id": "serve-start-20260904t120000z-abcd1234",
+    }
+    payload.update(overrides)
+    return new_envelope(**payload)
+
+
+class ConstructionTests(unittest.TestCase):
+    def test_success_envelope_round_trips_through_json(self) -> None:
+        envelope = base_envelope()
+        reloaded = json.loads(json.dumps(envelope))
+        validate_envelope(reloaded)
+        self.assertEqual(reloaded["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(reloaded["exit_code"], 0)
+        self.assertIsNone(reloaded["failure"])
+
+    def test_environment_always_carries_every_field(self) -> None:
+        environment = make_environment(source="declared", torch="2.7.1")
+        for field in ENVIRONMENT_FIELDS:
+            self.assertIn(field, environment)
+        self.assertEqual(
+            environment["unknown_fields"],
+            sorted(set(ENVIRONMENT_FIELDS) - {"torch"}),
+        )
+
+    def test_environment_unknown_fields_must_match_null_versions(self) -> None:
+        environment = make_environment(source="probe", torch="2.7.1")
+        environment["unknown_fields"] = []
+        with self.assertRaisesRegex(EnvelopeError, "unknown_fields"):
+            base_envelope(environment=environment)
+
+    def test_absolute_entry_point_is_rejected(self) -> None:
+        with self.assertRaisesRegex(EnvelopeError, "repo-relative"):
+            base_envelope(
+                operation=make_operation(
+                    entry_point="/opt/vaws/.agents/scripts/remote_exec.py",
+                    action="remote_exec",
+                )
+            )
+
+    def test_unknown_top_level_field_is_rejected(self) -> None:
+        envelope = base_envelope()
+        envelope["metrics"] = {"throughput": 1.0}
+        with self.assertRaisesRegex(EnvelopeError, "unknown top-level fields"):
+            validate_envelope(envelope)
+
+    def test_extensions_is_the_additive_escape_hatch(self) -> None:
+        envelope = base_envelope(extensions={"metrics": {"throughput": 1.0}})
+        validate_envelope(envelope)
+        self.assertEqual(envelope["extensions"]["metrics"]["throughput"], 1.0)
+
+    def test_default_exit_codes_distinguish_outcomes(self) -> None:
+        self.assertEqual(default_exit_code("success"), 0)
+        self.assertEqual(default_exit_code("failure"), 1)
+        self.assertEqual(default_exit_code("blocked"), 2)
+        self.assertEqual(default_exit_code("cancelled"), 3)
+
+
+class TaxonomyTests(unittest.TestCase):
+    def test_every_layer_has_a_worked_failure(self) -> None:
+        """One envelope per layer, mirroring docs/agent-feedback-contract.md."""
+        fixtures = {
+            "caller": ("bad_arguments", "--tp 4 conflicts with --devices 0,1"),
+            "tool": (
+                "tool_service_instant_timeout",
+                "remote_bash returned timeout in 40ms for every command",
+            ),
+            "transport": (
+                "ssh_mux_stream_died",
+                "ssh stream closed immediately over the shared ControlMaster",
+            ),
+            "remote_env": (
+                "hostname_unresolvable",
+                "gloo could not resolve the container hostname",
+            ),
+            "remote_workload": (
+                "workload_nonzero_exit",
+                "vllm serve exited 1 during model load",
+            ),
+            "device": ("npu_busy", "devices 0-3 already held by another lease"),
+            "unknown": (
+                "unattributed",
+                "service never bound the port and no log was produced",
+            ),
+        }
+        self.assertEqual(set(fixtures), set(LAYERS))
+        for layer, (reason_code, message) in fixtures.items():
+            with self.subTest(layer=layer):
+                failure = (
+                    unknown_failure(message=message)
+                    if layer == "unknown"
+                    else make_failure(
+                        layer=layer,
+                        reason_code=reason_code,
+                        message=message,
+                        attribution_basis=[f"observed: {message}"],
+                        confidence="high",
+                    )
+                )
+                envelope = base_envelope(
+                    outcome="failure",
+                    summary=message[:200],
+                    failure=failure,
+                    next_step=make_next_step(
+                        actions=["read the referenced log"],
+                    ),
+                )
+                validate_envelope(envelope)
+                self.assertEqual(envelope["failure"]["layer"], layer)
+                self.assertEqual(envelope["exit_code"], 1)
+
+    def test_layer_claim_without_evidence_is_rejected(self) -> None:
+        failure = make_failure(
+            layer="remote_workload",
+            reason_code="workload_nonzero_exit",
+            message="it broke",
+        )
+        with self.assertRaisesRegex(EnvelopeError, "attribution_basis"):
+            base_envelope(
+                outcome="failure",
+                failure=failure,
+                next_step=make_next_step(actions=["look at the log"]),
+            )
+
+    def test_unknown_layer_needs_no_basis_but_cannot_be_confident(self) -> None:
+        envelope = base_envelope(
+            outcome="failure",
+            failure=unknown_failure(message="no usable signal"),
+            next_step=make_next_step(
+                actions=["re-run with --timeout 1800 and keep the stderr log"]
+            ),
+        )
+        validate_envelope(envelope)
+        self.assertEqual(envelope["failure"]["confidence"], "low")
+        bad = unknown_failure(message="no usable signal")
+        bad["confidence"] = "high"
+        with self.assertRaisesRegex(EnvelopeError, "cannot be high"):
+            base_envelope(
+                outcome="failure",
+                failure=bad,
+                next_step=make_next_step(actions=["collect more evidence"]),
+            )
+
+    def test_ruled_out_cannot_contain_the_claimed_layer(self) -> None:
+        failure = make_failure(
+            layer="transport",
+            reason_code="ssh_connect_failed",
+            message="connection refused",
+            attribution_basis=["ssh exited 255 before the remote shell started"],
+            ruled_out=["transport"],
+        )
+        with self.assertRaisesRegex(EnvelopeError, "must not contain"):
+            base_envelope(
+                outcome="failure",
+                failure=failure,
+                next_step=make_next_step(actions=["check the container port"]),
+            )
+
+    def test_failure_requires_a_next_step(self) -> None:
+        with self.assertRaisesRegex(EnvelopeError, "next_step action"):
+            base_envelope(
+                outcome="failure",
+                failure=unknown_failure(message="no usable signal"),
+            )
+
+    def test_success_must_not_carry_a_failure(self) -> None:
+        with self.assertRaisesRegex(EnvelopeError, "must not carry a failure"):
+            base_envelope(failure=unknown_failure(message="stray"))
+
+    def test_known_signature_records_what_not_to_look_at(self) -> None:
+        envelope = base_envelope(
+            outcome="failure",
+            summary="gloo init failed on a fresh container",
+            failure=make_failure(
+                layer="remote_env",
+                reason_code="hostname_unresolvable",
+                message="gloo::makeDeviceForHostname failed for the container",
+                attribution_basis=[
+                    "stderr matches a recorded known-failure signature",
+                ],
+                confidence="high",
+                ruled_out=["remote_workload", "device"],
+            ),
+            next_step=make_next_step(
+                actions=[
+                    {
+                        "description": "map the container hostname in /etc/hosts",
+                        "command": "echo \"127.0.0.1 $(hostname)\" >> /etc/hosts",
+                    }
+                ],
+                do_not=[
+                    "do not tune GLOO_SOCKET_IFNAME or other HCCL env vars "
+                    "before /etc/hosts is fixed",
+                ],
+                knowledge=[
+                    knowledge_reference(
+                        entry_id="gloo-init-container-hostname-missing-from-etc-hosts",
+                        summary="fresh containers lack their own hostname mapping",
+                        avoidance="do not debug gloo/HCCL env vars first",
+                        score=7,
+                    )
+                ],
+            ),
+        )
+        validate_envelope(envelope)
+        self.assertTrue(envelope["next_step"]["do_not"])
+        self.assertEqual(
+            envelope["next_step"]["knowledge"][0]["entry_id"],
+            "gloo-init-container-hostname-missing-from-etc-hosts",
+        )
+
+
+class PartialSuccessTests(unittest.TestCase):
+    def _parts(self) -> list[dict]:
+        return [
+            make_part(unit="node-0", outcome="success"),
+            make_part(unit="node-1", outcome="success"),
+            make_part(unit="node-2", outcome="success"),
+            make_part(
+                unit="node-3",
+                outcome="failure",
+                layer="device",
+                reason_code="npu_busy",
+                summary="devices 4-7 held by another lease",
+            ),
+        ]
+
+    def test_three_of_four_nodes_is_partial_not_boolean(self) -> None:
+        parts = self._parts()
+        self.assertEqual(outcome_from_parts(parts), "partial")
+        failure = failure_from_parts(parts)
+        envelope = base_envelope(
+            outcome="partial",
+            summary="3/4 nodes started, node-3 blocked on devices",
+            failure=failure,
+            parts=parts,
+            next_step=make_next_step(actions=["release the node-3 device lease"]),
+        )
+        validate_envelope(envelope)
+        self.assertEqual(envelope["failure"]["layer"], "device")
+        self.assertEqual(envelope["exit_code"], 1)
+        self.assertEqual(len(envelope["parts"]), 4)
+
+    def test_mixed_part_layers_aggregate_to_unknown(self) -> None:
+        parts = [
+            make_part(unit="node-0", outcome="success"),
+            make_part(
+                unit="node-1", outcome="failure", layer="device", reason_code="npu_busy"
+            ),
+            make_part(
+                unit="node-2",
+                outcome="failure",
+                layer="transport",
+                reason_code="ssh_connect_failed",
+            ),
+        ]
+        failure = failure_from_parts(parts)
+        self.assertEqual(failure["layer"], "unknown")
+
+    def test_outcome_must_agree_with_parts(self) -> None:
+        with self.assertRaisesRegex(EnvelopeError, "disagrees with parts"):
+            base_envelope(
+                outcome="failure",
+                failure=failure_from_parts(self._parts()),
+                parts=self._parts(),
+                next_step=make_next_step(actions=["inspect node-3"]),
+            )
+
+    def test_failing_part_must_carry_a_layer(self) -> None:
+        parts = [
+            make_part(unit="node-0", outcome="success"),
+            make_part(unit="node-1", outcome="failure"),
+        ]
+        with self.assertRaisesRegex(EnvelopeError, "must carry a layer"):
+            base_envelope(
+                outcome="partial",
+                failure=unknown_failure(message="node-1 failed"),
+                parts=parts,
+                next_step=make_next_step(actions=["inspect node-1"]),
+            )
+
+    def test_partial_without_parts_is_rejected(self) -> None:
+        with self.assertRaisesRegex(EnvelopeError, "requires parts"):
+            base_envelope(
+                outcome="partial",
+                failure=unknown_failure(message="something partially failed"),
+                next_step=make_next_step(actions=["inspect the units"]),
+            )
+
+    def test_all_units_blocked_is_blocked_not_partial(self) -> None:
+        parts = [
+            make_part(unit="node-0", outcome="blocked", layer="caller"),
+            make_part(unit="node-1", outcome="blocked", layer="caller"),
+        ]
+        self.assertEqual(outcome_from_parts(parts), "blocked")
+
+
+class RetryTests(unittest.TestCase):
+    def test_retry_safe_is_derived_from_the_idempotency_class(self) -> None:
+        self.assertIs(
+            make_attempts(idempotency_class="idempotent")["idempotency"]["retry_safe"],
+            True,
+        )
+        self.assertIs(
+            make_attempts(idempotency_class="unsafe_to_retry")["idempotency"][
+                "retry_safe"
+            ],
+            False,
+        )
+        self.assertIsNone(
+            make_attempts(idempotency_class="unknown")["idempotency"]["retry_safe"]
+        )
+        self.assertIsNone(
+            make_attempts(idempotency_class="at_most_once")["idempotency"][
+                "retry_safe"
+            ]
+        )
+
+    def test_hand_edited_retry_safe_is_rejected(self) -> None:
+        attempts = make_attempts(idempotency_class="unknown")
+        attempts["idempotency"]["retry_safe"] = True
+        with self.assertRaisesRegex(EnvelopeError, "derived from class"):
+            base_envelope(attempts=attempts)
+
+    def test_retry_history_cannot_exceed_the_attempt_count(self) -> None:
+        attempts = make_attempts(
+            count=1,
+            records=[
+                {"index": 1, "outcome": "failure"},
+                {"index": 2, "outcome": "success"},
+            ],
+        )
+        with self.assertRaisesRegex(EnvelopeError, "not be longer"):
+            base_envelope(attempts=attempts)
+
+    def test_retry_history_records_the_per_attempt_layer(self) -> None:
+        attempts = make_attempts(
+            count=2,
+            records=[
+                {
+                    "index": 1,
+                    "outcome": "failure",
+                    "layer": "transport",
+                    "reason_code": "ssh_mux_stream_died",
+                },
+                {"index": 2, "outcome": "success"},
+            ],
+            idempotency_class="idempotent",
+            side_effects=["none: the probe only reads"],
+        )
+        envelope = base_envelope(attempts=attempts)
+        validate_envelope(envelope)
+        self.assertEqual(envelope["attempts"]["records"][0]["layer"], "transport")
+
+
+class CompositionTests(unittest.TestCase):
+    def _child(self, layer: str, reason_code: str) -> dict:
+        command = make_command(
+            argv=["python3", ".agents/scripts/remote_exec.py", "--session-id", "demo-1"]
+        )
+        return new_envelope(
+            operation=make_operation(
+                entry_point=".agents/scripts/remote_exec.py",
+                action="remote_exec",
+                target_kind="container",
+                target_id="demo-1",
+            ),
+            outcome="failure",
+            summary=f"remote_exec failed in layer {layer}",
+            attempt=make_attempt(
+                command=command, reproduce=command["display"], started_at=NOW
+            ),
+            failure=make_failure(
+                layer=layer,
+                reason_code=reason_code,
+                message="nested failure",
+                attribution_basis=["nested observation"],
+            ),
+            next_step=make_next_step(
+                actions=["read the nested log"],
+                do_not=["do not retry on the shared mux"],
+            ),
+            emitted_at=NOW,
+            envelope_id="remote-exec-20260904t120000z-11112222",
+        )
+
+    def test_child_digest_is_bounded(self) -> None:
+        digest = child_digest(self._child("transport", "ssh_mux_stream_died"))
+        self.assertNotIn("children", digest)
+        self.assertNotIn("attempt", digest)
+        self.assertEqual(digest["layer"], "transport")
+
+    def test_nested_layer_propagates_unchanged(self) -> None:
+        parent = base_envelope()
+        child = self._child("remote_workload", "workload_nonzero_exit")
+        composed = compose_child(parent, child, ref=".vaws-local/x/child.json")
+        self.assertEqual(composed["outcome"], "failure")
+        self.assertEqual(composed["failure"]["layer"], "remote_workload")
+        self.assertEqual(composed["children"][0]["depth"], 1)
+
+    def test_nested_caller_fault_becomes_the_parents_tool_fault(self) -> None:
+        self.assertEqual(escalate_child_layer("caller"), "tool")
+        parent = base_envelope()
+        composed = compose_child(parent, self._child("caller", "bad_arguments"))
+        self.assertEqual(composed["failure"]["layer"], "tool")
+        self.assertTrue(
+            any(
+                "built the arguments" in item
+                for item in composed["failure"]["attribution_basis"]
+            )
+        )
+
+    def test_composition_inherits_child_do_not_guidance(self) -> None:
+        parent = base_envelope()
+        composed = compose_child(
+            parent, self._child("transport", "ssh_mux_stream_died")
+        )
+        self.assertIn(
+            "do not retry on the shared mux", composed["next_step"]["do_not"]
+        )
+
+    def test_parent_with_its_own_failure_keeps_it(self) -> None:
+        parent = base_envelope(
+            outcome="failure",
+            failure=make_failure(
+                layer="tool",
+                reason_code="non_json_output",
+                message="child returned non-JSON stdout",
+                attribution_basis=["stdout did not parse as JSON"],
+            ),
+            next_step=make_next_step(actions=["read the raw child stdout"]),
+        )
+        composed = compose_child(
+            parent, self._child("remote_workload", "workload_nonzero_exit")
+        )
+        self.assertEqual(composed["failure"]["layer"], "tool")
+
+    def test_nested_envelope_in_children_is_rejected(self) -> None:
+        parent = base_envelope()
+        parent["children"] = [self._child("transport", "ssh_connect_failed")]
+        with self.assertRaisesRegex(EnvelopeError, "must be a digest"):
+            validate_envelope(parent)
+
+
+class BoundedOutputTests(unittest.TestCase):
+    def test_short_text_is_inlined(self) -> None:
+        preview = text_preview("short output")
+        self.assertFalse(preview["truncated"])
+        self.assertEqual(preview["text"], "short output")
+
+    def test_truncated_preview_without_a_ref_is_rejected(self) -> None:
+        preview = text_preview("x" * 20000)
+        self.assertTrue(preview["truncated"])
+        with self.assertRaisesRegex(EnvelopeError, "must carry a ref"):
+            base_envelope(evidence=make_evidence(previews={"stderr": preview}))
+
+    def test_truncated_preview_with_a_ref_is_accepted(self) -> None:
+        preview = text_preview(
+            "x" * 20000, ref=".vaws-local/serving/demo-1/stderr.log"
+        )
+        envelope = base_envelope(
+            evidence=make_evidence(
+                previews={"stderr": preview},
+                refs=[
+                    evidence_ref(
+                        name="stderr",
+                        kind="log",
+                        ref=".vaws-local/serving/demo-1/stderr.log",
+                        bytes_=20000,
+                    )
+                ],
+                run_id="profiling-20260904-120000-deadbeef",
+                manifest_ref=".vaws-local/profiling/runs/demo/manifest.json",
+            )
+        )
+        validate_envelope(envelope)
+        self.assertEqual(envelope["evidence"]["refs"][0]["kind"], "log")
+
+    def test_summary_is_length_capped(self) -> None:
+        with self.assertRaisesRegex(EnvelopeError, "at most"):
+            base_envelope(summary="x" * 401)
+
+
+class ReproducibilityTests(unittest.TestCase):
+    def test_remote_command_needs_argv_or_a_script_preview(self) -> None:
+        remote = make_remote_command(
+            endpoint_kind="container", endpoint_ref="session:demo-1"
+        )
+        command = base_command()
+        with self.assertRaisesRegex(EnvelopeError, "reproducible by hand"):
+            base_envelope(
+                attempt=make_attempt(
+                    command=command,
+                    reproduce=command["display"],
+                    remote_command=remote,
+                    started_at=NOW,
+                )
+            )
+
+    def test_remote_script_preview_carries_a_ref_when_truncated(self) -> None:
+        remote = make_remote_command(
+            endpoint_kind="container",
+            endpoint_ref="session:demo-1",
+            script="echo hello\n" * 2000,
+            script_ref=".vaws-local/remote-toolbox/logs/exec-1/script.sh",
+            cwd="/vllm-workspace",
+            env_keys=["ASCEND_RT_VISIBLE_DEVICES"],
+            timeout_seconds=600,
+        )
+        command = base_command()
+        envelope = base_envelope(
+            attempt=make_attempt(
+                command=command,
+                reproduce=command["display"],
+                remote_command=remote,
+                started_at=NOW,
+            )
+        )
+        validate_envelope(envelope)
+        self.assertTrue(
+            envelope["attempt"]["remote_command"]["script_preview"]["truncated"]
+        )
+
+    def test_reproduce_is_a_single_copy_pasteable_string(self) -> None:
+        command = make_command(
+            argv=[
+                "python3",
+                ".agents/skills/vllm-ascend-benchmark/scripts/bench_run.py",
+                "--model",
+                "/home/weights/Model With Space",
+            ]
+        )
+        self.assertIn("'/home/weights/Model With Space'", command["display"])
+
+    def test_empty_argv_is_rejected(self) -> None:
+        command = make_command(argv=[])
+        with self.assertRaisesRegex(EnvelopeError, "argv must not be empty"):
+            base_envelope(
+                attempt=make_attempt(
+                    command=command, reproduce="n/a", started_at=NOW
+                )
+            )
+
+
+class RedactionTests(unittest.TestCase):
+    def _identity_envelope(self) -> dict:
+        command = make_command(
+            argv=[
+                "ssh",
+                "-p",
+                "22",
+                "root@198.51.100.7",
+                "python3",
+                "/home/example-user/work/run.py",
+            ]
+        )
+        return base_envelope(
+            outcome="failure",
+            summary="ssh to the container failed",
+            command=command,
+            attempt=make_attempt(
+                command=command,
+                reproduce=command["display"],
+                started_at=NOW,
+            ),
+            failure=make_failure(
+                layer="transport",
+                reason_code="ssh_connect_failed",
+                message="ssh: connect to host 198.51.100.7 port 22: refused",
+                attribution_basis=["ssh exited 255 before the remote shell ran"],
+            ),
+            next_step=make_next_step(actions=["verify the container ssh port"]),
+            extensions={"env": {"HF_TOKEN": "hf_realsecretvaluegoeshere"}},
+        )
+
+    def test_routable_host_and_home_path_are_redacted(self) -> None:
+        envelope = self._identity_envelope()
+        self.assertTrue(leak_findings(envelope))
+        redacted = redact(envelope)
+        text = json.dumps(redacted)
+        self.assertNotIn("198.51.100.7", text)
+        self.assertNotIn("/home/example-user", text)
+        self.assertIn(REDACTED_HOST, text)
+        self.assertIn(REDACTED_HOME, text)
+        self.assertEqual(leak_findings(redacted), [])
+
+    def test_secret_like_keys_are_replaced_not_previewed(self) -> None:
+        redacted = redact(self._identity_envelope())
+        self.assertEqual(
+            redacted["extensions"]["env"]["HF_TOKEN"], REDACTED_SECRET
+        )
+
+    def test_documentation_addresses_are_redacted_too(self) -> None:
+        """Redaction does not reason about whether an address is 'safe'."""
+        command = make_command(
+            argv=["ssh", "root@192.0.2.10", "true"],
+        )
+        envelope = base_envelope(
+            command=command,
+            attempt=make_attempt(
+                command=command, reproduce=command["display"], started_at=NOW
+            ),
+        )
+        redacted = redact(envelope)
+        self.assertNotIn("192.0.2.10", json.dumps(redacted))
+        assert_publishable(redacted)
+
+    def test_shared_weight_paths_survive_redaction(self) -> None:
+        """Model paths name no user and are load-bearing for comparison."""
+        command = make_command(
+            argv=[
+                "python3",
+                ".agents/skills/vllm-ascend-benchmark/scripts/bench_run.py",
+                "--model",
+                "/home/weights/Qwen3.5-35B",
+            ]
+        )
+        envelope = base_envelope(
+            command=command,
+            attempt=make_attempt(
+                command=command, reproduce=command["display"], started_at=NOW
+            ),
+        )
+        redacted = redact(envelope)
+        self.assertIn("/home/weights/Qwen3.5-35B", json.dumps(redacted))
+        assert_publishable(redacted)
+
+    def test_loopback_and_invalid_hostnames_are_publishable(self) -> None:
+        command = make_command(
+            argv=["curl", "http://127.0.0.1:8000/health"],
+        )
+        envelope = base_envelope(
+            command=command,
+            attempt=make_attempt(
+                command=command, reproduce=command["display"], started_at=NOW
+            ),
+            extensions={"base_url": "http://container-1.example.invalid:8000"},
+        )
+        assert_publishable(envelope)
+
+    def test_publishable_dump_refuses_a_surviving_leak(self) -> None:
+        envelope = base_envelope(extensions={"note": "see 2001:db8:1:2::5 host"})
+        with self.assertRaises(EnvelopeRedactionError):
+            assert_publishable(envelope)
+        # A pattern redaction cannot reach is caught at serialization time.
+        self.assertIn(
+            "<redacted-host>", dumps_publishable(envelope)
+        )
+
+    def test_assert_publishable_reports_a_json_path(self) -> None:
+        envelope = base_envelope(extensions={"host": "203.0.113.9"})
+        with self.assertRaises(EnvelopeRedactionError) as ctx:
+            assert_publishable(envelope)
+        self.assertIn("$.extensions.host", str(ctx.exception))
+
+
+class VersioningTests(unittest.TestCase):
+    def test_same_version_is_validated_strictly(self) -> None:
+        envelope = base_envelope()
+        view = read_envelope(envelope)
+        self.assertEqual(view["compat_warnings"], [])
+
+    def test_future_version_is_read_leniently(self) -> None:
+        envelope = base_envelope(
+            outcome="failure",
+            failure=make_failure(
+                layer="transport",
+                reason_code="ssh_connect_failed",
+                message="refused",
+                attribution_basis=["ssh exited 255"],
+            ),
+            next_step=make_next_step(actions=["check the port"]),
+        )
+        future = json.loads(json.dumps(envelope))
+        future["schema_version"] = "vaws.result-envelope.v2"
+        future["outcome"] = "degraded"
+        future["failure"]["layer"] = "scheduler"
+        view = read_envelope(future)
+        self.assertEqual(view["outcome"], "failure")
+        self.assertEqual(view["failure"]["layer"], "unknown")
+        self.assertEqual(len(view["compat_warnings"]), 3)
+
+    def test_schema_document_matches_the_library_contract(self) -> None:
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(
+            schema["properties"]["schema_version"]["const"], SCHEMA_VERSION
+        )
+        self.assertEqual(
+            set(schema["required"]), set(base_envelope().keys())
+        )
+        self.assertEqual(
+            schema["$defs"]["layer"]["enum"], list(LAYERS)
+        )
+        self.assertEqual(
+            set(schema["properties"]["environment"]["required"])
+            - {"source", "captured_at", "unknown_fields"},
+            set(ENVIRONMENT_FIELDS),
+        )
+
+    def test_schema_document_validates_with_jsonschema_when_available(self) -> None:
+        try:
+            import jsonschema  # noqa: PLC0415
+        except ImportError:
+            self.skipTest("jsonschema is not installed; library validation is authoritative")
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(base_envelope(), schema)
+
+
+class EmissionTests(unittest.TestCase):
+    def test_emit_writes_one_line_delimited_object_and_returns_exit_code(self) -> None:
+        stream = io.StringIO()
+        envelope = base_envelope()
+        code = emit(envelope, stream=stream)
+        self.assertEqual(code, 0)
+        payload = stream.getvalue()
+        self.assertTrue(payload.endswith("\n"))
+        self.assertEqual(json.loads(payload)["envelope_id"], envelope["envelope_id"])
+
+    def test_progress_goes_to_the_given_stderr_stream(self) -> None:
+        stream = io.StringIO()
+        progress("probe", "waiting for ready", stream=stream, port=8000)
+        line = stream.getvalue().strip()
+        self.assertTrue(line.startswith("__VAWS_PROGRESS__="))
+        payload = json.loads(line.split("=", 1)[1])
+        self.assertEqual(payload["port"], 8000)
+
+
+class LintTests(unittest.TestCase):
+    def test_check_accepts_a_valid_envelope(self) -> None:
+        report = envelope_lint.check_payload(json.dumps(base_envelope()))
+        self.assertTrue(report["valid"], report["findings"])
+
+    def test_check_reports_non_json_stdout(self) -> None:
+        report = envelope_lint.check_payload("phase: starting\n{}\n")
+        self.assertFalse(report["valid"])
+        self.assertIn("not a single JSON document", report["findings"][0])
+
+    def test_check_reports_a_missing_layer_attribution(self) -> None:
+        envelope = base_envelope()
+        envelope["outcome"] = "failure"
+        envelope["exit_code"] = 1
+        report = envelope_lint.check_payload(json.dumps(envelope))
+        self.assertFalse(report["valid"])
+        self.assertTrue(
+            any("layer attribution" in finding for finding in report["findings"]),
+            report["findings"],
+        )
+
+    def test_static_scan_flags_a_non_conformant_script(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            (scripts / "legacy.py").write_text(
+                "import json\n"
+                "def main():\n"
+                "    print('starting')\n"
+                "    print(json.dumps({'status': 'failed'}))\n"
+                "    return 1\n"
+                "if __name__ == '__main__':\n"
+                "    raise SystemExit(main())\n",
+                encoding="utf-8",
+            )
+            report = envelope_lint.scan_tree(root)
+            self.assertEqual(report["entry_points"], 1)
+            self.assertEqual(report["conformant"], 0)
+            self.assertEqual(report["stdout_purity_risk"], 1)
+            result = report["results"][0]
+            self.assertTrue(result["checks"]["stdout_json"])
+            self.assertFalse(result["checks"]["envelope_library"])
+
+    def test_static_scan_recognizes_a_conformant_script(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            (scripts / "modern.py").write_text(
+                "from vaws_result_envelope import emit, make_failure, progress\n"
+                "def main():\n"
+                "    progress('start', 'working')\n"
+                "    return emit({})\n"
+                "if __name__ == '__main__':\n"
+                "    raise SystemExit(main())\n",
+                encoding="utf-8",
+            )
+            report = envelope_lint.scan_tree(root)
+            self.assertEqual(report["conformant"], 1)
+            self.assertEqual(report["conformance_rate"], 1.0)
+            self.assertEqual(report["stdout_purity_risk"], 0)
+
+    def test_test_modules_are_not_counted_as_entry_points(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "scripts").mkdir()
+            (root / "tests").mkdir()
+            guard = "if __name__ == '__main__':\n    pass\n"
+            (root / "scripts" / "test_thing.py").write_text(guard, encoding="utf-8")
+            (root / "tests" / "runner.py").write_text(guard, encoding="utf-8")
+            (root / "scripts" / "real.py").write_text(guard, encoding="utf-8")
+            self.assertEqual(
+                [path.name for path in envelope_lint.discover_entry_points(root)],
+                ["real.py"],
+            )
+
+    def test_lint_itself_emits_one_valid_envelope(self) -> None:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS / "envelope_lint.py"),
+                "scan",
+                "--root",
+                str(ROOT / ".agents" / "scripts"),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=str(ROOT),
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr[-2000:])
+        payload = json.loads(completed.stdout)
+        validate_envelope(payload)
+        self.assertNotIn("__VAWS_", completed.stdout)
+        self.assertIn("__VAWS_PROGRESS__=", completed.stderr)
+        self.assertGreater(payload["extensions"]["report"]["entry_points"], 0)
+
+    def test_lint_run_mode_rejects_a_non_conforming_command(self) -> None:
+        report = envelope_lint.run_and_check(
+            [sys.executable, "-c", "print('progress: starting')"], timeout=30
+        )
+        self.assertFalse(report["valid"])
+        self.assertTrue(report["findings"])
+
+    def test_lint_run_mode_accepts_the_lint_itself(self) -> None:
+        report = envelope_lint.run_and_check(
+            [
+                sys.executable,
+                str(SCRIPTS / "envelope_lint.py"),
+                "scan",
+                "--root",
+                str(ROOT / ".agents" / "hooks"),
+            ],
+            timeout=120,
+        )
+        self.assertTrue(report["valid"], report["findings"])
+        self.assertEqual(report["exit_code"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_result_envelope.py
+++ b/.agents/tests/test_result_envelope.py
@@ -1239,6 +1239,65 @@ class LintTests(unittest.TestCase):
         self.assertTrue(report["valid"], report["findings"])
         self.assertEqual(report["exit_code"], 0)
 
+    def test_lint_run_preserves_child_argv_separator(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            recorded = directory / "actual-argv.json"
+            envelope_path = directory / "child-envelope.json"
+            child = directory / "child.py"
+            envelope_path.write_text(
+                json.dumps(base_envelope()) + "\n", encoding="utf-8"
+            )
+            child.write_text(
+                "import json\n"
+                "import pathlib\n"
+                "import sys\n"
+                f"pathlib.Path({str(recorded)!r}).write_text("
+                "json.dumps(sys.argv[1:]), encoding='utf-8')\n"
+                f"sys.stdout.write(pathlib.Path({str(envelope_path)!r})"
+                ".read_text(encoding='utf-8'))\n"
+                "raise SystemExit("
+                "0 if sys.argv[1:] == ['--', '--literal'] else 67)\n",
+                encoding="utf-8",
+            )
+            child_argv = [sys.executable, str(child), "--", "--literal"]
+            direct = subprocess.run(
+                child_argv,
+                capture_output=True,
+                text=True,
+                check=False,
+                cwd=str(ROOT),
+            )
+            self.assertEqual(direct.returncode, 0, direct.stderr[-2000:])
+            self.assertEqual(
+                json.loads(recorded.read_text(encoding="utf-8")),
+                ["--", "--literal"],
+            )
+            wrapped = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPTS / "envelope_lint.py"),
+                    "run",
+                    "--",
+                    *child_argv,
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                cwd=str(ROOT),
+            )
+            self.assertEqual(
+                json.loads(recorded.read_text(encoding="utf-8")),
+                ["--", "--literal"],
+            )
+            payload = json.loads(wrapped.stdout)
+            validate_envelope(payload)
+            self.assertEqual(wrapped.returncode, 0, wrapped.stderr[-2000:])
+            report = payload["extensions"]["report"]
+            self.assertTrue(report["valid"], report["findings"])
+            self.assertEqual(report["command"], child_argv)
+            self.assertEqual(report["exit_code"], 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/agent-feedback-contract.md
+++ b/docs/agent-feedback-contract.md
@@ -292,8 +292,11 @@ eventually disagree with itself.
 `failure_from_parts()` summarizes: one shared layer across every failing unit
 is reported as that layer; a mix is reported as `unknown`, because "some nodes
 hit the transport and some hit the workload" genuinely is not one diagnosis.
-A failing part must carry a layer — `unknown` if that is the truth — so a
-per-node result is never less diagnosable than a whole-operation result.
+Shared `unknown` is still unknown: the helper keeps `confidence: "low"` even
+when every unit failed or was blocked. Counting more unattributed failures
+does not create an attribution, and the validator still rejects `unknown` +
+`high`. A failing part must carry a layer — `unknown` if that is the truth —
+so a per-node result is never less diagnosable than a whole-operation result.
 
 ## 5. Retries and idempotency
 
@@ -329,8 +332,16 @@ Most entry points are wrappers: `bench_run` calls `serve_start`, which calls
    propagates.
 4. **`do_not` guidance is inherited.** A known signature detected three frames
    down must not be lost on the way up.
+5. **Exclusions are frame-aware.** Child `ruled_out` values describe the
+   child's wrapper. After a nested `caller` fault becomes the parent's
+   `tool` fault, a child exclusion of `tool` is dropped: it is not an
+   exclusion of the parent's wrapper. Other child exclusions propagate.
+   The child's original fields stay on the child record/`ref`; composition
+   must not put the parent's attributed layer in the parent's `ruled_out`.
 
-`compose_child(parent, child, ref=…)` implements all four.
+`compose_child(parent, child, ref=…)` implements these rules, with
+`escalate_child_layer` and `propagate_child_ruled_out` as the layer and
+exclusion mappings.
 
 ## 7. Redaction and publishability
 

--- a/docs/agent-feedback-contract.md
+++ b/docs/agent-feedback-contract.md
@@ -1,0 +1,499 @@
+# Agent feedback contract — Result Envelope v1
+
+Whatever an agent runs in this workspace must come back with enough
+structured information to locate a failure **without re-running it**.
+
+This document is the contract. The library is
+`.agents/lib/vaws_result_envelope.py`, the machine-readable schema is
+`.agents/schemas/result-envelope-v1.schema.json`, and conformance is
+checkable with `.agents/scripts/envelope_lint.py`.
+
+## 1. Why this exists
+
+The workspace spans a local laptop, a remote Ascend host, a container, NPU
+devices and a model service. From the outside those layers look alike: a
+non-zero exit code, a truncated stderr tail, a timeout. The repository's own
+knowledge base already records the cost of confusing them — an *instant*
+timeout from the remote tool service is a tool-service fault, not a remote
+command fault, and the recorded avoidance for the gloo `/etc/hosts` signature
+is mostly a warning not to start tuning HCCL environment variables.
+
+Both recorded signatures share a shape: an environment or measurement problem
+that presents as a model bug, where starting from the traceback is the most
+expensive possible route. A result that does not say *which layer* it is
+talking about invites exactly that route.
+
+### What the survey found
+
+Read against a representative spread of the 107 `__main__`-guarded entry
+points under `.agents/`:
+
+| Observation | Evidence |
+|---|---|
+| The output convention is about *placement*, not *content*. | `.agents/README.md`: "Wrapper-style helpers should stream bounded phase progress on `stderr` and keep one final machine-readable JSON payload on `stdout`." Nothing about required fields. |
+| `status` is overloaded and inconsistent across scripts. | At least 14 distinct top-level `status` values appear across `.agents`: `failed` (48 files), `ok` (29), `ready` (11), `blocked` (9), `needs_input` (6), `not_found` (5), `unknown` (5), `needs_repair` (4), `skipped` (4), `timeout` (2), `cancelled` (2), `running` (2), `degraded` (2), plus `cleanup_failed` assigned through a variable in `bench_run.py`. A consumer cannot switch on it, and the values mix outcome, readiness and cause. |
+| No script attributes a layer. | `envelope_lint.py scan` finds `layer_attribution` in 1 of 107 entry points (the lint itself). |
+| Failure is frequently a bare string. | `.agents/skills/ascend-profiling-collection/scripts/profile_control.py` ends with `{"status": "failed", "error": str(exc)}`. Whether that exception was a bad `--action`, a dead SSH mux, a container without `python3`, or a service that never bound its port is unrecoverable from the payload. |
+| The one existing diagnosis helper is a single-cause guess. | `serve_start.py::diagnose_env_failure` pattern-matches stderr and always concludes "remote Python package version mismatch" with a `parity_sync --force-reinstall` recovery command. It is genuinely useful, and it is also the exact shape of a confident wrong attribution: it cannot say "I do not know". |
+| The shared exec path drops attribution on the floor. | `vaws_remote_toolbox.remote_exec` distinguishes `timeout` from a non-zero exit, but a timeout is reported identically whether SSH never connected, the mux dropped the stream, or the workload hung. `_cli_error` maps *any* unexpected exception to `status: failed` with `target: null`. |
+| Environment identity is captured but not attached to results. | `probe_remote` collects `torch`/`torch_npu`/`vllm`/`vllm_ascend`, CANN version files and `npu-smi` output, and `machine_*` normalizes a SoC token — but none of it appears in a `serve_start`, `bench_run` or `parity_sync` result, so two results cannot be compared and neither can become a knowledge candidate. |
+| Partial success collapses to a boolean. | `bench_run.py` invented `status: "cleanup_failed"` precisely because "the data is good but the service leaked" did not fit `ok`/`failed`. That is the right instinct with no structure to express it. |
+| Nested calls lose their inner result. | `_common.call_json_command` raises `RuntimeError("command failed (rc=…) … stdout=… stderr=…")`, so a child's structured payload is flattened into the parent's error *string*. |
+| Reproducibility is partial at best. | `remote_exec` records the remote `command` but not the wrapper script it was actually wrapped in; `parity_sync` builds a full low-level argv and only prints it under `--print-derived-args`. In the failure path the exact command is gone. |
+| 12 entry points can corrupt their own `stdout`. | `envelope_lint.py scan` reports `stdout_purity_risk: 12` — plain `print("…")` calls on the JSON channel. |
+
+The closest existing prior art is `.remote-dev/core/result.py` +
+`.remote-dev/schemas/result.schema.json`: a real result contract with
+`tool`, `invocation_id`, `target`, `outcome`, `status`, `summary`, `preview`,
+`refs`, `artifacts`, `next`. This design builds on it rather than around it:
+the outcome vocabulary, the preview/ref split and the invocation id all carry
+over. What it adds is the part `.remote-dev` deliberately left open —
+`outcome: "failed"` still does not say *which layer* failed, `target` is an
+untyped object, there is no environment identity, and `next` is free-form.
+
+## 2. The envelope
+
+One JSON object on `stdout`, in success and in failure. Progress lines stay on
+`stderr`. Top-level fields are fixed; additive data goes in `extensions`.
+
+```
+schema_version   "vaws.result-envelope.v1"
+envelope_id      stable id for this emission
+emitted_at       RFC3339 UTC
+operation        what was attempted: skill, entry_point, action, target
+outcome          success | partial | failure | blocked | cancelled
+exit_code        conventional process exit code (0/1/1/2/3)
+summary          one line, <= 400 chars
+attempt          the exact command that ran, reproducible by hand
+failure          null on success; layer attribution otherwise
+environment      soc/cann/driver/torch/torch_npu/vllm/vllm_ascend
+evidence         run_id, manifest_ref, refs[], previews{}
+next_step        actions[], do_not[], knowledge[]
+parts            per-unit results for fan-out operations
+attempts         retry history + idempotency class
+children         bounded digests of nested envelopes
+warnings         non-fatal notes
+extensions        additive, producer-defined
+```
+
+### 2.1 What was attempted
+
+`attempt.command` carries `argv`, a shell-quoted `display`, `cwd`,
+`env_keys` (**names only** — values are never carried, so the envelope cannot
+become the thing that leaks a credential) and `timeout_seconds`.
+`attempt.reproduce` is one copy-pasteable string.
+
+For remote work the local argv is not reproducible on its own, so
+`attempt.remote_command` carries the endpoint, and either the remote `argv` or
+a bounded `script_preview` with a `script_ref` to the full text. An envelope
+that claims a remote command but carries neither is rejected: an agent that
+cannot re-run the failing step by copy-paste will guess instead.
+
+### 2.2 Environment identity
+
+All seven fields are always present. An explicit `null` means "not captured";
+a *missing* key would be indistinguishable from a producer that never knew the
+field existed. `environment.unknown_fields` lists exactly the null ones, so a
+consumer can filter comparable results without walking the object, and
+`environment.source` records whether the values were probed, read from a
+manifest, declared by the caller, or cached.
+
+### 2.3 Evidence pointers
+
+`evidence.refs[]` are locators (`name`, `kind`, `ref`, optional `bytes` and
+`sha256`), never inlined content. `evidence.run_id` /
+`evidence.parent_run_id` / `evidence.manifest_ref` correlate the envelope with
+Run Manifest v1 (`.agents/lib/vaws_run_manifest.py`,
+`.agents/schemas/run-manifest-v1.schema.json`) so one envelope can be joined
+to the whole experiment it belonged to.
+
+### 2.4 Bounded output
+
+`text_preview()` keeps the head/tail shape of
+`.remote-dev/core/preview.py` — same field names, so a remote-dev result lifts
+into an envelope without reshaping — and adds one rule: **a truncated preview
+must carry a `ref`**. The validator rejects a truncated preview without one.
+A large payload can then never crowd out the diagnosis, because the diagnosis
+is always the bounded part and the bulk is always one dereference away.
+
+The shape is duplicated rather than imported: `.remote-dev/` is a substrate
+slated for extraction into its own repository, and `.agents/` must not take a
+hard import dependency across that boundary.
+
+## 3. The failure taxonomy
+
+Seven layers. `unknown` is a first-class outcome, not a fallback to the
+nearest guess.
+
+Two rules make that real:
+
+1. **Naming a layer is a claim, and the claim must cite evidence.**
+   `failure.attribution_basis` must be non-empty for every layer except
+   `unknown`. The validator enforces it.
+2. **`unknown` cannot be confident.** `confidence: "high"` with
+   `layer: "unknown"` is rejected, and a failing envelope must always carry at
+   least one `next_step.action` — for an unknown, the action is whatever would
+   narrow it.
+
+`failure.ruled_out[]` records the layers the evidence *excludes*. It carries as
+much value as the layer itself: the recorded gloo signature is worth having
+mostly because it tells you not to touch HCCL environment variables.
+
+### 3.1 `caller` — the invocation was wrong
+
+Bad arguments, missing target, an unsupported flag combination. Nothing was
+attempted downstream.
+
+```json
+{
+  "outcome": "blocked",
+  "failure": {
+    "layer": "caller", "confidence": "high", "reason_code": "bad_arguments",
+    "message": "--warmup-runs 3 must be less than --runs 3",
+    "attribution_basis": ["argument validation rejected the invocation before any remote call"],
+    "ruled_out": ["transport", "remote_env", "remote_workload", "device"]
+  },
+  "next_step": {"actions": [{"description": "re-run with --warmup-runs 1 --runs 3", "command": null, "ref": null}], "do_not": [], "knowledge": []}
+}
+```
+
+### 3.2 `tool` — the wrapper or tool service misbehaved
+
+A crash in our own code, non-JSON output from a child, or the recorded
+tool-service signature: `remote_bash` returning `timeout` *instantly* for
+every command while `remote_probe` and `remote_ls` keep working.
+
+```json
+{
+  "failure": {
+    "layer": "tool", "confidence": "high",
+    "reason_code": "tool_service_instant_timeout",
+    "message": "remote_bash returned timeout in 41ms for three different commands",
+    "attribution_basis": [
+      "timeout returned in 41ms; the configured timeout was 600s",
+      "remote_probe against the same endpoint succeeded in the same window"
+    ],
+    "ruled_out": ["remote_workload", "device"]
+  },
+  "next_step": {
+    "actions": [{"description": "fall back to a direct ssh invocation off the shared mux", "command": "ssh -o BatchMode=yes -p <port> root@<host> true", "ref": null}],
+    "do_not": ["do not debug the remote command; it never ran"],
+    "knowledge": [{"entry_id": "ssh-stream-over-shared-controlmaster-mux-dies-early", "summary": "instant timeout from the tool service is a tool-service fault", "avoidance": "do not retry the same stream command on the mux", "score": 6}]
+  }
+}
+```
+
+This is the entry the whole taxonomy exists for. Under the current
+convention this arrives as `{"status": "timeout"}` and costs an hour of
+debugging the wrong layer.
+
+### 3.3 `transport` — SSH, network, or multiplexing
+
+```json
+{
+  "failure": {
+    "layer": "transport", "confidence": "high", "reason_code": "ssh_mux_stream_died",
+    "message": "log stream over the shared ControlMaster closed after 0.4s",
+    "attribution_basis": [
+      "ssh exited 255 with no remote output",
+      "the same command over a dedicated connection (mux=False) streamed normally"
+    ],
+    "ruled_out": ["remote_workload"]
+  }
+}
+```
+
+### 3.4 `remote_env` — the container is wrong
+
+Missing path, import error, version mismatch, hostname not in `/etc/hosts`.
+This is the recorded gloo case, and it is the layer most often mistaken for
+`remote_workload`.
+
+```json
+{
+  "failure": {
+    "layer": "remote_env", "confidence": "high", "reason_code": "hostname_unresolvable",
+    "message": "gloo::makeDeviceForHostname failed for the container hostname",
+    "attribution_basis": ["stderr matches a recorded known-failure signature", "the same image serves TP1 successfully"],
+    "ruled_out": ["remote_workload", "device"]
+  },
+  "next_step": {
+    "actions": [{"description": "map the container hostname in /etc/hosts before serving", "command": "echo \"127.0.0.1 $(hostname)\" >> /etc/hosts", "ref": null}],
+    "do_not": ["do not tune GLOO_SOCKET_IFNAME or other HCCL env vars before /etc/hosts is fixed"],
+    "knowledge": [{"entry_id": "gloo-init-container-hostname-missing-from-etc-hosts", "summary": "fresh containers lack their own hostname mapping", "avoidance": "do not debug gloo/HCCL env vars first", "score": 8}]
+  }
+}
+```
+
+### 3.5 `remote_workload` — the code under test failed
+
+The only layer that says "the thing you are testing is guilty". Claiming it
+means claiming the environment was fine.
+
+```json
+{
+  "failure": {
+    "layer": "remote_workload", "confidence": "medium", "reason_code": "workload_nonzero_exit",
+    "message": "vllm serve exited 1 during weight load",
+    "attribution_basis": [
+      "the process reached the weight-load stage, so imports and CANN init succeeded",
+      "the same command on the baseline commit reached ready in the same container"
+    ],
+    "ruled_out": ["caller", "transport", "tool"]
+  }
+}
+```
+
+### 3.6 `device` — NPU or lease unavailable
+
+```json
+{
+  "failure": {
+    "layer": "device", "confidence": "high", "reason_code": "npu_busy",
+    "message": "devices 4-7 are held by another session lease",
+    "attribution_basis": ["npu-smi reports non-zero HBM on 4-7", "the local lease file records another session holding them"],
+    "ruled_out": ["remote_workload"]
+  }
+}
+```
+
+### 3.7 `unknown` — honest
+
+```json
+{
+  "failure": {
+    "layer": "unknown", "confidence": "low", "reason_code": "unattributed",
+    "message": "the service never bound its port and no stderr was produced",
+    "attribution_basis": [],
+    "ruled_out": ["caller"],
+    "signals": [{"kind": "stderr_bytes", "value": 0}]
+  },
+  "next_step": {
+    "actions": [{"description": "re-run with the launch wrapper's stderr retained, then re-attribute", "command": null, "ref": null}],
+    "do_not": ["do not attribute this to the code under test on this evidence"],
+    "knowledge": []
+  }
+}
+```
+
+## 4. Partial success
+
+A multi-host operation where three of four nodes succeeded is not a boolean.
+`parts[]` carries one record per unit (`unit`, `unit_kind`, `outcome`,
+`layer`, `reason_code`, `summary`, `refs`), and the aggregate `outcome` is
+*derived* from them — the validator rejects an envelope whose declared outcome
+disagrees with its parts, because a producer that hand-writes both will
+eventually disagree with itself.
+
+- every unit succeeded → `success`
+- some succeeded, some failed → `partial`
+- all failed → `failure` (or `blocked` when every failing unit was blocked)
+
+`failure_from_parts()` summarizes: one shared layer across every failing unit
+is reported as that layer; a mix is reported as `unknown`, because "some nodes
+hit the transport and some hit the workload" genuinely is not one diagnosis.
+A failing part must carry a layer — `unknown` if that is the truth — so a
+per-node result is never less diagnosable than a whole-operation result.
+
+## 5. Retries and idempotency
+
+`attempts.count` plus `attempts.records[]` (per-attempt outcome, layer,
+reason code, duration). A transport failure on attempt 1 that succeeded on
+attempt 2 is a *flake report*, and it is worth keeping even in a successful
+envelope.
+
+`attempts.idempotency.class` is one of `idempotent`, `at_most_once`,
+`unsafe_to_retry`, `unknown`. `retry_safe` is **derived** from the class, not
+set by the caller, so the two can never disagree, and it stays `null` unless
+the producer actually classified the operation. Defaulting an unclassified
+operation to "safe to retry" is how a benchmark gets run twice against a
+service that was already holding NPU memory.
+
+## 6. Composition of nested envelopes
+
+Most entry points are wrappers: `bench_run` calls `serve_start`, which calls
+`parity_sync`, which calls `remote_code_parity`. Composition rules:
+
+1. **A child appears as a bounded digest, not a nested envelope.**
+   `children[]` holds `envelope_id`, `entry_point`, `action`, `outcome`,
+   `layer`, `reason_code`, `summary`, `ref`, `depth`. The full child is
+   reachable through `ref`. A digest containing its own `children` is
+   rejected: a three-level call chain must not crowd out the diagnosis it
+   exists to deliver.
+2. **A parent with no failure of its own adopts the child's attribution.**
+   Re-guessing at each frame is how a `transport` fault becomes a
+   `remote_workload` fault two levels up.
+3. **A nested `caller` fault becomes the parent's `tool` fault.** The parent
+   *is* the caller — it built those arguments — so a child rejecting them is
+   the parent's bug, not the user's. This is the one layer that changes as it
+   propagates.
+4. **`do_not` guidance is inherited.** A known signature detected three frames
+   down must not be lost on the way up.
+
+`compose_child(parent, child, ref=…)` implements all four.
+
+## 7. Redaction and publishability
+
+At runtime the envelope carries host addresses, ports and absolute paths.
+That is correct — it is what makes the result actionable — and it also means
+**the envelope must never be the thing that writes them into a tracked file**.
+
+- `dumps(envelope)` — full fidelity. Only ever safe under untracked
+  `.vaws-local/`.
+- `redact(envelope)` — replaces IPv4/IPv6 literals, `user@host` pairs, home
+  paths and secret-like keys and values with stable placeholders. Only
+  loopback and `*.invalid` / `*.example` hostnames survive, because they
+  identify nothing and a diagnosis is much harder to read without them. RFC
+  5737 documentation ranges are deliberately *not* exempt: a redactor that has
+  to reason about whether an address is "safe" is a redactor that will
+  eventually be wrong. Shared data roots (`/home/weights`, `/home/models`,
+  `/home/data`, `/home/cache`, `/home/shared`) are exempt because they name no
+  user and a model path is load-bearing for comparing two results.
+- `leak_findings(payload)` — reports residual leaks as JSON paths.
+- `assert_publishable(envelope)` / `dumps_publishable(envelope)` — redact,
+  re-scan, and **refuse** rather than emit if anything survived.
+
+Anything heading for a PR body, a knowledge candidate or a tracked report goes
+through `dumps_publishable`.
+
+## 8. Versioning
+
+`schema_version` is the const string `"vaws.result-envelope.v1"`.
+
+- **Top level is strict.** Unknown top-level fields are rejected, because a
+  typo'd field name is the most common producer bug and silently accepting it
+  produces a result that looks fine and carries nothing.
+- **`extensions` is the additive escape hatch.** Producers put new or
+  experimental data there, and readers ignore what they do not recognize, so
+  adding a field never needs a version bump.
+- **A new required field or a new enum value requires v2.** Enum widening is
+  not backward compatible for a reader that switches on the value.
+- **Consumers lag producers, so reading is lenient.** `read_envelope()`
+  validates strictly on a version it knows and, on an unrecognized version,
+  downgrades unknown outcomes and unknown layers to safe values and records
+  the reason in `compat_warnings` instead of raising. A reader that crashes on
+  a newer producer is worse than a reader that says "I do not understand this
+  layer".
+
+`jsonschema` is not installed on the client machines this repo targets, so
+`validate_envelope()` in the library is authoritative and also enforces the
+cross-field rules the schema document can only partially express. The schema
+document is kept in sync by a test, and is used by `jsonschema` when the
+package happens to be importable.
+
+## 9. Checking conformance
+
+```
+python3 .agents/scripts/envelope_lint.py scan                     # static survey of .agents
+python3 .agents/scripts/envelope_lint.py scan --details           # + per-entry-point table
+python3 .agents/scripts/envelope_lint.py check --payload-file p.json
+python3 .agents/scripts/envelope_lint.py run -- python3 .agents/scripts/remote_probe.py --session-id x
+```
+
+`scan` is a source heuristic and says so: four required checks
+(`envelope_library`, `stdout_json`, `stderr_progress`, `layer_attribution`)
+define conformance, five more are reported to sequence a migration, and
+`stdout_purity_risk` names the exact line numbers where a plain `print()`
+can corrupt the JSON channel. `run` is the real check: exactly one valid
+envelope on `stdout`, no progress sentinel on `stdout`, and a process exit
+code that agrees with `exit_code`.
+
+The lint emits an envelope itself, so it is both the first conformant entry
+point and a worked example.
+
+Current state of this tree (`scan`, 2026-09-07): **1 of 107 entry points
+conform (0.9%)** — the lint itself. That number is meant to be low; a lint
+that pretended otherwise would be worthless. The useful signal is the
+per-check breakdown: 61.7% already emit JSON on `stdout` and 37.4% already
+keep progress on `stderr`, while 0.9% attribute a layer and 3.7% record
+environment identity.
+
+## 10. Migration plan
+
+**Nothing in this change adapts an existing script.** The library, schema,
+lint and this document are additive; adapting the entry points is sequenced
+below and will land as separate changes, because several agents are working in
+this repo concurrently and rewriting shared output shapes underneath them
+would be hostile.
+
+Migration is per-script and mechanical once the shared helpers land.
+
+**Wave 0 — shared helpers (one change, no behaviour change).**
+Add `envelope_*` helpers next to the existing `print_json` / `emit_progress`
+in `vaws_remote_toolbox`, `vllm-ascend-serving/scripts/_common.py`,
+`vllm-ascend-benchmark/scripts/_common.py`,
+`ascend-profiling-collection/scripts/_common.py` and
+`remote-code-parity/scripts/common.py`. Keep both emitters; nothing switches
+yet.
+
+**Wave 1 — the shared exec and probe path.**
+`vaws_remote_toolbox.remote_exec`, `probe_remote` and `_cli_error`, plus the
+thin `.agents/scripts/remote_*.py` wrappers that delegate to them. This is the
+highest-value wave: it is where `transport` vs `remote_env` vs
+`remote_workload` is actually distinguishable (SSH exit 255 and no remote
+output ⇒ `transport`; remote shell ran and the command exited non-zero ⇒
+`remote_workload`; timeout with a remote pid alive ⇒ `remote_workload`,
+timeout with nothing started ⇒ `transport`), and roughly 20 wrappers inherit
+the result for free. `probe_remote` already collects everything
+`environment` needs, so this wave is also where environment identity starts
+flowing.
+
+**Wave 2 — service lifecycle.**
+`serve_start.py`, `serve_status.py`, `serve_stop.py`, `serve_probe_npus.py`.
+Fold `diagnose_env_failure` into a `remote_env` attribution with a real
+`attribution_basis` and a `next_step.do_not` ("do not run bare `pip install`
+inside the container"), and give it the ability to return `unknown`. Attribute
+device-lease refusals to `device` rather than `blocked`-with-a-string.
+
+**Wave 3 — nested callers.**
+`bench_run.py`, `parity_sync.py`, `collect_torch_profile_case.py`,
+`run_remote_analyse.py`, `pd_serving.py`, `change_validation.py`. Replace
+`call_json_command`'s `RuntimeError(...)` string flattening with
+`compose_child`, and re-express `bench_run`'s invented `cleanup_failed` as
+`outcome: "partial"` with a `device` part for the leaked service.
+
+**Wave 4 — fan-out and local state.**
+`pd_serving.py` and any multi-host operation move to `parts[]`.
+`session_*`, `machine_*`, `modelscope_*`, `npu-fleet-monitor` follow; these
+are mostly `caller` / `tool` / local-state faults and are cheap.
+
+**Wave 5 — enforce.**
+Once each wave lands, raise `envelope_lint.py scan --fail-under` in CI to the
+new floor. Fix the 12 `stdout_purity_risk` scripts on the way through, since
+a plain `print()` breaks the contract regardless of the envelope.
+
+Per-script recipe: build `operation` and `attempt` before doing anything, so
+the failure path already has them; return an envelope from every exit path;
+never invent a layer without an `attribution_basis`; keep `print_json` as a
+thin alias during transition if callers parse the old shape.
+
+## 11. Adoption in the extracted `remote-dev` repo
+
+`.remote-dev/core/result.py` and `.remote-dev/schemas/result.schema.json` are
+the ancestor of this design and are unchanged by it. When `remote-dev` is
+extracted, it should adopt the envelope on its own terms:
+
+- Keep `remote-dev.result.v1` as the wire format for its MCP tools, and add
+  the envelope fields it is missing: a `failure` block with the same seven-layer
+  taxonomy, `environment`, and `attempt.reproduce`. Its `preview`/`refs`
+  split, `invocation_id` and `outcome` vocabulary already match.
+- Own the layers it can actually attribute — `caller`, `tool`, `transport`,
+  and `device` for lease refusals — and return `unknown` rather than
+  `remote_workload` for anything it only observed through an exit code. The
+  substrate rarely has the context to convict the code under test; the domain
+  skill above it does.
+- Keep the taxonomy as shared vocabulary rather than shared code, so neither
+  repo needs to import the other. `.agents/lib/vaws_result_envelope.py` and
+  the extracted `result.py` should stay independently vendorable, with the
+  enum lists and the layer semantics as the contract between them.
+- The composition rule that matters at the boundary: an `.agents` skill
+  wrapping a remote-dev tool call treats the tool's result as a **child**
+  envelope, so a nested `caller` fault surfaces as the skill's own `tool`
+  fault.
+
+## 12. The convention lines this replaces
+
+`AGENTS.md` and `.agents/README.md` currently carry the placement-only
+convention. Those files are owned by other agents in this cycle and are
+deliberately not edited here. The replacement text is in the pull request
+description for whoever lands it.


### PR DESCRIPTION
Add an additive Result Envelope v1 contract, library and conformance CLI so results preserve command identity, evidence, partial outcomes and explicit failure-layer attribution. Existing entry points are not yet migrated; the inventory in the document describes the original 161fed1 snapshot.

The final implementation also fixes three independently reproduced contract failures: aggregate unknown failures cannot claim high confidence; composing child failures cannot rule out the adopted parent layer; and the lint runner preserves child `--` argv tokens.

Validation on `de9743666c90b2427186779d47c573ef943ab6a7`: independent GPT-6 acceptance passed 72 tests with zero skips, reproduced all three failures on original `61ce3ac` and verified the corrected behavior plus positive controls, and passed compile/diff checks. No SSH/NPU run, broad wrapper migration or new default conformance gate is claimed.
