### PR TITLE
fix(session): allocate NPUs from occupancy, not from visibility

### DIFF
--- a/.agents/lib/vaws_session_state.py
+++ b/.agents/lib/vaws_session_state.py
@@ -306,11 +306,16 @@ def allocate_session_leases(
     if requested_devices is not None and npu_count is not None:
         raise SessionStateError("use only one of --devices or --npu-count")
     available_set = set(available_devices) if available_devices is not None else None
+    occupancy_unavailable = "cannot allocate NPU devices: host occupancy is unavailable"
     with file_lock(session_lock_dir(repo_root) / "leases.lock"):
         leases = load_leases(repo_root)
         bucket = _machine_lease_bucket(leases, machine_alias)
         allocated_devices: list[int] = []
         if requested_devices is not None:
+            if requested_devices and available_set is None:
+                # Unknown occupancy is not an empty free set. An explicit
+                # device list must not bypass a failed or unreadable probe.
+                raise SessionStateError(occupancy_unavailable)
             if available_set is not None:
                 missing = sorted(set(requested_devices) - available_set)
                 if missing:
@@ -328,12 +333,9 @@ def allocate_session_leases(
             if available_set is None:
                 # Without a host probe we cannot know how many NPUs exist or
                 # which are busy; guessing a fixed device range would hand out
-                # devices that may not exist. Fail fast instead of masking the
-                # probe failure.
-                raise SessionStateError(
-                    "cannot allocate by --npu-count: host NPU probe data is unavailable; "
-                    "fix the probe or request explicit --devices"
-                )
+                # devices that may not exist. Explicit --devices is not a
+                # bypass: that path fails closed on unknown occupancy too.
+                raise SessionStateError(occupancy_unavailable)
             candidates = sorted(available_set)
             for dev in candidates:
                 if _resource_owner(bucket, "npu_devices", str(dev)) in {None, sid}:

--- a/.agents/lib/vaws_session_state.py
+++ b/.agents/lib/vaws_session_state.py
@@ -314,9 +314,14 @@ def allocate_session_leases(
             if available_set is not None:
                 missing = sorted(set(requested_devices) - available_set)
                 if missing:
+                    # "Not available" covers both absent and busy on purpose:
+                    # the caller passes free devices, not visible ones, so a
+                    # device that exists but is in use lands here too. Saying
+                    # "not visible" would send the reader looking for a
+                    # hardware or driver problem that is not there.
                     raise SessionStateError(
-                        f"requested NPU devices are not visible on host: {missing}; "
-                        f"available={sorted(available_set)}"
+                        f"requested NPU devices are not available on host (absent or in use "
+                        f"by another process): {missing}; available={sorted(available_set)}"
                     )
             allocated_devices = list(requested_devices)
         elif npu_count:
@@ -336,7 +341,12 @@ def allocate_session_leases(
                 if len(allocated_devices) >= npu_count:
                     break
             if len(allocated_devices) < npu_count:
-                raise SessionStateError(f"not enough locally unleased NPU devices for session {sid}")
+                raise SessionStateError(
+                    f"not enough allocatable NPU devices for session {sid}: "
+                    f"{len(allocated_devices)} of {npu_count} after excluding devices busy on "
+                    f"the host and devices leased in this workspace "
+                    f"(host-free={sorted(available_set)})"
+                )
 
         for dev in allocated_devices:
             _reserve(bucket, "npu_devices", dev, sid)

--- a/.agents/skills/session-management/SKILL.md
+++ b/.agents/skills/session-management/SKILL.md
@@ -79,7 +79,7 @@ does not create another container or duplicate member leases.
 - `session_create.py` creates a fresh generated id when no explicit/env id is provided; it does not reuse `.vaws-local/current-session.json` as a creation default.
 - Existing-session lookup commands may use `.vaws-local/current-session.json` as a convenience fallback.
 - Do not reuse the base machine container for new parallel tasks. New tasks should use `session_create.py`.
-- For NPU work, reserve devices during creation with `--devices` or `--npu-count`; session-aware serving uses that lease by default. `--npu-count` requires a successful host NPU probe (no guessing of device ranges); if the probe fails, fix it or pass explicit `--devices`.
+- For NPU work, reserve devices during creation with `--devices` or `--npu-count`; session-aware serving uses that lease by default. Count-based and explicit-device allocation both require a known occupancy result; unknown occupancy and a known empty free set refuse the request. Port-only creation remains valid without NPUs.
 - `--reuse-existing` probes the existing container's SSH endpoint before reporting the session as reusable; a dead container returns `needs_repair` instead of a stale `ready`.
 - Metadata status changes never release remote leases. Confirmed container removal releases its leases even without `--release-leases`; worktree removal or stopping only the recorded service PID does not prove all remote resources are free.
 - Managed serving requires a nonempty live NPU lease matching the session snapshot. Empty or stale snapshots cannot fall through to idle-card selection.

--- a/.agents/skills/session-management/scripts/session_create.py
+++ b/.agents/skills/session-management/scripts/session_create.py
@@ -104,10 +104,59 @@ def parse_host_npu_devices(stdout: str) -> list[int]:
     Delegates to the shared npu-smi parser: on dual-chip A3 cards the card
     header rows (0-7) undercount the chips vLLM actually sees (0-15), so the
     old header-row regex made TP16 single-node launches impossible to lease.
+
+    Visibility only. Do **not** use this to decide what may be allocated: a
+    device can be visible and in use by somebody else. Use
+    ``parse_host_npu_availability`` for that.
     """
     from vaws_npu_coordination import parse_npu_smi_info  # noqa: PLC0415
 
     return parse_npu_smi_info(stdout).get("devices") or []
+
+
+def parse_host_npu_availability(stdout: str) -> tuple[list[int] | None, dict[str, Any]]:
+    """Which devices are free, or ``None`` when the host cannot tell us.
+
+    Allocation used to be driven by the visible-device list, which is wrong in
+    two separate ways and produced silent double-allocation:
+
+    * A visible device may be busy. The occupancy the parser reports in
+      ``busy``/``free`` was being discarded, so a card another process was
+      already using looked allocatable.
+    * When the parser cannot read the process table it fails closed and
+      reports ``status: failed`` — but it still returns the full ``devices``
+      list with ``busy: {}``. That reads as "every device is free" to a caller
+      that only looks at ``devices``. ``assign_resources`` already refuses to
+      allocate by count when availability is unknown, with a comment saying so;
+      the guard was simply never reachable, because a failed probe produced a
+      full list rather than ``None``.
+
+    So: unknown availability is ``None`` here, which is what makes that guard
+    fire. A probe that cannot establish occupancy must not be treated as an
+    empty occupancy table.
+    """
+    from vaws_npu_coordination import parse_npu_smi_info  # noqa: PLC0415
+
+    info = parse_npu_smi_info(stdout)
+    status = info.get("status")
+    visible = sorted(info.get("devices") or [])
+    busy_map = info.get("busy") or {}
+    diagnostics: dict[str, Any] = {
+        "probe_status": status,
+        "visible_devices": visible,
+        "busy_devices": sorted(int(d) for d in busy_map),
+        "busy_reasons": {str(d): busy_map[d] for d in busy_map},
+    }
+    if status != "ok":
+        diagnostics["availability"] = "unknown"
+        diagnostics["availability_reason"] = (
+            info.get("error") or f"npu-smi occupancy could not be established (status={status!r})"
+        )
+        return None, diagnostics
+    free = sorted(int(d) for d in (info.get("free") or []))
+    diagnostics["availability"] = "known"
+    diagnostics["free_devices"] = free
+    return free, diagnostics
 
 
 def probe_host_npu_devices(record: dict[str, Any]) -> tuple[list[int] | None, dict[str, Any]]:
@@ -139,9 +188,16 @@ def probe_host_npu_devices(record: dict[str, Any]) -> tuple[list[int] | None, di
     if result.returncode != 0:
         payload["status"] = "unavailable"
         return None, payload
-    devices = parse_host_npu_devices(result.stdout)
-    payload.update({"status": "ok" if devices else "unparsed", "devices": devices})
-    return devices or None, payload
+    free, diagnostics = parse_host_npu_availability(result.stdout)
+    payload.update(diagnostics)
+    payload["devices"] = diagnostics["visible_devices"]
+    if free is None:
+        # Availability unknown, not empty. Returning the visible list here is
+        # what allowed a session to be handed a card another process was using.
+        payload["status"] = "occupancy_unknown"
+        return None, payload
+    payload["status"] = "ok" if diagnostics["visible_devices"] else "unparsed"
+    return free or None, payload
 
 
 def host_port_available(record: dict[str, Any]) -> Any:

--- a/.agents/skills/session-management/scripts/session_create.py
+++ b/.agents/skills/session-management/scripts/session_create.py
@@ -197,7 +197,9 @@ def probe_host_npu_devices(record: dict[str, Any]) -> tuple[list[int] | None, di
         payload["status"] = "occupancy_unknown"
         return None, payload
     payload["status"] = "ok" if diagnostics["visible_devices"] else "unparsed"
-    return free or None, payload
+    # A successful parse of an empty free set is `[]`, not unknown occupancy.
+    # `free or None` collapsed that case and skipped the allocator's guard.
+    return free, payload
 
 
 def host_port_available(record: dict[str, Any]) -> Any:
@@ -596,8 +598,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.npu_count is not None and args.npu_count < 1:
             raise SessionStateError("--npu-count must be >= 1")
         available_devices, npu_probe = probe_host_npu_devices(base_record)
+        npu_requested = bool(requested_devices) or args.npu_count is not None
         if available_devices is None:
-            emit_progress("probe-npus", "host NPU device probe unavailable; validating syntax only", **npu_probe)
+            if npu_requested:
+                emit_progress(
+                    "probe-npus",
+                    "host NPU occupancy is unavailable; refusing NPU allocation",
+                    **npu_probe,
+                )
+            else:
+                emit_progress(
+                    "probe-npus",
+                    "host NPU occupancy is unavailable; continuing without NPU leases",
+                    **npu_probe,
+                )
         else:
             emit_progress("probe-npus", "host NPU device probe succeeded", devices=available_devices)
 

--- a/.agents/skills/session-management/tests/test_session_create_probes.py
+++ b/.agents/skills/session-management/tests/test_session_create_probes.py
@@ -3,19 +3,31 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[4]
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
-for _p in (str(SCRIPTS),):
+LIB = ROOT / ".agents" / "lib"
+for _p in (str(LIB), str(SCRIPTS)):
     if _p not in sys.path:
-        sys.path.insert(0, str(_p))
+        sys.path.insert(0, _p)
 
+import session_create  # noqa: E402
 from session_create import (  # noqa: E402
     parse_host_npu_availability,
     parse_host_npu_devices,
+    probe_host_npu_devices,
+)
+from vaws_session_state import (  # noqa: E402
+    SessionStateError,
+    allocate_session_leases,
+    session_leases_path,
+    session_live_leases,
 )
 
 # Dual-chip A3 card layout: 8 cards x 2 chips; chip rows carry Phy-IDs 0-15
@@ -75,6 +87,30 @@ A3_WITH_RUNNING_PROCESS = A3_DUAL_CHIP.replace(
     "| 1       0                 | 3412          | python                   | 41235                   |",
 )
 
+# visible [0,1], busy [0], free [1]
+SINGLE_CHIP_BUSY_0 = SINGLE_CHIP.replace(
+    "| No running processes found                                                          |",
+    "| 0       0                 | 3412          | python                   | 41235                   |",
+)
+
+# visible [0], busy [0], free [], status ok
+SINGLE_DEVICE_ALL_BUSY = """\
++---------------------------+---------------+----------------------------------------------------+
+| NPU   Name                | Health        | Power(W)    Temp(C)           Hugepages-Usage(page)|
+| Chip  Phy-ID              | Bus-Id        | AICore(%)   Memory-Usage(MB)  HBM-Usage(MB)        |
++===========================+===============+====================================================+
+| 0     Ascend910B4         | OK            | 72.6        42                0    / 0             |
+| 0     0                   | 0000:C1:00.0  | 0           0    / 0          1151 / 32768         |
++===========================+===============+====================================================+
+| NPU     Chip              | Process id    | Process name             | Process memory(MB)      |
++===========================+===============+====================================================+
+| 0       0                 | 3412          | python                   | 41235                   |
++------------------------------------------------------------------------------------------------+
+"""
+
+HOST_RECORD = {"host": {"ip": "192.0.2.10", "user": "root", "port": 22}}
+MACHINE = "host"
+
 
 class ParseHostNpuDevicesTests(unittest.TestCase):
     def test_dual_chip_a3_returns_phy_ids(self) -> None:
@@ -88,10 +124,6 @@ class ParseHostNpuDevicesTests(unittest.TestCase):
 
     def test_empty_output(self) -> None:
         self.assertEqual(parse_host_npu_devices(""), [])
-
-
-if __name__ == "__main__":
-    unittest.main()
 
 
 class ParseHostNpuAvailabilityTests(unittest.TestCase):
@@ -133,3 +165,189 @@ class ParseHostNpuAvailabilityTests(unittest.TestCase):
         # allocatable. Callers that need the latter must ask for availability.
         self.assertEqual([0, 1], parse_host_npu_devices(HEADER_ONLY))
         self.assertIsNone(parse_host_npu_availability(HEADER_ONLY)[0])
+
+
+def _probe_host(*, stdout: str = "", returncode: int = 0, timeout: bool = False):
+    if timeout:
+        runner = mock.Mock(
+            side_effect=subprocess.TimeoutExpired(cmd=["ssh"], timeout=30, output="", stderr="")
+        )
+    else:
+        runner = mock.Mock(
+            return_value=subprocess.CompletedProcess(
+                args=["ssh"],
+                returncode=returncode,
+                stdout=stdout,
+                stderr="" if returncode == 0 else "ssh failed",
+            )
+        )
+    with mock.patch.object(session_create.subprocess, "run", runner):
+        return probe_host_npu_devices(HOST_RECORD)
+
+
+def _allocate(root: Path, session_id: str, **kwargs):
+    return allocate_session_leases(
+        repo_root=root,
+        machine_alias=MACHINE,
+        session_id=session_id,
+        port_available=lambda _port: True,
+        **kwargs,
+    )
+
+
+def _live(root: Path, session_id: str) -> dict:
+    return session_live_leases(repo_root=root, machine_alias=MACHINE, session_id=session_id)
+
+
+class ProbeHostNpuDevicesAllocationTests(unittest.TestCase):
+    """Pin the probe wrapper, not just the parser, then feed the allocator."""
+
+    def _assert_no_lease_or_port(self, root: Path, session_id: str) -> None:
+        self.assertFalse(session_leases_path(root).exists())
+        self.assertEqual(
+            _live(root, session_id),
+            {"npu_devices": [], "container_ssh_ports": [], "service_ports": []},
+        )
+
+    def test_partial_busy_allocates_only_the_free_device(self) -> None:
+        free, payload = _probe_host(stdout=SINGLE_CHIP_BUSY_0)
+        self.assertEqual(free, [1])
+        self.assertEqual(payload["availability"], "known")
+        self.assertEqual(payload["visible_devices"], [0, 1])
+        self.assertEqual(payload["busy_devices"], [0])
+        self.assertEqual(payload["free_devices"], [1])
+        self.assertEqual(payload["status"], "ok")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            explicit = _allocate(
+                root, "sess-explicit", requested_devices=[1], available_devices=free, container_ssh_port=46001
+            )
+            self.assertEqual(explicit["npu_devices"], [1])
+            self.assertEqual(_live(root, "sess-explicit")["npu_devices"], [1])
+            self.assertEqual(_live(root, "sess-explicit")["container_ssh_ports"], [46001])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            counted = _allocate(root, "sess-count", npu_count=1, available_devices=free, container_ssh_port=46002)
+            self.assertEqual(counted["npu_devices"], [1])
+            self.assertEqual(_live(root, "sess-count")["npu_devices"], [1])
+            self.assertEqual(_live(root, "sess-count")["container_ssh_ports"], [46002])
+
+    def test_partial_busy_refuses_busy_device_and_oversize_count(self) -> None:
+        free, _payload = _probe_host(stdout=SINGLE_CHIP_BUSY_0)
+        self.assertEqual(free, [1])
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(SessionStateError):
+                _allocate(root, "sess-busy", requested_devices=[0], available_devices=free)
+            self._assert_no_lease_or_port(root, "sess-busy")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(SessionStateError):
+                _allocate(root, "sess-count", npu_count=2, available_devices=free)
+            self._assert_no_lease_or_port(root, "sess-count")
+
+    def test_known_empty_free_set_returns_empty_list_and_refuses_both_modes(self) -> None:
+        free, payload = _probe_host(stdout=SINGLE_DEVICE_ALL_BUSY)
+        self.assertEqual(free, [])
+        self.assertIsNotNone(free)
+        self.assertEqual(payload["availability"], "known")
+        self.assertEqual(payload["visible_devices"], [0])
+        self.assertEqual(payload["busy_devices"], [0])
+        self.assertEqual(payload["free_devices"], [])
+        self.assertEqual(payload["status"], "ok")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(SessionStateError):
+                _allocate(root, "sess-explicit", requested_devices=[0], available_devices=free)
+            with self.assertRaises(SessionStateError):
+                _allocate(root, "sess-count", npu_count=1, available_devices=free)
+            self._assert_no_lease_or_port(root, "sess-explicit")
+            self._assert_no_lease_or_port(root, "sess-count")
+
+    def test_unreadable_process_table_returns_none_and_refuses_both_modes(self) -> None:
+        free, payload = _probe_host(stdout=HEADER_ONLY)
+        self.assertIsNone(free)
+        self.assertEqual(payload["availability"], "unknown")
+        self.assertEqual(payload["status"], "occupancy_unknown")
+        self.assertTrue(payload["availability_reason"])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable"):
+                _allocate(root, "sess-explicit", requested_devices=[0], available_devices=free)
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable"):
+                _allocate(root, "sess-count", npu_count=1, available_devices=free)
+            self._assert_no_lease_or_port(root, "sess-explicit")
+            self._assert_no_lease_or_port(root, "sess-count")
+
+    def test_ssh_failure_returns_none_and_does_not_fall_back_to_visibility(self) -> None:
+        free, payload = _probe_host(stdout=SINGLE_CHIP, returncode=255)
+        self.assertIsNone(free)
+        self.assertEqual(payload["status"], "unavailable")
+        self.assertNotIn("availability", payload)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable"):
+                _allocate(root, "sess-explicit", requested_devices=[0], available_devices=free)
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable"):
+                _allocate(root, "sess-count", npu_count=1, available_devices=free)
+            self._assert_no_lease_or_port(root, "sess-explicit")
+            self._assert_no_lease_or_port(root, "sess-count")
+
+    def test_probe_timeout_returns_none_and_refuses_both_modes(self) -> None:
+        free, payload = _probe_host(timeout=True)
+        self.assertIsNone(free)
+        self.assertEqual(payload["status"], "timeout")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable"):
+                _allocate(root, "sess-explicit", requested_devices=[0], available_devices=free)
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable"):
+                _allocate(root, "sess-count", npu_count=1, available_devices=free)
+            self._assert_no_lease_or_port(root, "sess-explicit")
+            self._assert_no_lease_or_port(root, "sess-count")
+
+    def test_locally_leased_free_device_is_excluded_by_existing_ownership(self) -> None:
+        free, _payload = _probe_host(stdout=SINGLE_CHIP_BUSY_0)
+        self.assertEqual(free, [1])
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            owner = _allocate(
+                root, "sess-owner", requested_devices=[1], available_devices=free, container_ssh_port=46001
+            )
+            self.assertEqual(owner["npu_devices"], [1])
+            with self.assertRaisesRegex(SessionStateError, "already leased"):
+                _allocate(root, "sess-other", requested_devices=[1], available_devices=free)
+            with self.assertRaisesRegex(SessionStateError, "not enough allocatable"):
+                _allocate(root, "sess-count", npu_count=1, available_devices=free)
+            self.assertEqual(_live(root, "sess-owner")["npu_devices"], [1])
+            self.assertEqual(_live(root, "sess-owner")["container_ssh_ports"], [46001])
+            self.assertEqual(
+                _live(root, "sess-other"),
+                {"npu_devices": [], "container_ssh_ports": [], "service_ports": []},
+            )
+            self.assertEqual(
+                _live(root, "sess-count"),
+                {"npu_devices": [], "container_ssh_ports": [], "service_ports": []},
+            )
+
+    def test_no_npu_request_still_allocates_a_port_when_occupancy_is_unknown(self) -> None:
+        free, payload = _probe_host(stdout=HEADER_ONLY)
+        self.assertIsNone(free)
+        self.assertEqual(payload["availability"], "unknown")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            leases = _allocate(root, "sess-port", available_devices=free, container_ssh_port=46009)
+            self.assertEqual(leases["npu_devices"], [])
+            self.assertEqual(leases["container_ssh_port"], 46009)
+            self.assertEqual(_live(root, "sess-port")["npu_devices"], [])
+            self.assertEqual(_live(root, "sess-port")["container_ssh_ports"], [46009])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/session-management/tests/test_session_create_probes.py
+++ b/.agents/skills/session-management/tests/test_session_create_probes.py
@@ -13,7 +13,10 @@ for _p in (str(SCRIPTS),):
     if _p not in sys.path:
         sys.path.insert(0, str(_p))
 
-from session_create import parse_host_npu_devices  # noqa: E402
+from session_create import (  # noqa: E402
+    parse_host_npu_availability,
+    parse_host_npu_devices,
+)
 
 # Dual-chip A3 card layout: 8 cards x 2 chips; chip rows carry Phy-IDs 0-15
 # which are the device ids vLLM / ASCEND_RT_VISIBLE_DEVICES actually use.
@@ -64,6 +67,14 @@ HEADER_ONLY = """\
 | 1     Ascend910           | OK            | 170.9       53                0    / 0             |
 """
 
+# Same A3 layout, but somebody else is already running on Phy-ID 2. This is the
+# case that used to be invisible to allocation: the device is healthy, visible
+# and taken.
+A3_WITH_RUNNING_PROCESS = A3_DUAL_CHIP.replace(
+    "| No running processes found                                                          |",
+    "| 1       0                 | 3412          | python                   | 41235                   |",
+)
+
 
 class ParseHostNpuDevicesTests(unittest.TestCase):
     def test_dual_chip_a3_returns_phy_ids(self) -> None:
@@ -81,3 +92,44 @@ class ParseHostNpuDevicesTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ParseHostNpuAvailabilityTests(unittest.TestCase):
+    """Allocation must never be driven by the visible-device list.
+
+    Two ways that was wrong, both of which handed out cards somebody else was
+    using, and neither of which raised anything:
+
+    * a visible device can be busy, and the parser's occupancy was discarded
+    * a parser that fails closed still reports every device with an empty busy
+      table, which reads as "all free" to a caller that only looks at devices
+    """
+
+    def test_idle_host_offers_every_visible_device(self) -> None:
+        free, diagnostics = parse_host_npu_availability(A3_DUAL_CHIP)
+        self.assertEqual([0, 1, 2, 3], free)
+        self.assertEqual("known", diagnostics["availability"])
+        self.assertEqual([], diagnostics["busy_devices"])
+
+    def test_a_device_in_use_is_not_offered(self) -> None:
+        free, diagnostics = parse_host_npu_availability(A3_WITH_RUNNING_PROCESS)
+        self.assertIsNotNone(free)
+        self.assertNotIn(2, free, "a device with a running process must not be allocatable")
+        self.assertIn(2, diagnostics["busy_devices"])
+        self.assertEqual([0, 1, 2, 3], diagnostics["visible_devices"])
+
+    def test_unreadable_process_table_yields_unknown_not_empty(self) -> None:
+        # HEADER_ONLY has no process table at all, so occupancy cannot be
+        # established. The old code returned [0, 1] here and allocation
+        # proceeded; assign_resources' fail-fast guard for unknown availability
+        # was unreachable because a failed probe never produced None.
+        free, diagnostics = parse_host_npu_availability(HEADER_ONLY)
+        self.assertIsNone(free)
+        self.assertEqual("unknown", diagnostics["availability"])
+        self.assertTrue(diagnostics["availability_reason"])
+
+    def test_visibility_helper_still_reports_visible_devices(self) -> None:
+        # parse_host_npu_devices keeps its meaning: what exists, not what is
+        # allocatable. Callers that need the latter must ask for availability.
+        self.assertEqual([0, 1], parse_host_npu_devices(HEADER_ONLY))
+        self.assertIsNone(parse_host_npu_availability(HEADER_ONLY)[0])

--- a/.agents/tests/test_vaws_scaffold_safety.py
+++ b/.agents/tests/test_vaws_scaffold_safety.py
@@ -25,6 +25,7 @@ from vaws_session_state import (  # noqa: E402
     allocate_service_port,
     allocate_session_leases,
     release_service_port,
+    session_leases_path,
     session_live_leases,
     require_session_npu_lease,
     release_all_session_leases,
@@ -260,6 +261,65 @@ class LeaseValidationTests(unittest.TestCase):
                 )["service_ports"],
                 [],
             )
+
+    def test_unknown_occupancy_refuses_npu_requests_but_allows_port_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable") as explicit:
+                allocate_session_leases(
+                    repo_root=root,
+                    machine_alias="host",
+                    session_id="sess-explicit",
+                    requested_devices=[0],
+                    port_available=lambda _port: True,
+                )
+            self.assertNotIn("--devices", str(explicit.exception))
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable") as counted:
+                allocate_session_leases(
+                    repo_root=root,
+                    machine_alias="host",
+                    session_id="sess-count",
+                    npu_count=1,
+                    port_available=lambda _port: True,
+                )
+            self.assertNotIn("--devices", str(counted.exception))
+            self.assertFalse(session_leases_path(root).exists())
+            leases = allocate_session_leases(
+                repo_root=root,
+                machine_alias="host",
+                session_id="sess-port",
+                container_ssh_port=46009,
+                port_available=lambda _port: True,
+            )
+            self.assertEqual(leases["npu_devices"], [])
+            self.assertEqual(leases["container_ssh_port"], 46009)
+            self.assertEqual(
+                session_live_leases(repo_root=root, machine_alias="host", session_id="sess-port"),
+                {"npu_devices": [], "container_ssh_ports": [46009], "service_ports": []},
+            )
+
+    def test_known_empty_free_set_refuses_explicit_and_count_requests(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(SessionStateError):
+                allocate_session_leases(
+                    repo_root=root,
+                    machine_alias="host",
+                    session_id="sess-explicit",
+                    requested_devices=[0],
+                    available_devices=[],
+                    port_available=lambda _port: True,
+                )
+            with self.assertRaises(SessionStateError):
+                allocate_session_leases(
+                    repo_root=root,
+                    machine_alias="host",
+                    session_id="sess-count",
+                    npu_count=1,
+                    available_devices=[],
+                    port_available=lambda _port: True,
+                )
+            self.assertFalse(session_leases_path(root).exists())
 
 
 class WorktreeCreateTests(unittest.TestCase):


### PR DESCRIPTION
Session creation could allocate a visible NPU that was already busy, and explicit `--devices` could bypass an unavailable occupancy probe. The probe now supplies the free-device set while preserving `[]` (known to have no free devices) and `None` (occupancy unknown). Both explicit-device and count-based requests fail closed when occupancy is unknown, and a known empty free set cannot authorize either request. Port-only creation remains supported.

The existing visibility parser keeps its visibility-only meaning. Probe diagnostics retain visible, busy and free devices plus the failure reason; progress messages and session guidance no longer suggest explicit devices as an unsafe fallback. This change does not replace the host NPU queue or provide cross-workspace allocation arbitration.

Validation on `765cb9891f49b6651547ba39a39d11a6d352c4d1`:

- Independent probe-to-allocator checks cover busy/empty/unknown results, SSH failure and timeout mocks, partial-free success, preservation of another session's leases, port-only creation, and no persisted NPU/port leases after refusal.
- Session-management suite: 81 passed; `.agents/tests`: 58 passed; direct probe suite: 16 passed. No skips.
- Pure Python and mocked transport/POSIX state checks only. No SSH/NPU or shared-host execution; real contended-host parsing and cross-workspace arbitration are not established by these tests.
