### PR TITLE
fix: close the unevidenced-verdict paths in the validation/debug family

### DIFF
--- a/.agents/skills/vllm-ascend-change-validation/SKILL.md
+++ b/.agents/skills/vllm-ascend-change-validation/SKILL.md
@@ -12,7 +12,7 @@ Use this Skill as the validation planner and evidence aggregator for a code chan
 1. Obtain the exact baseline and candidate diff, including relevant untracked files.
 2. Run `scripts/change_validation.py plan`.
 3. Review `impact-analysis.json` and `validation-plan.json`; correct false-positive or missing mappings before consuming NPU resources.
-4. Execute required items with the owning Skill:
+4. Execute required items with the owning Skill, creating every downstream run with this plan's run ID as its `parent_run_id` (`--parent-run-id` on `init`, or the `parent_run_id` config key). `link` refuses runs that were not created for this plan:
    - correctness evidence: `vllm-ascend-correctness-validation`;
    - eager-pass/graph-fail diagnosis: `vllm-ascend-graph-debug`;
    - service lifecycle: `vllm-ascend-serving`;
@@ -48,6 +48,7 @@ Read:
 - Distinguish `required` and `recommended`; resource constraints do not silently downgrade required evidence.
 - Treat child `failed` as failed, child non-terminal/inconclusive or missing required coverage as inconclusive.
 - A passed parent requires every required item to be covered by at least one passed child run.
+- Only link runs whose `parent_run_id` is this plan and whose `passed` state carries artifacts; never edit a child manifest to make it linkable.
 - Record unsupported, unknown, and intentionally omitted combinations under known limitations.
 - Do not duplicate Serving, correctness, Benchmark, Profiling, graph-debug, distributed-debug, or operator-debug implementation.
 - Keep run state under `.vaws-local/change-validation/`.

--- a/.agents/skills/vllm-ascend-change-validation/references/acceptance.md
+++ b/.agents/skills/vllm-ascend-change-validation/references/acceptance.md
@@ -18,6 +18,8 @@
 ## Evidence
 
 - [ ] Each linked run has a valid Run Manifest.
+- [ ] Each linked run was created with this plan's `run_id` as its `parent_run_id`.
+- [ ] Each passed linked run carries artifacts that a reviewer can open.
 - [ ] Each link names the plan item IDs it covers.
 - [ ] Failed, inconclusive, cancelled, running, and planned children are not treated as passing.
 - [ ] Correctness, performance, graph, distributed, operator, and profiling evidence use their owning workflows.

--- a/.agents/skills/vllm-ascend-change-validation/references/behavior.md
+++ b/.agents/skills/vllm-ascend-change-validation/references/behavior.md
@@ -60,7 +60,13 @@ Link the downstream `manifest.json` and one or more plan IDs. The parent records
 - absolute manifest location;
 - covered plan items.
 
-A child with another non-null parent ID cannot be linked. Duplicate child run IDs are rejected.
+`link` fails closed on three conditions, each with an error naming the child run and what is missing:
+
+- the child's `parent_run_id` is `null`: the run was not created as evidence for this plan. Downstream runs must be created with this plan's `run_id` (`correctness_run.py init --parent-run-id`, `graph_debug_case.py init --parent-run-id`, or the `parent_run_id` key of the performance-regression and distributed-debug configs). A manifest created before the plan existed cannot be linked retroactively;
+- the child's `parent_run_id` names a different run;
+- the child is `passed` but links no artifacts: a passed manifest without evidence cannot cover a plan item.
+
+Duplicate child run IDs are rejected. The parent-child check is now a real constraint: before this change a `null` parent satisfied it, so it could never fail.
 
 ## Final status
 

--- a/.agents/skills/vllm-ascend-change-validation/references/command-recipes.md
+++ b/.agents/skills/vllm-ascend-change-validation/references/command-recipes.md
@@ -41,7 +41,9 @@ python -B .agents/skills/vllm-ascend-change-validation/scripts/change_validation
 
 ## Link evidence
 
-Read `validation-plan.json`, then link the exact plan IDs:
+Create every downstream run with this plan's run ID as its parent, for example
+`correctness_run.py init --parent-run-id change-validation-001`, then read
+`validation-plan.json` and link the exact plan IDs:
 
 ```bash
 python -B .agents/skills/vllm-ascend-change-validation/scripts/change_validation.py link \
@@ -50,6 +52,10 @@ python -B .agents/skills/vllm-ascend-change-validation/scripts/change_validation
   --covers correctness-multi-rank-metadata-consistency \
   --covers correctness-eager
 ```
+
+`link` exits 1 when the child manifest has no `parent_run_id`, names another
+parent, or is `passed` with no artifacts. The error says which; fix the
+downstream run rather than editing its manifest.
 
 ## Finalize
 

--- a/.agents/skills/vllm-ascend-change-validation/scripts/change_validation.py
+++ b/.agents/skills/vllm-ascend-change-validation/scripts/change_validation.py
@@ -431,6 +431,40 @@ def plan_change(
     }
 
 
+PARENT_RUN_ID_HINT = (
+    "create downstream runs for this plan with "
+    "`correctness_run.py init --parent-run-id`, "
+    "`graph_debug_case.py init --parent-run-id`, or the `parent_run_id` key of "
+    "the performance-regression / distributed-debug config"
+)
+
+
+def check_child_evidence(child: Mapping[str, Any], *, parent_run_id: str) -> None:
+    """Reject a child manifest that cannot serve as evidence for this plan.
+
+    The child must have been created for this plan (its `parent_run_id` names
+    this run), and a `passed` child must carry at least one artifact: a passed
+    manifest with nothing attached is a verdict without evidence.
+    """
+    child_parent = child.get("parent_run_id")
+    if child_parent is None:
+        raise ChangeValidationError(
+            f"child run {child['run_id']!r} has no parent_run_id; it was not "
+            f"created as evidence for {parent_run_id!r} and cannot be linked. "
+            + PARENT_RUN_ID_HINT
+        )
+    if child_parent != parent_run_id:
+        raise ChangeValidationError(
+            f"child run {child['run_id']!r} belongs to parent {child_parent!r}, "
+            f"not {parent_run_id!r}"
+        )
+    if child["status"] == "passed" and not child.get("artifacts"):
+        raise ChangeValidationError(
+            f"child run {child['run_id']!r} is passed but links no artifacts; "
+            "a passed manifest without evidence cannot cover a plan item"
+        )
+
+
 def link_run(
     output_dir: Path,
     *,
@@ -447,10 +481,7 @@ def link_run(
         raise ChangeValidationError("at least one --covers item is required")
     child = load_manifest(child_manifest_path)
     parent = load_manifest(output_dir / "manifest.json")
-    if child.get("parent_run_id") not in {None, parent["run_id"]}:
-        raise ChangeValidationError(
-            f"child parent_run_id belongs to another run: {child.get('parent_run_id')}"
-        )
+    check_child_evidence(child, parent_run_id=parent["run_id"])
     links = _load_json(output_dir / "linked-runs.json", "linked runs")
     if any(link["run_id"] == child["run_id"] for link in links["runs"]):
         raise ChangeValidationError(f"child run is already linked: {child['run_id']}")

--- a/.agents/skills/vllm-ascend-change-validation/tests/test_change_validation.py
+++ b/.agents/skills/vllm-ascend-change-validation/tests/test_change_validation.py
@@ -17,7 +17,12 @@ LIB = ROOT / ".agents" / "lib"
 if str(LIB) not in sys.path:
     sys.path.insert(0, str(LIB))
 
-from vaws_run_manifest import new_manifest, transition_status, write_manifest  # noqa: E402
+from vaws_run_manifest import (  # noqa: E402
+    add_artifact,
+    new_manifest,
+    transition_status,
+    write_manifest,
+)
 
 
 def load_module():
@@ -106,38 +111,52 @@ class PlanningTests(unittest.TestCase):
         self.assertTrue(plan["manual_review_required"])
 
 
+def plan_graph_change(output: Path, run_id: str = "change-validation-1") -> list[str]:
+    change_validation.plan_change(
+        output,
+        run_id=run_id,
+        baseline="base",
+        candidate="candidate",
+        goal="graph fix",
+        target_repositories=["vllm-ascend"],
+        diff_text=unified_diff("graph_mode.py"),
+        knowledge_path=KNOWLEDGE,
+        created_at=NOW,
+    )
+    plan = json.loads((output / "validation-plan.json").read_text(encoding="utf-8"))
+    return [item["id"] for item in plan["items"] if item["priority"] == "required"]
+
+
+def passed_child(
+    path: Path,
+    *,
+    parent_run_id: str | None,
+    with_artifact: bool = True,
+    run_type: str = "correctness",
+) -> None:
+    child = new_manifest(
+        run_type=run_type,
+        run_id="child-1",
+        parent_run_id=parent_run_id,
+        created_at=NOW,
+    )
+    child = transition_status(child, "running", updated_at=NOW)
+    if with_artifact:
+        child = add_artifact(
+            child, name="comparison", kind="comparison", uri="comparison.json", updated_at=NOW
+        )
+    child = transition_status(child, "passed", updated_at=NOW)
+    write_manifest(path, child)
+
+
 class AggregationTests(unittest.TestCase):
     def test_passed_child_can_complete_required_plan(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             output = root / "change"
-            change_validation.plan_change(
-                output,
-                run_id="change-validation-1",
-                baseline="base",
-                candidate="candidate",
-                goal="graph fix",
-                target_repositories=["vllm-ascend"],
-                diff_text=unified_diff("graph_mode.py"),
-                knowledge_path=KNOWLEDGE,
-                created_at=NOW,
-            )
-            plan = json.loads(
-                (output / "validation-plan.json").read_text(encoding="utf-8")
-            )
-            required_ids = [
-                item["id"] for item in plan["items"] if item["priority"] == "required"
-            ]
+            required_ids = plan_graph_change(output)
             child_path = root / "child-manifest.json"
-            child = new_manifest(
-                run_type="correctness",
-                run_id="correctness-child-1",
-                parent_run_id="change-validation-1",
-                created_at=NOW,
-            )
-            child = transition_status(child, "running", updated_at=NOW)
-            child = transition_status(child, "passed", updated_at=NOW)
-            write_manifest(child_path, child)
+            passed_child(child_path, parent_run_id="change-validation-1")
             change_validation.link_run(
                 output,
                 child_manifest_path=child_path,
@@ -147,7 +166,66 @@ class AggregationTests(unittest.TestCase):
             result = change_validation.finalize(output, updated_at=NOW)
             self.assertEqual(result["status"], "passed")
             report = (output / "pr-validation-report.md").read_text(encoding="utf-8")
-            self.assertIn("correctness-child-1", report)
+            self.assertIn("child-1", report)
+
+    def test_child_without_parent_run_id_is_rejected(self) -> None:
+        """Regression: a null parent_run_id used to satisfy the parent check."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            output = root / "change"
+            required_ids = plan_graph_change(output)
+            child_path = root / "orphan.json"
+            passed_child(child_path, parent_run_id=None)
+            with self.assertRaisesRegex(
+                change_validation.ChangeValidationError,
+                "has no parent_run_id.*--parent-run-id",
+            ):
+                change_validation.link_run(
+                    output,
+                    child_manifest_path=child_path,
+                    covers=required_ids,
+                    updated_at=NOW,
+                )
+            links = json.loads((output / "linked-runs.json").read_text(encoding="utf-8"))
+            self.assertEqual(links["runs"], [])
+            result = change_validation.finalize(output, updated_at=NOW)
+            self.assertEqual(result["status"], "inconclusive")
+
+    def test_child_of_another_parent_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            output = root / "change"
+            required_ids = plan_graph_change(output)
+            child_path = root / "foreign.json"
+            passed_child(child_path, parent_run_id="change-validation-other")
+            with self.assertRaisesRegex(
+                change_validation.ChangeValidationError, "belongs to parent"
+            ):
+                change_validation.link_run(
+                    output,
+                    child_manifest_path=child_path,
+                    covers=required_ids,
+                    updated_at=NOW,
+                )
+
+    def test_passed_child_without_artifacts_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            output = root / "change"
+            required_ids = plan_graph_change(output)
+            child_path = root / "bare.json"
+            passed_child(
+                child_path, parent_run_id="change-validation-1", with_artifact=False
+            )
+            with self.assertRaisesRegex(
+                change_validation.ChangeValidationError, "links no artifacts"
+            ):
+                change_validation.link_run(
+                    output,
+                    child_manifest_path=child_path,
+                    covers=required_ids,
+                    updated_at=NOW,
+                )
 
     def test_missing_required_evidence_is_inconclusive(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/.agents/skills/vllm-ascend-correctness-validation/SKILL.md
+++ b/.agents/skills/vllm-ascend-correctness-validation/SKILL.md
@@ -14,8 +14,8 @@ Produce traceable correctness evidence instead of treating a successful request 
 3. Before remote execution, use `remote-code-parity` for each state.
 4. For offline cases, run `scripts/remote_correctness_harness.py` inside the remote NPU container. The harness prioritizes the materialized `vllm/` and `vllm-ascend/` source roots and propagates them through `PYTHONPATH`, so launching from `/vllm-workspace` or spawning a `python -m` child cannot resolve the outer repository directory as a false `vllm` namespace package.
 5. For online cases, use `vllm-ascend-serving`, then run the same harness in `online-chat` mode.
-6. Use `scripts/correctness_run.py init` to create the run directory and Run Manifest v1.
-7. Use `scripts/correctness_run.py compare` to normalize the evidence into a classification and report.
+6. Use `scripts/correctness_run.py init` to create the run directory and Run Manifest v1. Pass `--parent-run-id` for PR evidence, and declare any intentional non-code difference between the two states with `--allowed-difference KEY` (for example `engine_args.enforce_eager` for eager versus graph).
+7. Use `scripts/correctness_run.py compare` to normalize the evidence into a classification and report. It first checks that both results carry an `execution` block and differ only in declared keys; an undeclared difference aborts the comparison instead of being reported as a code regression.
 8. Route failures:
    - eager pass and graph fail: `vllm-ascend-graph-debug`;
    - multi-rank hang or inconsistent rank metadata: `vllm-ascend-distributed-debug` when available;
@@ -54,8 +54,8 @@ Do not relabel infrastructure failures as correctness regressions. Do not treat 
 ## Structured entry points
 
 - `scripts/correctness_run.py`: initialize a run, compare normalized baseline and candidate outputs, write `comparison.json`, `report.md`, `reproduction.sh`, and update Run Manifest v1.
-- `scripts/remote_correctness_harness.py`: execute offline generate, offline chat, or online chat cases and write the normalized result contract.
-- `scripts/aisbench_adapter.py`: prepare an AISBench accuracy command/config and normalize task metrics into the correctness result contract.
+- `scripts/remote_correctness_harness.py`: execute offline generate, offline chat, or online chat cases and write the normalized result contract, including the `execution` identity (`engine_args`, model, service, case digest) that decided the run.
+- `scripts/aisbench_adapter.py`: prepare an AISBench accuracy command/config and normalize task metrics into the correctness result contract; `normalize` requires `--execution` to declare the benchmarked service.
 
 Read as needed:
 

--- a/.agents/skills/vllm-ascend-correctness-validation/references/acceptance.md
+++ b/.agents/skills/vllm-ascend-correctness-validation/references/acceptance.md
@@ -19,6 +19,8 @@
 ## Comparison
 
 - [ ] Every planned case has baseline and candidate evidence.
+- [ ] Both results carry an `execution` block, and every difference between them was declared at `init` with `--allowed-difference`; `compare` refuses undeclared differences.
+- [ ] A verdict on a run with declared differences is read as attributable to the declared variable, not to the code change.
 - [ ] Token or text comparison is used where exactness is meaningful.
 - [ ] Numeric tolerances are explicit and justified.
 - [ ] Task metric direction and regression thresholds are explicit.
@@ -26,7 +28,7 @@
 
 ## Delivery
 
-- [ ] `manifest.json`, `cases.json`, `comparison.json`, `report.md`, raw outputs, and `reproduction.sh` exist.
+- [ ] `manifest.json`, `cases.json`, `execution.json`, `comparison.json`, `report.md`, raw outputs, and `reproduction.sh` exist.
 - [ ] Run Manifest v1 validates and links every delivered artifact.
 - [ ] The report lists unsupported and untested combinations.
 - [ ] A passed run contains only exact or within-tolerance cases.

--- a/.agents/skills/vllm-ascend-correctness-validation/references/aisbench.md
+++ b/.agents/skills/vllm-ascend-correctness-validation/references/aisbench.md
@@ -48,8 +48,15 @@ Select the exact `summary_*.csv` produced by the run:
 python -B .agents/skills/vllm-ascend-correctness-validation/scripts/aisbench_adapter.py normalize \
   --summary-csv /remote/output/summary/summary_20260725_120000.csv \
   --label baseline \
+  --execution '{"served_model":"example","engine_args":{"tensor_parallel_size":2,"enforce_eager":false},"base_url":"http://<host>:<port>"}' \
   --output /remote/output/baseline-normalized.json
 ```
+
+`--execution` is required: AISBench never sees the engine, so the service that
+produced the summary must be declared (`served_model`, the `engine_args` it was
+started with, optionally `base_url`). `correctness_run.py compare` refuses any
+baseline/candidate difference in this block that was not declared at `init`
+with `--allowed-difference`.
 
 Repeat with the candidate summary. Compare both normalized files with the same `aisbench-cases.json`.
 

--- a/.agents/skills/vllm-ascend-correctness-validation/references/behavior.md
+++ b/.agents/skills/vllm-ascend-correctness-validation/references/behavior.md
@@ -58,6 +58,16 @@ Each state writes:
 {
   "schema_version": 1,
   "label": "baseline",
+  "execution": {
+    "model": "/models/example",
+    "engine_args": {
+      "tensor_parallel_size": 2,
+      "enforce_eager": true
+    },
+    "base_url": null,
+    "served_model": null,
+    "cases_sha256": "<64 lowercase hex>"
+  },
   "cases": [
     {
       "id": "chat-smoke",
@@ -81,6 +91,20 @@ Each state writes:
 ```
 
 `status` is `ok`, `error`, or `unsupported`. An executor may provide text, token IDs, token strings, numeric evidence, task metrics, or a relevant subset.
+
+`execution` records what decided the run's behaviour besides the code under test. The harness fills it from its config (`engine_args`, `model`, `base_url`, `served_model`) and adds `cases_sha256`, the digest of the case array it actually executed. The AISBench adapter requires it via `normalize --execution`. It is a declaration of the launch configuration, not an observation of the running service.
+
+## Execution identity check
+
+`compare` refuses to classify anything until the two results are shown to be a comparable pair:
+
+- each result's `label` must equal the `baseline_label` / `candidate_label` recorded at `init` (passing one file twice is rejected);
+- both results must carry an `execution` block with an `engine_args` object;
+- every key where the two `execution` blocks differ (`engine_args.*` flattened, plus `model`, `base_url`, `served_model`, `cases_sha256`) must have been declared at `init` with `--allowed-difference KEY`.
+
+An undeclared difference aborts the comparison with the list of differing keys and leaves the manifest non-terminal. This is what stops a deliberate eager-versus-graph comparison from being reported as a code regression: with `--allowed-difference engine_args.enforce_eager` the comparison runs, and the report and `execution.json` state that the divergence is attributable to that declared variable. Without the declaration the comparison is not a code comparison and is not performed.
+
+The check compares declared launch configuration. It cannot see differences that were never written into the harness config (for example an online service restarted with other flags but the same `base_url`).
 
 ## Comparison precedence
 
@@ -112,12 +136,13 @@ correctness-run/
 ├── raw_outputs/
 │   ├── baseline.json
 │   └── candidate.json
+├── execution.json
 ├── comparison.json
 ├── report.md
 └── reproduction.sh
 ```
 
-The normalized files are the comparison source. Mixed service or vLLM stdout is supporting evidence, not a parser contract.
+The normalized files are the comparison source. Mixed service or vLLM stdout is supporting evidence, not a parser contract. `execution.json` holds both sides' execution identity, the declared allowed differences, and the observed differences; the manifest links it and the raw outputs with SHA256, and `comparison.json` embeds the same block under `execution`.
 
 ## Routing
 

--- a/.agents/skills/vllm-ascend-correctness-validation/references/command-recipes.md
+++ b/.agents/skills/vllm-ascend-correctness-validation/references/command-recipes.md
@@ -14,8 +14,20 @@ python -B .agents/skills/vllm-ascend-correctness-validation/scripts/correctness_
   --workspace-snapshot '{"workspace":"<snapshot>","dirty":false}' \
   --environment '{"machine":"<alias>","cann":"<version>","torch_npu":"<version>"}' \
   --model '{"path":"<remote-model-path>"}' \
-  --topology '{"tp":2,"devices":[0,1]}'
+  --topology '{"tp":2,"devices":[0,1]}' \
+  --parent-run-id change-validation-001
 ```
+
+For a deliberate eager-versus-graph comparison, declare the variable under test
+so `compare` accepts that one difference and records it with the verdict:
+
+```bash
+  --allowed-difference engine_args.enforce_eager
+```
+
+Any other difference between the two results' `execution` blocks aborts the
+comparison. `--parent-run-id` is required for the run to be linkable by
+`change_validation.py link`.
 
 ## Execute normalized cases
 
@@ -52,6 +64,10 @@ Harness config includes the case array plus:
 }
 ```
 
+The harness copies `model`, `engine_args`, `base_url`, and `served_model` into
+the result's `execution` block and adds `cases_sha256`. Use the same case array
+verbatim in both harness configs; a different array is an undeclared difference.
+
 ## Compare
 
 ```bash
@@ -61,4 +77,8 @@ python -B .agents/skills/vllm-ascend-correctness-validation/scripts/correctness_
   --candidate /path/to/candidate-result.json
 ```
 
-Read the compact stdout first, then inspect `report.md` and only the relevant raw evidence.
+`compare` first checks that the two results are a comparable pair: labels match
+the run, both carry `execution`, and every `execution` difference was declared
+at `init`. An undeclared difference exits 1 naming the keys and writes no
+comparison. Read the compact stdout first (it lists `observed_differences`),
+then inspect `report.md` and only the relevant raw evidence.

--- a/.agents/skills/vllm-ascend-correctness-validation/scripts/aisbench_adapter.py
+++ b/.agents/skills/vllm-ascend-correctness-validation/scripts/aisbench_adapter.py
@@ -231,12 +231,37 @@ def prepare(
     }
 
 
+def validate_execution(execution: Any) -> dict[str, Any]:
+    """Require the execution identity the comparator needs to attribute results.
+
+    AISBench never sees the engine, so the operator must declare which service
+    produced the summary: at least `served_model` and the `engine_args` it was
+    started with (an empty object is allowed only when nothing non-default was
+    passed). The comparator diffs this block between baseline and candidate.
+    """
+    if not isinstance(execution, Mapping):
+        raise AisbenchAdapterError("execution must be a JSON object")
+    engine_args = execution.get("engine_args")
+    if not isinstance(engine_args, Mapping):
+        raise AisbenchAdapterError(
+            "execution.engine_args must be an object describing how the "
+            "benchmarked service was started (use {} only if no non-default "
+            "engine arguments were passed)"
+        )
+    served_model = execution.get("served_model")
+    if not isinstance(served_model, str) or not served_model.strip():
+        raise AisbenchAdapterError("execution.served_model must be a non-empty string")
+    return dict(execution)
+
+
 def normalize_summary(
     summary_csv: Path,
     *,
     label: str,
+    execution: Mapping[str, Any],
     model_column: str = MODEL_ABBR,
 ) -> dict[str, Any]:
+    execution_block = validate_execution(execution)
     try:
         stream = summary_csv.open("r", encoding="utf-8-sig", newline="")
     except OSError as exc:
@@ -297,6 +322,7 @@ def normalize_summary(
     return {
         "schema_version": SCHEMA_VERSION,
         "label": label,
+        "execution": execution_block,
         "adapter": {
             "name": "aisbench",
             "summary_csv": str(summary_csv.resolve()),
@@ -330,8 +356,27 @@ def build_parser() -> argparse.ArgumentParser:
     normalize.add_argument("--summary-csv", required=True, type=Path)
     normalize.add_argument("--label", required=True)
     normalize.add_argument("--model-column", default=MODEL_ABBR)
+    normalize.add_argument(
+        "--execution",
+        required=True,
+        help=(
+            "JSON object naming the benchmarked service: served_model, engine_args "
+            "it was started with, and optionally base_url; the comparator refuses "
+            "undeclared baseline/candidate differences in this block"
+        ),
+    )
     normalize.add_argument("--output", required=True, type=Path)
     return parser
+
+
+def _json_object(raw: str, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise AisbenchAdapterError(f"{label} must be valid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise AisbenchAdapterError(f"{label} must be a JSON object")
+    return value
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -361,6 +406,7 @@ def main(argv: list[str] | None = None) -> int:
             normalized = normalize_summary(
                 args.summary_csv,
                 label=args.label,
+                execution=_json_object(args.execution, "execution"),
                 model_column=args.model_column,
             )
             _atomic_write(

--- a/.agents/skills/vllm-ascend-correctness-validation/scripts/correctness_run.py
+++ b/.agents/skills/vllm-ascend-correctness-validation/scripts/correctness_run.py
@@ -26,12 +26,15 @@ from vaws_run_manifest import (  # noqa: E402
     add_artifact,
     load_manifest,
     new_manifest,
+    sha256_file,
     transition_status,
     write_manifest,
 )
 
 SCHEMA_VERSION = 1
 SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+# Keys of the result `execution` block that are flattened one level (dotted).
+EXECUTION_NESTED_FIELDS = ("engine_args",)
 CASE_MODES = frozenset({"offline-generate", "offline-chat", "online-chat", "aisbench"})
 RESULT_STATUSES = frozenset({"ok", "error", "unsupported"})
 PASS_CLASSES = frozenset({"exact_match", "numerical_difference_within_tolerance"})
@@ -190,10 +193,18 @@ def init_run(
     topology: Mapping[str, Any] | None = None,
     baseline_command: Sequence[str] | None = None,
     candidate_command: Sequence[str] | None = None,
+    allowed_differences: Sequence[str] | None = None,
+    parent_run_id: str | None = None,
     created_at: str | None = None,
 ) -> dict[str, Any]:
     if run_dir.exists() and any(run_dir.iterdir()):
         raise CorrectnessError(f"run directory is not empty: {run_dir}")
+    if baseline_label == candidate_label:
+        raise CorrectnessError("baseline-label and candidate-label must differ")
+    declared = sorted(set(allowed_differences or []))
+    for key in declared:
+        if not key.strip():
+            raise CorrectnessError("allowed-difference keys must be non-empty")
     cases_document = _load_json(cases_path, "cases file")
     validate_cases_document(cases_document)
     timestamp = created_at or utc_now()
@@ -208,6 +219,7 @@ def init_run(
         "candidate_label": candidate_label,
         "baseline_command": list(baseline_command or []),
         "candidate_command": list(candidate_command or []),
+        "allowed_differences": declared,
         "status": "planned",
         "created_at": timestamp,
         "updated_at": timestamp,
@@ -225,6 +237,7 @@ def init_run(
     manifest = new_manifest(
         run_type="correctness",
         run_id=run_id,
+        parent_run_id=parent_run_id,
         workspace_snapshot=workspace_snapshot,
         environment=environment,
         model=model,
@@ -539,6 +552,9 @@ def render_report(
     ]
     for row in comparison["cases"]:
         lines.append(f"| `{row['id']}` | `{row['classification']}` |")
+    if isinstance(comparison.get("execution"), Mapping):
+        lines.append("")
+        lines.extend(render_identity_section(comparison["execution"]))
     lines.extend(["", "## Details", ""])
     for row in comparison["cases"]:
         lines.extend(
@@ -556,6 +572,132 @@ def render_report(
     return "\n".join(lines)
 
 
+def validate_execution_block(document: Mapping[str, Any], *, label: str) -> dict[str, Any]:
+    """Require the `execution` identity a result must carry to be comparable."""
+    execution = document.get("execution")
+    if not isinstance(execution, Mapping):
+        raise CorrectnessError(
+            f"{label} result has no execution block; it does not record which "
+            "engine_args, model, or service produced it, so the comparison "
+            "could not attribute a difference to code. Produce results with "
+            "the current remote_correctness_harness.py or "
+            "aisbench_adapter.py normalize --execution"
+        )
+    engine_args = execution.get("engine_args")
+    if not isinstance(engine_args, Mapping):
+        raise CorrectnessError(f"{label} result execution.engine_args must be an object")
+    return dict(execution)
+
+
+def flatten_execution(execution: Mapping[str, Any]) -> dict[str, Any]:
+    """Flatten nested identity fields into dotted keys for a per-key diff."""
+    flat: dict[str, Any] = {}
+    for key, value in execution.items():
+        if key in EXECUTION_NESTED_FIELDS and isinstance(value, Mapping):
+            for nested_key, nested_value in value.items():
+                flat[f"{key}.{nested_key}"] = nested_value
+        else:
+            flat[key] = value
+    return flat
+
+
+def execution_differences(
+    baseline: Mapping[str, Any], candidate: Mapping[str, Any]
+) -> list[dict[str, Any]]:
+    """Every dotted identity key whose value differs between the two runs."""
+    left = flatten_execution(baseline)
+    right = flatten_execution(candidate)
+    rows: list[dict[str, Any]] = []
+    for key in sorted(set(left) | set(right)):
+        left_value = left.get(key)
+        right_value = right.get(key)
+        if left_value != right_value:
+            rows.append({"key": key, "baseline": left_value, "candidate": right_value})
+    return rows
+
+
+def check_run_identity(
+    run_state: Mapping[str, Any],
+    baseline: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Refuse to compare two runs that differ in anything not declared at init.
+
+    The result label must match the side it is passed as, both results must
+    carry an execution block, and every execution difference must be listed in
+    `allowed_differences`. An undeclared difference means the comparison would
+    attribute a divergence to code that may instead come from eager/graph mode,
+    tensor-parallel degree, a different model, or a different case array.
+    """
+    problems: list[str] = []
+    for side, document in (("baseline", baseline), ("candidate", candidate)):
+        expected = run_state[f"{side}_label"]
+        actual = document.get("label")
+        if actual != expected:
+            problems.append(
+                f"{side} result label is {actual!r} but this run's {side} label "
+                f"is {expected!r}"
+            )
+    if problems:
+        raise CorrectnessError("; ".join(problems))
+    baseline_execution = validate_execution_block(baseline, label="baseline")
+    candidate_execution = validate_execution_block(candidate, label="candidate")
+    differences = execution_differences(baseline_execution, candidate_execution)
+    allowed = set(run_state.get("allowed_differences", []))
+    undeclared = [row["key"] for row in differences if row["key"] not in allowed]
+    if undeclared:
+        raise CorrectnessError(
+            "baseline and candidate executions differ in undeclared fields: "
+            + ", ".join(undeclared)
+            + "; a divergence could not be attributed to code. If the difference "
+            "is the variable under test, declare it at init with "
+            "--allowed-difference KEY; otherwise rerun the states identically"
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "baseline": {"label": baseline["label"], "execution": baseline_execution},
+        "candidate": {"label": candidate["label"], "execution": candidate_execution},
+        "allowed_differences": sorted(allowed),
+        "observed_differences": differences,
+        "identical_execution": not differences,
+    }
+
+
+def render_identity_section(identity: Mapping[str, Any]) -> list[str]:
+    lines = ["## Execution identity", ""]
+    if identity["identical_execution"]:
+        lines.append("- Baseline and candidate executions are identical apart from code.")
+    else:
+        lines.append(
+            "- Declared differences under test: "
+            + ", ".join(f"`{key}`" for key in identity["allowed_differences"])
+        )
+        lines.append("- Observed differences:")
+        for row in identity["observed_differences"]:
+            lines.append(
+                f"  - `{row['key']}`: baseline `{json.dumps(row['baseline'])}` "
+                f"vs candidate `{json.dumps(row['candidate'])}`"
+            )
+        lines.append(
+            "- A regression verdict on this run is attributable to the declared "
+            "variable(s), not necessarily to the code change."
+        )
+    lines.extend(["", "```json"])
+    lines.append(
+        json.dumps(
+            {
+                side: identity[side]["execution"]
+                for side in ("baseline", "candidate")
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    lines.extend(["```", ""])
+    return lines
+
+
 def compare_run(
     run_dir: Path,
     *,
@@ -569,12 +711,16 @@ def compare_run(
     cases = _load_json(run_dir / "cases.json", "cases")
     baseline = _load_json(baseline_path, "baseline result")
     candidate = _load_json(candidate_path, "candidate result")
+    emit_progress("check-identity", baseline=str(baseline_path), candidate=str(candidate_path))
+    identity = check_run_identity(run_state, baseline, candidate)
     emit_progress("compare", cases=len(cases.get("cases", [])))
     comparison = compare_documents(cases, baseline, candidate)
+    comparison["execution"] = identity
     raw_dir = run_dir / "raw_outputs"
     raw_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy2(baseline_path, raw_dir / "baseline.json")
     shutil.copy2(candidate_path, raw_dir / "candidate.json")
+    _atomic_write_json(run_dir / "execution.json", identity)
     _atomic_write_json(run_dir / "comparison.json", comparison)
     _atomic_write_text(
         run_dir / "report.md",
@@ -594,11 +740,17 @@ def compare_run(
     for name, kind, uri in (
         ("baseline-output", "raw-output", "raw_outputs/baseline.json"),
         ("candidate-output", "raw-output", "raw_outputs/candidate.json"),
+        ("execution-identity", "execution-identity", "execution.json"),
         ("comparison", "comparison", "comparison.json"),
         ("report", "report", "report.md"),
     ):
         manifest = add_artifact(
-            manifest, name=name, kind=kind, uri=uri, updated_at=timestamp
+            manifest,
+            name=name,
+            kind=kind,
+            uri=uri,
+            sha256=sha256_file(run_dir / uri),
+            updated_at=timestamp,
         )
     manifest = transition_status(manifest, comparison["status"], updated_at=timestamp)
     write_manifest(run_dir / "manifest.json", manifest)
@@ -630,6 +782,22 @@ def build_parser() -> argparse.ArgumentParser:
     init.add_argument("--topology", default="{}")
     init.add_argument("--baseline-command", action="append", default=[])
     init.add_argument("--candidate-command", action="append", default=[])
+    init.add_argument(
+        "--allowed-difference",
+        action="append",
+        default=[],
+        metavar="KEY",
+        help=(
+            "execution identity key the two states are meant to differ in, e.g. "
+            "engine_args.enforce_eager for an eager-versus-graph comparison; "
+            "compare refuses any undeclared difference"
+        ),
+    )
+    init.add_argument(
+        "--parent-run-id",
+        default=None,
+        help="run_id of the change-validation plan this run is evidence for",
+    )
 
     compare = subparsers.add_parser("compare", help="compare normalized outputs")
     compare.add_argument("--run-dir", required=True, type=Path)
@@ -657,11 +825,14 @@ def main(argv: list[str] | None = None) -> int:
                 topology=_json_object(args.topology, "topology"),
                 baseline_command=args.baseline_command,
                 candidate_command=args.candidate_command,
+                allowed_differences=args.allowed_difference,
+                parent_run_id=args.parent_run_id,
             )
             payload = {
                 "status": "created",
                 "run_id": run_state["run_id"],
                 "run_dir": str(args.run_dir.resolve()),
+                "allowed_differences": run_state["allowed_differences"],
             }
         else:
             comparison = compare_run(
@@ -672,6 +843,9 @@ def main(argv: list[str] | None = None) -> int:
             payload = {
                 "status": comparison["status"],
                 "primary_classification": comparison["primary_classification"],
+                "observed_differences": [
+                    row["key"] for row in comparison["execution"]["observed_differences"]
+                ],
                 "comparison": str((args.run_dir / "comparison.json").resolve()),
                 "report": str((args.run_dir / "report.md").resolve()),
             }

--- a/.agents/skills/vllm-ascend-correctness-validation/scripts/remote_correctness_harness.py
+++ b/.agents/skills/vllm-ascend-correctness-validation/scripts/remote_correctness_harness.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sys
@@ -14,6 +15,36 @@ from typing import Any, Mapping
 
 SCHEMA_VERSION = 1
 SUPPORTED_MODES = frozenset({"offline-generate", "offline-chat", "online-chat"})
+
+
+def cases_sha256(cases: list[Any]) -> str:
+    """Canonical digest of the case array this run actually executed."""
+    encoded = json.dumps(
+        cases, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def execution_identity(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Record what decided this run's behaviour besides the code under test.
+
+    `engine_args` selects eager versus graph execution, tensor-parallel degree,
+    and feature flags; `model`, `base_url`, and `served_model` name the engine
+    or service; `cases_sha256` pins the exact case array. Without this block a
+    comparison cannot tell an intentional eager/graph experiment from a code
+    regression, so it travels with every result file.
+    """
+    engine_args = config.get("engine_args", {})
+    if not isinstance(engine_args, Mapping):
+        raise HarnessError("engine_args must be an object")
+    identity: dict[str, Any] = {
+        "engine_args": dict(engine_args),
+        "cases_sha256": cases_sha256(list(config["cases"])),
+    }
+    for field in ("model", "base_url", "served_model"):
+        value = config.get(field)
+        identity[field] = str(value) if isinstance(value, str) and value else None
+    return identity
 
 
 class HarnessError(ValueError):
@@ -149,6 +180,7 @@ def _build_offline_engine(config: Mapping[str, Any]):
 
 def execute_config(config: Mapping[str, Any]) -> dict[str, Any]:
     label = str(config.get("label", "unnamed"))
+    execution = execution_identity(config)
     offline_cases = [
         case
         for case in config["cases"]
@@ -250,6 +282,7 @@ def execute_config(config: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "schema_version": SCHEMA_VERSION,
         "label": label,
+        "execution": execution,
         "cases": results,
     }
 

--- a/.agents/skills/vllm-ascend-correctness-validation/tests/test_correctness.py
+++ b/.agents/skills/vllm-ascend-correctness-validation/tests/test_correctness.py
@@ -58,6 +58,45 @@ def result(case_id: str, output: dict, *, metrics: dict | None = None) -> dict:
     }
 
 
+def execution(**engine_args) -> dict:
+    return {
+        "model": "/models/example",
+        "engine_args": {"tensor_parallel_size": 2, **engine_args},
+        "base_url": None,
+        "served_model": None,
+        "cases_sha256": "a" * 64,
+    }
+
+
+def result_document(label: str, cases: list[dict], *, execution_block: dict | None = None) -> dict:
+    document = {"schema_version": 1, "label": label, "cases": cases}
+    if execution_block is not None:
+        document["execution"] = execution_block
+    return document
+
+
+def write_json(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def init_run(root: Path, **overrides) -> Path:
+    cases_path = write_json(
+        root / "source-cases.json", {"schema_version": 1, "cases": [case()]}
+    )
+    run_dir = root / "run"
+    arguments = {
+        "run_id": "correctness-case-1",
+        "cases_path": cases_path,
+        "baseline_label": "base",
+        "candidate_label": "candidate",
+        "created_at": NOW,
+    }
+    arguments.update(overrides)
+    correctness.init_run(run_dir, **arguments)
+    return run_dir
+
+
 class ComparisonTests(unittest.TestCase):
     def test_exact_token_match_passes(self) -> None:
         config = {"schema_version": 1, "cases": [case()]}
@@ -141,28 +180,16 @@ class ComparisonTests(unittest.TestCase):
     def test_full_run_writes_required_artifacts(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            cases_path = root / "source-cases.json"
-            cases_path.write_text(
-                json.dumps({"schema_version": 1, "cases": [case()]}),
-                encoding="utf-8",
+            run_dir = init_run(root, parent_run_id="change-validation-1")
+            cases = [result("case-1", {"text": "ok"})]
+            baseline = write_json(
+                root / "baseline.json",
+                result_document("base", cases, execution_block=execution()),
             )
-            run_dir = root / "run"
-            correctness.init_run(
-                run_dir,
-                run_id="correctness-case-1",
-                cases_path=cases_path,
-                baseline_label="base",
-                candidate_label="candidate",
-                created_at=NOW,
+            candidate = write_json(
+                root / "candidate.json",
+                result_document("candidate", cases, execution_block=execution()),
             )
-            normalized = {
-                "schema_version": 1,
-                "cases": [result("case-1", {"text": "ok"})],
-            }
-            baseline = root / "baseline.json"
-            candidate = root / "candidate.json"
-            baseline.write_text(json.dumps(normalized), encoding="utf-8")
-            candidate.write_text(json.dumps(normalized), encoding="utf-8")
             comparison = correctness.compare_run(
                 run_dir,
                 baseline_path=baseline,
@@ -170,16 +197,157 @@ class ComparisonTests(unittest.TestCase):
                 updated_at=NOW,
             )
             self.assertEqual(comparison["status"], "passed")
+            self.assertTrue(comparison["execution"]["identical_execution"])
             for relative in (
                 "manifest.json",
                 "cases.json",
                 "comparison.json",
+                "execution.json",
                 "report.md",
                 "reproduction.sh",
                 "raw_outputs/baseline.json",
                 "raw_outputs/candidate.json",
             ):
                 self.assertTrue((run_dir / relative).is_file(), relative)
+            manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["parent_run_id"], "change-validation-1")
+            artifacts = {row["name"]: row for row in manifest["artifacts"]}
+            self.assertIn("execution-identity", artifacts)
+            for name in ("baseline-output", "candidate-output", "execution-identity"):
+                self.assertRegex(artifacts[name]["sha256"], r"^[0-9a-f]{64}$")
+
+
+class ExecutionIdentityTests(unittest.TestCase):
+    def test_undeclared_engine_args_difference_is_refused(self) -> None:
+        """Regression: eager-vs-graph used to be reported as a code regression."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_dir = init_run(root)
+            baseline = write_json(
+                root / "baseline.json",
+                result_document(
+                    "base",
+                    [result("case-1", {"token_ids": [1, 2]})],
+                    execution_block=execution(enforce_eager=True),
+                ),
+            )
+            candidate = write_json(
+                root / "candidate.json",
+                result_document(
+                    "candidate",
+                    [result("case-1", {"token_ids": [1, 3]})],
+                    execution_block=execution(enforce_eager=False),
+                ),
+            )
+            with self.assertRaisesRegex(
+                correctness.CorrectnessError,
+                r"undeclared fields: engine_args\.enforce_eager.*--allowed-difference",
+            ):
+                correctness.compare_run(
+                    run_dir, baseline_path=baseline, candidate_path=candidate, updated_at=NOW
+                )
+            manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["status"], "planned")
+            self.assertFalse((run_dir / "comparison.json").exists())
+
+    def test_declared_difference_is_recorded_with_the_verdict(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_dir = init_run(root, allowed_differences=["engine_args.enforce_eager"])
+            baseline = write_json(
+                root / "baseline.json",
+                result_document(
+                    "base",
+                    [result("case-1", {"token_ids": [1, 2]})],
+                    execution_block=execution(enforce_eager=True),
+                ),
+            )
+            candidate = write_json(
+                root / "candidate.json",
+                result_document(
+                    "candidate",
+                    [result("case-1", {"token_ids": [1, 3]})],
+                    execution_block=execution(enforce_eager=False),
+                ),
+            )
+            comparison = correctness.compare_run(
+                run_dir, baseline_path=baseline, candidate_path=candidate, updated_at=NOW
+            )
+            self.assertEqual(comparison["status"], "failed")
+            self.assertEqual(comparison["primary_classification"], "token_divergence")
+            identity = comparison["execution"]
+            self.assertEqual(identity["allowed_differences"], ["engine_args.enforce_eager"])
+            self.assertEqual(
+                [row["key"] for row in identity["observed_differences"]],
+                ["engine_args.enforce_eager"],
+            )
+            recorded = json.loads((run_dir / "execution.json").read_text(encoding="utf-8"))
+            self.assertEqual(recorded["baseline"]["execution"]["engine_args"]["enforce_eager"], True)
+            self.assertEqual(recorded["candidate"]["execution"]["engine_args"]["enforce_eager"], False)
+            report = (run_dir / "report.md").read_text(encoding="utf-8")
+            self.assertIn("## Execution identity", report)
+            self.assertIn("engine_args.enforce_eager", report)
+
+    def test_result_without_execution_block_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_dir = init_run(root)
+            cases = [result("case-1", {"text": "ok"})]
+            baseline = write_json(root / "baseline.json", result_document("base", cases))
+            candidate = write_json(
+                root / "candidate.json",
+                result_document("candidate", cases, execution_block=execution()),
+            )
+            with self.assertRaisesRegex(
+                correctness.CorrectnessError, "baseline result has no execution block"
+            ):
+                correctness.compare_run(
+                    run_dir, baseline_path=baseline, candidate_path=candidate, updated_at=NOW
+                )
+
+    def test_same_file_passed_twice_is_refused_by_label(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_dir = init_run(root)
+            same = write_json(
+                root / "same.json",
+                result_document(
+                    "base", [result("case-1", {"text": "ok"})], execution_block=execution()
+                ),
+            )
+            with self.assertRaisesRegex(
+                correctness.CorrectnessError, "candidate result label is 'base'"
+            ):
+                correctness.compare_run(
+                    run_dir, baseline_path=same, candidate_path=same, updated_at=NOW
+                )
+
+    def test_different_case_arrays_are_an_undeclared_difference(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_dir = init_run(root)
+            cases = [result("case-1", {"text": "ok"})]
+            left = execution()
+            right = execution()
+            right["cases_sha256"] = "b" * 64
+            baseline = write_json(
+                root / "baseline.json", result_document("base", cases, execution_block=left)
+            )
+            candidate = write_json(
+                root / "candidate.json",
+                result_document("candidate", cases, execution_block=right),
+            )
+            with self.assertRaisesRegex(
+                correctness.CorrectnessError, "undeclared fields: cases_sha256"
+            ):
+                correctness.compare_run(
+                    run_dir, baseline_path=baseline, candidate_path=candidate, updated_at=NOW
+                )
+
+    def test_identical_labels_are_rejected_at_init(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(correctness.CorrectnessError, "must differ"):
+                init_run(Path(tmp), baseline_label="same", candidate_label="same")
 
 
 class HarnessTests(unittest.TestCase):
@@ -230,14 +398,47 @@ class HarnessTests(unittest.TestCase):
         self.assertEqual(normalized["numerics"]["logprobs"], [-0.1, -0.2])
 
     def test_unknown_mode_is_normalized_as_unsupported(self) -> None:
-        result_document = harness.execute_config(
+        document = harness.execute_config(
             {
                 "schema_version": 1,
                 "label": "test",
                 "cases": [{"id": "unsupported-1", "mode": "future-mode"}],
             }
         )
-        self.assertEqual(result_document["cases"][0]["status"], "unsupported")
+        self.assertEqual(document["cases"][0]["status"], "unsupported")
+
+    def test_result_records_engine_args_and_case_digest(self) -> None:
+        """Regression: engine_args used to reach neither result nor manifest."""
+        cases = [{"id": "unsupported-1", "mode": "future-mode"}]
+        config = {
+            "schema_version": 1,
+            "label": "candidate",
+            "model": "/models/example",
+            "engine_args": {"enforce_eager": False, "tensor_parallel_size": 2},
+            "base_url": "http://service.invalid:8000",
+            "served_model": "example",
+            "cases": cases,
+        }
+        document = harness.execute_config(config)
+        self.assertEqual(
+            document["execution"]["engine_args"],
+            {"enforce_eager": False, "tensor_parallel_size": 2},
+        )
+        self.assertEqual(document["execution"]["model"], "/models/example")
+        self.assertEqual(document["execution"]["served_model"], "example")
+        self.assertEqual(document["execution"]["cases_sha256"], harness.cases_sha256(cases))
+        correctness.validate_execution_block(document, label="candidate")
+
+    def test_non_object_engine_args_are_rejected_before_execution(self) -> None:
+        with self.assertRaisesRegex(harness.HarnessError, "engine_args"):
+            harness.execute_config(
+                {
+                    "schema_version": 1,
+                    "label": "x",
+                    "engine_args": ["--enforce-eager"],
+                    "cases": [{"id": "c", "mode": "future-mode"}],
+                }
+            )
 
 
 class AisbenchAdapterTests(unittest.TestCase):
@@ -282,9 +483,36 @@ class AisbenchAdapterTests(unittest.TestCase):
                 "gsm8k,abc123,accuracy,gen,56.7\n",
                 encoding="utf-8",
             )
-            normalized = aisbench.normalize_summary(summary, label="baseline")
+            normalized = aisbench.normalize_summary(
+                summary,
+                label="baseline",
+                execution={"served_model": "example", "engine_args": {"enforce_eager": True}},
+            )
             self.assertEqual(normalized["cases"][0]["status"], "ok")
             self.assertEqual(normalized["cases"][0]["metrics"]["accuracy"], 56.7)
+            self.assertEqual(normalized["execution"]["engine_args"], {"enforce_eager": True})
+            correctness.validate_execution_block(normalized, label="baseline")
+
+    def test_normalize_requires_execution_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            summary = Path(tmp) / "summary.csv"
+            summary.write_text(
+                "dataset,version,metric,mode,vaws-correctness\n"
+                "gsm8k,abc123,accuracy,gen,56.7\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                aisbench.AisbenchAdapterError, "execution.engine_args must be an object"
+            ):
+                aisbench.normalize_summary(
+                    summary, label="baseline", execution={"served_model": "example"}
+                )
+            with self.assertRaisesRegex(
+                aisbench.AisbenchAdapterError, "execution.served_model"
+            ):
+                aisbench.normalize_summary(
+                    summary, label="baseline", execution={"engine_args": {}}
+                )
 
 
 if __name__ == "__main__":

--- a/.agents/skills/vllm-ascend-distributed-debug/SKILL.md
+++ b/.agents/skills/vllm-ascend-distributed-debug/SKILL.md
@@ -20,7 +20,11 @@ root cause from one rank's log alone.
    cross-rank phase divergence.
 5. Form one or more falsifiable hypotheses from the report.
 6. Reduce one parallel dimension at a time. Record each reduced case separately.
-7. After a fix, rerun both the smallest reproducer and the original topology.
+7. After a fix, rerun both the smallest reproducer and the original topology
+   with event collection. Each rank must emit `rank_complete` as its last
+   event; `analyze` marks the manifest `passed` only when every rank completed
+   and no finding was raised. Set `parent_run_id` in the case config when the
+   case is evidence for a change-validation plan.
 
 ## Entry point
 
@@ -29,7 +33,9 @@ root cause from one rank's log alone.
 - `init`: validate the topology contract and create the complete evidence layout;
 - `ingest`: validate and append normalized rank events;
 - `analyze`: produce deterministic findings, per-rank last progress, and a Run
-  Manifest-linked report.
+  Manifest-linked report; the manifest becomes `failed` on a confirmed finding,
+  `passed` only when every rank ended with `rank_complete` and nothing was
+  found, and `inconclusive` otherwise.
 
 Read only the reference needed for the current phase:
 

--- a/.agents/skills/vllm-ascend-distributed-debug/references/acceptance.md
+++ b/.agents/skills/vllm-ascend-distributed-debug/references/acceptance.md
@@ -20,5 +20,6 @@
 
 - [ ] A regression test covers the proved invariant when practical.
 - [ ] The smallest reproducer passes after the fix.
-- [ ] The original topology passes after the fix.
+- [ ] The original topology passes after the fix, and its case analyzes to `completed-without-mismatch` (every rank ends with `rank_complete`, no findings).
+- [ ] A `passed` manifest rests on that analysis, not on an assertion.
 - [ ] Temporary debug instrumentation is removed or explicitly retained.

--- a/.agents/skills/vllm-ascend-distributed-debug/references/behavior.md
+++ b/.agents/skills/vllm-ascend-distributed-debug/references/behavior.md
@@ -32,6 +32,25 @@ Environment snapshots must contain no credentials or tokens.
 All events require timestamp, rank, phase, and event. `collective_enter` and
 `collective_exit` also require group, sequence, and operation.
 
+`rank_complete` is the completion marker: a rank emits it as its final event
+when the reproduction ran through on that rank. It is the only structural
+evidence that separates "no mismatch was detected in what we captured" from
+"every rank finished without a mismatch".
+
+```json
+{
+  "timestamp": "2026-07-25T12:05:00Z",
+  "rank": 3,
+  "phase": "shutdown",
+  "event": "rank_complete"
+}
+```
+
+## Case config
+
+`parent_run_id` is optional and names the change-validation plan this case is
+evidence for; `change_validation.py link` refuses manifests without it.
+
 ## Finding confidence
 
 - `confirmed`: explicit structured evidence violates topology, group, operation,
@@ -41,6 +60,24 @@ All events require timestamp, rank, phase, and event. `collective_enter` and
 - `incomplete`: required ranks or evidence are absent.
 
 Missing evidence never becomes a confirmed finding.
+
+## Analysis status and Run Manifest
+
+`analyze` computes one analysis status and maps it onto the manifest:
+
+| Analysis status | Meaning | Manifest |
+|---|---|---|
+| `diagnosed` | at least one `confirmed` finding | `failed` |
+| `inconclusive` | an `incomplete` finding, or no events at all | `inconclusive` |
+| `hypothesis` | only `candidate` findings | `inconclusive` |
+| `no-mismatch-detected` | no findings, but some rank's last event is not `rank_complete` | `inconclusive` |
+| `completed-without-mismatch` | no findings and every rank's last event is `rank_complete` | `passed` |
+
+`passed` therefore requires positive evidence from every rank that the run
+finished, not merely the absence of detected problems. `analysis.json` lists
+`completed_ranks` and `incomplete_ranks`. Ingest all events, including the
+completion markers, before calling `analyze`; the manifest becomes terminal on
+the first `analyze`.
 
 ## Case layout
 

--- a/.agents/skills/vllm-ascend-distributed-debug/references/command-recipes.md
+++ b/.agents/skills/vllm-ascend-distributed-debug/references/command-recipes.md
@@ -29,3 +29,12 @@ python -B .agents/skills/vllm-ascend-distributed-debug/scripts/distributed_debug
 
 Use `analysis.json` to select one controlled topology reduction. Do not change
 multiple parallel dimensions in the same experiment.
+
+## Verify a fix
+
+Rerun the original topology with event collection, make every rank emit
+`rank_complete` as its last event, ingest all events, then analyze. The manifest
+becomes `passed` only for `completed-without-mismatch`: no findings and a
+completion marker from every rank. If `incomplete_ranks` is non-empty the result
+stays `inconclusive`; collect the missing ranks' events rather than asserting
+success by hand.

--- a/.agents/skills/vllm-ascend-distributed-debug/scripts/distributed_debug.py
+++ b/.agents/skills/vllm-ascend-distributed-debug/scripts/distributed_debug.py
@@ -41,6 +41,15 @@ REQUIRED_RANK_FIELDS = (
     "dcp_rank",
 )
 COLLECTIVE_EVENTS = {"collective_enter", "collective_exit"}
+# A rank emits this as its final event when the reproduction ran to completion
+# on that rank. It is the only structural evidence that distinguishes "no
+# mismatch was detected" from "every rank finished without a mismatch"; the
+# manifest can only become `passed` when every rank ends with it.
+RANK_COMPLETE_EVENT = "rank_complete"
+ANALYSIS_TO_MANIFEST_STATUS = {
+    "diagnosed": "failed",
+    "completed-without-mismatch": "passed",
+}
 
 
 class DistributedDebugError(ValueError):
@@ -113,6 +122,11 @@ def validate_config(config: Mapping[str, Any]) -> None:
         errors.append(f"schema_version must be {SCHEMA_VERSION}")
     if not isinstance(config.get("run_id"), str) or not config["run_id"]:
         errors.append("run_id must be a non-empty string")
+    parent_run_id = config.get("parent_run_id")
+    if parent_run_id is not None and (
+        not isinstance(parent_run_id, str) or not parent_run_id.strip()
+    ):
+        errors.append("parent_run_id must be a non-empty string when present")
     world_size = config.get("expected_world_size")
     if not isinstance(world_size, int) or isinstance(world_size, bool) or world_size < 1:
         errors.append("expected_world_size must be a positive integer")
@@ -259,6 +273,7 @@ def init_case(
     manifest = new_manifest(
         run_type="debug",
         run_id=config["run_id"],
+        parent_run_id=config.get("parent_run_id"),
         workspace_snapshot=config.get("workspace_snapshot", {}),
         environment=config.get("environment", {}),
         model=config.get("model", {}),
@@ -452,12 +467,22 @@ def analyze_evidence(
         )
     confirmed = [row["code"] for row in findings if row["severity"] == "confirmed"]
     incomplete = [row["code"] for row in findings if row["severity"] == "incomplete"]
+    completed_ranks = sorted(
+        rank
+        for rank, rows in events_by_rank.items()
+        if rows[-1]["event"] == RANK_COMPLETE_EVENT
+    )
+    incomplete_ranks = sorted(ranks - set(completed_ranks))
     if confirmed:
         status = "diagnosed"
     elif incomplete or not events_by_rank:
         status = "inconclusive"
     elif findings:
         status = "hypothesis"
+    elif not incomplete_ranks:
+        # Every rank reported, none violated an invariant, and every rank's
+        # final event is completion: the topology demonstrably ran through.
+        status = "completed-without-mismatch"
     else:
         status = "no-mismatch-detected"
     return {
@@ -469,6 +494,8 @@ def analyze_evidence(
         "findings": findings,
         "confirmed_findings": confirmed,
         "evidence_gaps": incomplete,
+        "completed_ranks": completed_ranks,
+        "incomplete_ranks": incomplete_ranks,
     }
 
 
@@ -485,6 +512,13 @@ def render_report(analysis: Mapping[str, Any]) -> str:
     ]
     if not analysis["findings"]:
         lines.append("No structured rank, group, endpoint, or collective mismatch was detected.")
+        if analysis["incomplete_ranks"]:
+            lines.append(
+                "Ranks without a final `rank_complete` event (the run is not proved "
+                f"to have finished on them): {analysis['incomplete_ranks']}"
+            )
+        else:
+            lines.append("Every rank ended with `rank_complete`.")
     for row in analysis["findings"]:
         lines.extend(
             [
@@ -530,13 +564,15 @@ def analyze_case(
         manifest = add_artifact(
             manifest, name=name, kind=kind, uri=uri, updated_at=timestamp
         )
-    terminal = "failed" if analysis["status"] == "diagnosed" else "inconclusive"
+    terminal = ANALYSIS_TO_MANIFEST_STATUS.get(analysis["status"], "inconclusive")
     manifest = transition_status(manifest, terminal, updated_at=timestamp)
     write_manifest(output_dir / "manifest.json", manifest)
     return {
         "status": analysis["status"],
+        "manifest_status": terminal,
         "confirmed_findings": analysis["confirmed_findings"],
         "evidence_gaps": analysis["evidence_gaps"],
+        "incomplete_ranks": analysis["incomplete_ranks"],
         "analysis": str((output_dir / "analysis.json").resolve()),
         "report": str((output_dir / "report.md").resolve()),
     }

--- a/.agents/skills/vllm-ascend-distributed-debug/tests/test_distributed_debug.py
+++ b/.agents/skills/vllm-ascend-distributed-debug/tests/test_distributed_debug.py
@@ -139,7 +139,7 @@ class DistributedDebugTests(unittest.TestCase):
         self.assertEqual(analysis["status"], "inconclusive")
         self.assertEqual(analysis["evidence_gaps"], ["missing-rank-evidence"])
 
-    def test_full_lifecycle_writes_manifest_and_report(self) -> None:
+    def test_no_mismatch_without_completion_stays_inconclusive(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             config_path = root / "config.json"
@@ -159,11 +159,94 @@ class DistributedDebugTests(unittest.TestCase):
             )
             result = distributed.analyze_case(output, updated_at=NOW)
             self.assertEqual(result["status"], "no-mismatch-detected")
+            self.assertEqual(result["incomplete_ranks"], [0, 1])
             self.assertTrue((output / "report.md").is_file())
             manifest = json.loads(
                 (output / "manifest.json").read_text(encoding="utf-8")
             )
             self.assertEqual(manifest["status"], "inconclusive")
+
+    def test_every_rank_completing_without_mismatch_is_passed(self) -> None:
+        """Regression: the manifest could only ever become failed/inconclusive."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            case = config()
+            case["parent_run_id"] = "change-validation-1"
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(case), encoding="utf-8")
+            output = root / "case"
+            distributed.init_case(output, config_path=config_path, created_at=NOW)
+            rows = []
+            for kind in ("collective_enter", "collective_exit"):
+                rows.extend([event(0, kind), event(1, kind)])
+            for rank in (0, 1):
+                rows.append(
+                    {
+                        "timestamp": f"2026-07-25T12:00:1{rank}Z",
+                        "rank": rank,
+                        "phase": "shutdown",
+                        "event": distributed.RANK_COMPLETE_EVENT,
+                    }
+                )
+            events_path = root / "events.jsonl"
+            events_path.write_text(
+                "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+            )
+            distributed.ingest_events(output, events_path=events_path, updated_at=NOW)
+            result = distributed.analyze_case(output, updated_at=NOW)
+            self.assertEqual(result["status"], "completed-without-mismatch")
+            self.assertEqual(result["manifest_status"], "passed")
+            manifest = json.loads((output / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["status"], "passed")
+            self.assertEqual(manifest["parent_run_id"], "change-validation-1")
+            self.assertIn("analysis", {row["name"] for row in manifest["artifacts"]})
+
+    def test_one_rank_missing_completion_is_not_passed(self) -> None:
+        case = config()
+        rows = []
+        for kind in ("collective_enter", "collective_exit"):
+            rows.extend([event(0, kind), event(1, kind)])
+        rows.append(
+            {
+                "timestamp": "2026-07-25T12:00:10Z",
+                "rank": 0,
+                "phase": "model-execute",
+                "event": distributed.RANK_COMPLETE_EVENT,
+            }
+        )
+        analysis = distributed.analyze_evidence(
+            {"ranks": case["ranks"], "groups": case["groups"]},
+            case["network_endpoints"],
+            rows,
+        )
+        self.assertEqual(analysis["status"], "no-mismatch-detected")
+        self.assertEqual(analysis["completed_ranks"], [0])
+        self.assertEqual(analysis["incomplete_ranks"], [1])
+
+    def test_completion_does_not_override_a_confirmed_finding(self) -> None:
+        case = config()
+        rows = [
+            event(0, "collective_enter", operation="all_reduce"),
+            event(1, "collective_enter", operation="all_gather"),
+        ]
+        for rank in (0, 1):
+            rows.append(
+                {
+                    "timestamp": f"2026-07-25T12:00:1{rank}Z",
+                    "rank": rank,
+                    "phase": "model-execute",
+                    "event": distributed.RANK_COMPLETE_EVENT,
+                }
+            )
+        analysis = distributed.analyze_evidence(
+            {"ranks": case["ranks"], "groups": case["groups"]},
+            case["network_endpoints"],
+            rows,
+        )
+        self.assertEqual(analysis["status"], "diagnosed")
+        self.assertEqual(
+            distributed.ANALYSIS_TO_MANIFEST_STATUS[analysis["status"]], "failed"
+        )
 
 
 if __name__ == "__main__":

--- a/.agents/skills/vllm-ascend-graph-debug/SKILL.md
+++ b/.agents/skills/vllm-ascend-graph-debug/SKILL.md
@@ -11,10 +11,10 @@ description: Diagnose vLLM Ascend cudagraph and ACL Graph compile, capture, repl
 
 从仓库根目录使用 `scripts/graph_debug_case.py`：
 
-1. `init` 创建 `.vaws-local/graph-debug/<case-id>/case.json` 和 Run Manifest v1。
+1. `init` 创建 `.vaws-local/graph-debug/<case-id>/case.json` 和 Run Manifest v1；作为 PR 证据时传 `--parent-run-id`。
 2. 每轮单变量实验后立即用 `record` 追加假设、预期、观测、结论和下一步。
 3. 需要中间状态对拍时，用 `compare` 对齐 eager/graph JSONL snapshot 并找到首个分叉。
-4. 修复后用 `finalize` 同时记录最小复现、原始复现和 instrumentation 清理状态。
+4. 修复后用 `finalize` 同时记录最小复现、原始复现和 instrumentation 清理状态；每个 `pass` 都必须附上对应的重跑输出（`--minimal-evidence` / `--original-evidence`），且至少有一条 `record`。没有证据的 `pass` 会被拒绝，manifest 不会进入 `passed`。
 
 按需读取：
 
@@ -227,7 +227,7 @@ export HCCL_DETERMINISTIC=true
 定位完成后：
 
 1. 删除或关闭 debug buffer、同步、落盘、确定性调试开关。
-2. 用最小复现验证修复。
-3. 用原始复现验证问题不再出现。
-4. 运行 `finalize`，写清根因、修复点、已验证场景和仍未覆盖的风险。
+2. 用最小复现验证修复，保留重跑输出。
+3. 用原始复现验证问题不再出现，保留重跑输出。
+4. 运行 `finalize`，写清根因、修复点、已验证场景和仍未覆盖的风险，并用 `--minimal-evidence` / `--original-evidence` 附上两份重跑输出。
 5. 对照 [Acceptance](references/acceptance.md) 验证 `case.json`、comparison artifacts 和 Run Manifest。

--- a/.agents/skills/vllm-ascend-graph-debug/references/acceptance.md
+++ b/.agents/skills/vllm-ascend-graph-debug/references/acceptance.md
@@ -27,8 +27,9 @@ Do not mark a graph-debug case resolved until every required item passes.
 ## Resolution
 
 - [ ] Root cause and fix are recorded.
-- [ ] The minimal reproduction passes after the fix.
-- [ ] The original reproduction passes after the fix.
+- [ ] At least one controlled experiment is recorded in `case.json`.
+- [ ] The minimal reproduction passes after the fix, and its rerun output is attached with `--minimal-evidence`.
+- [ ] The original reproduction passes after the fix, and its rerun output is attached with `--original-evidence`.
 - [ ] Temporary buffers, logging, synchronization, deterministic overrides, and workarounds are removed or intentionally disabled.
-- [ ] `case.json`, comparison artifacts, and Run Manifest v1 validate.
+- [ ] `case.json`, comparison artifacts, `validation/` evidence, and Run Manifest v1 validate, and the manifest links the evidence with SHA256.
 - [ ] Remaining untested combinations are listed as risks rather than implied supported.

--- a/.agents/skills/vllm-ascend-graph-debug/references/behavior.md
+++ b/.agents/skills/vllm-ascend-graph-debug/references/behavior.md
@@ -16,18 +16,31 @@ Use `scripts/graph_debug_case.py` to keep one structured case directory:
 case-dir/
 ├── case.json
 ├── manifest.json
-└── comparisons/
-    └── comparison-001.json
+├── comparisons/
+│   └── comparison-001.json
+└── validation/
+    ├── minimal-reproduction.<ext>
+    └── original-reproduction.<ext>
 ```
 
 The lifecycle is:
 
-1. `init`: record environment, workspace snapshot, topology, reproduction, eager result, graph result, and the classified failure stage.
+1. `init`: record environment, workspace snapshot, topology, reproduction, eager result, graph result, and the classified failure stage. Pass `--parent-run-id` when the case is evidence for a change-validation plan; `link` refuses cases without it.
 2. `record`: append one single-variable experiment with its hypothesis, expected observation, actual observation, conclusion, and next step.
 3. `compare`: align eager and graph snapshots by `step/layer/rank/tag`, compare statistics and optional samples, then record the first divergence.
-4. `finalize`: record the root cause, fix, minimal-reproduction result, original-reproduction result, and debug-instrumentation cleanup.
+4. `finalize`: record the root cause, fix, minimal-reproduction result, original-reproduction result, and debug-instrumentation cleanup, attaching the rerun output behind every `pass` claim.
 
 A case is resolved only when both reproductions pass and instrumentation is removed or disabled. Other final results are `inconclusive`.
+
+### Resolution evidence
+
+`finalize` fails closed. It refuses to write a resolution when any of these is missing, and its error names every missing item at once:
+
+- `--minimal-result pass` requires `--minimal-evidence PATH`, the non-empty output of rerunning the minimal reproduction after the fix;
+- `--original-result pass` requires `--original-evidence PATH`, the non-empty output of rerunning the original reproduction after the fix;
+- resolving a case (both results `pass`) requires at least one recorded experiment.
+
+Evidence files are copied into `validation/`, hashed, and linked from the Run Manifest as `reproduction-rerun-output` artifacts, so a reviewer can open exactly what the `pass` claim rests on. A `fail` result needs no evidence file; it can only lead to `inconclusive`. The script checks that evidence exists and is non-empty; it does not interpret its contents.
 
 ## Snapshot contract
 
@@ -82,10 +95,12 @@ Default tolerances are zero. Choose non-zero tolerances explicitly and record wh
 
 ## Run Manifest integration
 
-`init` creates Run Manifest v1 with `run_type=debug`. The first experiment or comparison moves it to `running`. Each comparison becomes a linked artifact. `finalize` links `case.json` and moves the manifest to:
+`init` creates Run Manifest v1 with `run_type=debug` and the optional `parent_run_id`. The first experiment or comparison moves it to `running`. Each comparison becomes a linked artifact. `finalize` links `case.json` and every validation evidence file (with SHA256) and moves the manifest to:
 
 - `passed` for a resolved case;
 - `inconclusive` otherwise.
+
+`passed` is unreachable without at least one experiment record and two hashed rerun outputs; `init` followed directly by `finalize` is rejected.
 
 Do not store passwords, tokens, credentials, or secret environment variables in case inputs.
 

--- a/.agents/skills/vllm-ascend-graph-debug/references/command-recipes.md
+++ b/.agents/skills/vllm-ascend-graph-debug/references/command-recipes.md
@@ -15,10 +15,13 @@ python -B .agents/skills/vllm-ascend-graph-debug/scripts/graph_debug_case.py ini
   --workspace-snapshot '{"workspace":"<commit-or-snapshot>","dirty":false}' \
   --environment '{"machine":"<alias>","cann":"<version>","torch_npu":"<version>"}' \
   --model '{"path":"<remote-model-path>"}' \
-  --topology '{"tp":2,"devices":[0,1]}'
+  --topology '{"tp":2,"devices":[0,1]}' \
+  --parent-run-id change-validation-001
 ```
 
-Never place secrets in JSON arguments.
+Never place secrets in JSON arguments. `--parent-run-id` is the change-validation
+run this case will be linked to; omit it only for cases that will never be PR
+evidence, because `change_validation.py link` rejects manifests without it.
 
 ## Record one controlled experiment
 
@@ -55,5 +58,13 @@ python -B .agents/skills/vllm-ascend-graph-debug/scripts/graph_debug_case.py fin
   --fix "copy slot mapping into the fixed graph input buffer before replay" \
   --minimal-result pass \
   --original-result pass \
-  --cleanup-status removed
+  --cleanup-status removed \
+  --minimal-evidence /path/to/minimal-rerun-output.log \
+  --original-evidence /path/to/original-rerun-output.log
 ```
+
+Every `pass` result must be backed by the corresponding `--*-evidence` file (the
+rerun output after the fix); the files are copied into `validation/` and hashed
+into the manifest. Finalize also requires at least one prior `record`. When
+something is missing the command exits 1 and lists every missing item, leaving
+the case `active` and the manifest non-terminal.

--- a/.agents/skills/vllm-ascend-graph-debug/scripts/graph_debug_case.py
+++ b/.agents/skills/vllm-ascend-graph-debug/scripts/graph_debug_case.py
@@ -8,6 +8,7 @@ import json
 import math
 import os
 import re
+import shutil
 import sys
 import tempfile
 from datetime import datetime, timezone
@@ -24,6 +25,7 @@ from vaws_run_manifest import (  # noqa: E402
     add_artifact,
     load_manifest,
     new_manifest,
+    sha256_file,
     transition_status,
     write_manifest,
 )
@@ -33,6 +35,11 @@ SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
 STAGES = ("compile", "capture", "replay", "accuracy", "unknown")
 BASELINE_RESULTS = ("pass", "fail", "not-run")
 SNAPSHOT_KEY_FIELDS = ("step", "layer", "rank", "tag")
+VALIDATION_DIR = "validation"
+VALIDATION_EVIDENCE = {
+    "minimal": ("minimal-reproduction", "--minimal-evidence"),
+    "original": ("original-reproduction", "--original-evidence"),
+}
 
 
 class GraphDebugError(ValueError):
@@ -139,6 +146,7 @@ def init_case(
     workspace_snapshot: Mapping[str, Any] | None = None,
     model: Mapping[str, Any] | None = None,
     topology: Mapping[str, Any] | None = None,
+    parent_run_id: str | None = None,
     created_at: str | None = None,
 ) -> dict[str, Any]:
     if case_dir.exists() and any(case_dir.iterdir()):
@@ -168,6 +176,7 @@ def init_case(
     manifest = new_manifest(
         run_type="debug",
         run_id=case_id,
+        parent_run_id=parent_run_id,
         workspace_snapshot=workspace_snapshot,
         environment=environment,
         model=model,
@@ -474,6 +483,53 @@ def compare_case(
     return comparison, output
 
 
+def _check_evidence_file(path: Path, *, flag: str) -> str | None:
+    if not path.is_file():
+        return f"{flag} is not a file: {path}"
+    if path.stat().st_size == 0:
+        return f"{flag} is empty: {path}"
+    return None
+
+
+def missing_resolution_evidence(
+    case: Mapping[str, Any],
+    *,
+    minimal_result: str,
+    original_result: str,
+    minimal_evidence: Path | None,
+    original_evidence: Path | None,
+) -> list[str]:
+    """List every reason a pass claim cannot be accepted as recorded evidence.
+
+    A `pass` result for either reproduction must be backed by the rerun output
+    it rests on, and a case cannot be resolved without at least one recorded
+    controlled experiment. Every missing item is named so the operator can fix
+    them all in one round instead of discovering them one failure at a time.
+    """
+    missing: list[str] = []
+    for kind, result, evidence in (
+        ("minimal", minimal_result, minimal_evidence),
+        ("original", original_result, original_evidence),
+    ):
+        artifact_name, flag = VALIDATION_EVIDENCE[kind]
+        if result == "pass" and evidence is None:
+            missing.append(
+                f"{kind}-result pass requires {flag} pointing at the "
+                f"{artifact_name} rerun output"
+            )
+        elif evidence is not None:
+            problem = _check_evidence_file(evidence, flag=flag)
+            if problem:
+                missing.append(problem)
+    claims_resolution = minimal_result == "pass" and original_result == "pass"
+    if claims_resolution and not case["experiments"]:
+        missing.append(
+            "no controlled experiment recorded (run `record` at least once "
+            "before claiming resolution)"
+        )
+    return missing
+
+
 def finalize_case(
     case_dir: Path,
     *,
@@ -482,6 +538,8 @@ def finalize_case(
     minimal_result: str,
     original_result: str,
     cleanup_status: str,
+    minimal_evidence: Path | None = None,
+    original_evidence: Path | None = None,
     updated_at: str | None = None,
 ) -> dict[str, Any]:
     case = load_case(case_dir)
@@ -493,18 +551,55 @@ def finalize_case(
         raise GraphDebugError("cleanup-status must be removed, disabled, or pending")
     if not root_cause.strip() or not fix.strip():
         raise GraphDebugError("root-cause and fix must be non-empty")
+
+    missing = missing_resolution_evidence(
+        case,
+        minimal_result=minimal_result,
+        original_result=original_result,
+        minimal_evidence=minimal_evidence,
+        original_evidence=original_evidence,
+    )
+    if missing:
+        raise GraphDebugError(
+            "cannot finalize without evidence: " + "; ".join(missing)
+        )
+    evidence_sources = {
+        kind: evidence
+        for kind, evidence in (
+            ("minimal", minimal_evidence),
+            ("original", original_evidence),
+        )
+        if evidence is not None
+    }
     resolved = (
         minimal_result == "pass"
         and original_result == "pass"
         and cleanup_status in {"removed", "disabled"}
     )
+
     timestamp = updated_at or utc_now()
+    validation_records: dict[str, dict[str, Any]] = {}
+    for kind, source in evidence_sources.items():
+        artifact_name, _flag = VALIDATION_EVIDENCE[kind]
+        suffix = source.suffix if source.suffix else ".log"
+        destination = case_dir / VALIDATION_DIR / f"{artifact_name}{suffix}"
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        validation_records[kind] = {
+            "path": destination.relative_to(case_dir).as_posix(),
+            "source": str(source.resolve()),
+            "sha256": sha256_file(destination),
+        }
+
     case["resolution"] = {
         "root_cause": root_cause,
         "fix": fix,
         "minimal_reproduction": minimal_result,
         "original_reproduction": original_result,
         "debug_instrumentation": cleanup_status,
+        "validation_evidence": validation_records,
+        "experiment_count": len(case["experiments"]),
+        "comparison_count": len(case["comparisons"]),
         "resolved_at": timestamp,
     }
     case["status"] = "resolved" if resolved else "inconclusive"
@@ -513,6 +608,16 @@ def finalize_case(
     _atomic_write_json(_case_path(case_dir), case)
 
     manifest = _ensure_manifest_running(case_dir, updated_at=timestamp)
+    for kind, record_row in sorted(validation_records.items()):
+        artifact_name, _flag = VALIDATION_EVIDENCE[kind]
+        manifest = add_artifact(
+            manifest,
+            name=f"validation-{artifact_name}",
+            kind="reproduction-rerun-output",
+            uri=record_row["path"],
+            sha256=record_row["sha256"],
+            updated_at=timestamp,
+        )
     manifest = add_artifact(
         manifest,
         name="graph-debug-case",
@@ -542,6 +647,11 @@ def build_parser() -> argparse.ArgumentParser:
     init.add_argument("--workspace-snapshot", default="{}")
     init.add_argument("--model", default="{}")
     init.add_argument("--topology", default="{}")
+    init.add_argument(
+        "--parent-run-id",
+        default=None,
+        help="run_id of the change-validation plan this case is evidence for",
+    )
 
     record = subparsers.add_parser("record", help="append one controlled experiment")
     record.add_argument("--case-dir", required=True, type=Path)
@@ -568,6 +678,18 @@ def build_parser() -> argparse.ArgumentParser:
     finalize.add_argument(
         "--cleanup-status", required=True, choices=("removed", "disabled", "pending")
     )
+    finalize.add_argument(
+        "--minimal-evidence",
+        type=Path,
+        default=None,
+        help="rerun output of the minimal reproduction; required when its result is pass",
+    )
+    finalize.add_argument(
+        "--original-evidence",
+        type=Path,
+        default=None,
+        help="rerun output of the original reproduction; required when its result is pass",
+    )
     return parser
 
 
@@ -589,6 +711,7 @@ def main(argv: list[str] | None = None) -> int:
                 ),
                 model=_json_object(args.model, "model"),
                 topology=_json_object(args.topology, "topology"),
+                parent_run_id=args.parent_run_id,
             )
             payload = {
                 "status": "created",
@@ -629,11 +752,14 @@ def main(argv: list[str] | None = None) -> int:
                 minimal_result=args.minimal_result,
                 original_result=args.original_result,
                 cleanup_status=args.cleanup_status,
+                minimal_evidence=args.minimal_evidence,
+                original_evidence=args.original_evidence,
             )
             payload = {
                 "status": case["status"],
                 "case_id": case["case_id"],
                 "case": str(_case_path(args.case_dir).resolve()),
+                "validation_evidence": case["resolution"]["validation_evidence"],
             }
     except (GraphDebugError, RunManifestError) as exc:
         print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))

--- a/.agents/skills/vllm-ascend-graph-debug/tests/test_graph_debug_case.py
+++ b/.agents/skills/vllm-ascend-graph-debug/tests/test_graph_debug_case.py
@@ -53,29 +53,47 @@ def record(*, layer: int, sample: list[float]) -> dict:
     }
 
 
+def init_case(case_dir: Path, case_id: str = "graph-case-1", **overrides) -> dict:
+    arguments = {
+        "case_id": case_id,
+        "stage": "accuracy",
+        "eager_result": "pass",
+        "graph_result": "fail",
+        "reproduction": "fixed input",
+        "created_at": NOW,
+    }
+    arguments.update(overrides)
+    return graph_debug.init_case(case_dir, **arguments)
+
+
+def record_one_experiment(case_dir: Path) -> None:
+    graph_debug.record_experiment(
+        case_dir,
+        variable="capture size",
+        hypothesis="padding causes divergence",
+        expected="smaller capture removes divergence",
+        observed="divergence remains",
+        conclusion="capture size excluded",
+        next_step="inspect metadata",
+        updated_at=NOW,
+    )
+
+
+def write_evidence(root: Path) -> tuple[Path, Path]:
+    minimal = root / "minimal-rerun.log"
+    original = root / "original-rerun.log"
+    minimal.write_text("minimal reproduction: 32/32 tokens match\n", encoding="utf-8")
+    original.write_text("original reproduction: exact match\n", encoding="utf-8")
+    return minimal, original
+
+
 class GraphDebugCaseTests(unittest.TestCase):
     def test_case_lifecycle_resolves_only_after_both_reproductions_pass(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             case_dir = Path(tmp) / "case"
-            graph_debug.init_case(
-                case_dir,
-                case_id="graph-case-1",
-                stage="accuracy",
-                eager_result="pass",
-                graph_result="fail",
-                reproduction="fixed input",
-                created_at=NOW,
-            )
-            graph_debug.record_experiment(
-                case_dir,
-                variable="capture size",
-                hypothesis="padding causes divergence",
-                expected="smaller capture removes divergence",
-                observed="divergence remains",
-                conclusion="capture size excluded",
-                next_step="inspect metadata",
-                updated_at=NOW,
-            )
+            init_case(case_dir, parent_run_id="change-validation-1")
+            record_one_experiment(case_dir)
+            minimal, original = write_evidence(Path(tmp))
             case = graph_debug.finalize_case(
                 case_dir,
                 root_cause="stale metadata",
@@ -83,25 +101,111 @@ class GraphDebugCaseTests(unittest.TestCase):
                 minimal_result="pass",
                 original_result="pass",
                 cleanup_status="removed",
+                minimal_evidence=minimal,
+                original_evidence=original,
                 updated_at=NOW,
             )
             self.assertEqual(case["status"], "resolved")
+            self.assertEqual(case["resolution"]["experiment_count"], 1)
             manifest = json.loads((case_dir / "manifest.json").read_text(encoding="utf-8"))
             self.assertEqual(manifest["status"], "passed")
-            self.assertEqual(manifest["artifacts"][0]["name"], "graph-debug-case")
+            self.assertEqual(manifest["parent_run_id"], "change-validation-1")
+            artifacts = {row["name"]: row for row in manifest["artifacts"]}
+            self.assertIn("graph-debug-case", artifacts)
+            for name in ("validation-minimal-reproduction", "validation-original-reproduction"):
+                self.assertIn(name, artifacts)
+                self.assertRegex(artifacts[name]["sha256"], r"^[0-9a-f]{64}$")
+                self.assertTrue((case_dir / artifacts[name]["uri"]).is_file())
+
+    def test_init_then_finalize_cannot_reach_passed(self) -> None:
+        """Regression: two commands and zero evidence used to yield `passed`."""
+        with tempfile.TemporaryDirectory() as tmp:
+            case_dir = Path(tmp) / "case"
+            init_case(case_dir, stage="unknown")
+            with self.assertRaisesRegex(
+                graph_debug.GraphDebugError,
+                r"--minimal-evidence.*--original-evidence.*no controlled experiment",
+            ):
+                graph_debug.finalize_case(
+                    case_dir,
+                    root_cause="x",
+                    fix="y",
+                    minimal_result="pass",
+                    original_result="pass",
+                    cleanup_status="removed",
+                    updated_at=NOW,
+                )
+            manifest = json.loads((case_dir / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["status"], "planned")
+            case = json.loads((case_dir / "case.json").read_text(encoding="utf-8"))
+            self.assertEqual(case["status"], "active")
+
+    def test_pass_claim_without_experiments_is_rejected_even_with_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            case_dir = Path(tmp) / "case"
+            init_case(case_dir)
+            minimal, original = write_evidence(Path(tmp))
+            with self.assertRaisesRegex(
+                graph_debug.GraphDebugError, "no controlled experiment recorded"
+            ):
+                graph_debug.finalize_case(
+                    case_dir,
+                    root_cause="x",
+                    fix="y",
+                    minimal_result="pass",
+                    original_result="pass",
+                    cleanup_status="removed",
+                    minimal_evidence=minimal,
+                    original_evidence=original,
+                    updated_at=NOW,
+                )
+
+    def test_empty_evidence_file_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            case_dir = Path(tmp) / "case"
+            init_case(case_dir)
+            record_one_experiment(case_dir)
+            minimal, original = write_evidence(Path(tmp))
+            original.write_text("", encoding="utf-8")
+            with self.assertRaisesRegex(
+                graph_debug.GraphDebugError, "--original-evidence is empty"
+            ):
+                graph_debug.finalize_case(
+                    case_dir,
+                    root_cause="x",
+                    fix="y",
+                    minimal_result="pass",
+                    original_result="pass",
+                    cleanup_status="removed",
+                    minimal_evidence=minimal,
+                    original_evidence=original,
+                    updated_at=NOW,
+                )
+
+    def test_failed_reproduction_can_close_inconclusive_without_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            case_dir = Path(tmp) / "case"
+            init_case(case_dir, case_id="graph-case-3", stage="replay")
+            case = graph_debug.finalize_case(
+                case_dir,
+                root_cause="event mismatch",
+                fix="pair replay events",
+                minimal_result="pass",
+                original_result="fail",
+                cleanup_status="removed",
+                minimal_evidence=write_evidence(Path(tmp))[0],
+                updated_at=NOW,
+            )
+            self.assertEqual(case["status"], "inconclusive")
+            manifest = json.loads((case_dir / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["status"], "inconclusive")
 
     def test_pending_cleanup_is_inconclusive(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             case_dir = Path(tmp) / "case"
-            graph_debug.init_case(
-                case_dir,
-                case_id="graph-case-2",
-                stage="replay",
-                eager_result="pass",
-                graph_result="fail",
-                reproduction="fixed input",
-                created_at=NOW,
-            )
+            init_case(case_dir, case_id="graph-case-2", stage="replay")
+            record_one_experiment(case_dir)
+            minimal, original = write_evidence(Path(tmp))
             case = graph_debug.finalize_case(
                 case_dir,
                 root_cause="event mismatch",
@@ -109,9 +213,37 @@ class GraphDebugCaseTests(unittest.TestCase):
                 minimal_result="pass",
                 original_result="pass",
                 cleanup_status="pending",
+                minimal_evidence=minimal,
+                original_evidence=original,
                 updated_at=NOW,
             )
             self.assertEqual(case["status"], "inconclusive")
+
+    def test_cli_finalize_without_evidence_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            case_dir = Path(tmp) / "case"
+            init_case(case_dir)
+            record_one_experiment(case_dir)
+            exit_code = graph_debug.main(
+                [
+                    "finalize",
+                    "--case-dir",
+                    str(case_dir),
+                    "--root-cause",
+                    "x",
+                    "--fix",
+                    "y",
+                    "--minimal-result",
+                    "pass",
+                    "--original-result",
+                    "pass",
+                    "--cleanup-status",
+                    "removed",
+                ]
+            )
+            self.assertEqual(exit_code, 1)
+            manifest = json.loads((case_dir / "manifest.json").read_text(encoding="utf-8"))
+            self.assertNotEqual(manifest["status"], "passed")
 
     def test_snapshot_comparison_reports_first_sorted_divergence(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/.agents/skills/vllm-ascend-performance-regression/SKILL.md
+++ b/.agents/skills/vllm-ascend-performance-regression/SKILL.md
@@ -11,8 +11,8 @@ Wrap `vllm-ascend-benchmark` with a controlled two-state experiment.
 
 1. Create independent baseline and candidate worktrees and `session-management` sessions.
 2. Use the same machine allocation policy, NPU count, model and weight hash, environment, topology, Serving arguments, Benchmark arguments, dataset, request rate, and concurrency.
-3. Put all non-code conditions in the experiment `shared` object.
-4. Run `scripts/performance_regression.py plan`.
+3. Put all non-code conditions in the experiment `shared` object. `plan` requires `machine`, `npu_devices`, `model`, `environment`, `topology` (with `tp` and `dp`), `serve_args`, `bench_args`, `dataset`, `max_concurrency`, and `request_rate`; a `shared` object without them cannot produce a parity certificate.
+4. Run `scripts/performance_regression.py plan`; set `parent_run_id` in the config when the experiment is evidence for a change-validation plan.
 5. Follow `schedule.json` exactly. Before each state executes, establish `remote-code-parity`, start or confirm its service, then call `vllm-ascend-benchmark`.
 6. Normalize each raw Benchmark result with `normalize`, then call `record`.
 7. Run `analyze` only after the schedule is complete.
@@ -35,7 +35,7 @@ candidate 3
 
 `scripts/performance_regression.py` provides:
 
-- `plan`: validate experiment parity, generate the alternating schedule, and create Run Manifest v1;
+- `plan`: validate that `shared` declares every parity condition, generate the alternating schedule, write a `parity-check.json` that names what it did and did not verify, and create Run Manifest v1;
 - `normalize`: convert one single-run or aggregated Benchmark result into the measurement contract;
 - `record`: accept the next normalized measurement only when its state, phase, ordinal, and config hash match the schedule;
 - `analyze`: exclude warmups, report mean, sample deviation, coefficient of variation, outliers, relative change, and threshold verdict.

--- a/.agents/skills/vllm-ascend-performance-regression/references/acceptance.md
+++ b/.agents/skills/vllm-ascend-performance-regression/references/acceptance.md
@@ -3,7 +3,8 @@
 ## Parity
 
 - [ ] Baseline and candidate use distinct worktrees and sessions.
-- [ ] Machine policy, devices, model and weight hash, environment, topology, Serving arguments, Benchmark arguments, dataset, request rate, and concurrency are identical.
+- [ ] Machine policy, devices, model and weight hash, environment, topology (`tp` and `dp`), Serving arguments, Benchmark arguments, dataset, request rate, and concurrency are written into `shared`; `plan` refuses a config missing any of them.
+- [ ] `parity-check.json` was read including its `not_checked` list; it certifies the declaration, not the observed runtime.
 - [ ] Every measurement uses the planned config hash.
 
 ## Execution

--- a/.agents/skills/vllm-ascend-performance-regression/references/behavior.md
+++ b/.agents/skills/vllm-ascend-performance-regression/references/behavior.md
@@ -6,6 +6,7 @@
 {
   "schema_version": 1,
   "run_id": "performance-change-001",
+  "parent_run_id": "change-validation-001",
   "baseline": {
     "label": "baseline",
     "code_snapshot": "abc123",
@@ -28,11 +29,14 @@
       "torch_npu": "..."
     },
     "topology": {
-      "tp": 2
+      "tp": 2,
+      "dp": 1
     },
     "serve_args": [],
     "bench_args": [],
-    "dataset": "sharegpt"
+    "dataset": "sharegpt",
+    "max_concurrency": 16,
+    "request_rate": "inf"
   },
   "warmups": 1,
   "runs": 3,
@@ -51,7 +55,36 @@
 }
 ```
 
-All conditions except code snapshot, session ID, and display label belong in `shared`. Its canonical SHA256 is the required `config_hash`.
+All conditions except code snapshot, session ID, and display label belong in `shared`. Its canonical SHA256 is the required `config_hash`. `parent_run_id` is optional and names the change-validation plan this experiment is evidence for; `change_validation.py link` refuses manifests without it.
+
+### Required `shared` keys
+
+`plan` rejects a config unless `shared` records every condition the parity certificate claims to hold constant:
+
+| Key | Constraint |
+|---|---|
+| `machine` | non-empty string |
+| `npu_devices` | non-empty array of non-negative device indices |
+| `model` | non-empty object (path and weight hash) |
+| `environment` | non-empty object (CANN, torch_npu, driver versions) |
+| `topology` | object with positive-integer `tp` and `dp`; record `1` explicitly |
+| `serve_args` | array of strings |
+| `bench_args` | array of strings |
+| `dataset` | non-empty string |
+| `max_concurrency` | positive integer |
+| `request_rate` | positive number or `"inf"` |
+
+The rejection lists every missing or malformed key. Hashing a free-form object such as `{"note": "same"}` would produce a `config_hash` that certifies nothing, so it is not allowed.
+
+## Parity check
+
+`parity-check.json` states what it verified and on what basis:
+
+- `basis`: `declared-configuration`. The certificate proves the operator recorded every required non-code condition once and that both states are pinned to the same declaration by `config_hash`;
+- `checks`: required keys present, `topology.tp`/`topology.dp` recorded, sessions distinct, code snapshots recorded;
+- `not_checked`: the observed runtime configuration of either service, raw Benchmark artifact contents, and whether a measurement labelled `baseline` really came from that state.
+
+Read `not_checked` before citing the certificate; it is a declaration gate, not an observation of what ran.
 
 ## Benchmark normalization
 

--- a/.agents/skills/vllm-ascend-performance-regression/scripts/performance_regression.py
+++ b/.agents/skills/vllm-ascend-performance-regression/scripts/performance_regression.py
@@ -39,6 +39,23 @@ DEFAULT_BENCHMARK_METRICS = {
     "itl": "mean_itl_ms",
     "acceptance_rate": "acceptance_rate",
 }
+# Every non-code condition the parity certificate claims to hold constant. The
+# `config_hash` is only meaningful if these are actually written down: hashing a
+# free-form `shared` object proves nothing about concurrency or parallelism.
+REQUIRED_SHARED_KEYS = (
+    "machine",
+    "npu_devices",
+    "model",
+    "environment",
+    "topology",
+    "serve_args",
+    "bench_args",
+    "dataset",
+    "max_concurrency",
+    "request_rate",
+)
+REQUIRED_TOPOLOGY_KEYS = ("tp", "dp")
+PARITY_ALLOWED_DIFFERENCES = ("code_snapshot", "session_id", "label")
 
 
 class PerformanceRegressionError(ValueError):
@@ -151,6 +168,77 @@ def normalize_benchmark_result(
     return measurement
 
 
+def _is_positive_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def _is_string_list(value: Any) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def validate_shared(shared: Mapping[str, Any]) -> list[str]:
+    """Return every reason `shared` does not pin the identity parity claims.
+
+    The parity certificate promises baseline and candidate differ only in code.
+    That promise is empty unless machine, devices, model, environment, parallel
+    topology (including the data-parallel degree), Serving and Benchmark
+    arguments, dataset, concurrency, and request rate are explicitly recorded.
+    """
+    errors: list[str] = []
+    missing = [key for key in REQUIRED_SHARED_KEYS if key not in shared]
+    if missing:
+        errors.append(
+            "shared is missing required parity keys: " + ", ".join(missing)
+        )
+    checks: dict[str, tuple[Any, str]] = {
+        "machine": (
+            lambda value: isinstance(value, str) and bool(value.strip()),
+            "must be a non-empty string",
+        ),
+        "npu_devices": (
+            lambda value: isinstance(value, list)
+            and bool(value)
+            and all(isinstance(item, int) and not isinstance(item, bool) and item >= 0 for item in value),
+            "must be a non-empty array of non-negative device indices",
+        ),
+        "model": (
+            lambda value: isinstance(value, Mapping) and bool(value),
+            "must be a non-empty object",
+        ),
+        "environment": (
+            lambda value: isinstance(value, Mapping) and bool(value),
+            "must be a non-empty object",
+        ),
+        "serve_args": (_is_string_list, "must be an array of strings"),
+        "bench_args": (_is_string_list, "must be an array of strings"),
+        "dataset": (
+            lambda value: isinstance(value, str) and bool(value.strip()),
+            "must be a non-empty string",
+        ),
+        "max_concurrency": (_is_positive_int, "must be a positive integer"),
+        "request_rate": (
+            lambda value: value == "inf"
+            or (isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0),
+            'must be a positive number or "inf"',
+        ),
+    }
+    for key, (predicate, message) in checks.items():
+        if key in shared and not predicate(shared[key]):
+            errors.append(f"shared.{key} {message}")
+    topology = shared.get("topology")
+    if "topology" in shared:
+        if not isinstance(topology, Mapping) or not topology:
+            errors.append("shared.topology must be a non-empty object")
+        else:
+            for key in REQUIRED_TOPOLOGY_KEYS:
+                if not _is_positive_int(topology.get(key)):
+                    errors.append(
+                        f"shared.topology.{key} must be a positive integer "
+                        "(record the parallel degree explicitly, even when it is 1)"
+                    )
+    return errors
+
+
 def validate_config(config: Mapping[str, Any]) -> None:
     errors: list[str] = []
     if config.get("schema_version") != SCHEMA_VERSION:
@@ -171,6 +259,13 @@ def validate_config(config: Mapping[str, Any]) -> None:
     shared = config.get("shared")
     if not isinstance(shared, Mapping) or not shared:
         errors.append("shared must be a non-empty object")
+    else:
+        errors.extend(validate_shared(shared))
+    parent_run_id = config.get("parent_run_id")
+    if parent_run_id is not None and (
+        not isinstance(parent_run_id, str) or not parent_run_id.strip()
+    ):
+        errors.append("parent_run_id must be a non-empty string when present")
     runs = config.get("runs")
     if not isinstance(runs, int) or isinstance(runs, bool) or runs < 2:
         errors.append("runs must be an integer of at least 2")
@@ -229,6 +324,55 @@ def build_schedule(*, warmups: int, runs: int) -> list[dict[str, Any]]:
     return schedule
 
 
+def build_parity_check(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Describe exactly what the parity certificate did and did not verify.
+
+    The certificate is declarative: it proves the operator wrote down every
+    required non-code condition once and that both states are pinned to that
+    same declaration by `config_hash`. It does not observe what the services
+    actually ran with; `basis` and `not_checked` say so in the artifact itself.
+    """
+    shared = config["shared"]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "passed",
+        "basis": "declared-configuration",
+        "config_hash": config_hash(shared),
+        "shared": shared,
+        "allowed_difference": list(PARITY_ALLOWED_DIFFERENCES),
+        "checks": [
+            {
+                "check": "required-shared-keys-present",
+                "keys": list(REQUIRED_SHARED_KEYS),
+                "result": "passed",
+            },
+            {
+                "check": "topology-parallel-degrees-recorded",
+                "keys": [f"topology.{key}" for key in REQUIRED_TOPOLOGY_KEYS],
+                "values": {key: shared["topology"][key] for key in REQUIRED_TOPOLOGY_KEYS},
+                "result": "passed",
+            },
+            {
+                "check": "distinct-sessions",
+                "baseline": config["baseline"]["session_id"],
+                "candidate": config["candidate"]["session_id"],
+                "result": "passed",
+            },
+            {
+                "check": "code-snapshots-recorded",
+                "baseline": config["baseline"]["code_snapshot"],
+                "candidate": config["candidate"]["code_snapshot"],
+                "result": "passed",
+            },
+        ],
+        "not_checked": [
+            "observed runtime configuration of either service",
+            "raw Benchmark artifact contents or hashes",
+            "that measurements labelled baseline/candidate came from that state",
+        ],
+    }
+
+
 def plan(
     output_dir: Path,
     *,
@@ -264,13 +408,7 @@ def plan(
     }
     output_dir.mkdir(parents=True, exist_ok=True)
     _write_json(output_dir / "experiment-config.json", config)
-    _write_json(output_dir / "parity-check.json", {
-        "schema_version": SCHEMA_VERSION,
-        "status": "passed",
-        "config_hash": fingerprint,
-        "shared": config["shared"],
-        "allowed_difference": ["code_snapshot", "session_id", "label"],
-    })
+    _write_json(output_dir / "parity-check.json", build_parity_check(config))
     _write_json(output_dir / "schedule.json", schedule)
     _write_json(output_dir / "measurements.json", measurements)
     _write_json(output_dir / "run.json", state)
@@ -284,13 +422,14 @@ def plan(
     manifest = new_manifest(
         run_type="performance",
         run_id=run_id,
+        parent_run_id=config.get("parent_run_id"),
         workspace_snapshot={
             "baseline": config["baseline"]["code_snapshot"],
             "candidate": config["candidate"]["code_snapshot"],
         },
-        environment=config["shared"].get("environment", {}),
-        model=config["shared"].get("model", {}),
-        topology=config["shared"].get("topology", {}),
+        environment=config["shared"]["environment"],
+        model=config["shared"]["model"],
+        topology=config["shared"]["topology"],
         created_at=timestamp,
     )
     for name, kind, uri in (

--- a/.agents/skills/vllm-ascend-performance-regression/tests/test_performance_regression.py
+++ b/.agents/skills/vllm-ascend-performance-regression/tests/test_performance_regression.py
@@ -49,10 +49,12 @@ def config() -> dict:
             "npu_devices": [0, 1],
             "model": {"path": "/models/example"},
             "environment": {"cann": "test"},
-            "topology": {"tp": 2},
+            "topology": {"tp": 2, "dp": 1},
             "serve_args": [],
             "bench_args": [],
             "dataset": "test",
+            "max_concurrency": 8,
+            "request_rate": "inf",
         },
         "warmups": 1,
         "runs": 3,
@@ -141,6 +143,65 @@ class PerformanceRegressionTests(unittest.TestCase):
         invalid["candidate"]["session_id"] = invalid["baseline"]["session_id"]
         with self.assertRaisesRegex(performance.PerformanceRegressionError, "different"):
             performance.validate_config(invalid)
+
+    def test_free_form_shared_cannot_produce_parity_certificate(self) -> None:
+        """Regression: `{"note": "same"}` used to pass parity with nothing pinned."""
+        invalid = config()
+        invalid["shared"] = {"note": "same"}
+        with self.assertRaisesRegex(
+            performance.PerformanceRegressionError,
+            r"missing required parity keys: .*max_concurrency.*request_rate",
+        ) as raised:
+            performance.validate_config(invalid)
+        for key in performance.REQUIRED_SHARED_KEYS:
+            self.assertIn(key, str(raised.exception))
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(invalid), encoding="utf-8")
+            with self.assertRaises(performance.PerformanceRegressionError):
+                performance.plan(root / "run", config_path=config_path, created_at=NOW)
+            self.assertFalse((root / "run" / "parity-check.json").exists())
+
+    def test_topology_without_data_parallel_degree_is_rejected(self) -> None:
+        invalid = config()
+        invalid["shared"]["topology"] = {"tp": 2}
+        with self.assertRaisesRegex(
+            performance.PerformanceRegressionError, r"shared\.topology\.dp"
+        ):
+            performance.validate_config(invalid)
+
+    def test_concurrency_must_be_positive_integer(self) -> None:
+        invalid = config()
+        invalid["shared"]["max_concurrency"] = "8"
+        with self.assertRaisesRegex(
+            performance.PerformanceRegressionError, r"shared\.max_concurrency"
+        ):
+            performance.validate_config(invalid)
+
+    def test_parity_check_names_what_it_verified(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config_path = root / "config.json"
+            experiment = config()
+            experiment["parent_run_id"] = "change-validation-1"
+            config_path.write_text(json.dumps(experiment), encoding="utf-8")
+            output = root / "run"
+            performance.plan(output, config_path=config_path, created_at=NOW)
+            parity = json.loads((output / "parity-check.json").read_text(encoding="utf-8"))
+            self.assertEqual(parity["basis"], "declared-configuration")
+            checks = {row["check"]: row for row in parity["checks"]}
+            self.assertEqual(
+                checks["required-shared-keys-present"]["keys"],
+                list(performance.REQUIRED_SHARED_KEYS),
+            )
+            self.assertEqual(
+                checks["topology-parallel-degrees-recorded"]["values"], {"tp": 2, "dp": 1}
+            )
+            self.assertTrue(parity["not_checked"])
+            manifest = json.loads((output / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["parent_run_id"], "change-validation-1")
+            self.assertEqual(manifest["topology"], {"tp": 2, "dp": 1})
 
     def test_regression_is_detected(self) -> None:
         experiment = config()


### PR DESCRIPTION
Close paths where validation/debug workflows could record success without the required evidence. Graph finalization requires its controlled experiment and output evidence; change validation requires correctly linked child runs and artifacts; performance requires actual configuration parity; correctness checks labels and execution differences. Preserve supported single-state graph completion and distributed completion without a detected mismatch.

The accepted source is integrated with scaffold main through ordinary merges, preserving the original commit history. Independent GPT-6 acceptance on stage `972104a95279031a408172c944b13efa15440651` and its #95 successor passed 11 actual CLI scenarios per stage; the final stack passed 212 tests with zero skips. Source union, ancestry, compile/catalog and whitespace checks passed. A separate prospective-public-tree check confirmed the same source blobs and a passing boundary guard against public main `1b0c2ebe`. No new remote/NPU campaign is claimed.
