### PR TITLE
fix: close stale-lock double-lease and artifact path escape

### DIFF
--- a/.agents/lib/vaws_remote_toolbox.py
+++ b/.agents/lib/vaws_remote_toolbox.py
@@ -1210,6 +1210,43 @@ def _remote_join(root: str, relpath: str) -> str:
     return str(PurePosixPath(root) / PurePosixPath(relpath))
 
 
+def _safe_local_artifact_path(local_dir: Path, relpath: object) -> Path:
+    """Resolve ``relpath`` under ``local_dir`` or raise.
+
+    Duplicates the lexical + resolve-and-contain guard in
+    ``.remote-dev/core/artifact_ops.py``. The two copies drifted; this
+    path previously joined the manifest relpath with no ``..`` check.
+    Reject before any mkdir so a hostile entry cannot escape.
+    """
+    if not isinstance(relpath, str) or relpath == "":
+        raise RemoteToolboxError(f"invalid artifact relpath: {relpath!r}")
+    if "\x00" in relpath:
+        raise RemoteToolboxError(f"invalid artifact relpath: {relpath!r}")
+    effective = "artifact" if relpath == "." else relpath
+    rel = PurePosixPath(effective)
+    if rel.is_absolute() or any(part in {"..", ""} for part in rel.parts):
+        raise RemoteToolboxError(f"unsafe artifact relpath: {relpath}")
+    root = local_dir.resolve()
+    candidate = root.joinpath(*rel.parts)
+    resolved = candidate.resolve()
+    if resolved != root and root not in resolved.parents:
+        raise RemoteToolboxError(f"artifact relpath escapes local dir: {relpath}")
+    return candidate
+
+
+def _manifest_local_paths(
+    local_dir: Path, files: Iterable[dict[str, Any]]
+) -> list[Path] | str:
+    """Validate every manifest relpath. Return paths or an error string."""
+    resolved: list[Path] = []
+    for file_info in files:
+        try:
+            resolved.append(_safe_local_artifact_path(local_dir, file_info.get("relpath")))
+        except RemoteToolboxError as exc:
+            return str(exc)
+    return resolved
+
+
 def artifact_pull(
     target: RemoteTarget,
     *,
@@ -1231,13 +1268,24 @@ def artifact_pull(
             "artifacts": {"manifest": manifest},
             "logs": {},
         }
+    files = list(manifest.get("files") or [])
+    validated = _manifest_local_paths(local_dir, files)
+    if isinstance(validated, str):
+        return {
+            "status": "failed",
+            "target": target.to_dict(),
+            "started_at": started_at,
+            "duration_ms": duration_ms(start),
+            "error": validated,
+            "artifacts": {"manifest": manifest},
+            "logs": {},
+        }
     ensure_state_dir(local_dir)
     pulled: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
     pending: list[dict[str, Any]] = []
-    for file_info in manifest.get("files", []):
+    for file_info, local_path in zip(files, validated):
         relpath = file_info["relpath"]
-        local_path = local_dir / ("artifact" if relpath == "." else relpath)
         ensure_state_dir(local_path.parent)
         if local_path.exists() and _sha256_file(local_path) == file_info["sha256"]:
             skipped.append({"relpath": relpath, "local_path": str(local_path), "reason": "hash-match"})
@@ -1305,7 +1353,10 @@ def _artifact_pull_single(
     timeout: float | None,
 ) -> dict[str, Any]:
     relpath = file_info["relpath"]
-    local_path = local_dir / ("artifact" if relpath == "." else relpath)
+    try:
+        local_path = _safe_local_artifact_path(local_dir, relpath)
+    except RemoteToolboxError as exc:
+        return {"status": "failed", "error": str(exc)}
     ensure_state_dir(local_path.parent)
     remote_file = _remote_join(remote_path, relpath)
     tmp = local_path.with_suffix(local_path.suffix + ".tmp")
@@ -1391,7 +1442,15 @@ def _artifact_pull_tar_batch(
                 extracted = tf.extractfile(member)
                 if extracted is None:
                     continue
-                local_path = local_dir / relpath
+                try:
+                    local_path = _safe_local_artifact_path(local_dir, relpath)
+                except RemoteToolboxError as exc:
+                    return {
+                        "status": "failed",
+                        "error": str(exc),
+                        "artifacts": {"pulled": pulled},
+                        "logs": {},
+                    }
                 ensure_state_dir(local_path.parent)
                 tmp = local_path.with_suffix(local_path.suffix + ".tmp")
                 with tmp.open("wb") as fh:

--- a/.agents/lib/vaws_run_manifest.py
+++ b/.agents/lib/vaws_run_manifest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import re
 import tempfile
@@ -102,6 +103,31 @@ def _require_mapping(value: Any, path: str, errors: list[str]) -> Mapping[str, A
     return value
 
 
+def _is_json_native(value: Any) -> bool:
+    """True when ``value`` survives JSON dump/load without coercion.
+
+    The published schema is the contract; this check is a strict subset
+    so integer keys, NaN/Inf, tuples and other non-JSON values cannot
+    validate and then round-trip as something else.
+    """
+    if value is None or isinstance(value, str):
+        return True
+    if isinstance(value, bool):
+        return True
+    if isinstance(value, int):
+        return True
+    if isinstance(value, float):
+        return math.isfinite(value)
+    if isinstance(value, list):
+        return all(_is_json_native(item) for item in value)
+    if isinstance(value, dict):
+        return all(
+            isinstance(key, str) and _is_json_native(item)
+            for key, item in value.items()
+        )
+    return False
+
+
 def _validate_safe_id(value: Any, path: str, errors: list[str], *, nullable: bool = False) -> None:
     if value is None and nullable:
         return
@@ -124,16 +150,24 @@ def _validate_artifacts(value: Any, errors: list[str]) -> None:
             if name in names:
                 errors.append(f"artifact name is duplicated: {name!r}")
             names.add(name)
+        unknown = sorted(set(item) - {"name", "kind", "uri", "sha256"})
+        if unknown:
+            errors.append(
+                f"artifacts[{index}] has unknown fields: {', '.join(unknown)}"
+            )
         sha256 = item.get("sha256")
-        if sha256 is not None and (
+        if "sha256" in item and (
             not isinstance(sha256, str) or not SHA256_RE.fullmatch(sha256)
         ):
-            errors.append(f"artifacts[{index}].sha256 must be 64 lowercase hex characters")
+            errors.append(
+                f"artifacts[{index}].sha256 must be 64 lowercase hex characters"
+            )
 
 
 def validate_manifest(manifest: Mapping[str, Any]) -> None:
     errors: list[str] = []
-    if manifest.get("schema_version") != SCHEMA_VERSION:
+    version = manifest.get("schema_version")
+    if type(version) is not int or version != SCHEMA_VERSION:
         errors.append(f"schema_version must be {SCHEMA_VERSION}")
     _validate_safe_id(manifest.get("run_id"), "run_id", errors)
     _validate_safe_id(manifest.get("parent_run_id"), "parent_run_id", errors, nullable=True)
@@ -146,7 +180,13 @@ def validate_manifest(manifest: Mapping[str, Any]) -> None:
         errors.append(f"status must be one of: {', '.join(sorted(RUN_STATUSES))}")
 
     for field in ("workspace_snapshot", "environment", "model", "topology"):
-        _require_mapping(manifest.get(field), field, errors)
+        mapping = _require_mapping(manifest.get(field), field, errors)
+        if mapping and not _is_json_native(
+            mapping if isinstance(mapping, dict) else dict(mapping)
+        ):
+            errors.append(
+                f"{field} must be JSON-native (string keys, no NaN/Inf)"
+            )
 
     command = manifest.get("command")
     if not isinstance(command, list) or any(not isinstance(part, str) for part in command):
@@ -256,7 +296,14 @@ def write_manifest(path: Path, manifest: Mapping[str, Any]) -> None:
     temporary = Path(temporary_name)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
-            json.dump(manifest, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            json.dump(
+                manifest,
+                stream,
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+                allow_nan=False,
+            )
             stream.write("\n")
             stream.flush()
             os.fsync(stream.fileno())

--- a/.agents/lib/vaws_run_manifest.py
+++ b/.agents/lib/vaws_run_manifest.py
@@ -41,7 +41,8 @@ SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
 SECRET_ENV_RE = re.compile(
-    r"(?:^|_)(?:API_?KEY|ACCESS_?KEY|AUTH|CREDENTIAL|PASS(?:WORD)?|SECRET|TOKEN)(?:_|$)",
+    r"(?:^|_)(?:API_?KEY|ACCESS_?KEY|AUTH|CREDENTIAL|"
+    r"PASS(?:WD|WORD)?|SECRET|TOKEN|KEY)(?:_|$)",
     re.IGNORECASE,
 )
 

--- a/.agents/lib/vaws_session_state.py
+++ b/.agents/lib/vaws_session_state.py
@@ -306,11 +306,16 @@ def allocate_session_leases(
     if requested_devices is not None and npu_count is not None:
         raise SessionStateError("use only one of --devices or --npu-count")
     available_set = set(available_devices) if available_devices is not None else None
+    occupancy_unavailable = "cannot allocate NPU devices: host occupancy is unavailable"
     with file_lock(session_lock_dir(repo_root) / "leases.lock"):
         leases = load_leases(repo_root)
         bucket = _machine_lease_bucket(leases, machine_alias)
         allocated_devices: list[int] = []
         if requested_devices is not None:
+            if requested_devices and available_set is None:
+                # Unknown occupancy is not an empty free set. An explicit
+                # device list must not bypass a failed or unreadable probe.
+                raise SessionStateError(occupancy_unavailable)
             if available_set is not None:
                 missing = sorted(set(requested_devices) - available_set)
                 if missing:
@@ -328,12 +333,9 @@ def allocate_session_leases(
             if available_set is None:
                 # Without a host probe we cannot know how many NPUs exist or
                 # which are busy; guessing a fixed device range would hand out
-                # devices that may not exist. Fail fast instead of masking the
-                # probe failure.
-                raise SessionStateError(
-                    "cannot allocate by --npu-count: host NPU probe data is unavailable; "
-                    "fix the probe or request explicit --devices"
-                )
+                # devices that may not exist. Explicit --devices is not a
+                # bypass: that path fails closed on unknown occupancy too.
+                raise SessionStateError(occupancy_unavailable)
             candidates = sorted(available_set)
             for dev in candidates:
                 if _resource_owner(bucket, "npu_devices", str(dev)) in {None, sid}:

--- a/.agents/lib/vaws_session_state.py
+++ b/.agents/lib/vaws_session_state.py
@@ -4,12 +4,15 @@
 from __future__ import annotations
 
 import contextlib
+import errno
+import fcntl
 import json
 import os
 import re
 import socket
 import sys
 import tempfile
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -70,6 +73,119 @@ def _load_json(path: Path, default: Any | None = None) -> Any:
         raise SessionStateError(f"invalid JSON in {path}: {exc}") from exc
 
 
+class _FlockUnsupported(Exception):
+    """Raised when fcntl.flock is not supported on this filesystem."""
+
+
+_GUARD_THREAD_LOCKS: dict[str, threading.Lock] = {}
+_GUARD_THREAD_LOCKS_MU = threading.Lock()
+_FLOCK_UNSUPPORTED_ERRNOS = {
+    errno.ENOTSUP,
+    errno.ENOSYS,
+    getattr(errno, "EOPNOTSUPP", errno.ENOTSUP),
+}
+_FLOCK_BUSY_ERRNOS = {errno.EAGAIN, errno.EACCES, errno.EWOULDBLOCK}
+
+
+def _guard_path(lock_path: Path) -> Path:
+    return lock_path.with_name(f"{lock_path.name}.guard")
+
+
+def _thread_gate(lock_path: Path) -> threading.Lock:
+    key = os.path.normpath(str(lock_path))
+    with _GUARD_THREAD_LOCKS_MU:
+        gate = _GUARD_THREAD_LOCKS.get(key)
+        if gate is None:
+            gate = threading.Lock()
+            _GUARD_THREAD_LOCKS[key] = gate
+        return gate
+
+
+def _timed_out(path: Path) -> SessionStateError:
+    return SessionStateError(f"timed out waiting for session lock {path}")
+
+
+@contextlib.contextmanager
+def _reclaim_gate(lock_path: Path, *, deadline: float, poll_seconds: float):
+    """Serialize reclaim/release on a never-unlinked sidecar.
+
+    The lease file stays an O_EXCL lock. This gate only covers unlink of
+    that file. A per-path threading.Lock covers same-process waiters if
+    flock is process-scoped; fcntl.flock covers other processes on local
+    POSIX filesystems. NFS and cross-host coherence are out of scope.
+    ENOTSUP fails closed for reclaim.
+    """
+    guard = _guard_path(lock_path)
+    ensure_state_dir(guard.parent)
+    thread_gate = _thread_gate(lock_path)
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise _timed_out(lock_path)
+        if thread_gate.acquire(timeout=min(poll_seconds, remaining)):
+            break
+    fd = os.open(str(guard), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError as exc:
+                if exc.errno in _FLOCK_UNSUPPORTED_ERRNOS:
+                    raise _FlockUnsupported() from exc
+                if exc.errno not in _FLOCK_BUSY_ERRNOS:
+                    raise
+                if time.monotonic() >= deadline:
+                    raise _timed_out(lock_path)
+                time.sleep(poll_seconds)
+        try:
+            yield
+        finally:
+            with contextlib.suppress(OSError):
+                fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+        thread_gate.release()
+
+
+def _lock_identity(path: Path) -> tuple[int, int] | None:
+    try:
+        st = os.lstat(path)
+    except FileNotFoundError:
+        return None
+    return (st.st_dev, st.st_ino)
+
+
+def _lock_is_stale(path: Path, stale_after_seconds: float) -> bool:
+    try:
+        st = os.lstat(path)
+    except FileNotFoundError:
+        return False
+    return (time.time() - st.st_mtime) >= stale_after_seconds
+
+
+def _reclaim_stale_lock(path: Path, stale_after_seconds: float) -> None:
+    identity = _lock_identity(path)
+    if identity is None or not _lock_is_stale(path, stale_after_seconds):
+        return
+    current = _lock_identity(path)
+    if current != identity or not _lock_is_stale(path, stale_after_seconds):
+        return
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        return
+
+
+def _unlink_if_identity(path: Path, identity: tuple[int, int]) -> None:
+    if _lock_identity(path) != identity:
+        return
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        return
+
+
 @contextlib.contextmanager
 def file_lock(
     path: Path,
@@ -78,6 +194,15 @@ def file_lock(
     poll_seconds: float = DEFAULT_LOCK_POLL_SECONDS,
     stale_after_seconds: float = DEFAULT_STALE_LOCK_SECONDS,
 ):
+    """Acquire an O_EXCL lease file, reclaiming a stale holder safely.
+
+    Reclaim and release are serialized under ``{name}.guard``. A waiter
+    must re-check inode and mtime under that gate before unlink, and a
+    holder unlinks only its own inode. This is atomic on local POSIX
+    filesystems for threads and processes that honor the gate. It does
+    not claim NFS or cross-host lock coherence; if flock is ENOTSUP,
+    reclaim fails closed and the stale lease is left in place.
+    """
     ensure_state_dir(path.parent)
     deadline = time.monotonic() + timeout_seconds
     owner = {
@@ -86,30 +211,49 @@ def file_lock(
         "created_at": utc_now_iso(),
     }
     fd: int | None = None
+    identity: tuple[int, int] | None = None
     while True:
         try:
             fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
             os.write(fd, json.dumps(owner, ensure_ascii=False).encode("utf-8"))
+            st = os.fstat(fd)
+            identity = (st.st_dev, st.st_ino)
             break
         except FileExistsError:
             try:
+                # path.stat() is the unguarded verdict; reclaim re-checks
+                # with lstat under the gate so a stale reading cannot
+                # unlink a newer holder's inode.
                 age = time.time() - path.stat().st_mtime
             except FileNotFoundError:
                 continue
             if age >= stale_after_seconds:
-                with contextlib.suppress(FileNotFoundError):
-                    path.unlink()
+                try:
+                    with _reclaim_gate(
+                        path, deadline=deadline, poll_seconds=poll_seconds
+                    ):
+                        _reclaim_stale_lock(path, stale_after_seconds)
+                except _FlockUnsupported:
+                    if time.monotonic() >= deadline:
+                        raise _timed_out(path)
+                    time.sleep(poll_seconds)
                 continue
             if time.monotonic() >= deadline:
-                raise SessionStateError(f"timed out waiting for session lock {path}")
+                raise _timed_out(path)
             time.sleep(poll_seconds)
     try:
         yield path
     finally:
-        if fd is not None:
+        if fd is not None and identity is not None:
+            release_deadline = time.monotonic() + timeout_seconds
+            try:
+                with _reclaim_gate(
+                    path, deadline=release_deadline, poll_seconds=poll_seconds
+                ):
+                    _unlink_if_identity(path, identity)
+            except (_FlockUnsupported, SessionStateError):
+                _unlink_if_identity(path, identity)
             os.close(fd)
-        with contextlib.suppress(FileNotFoundError):
-            path.unlink()
 
 
 def sessions_root(repo_root: Path = ROOT) -> Path:

--- a/.agents/lib/vaws_session_state.py
+++ b/.agents/lib/vaws_session_state.py
@@ -124,11 +124,14 @@ def _reclaim_gate(lock_path: Path, *, deadline: float, poll_seconds: float):
             raise _timed_out(lock_path)
         if thread_gate.acquire(timeout=min(poll_seconds, remaining)):
             break
-    fd = os.open(str(guard), os.O_CREAT | os.O_RDWR, 0o600)
+    fd: int | None = None
+    locked = False
     try:
+        fd = os.open(str(guard), os.O_CREAT | os.O_RDWR, 0o600)
         while True:
             try:
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                locked = True
                 break
             except OSError as exc:
                 if exc.errno in _FLOCK_UNSUPPORTED_ERRNOS:
@@ -141,11 +144,15 @@ def _reclaim_gate(lock_path: Path, *, deadline: float, poll_seconds: float):
         try:
             yield
         finally:
-            with contextlib.suppress(OSError):
-                fcntl.flock(fd, fcntl.LOCK_UN)
+            if locked:
+                with contextlib.suppress(OSError):
+                    fcntl.flock(fd, fcntl.LOCK_UN)
     finally:
-        os.close(fd)
-        thread_gate.release()
+        try:
+            if fd is not None:
+                os.close(fd)
+        finally:
+            thread_gate.release()
 
 
 def _lock_identity(path: Path) -> tuple[int, int] | None:
@@ -165,6 +172,7 @@ def _lock_is_stale(path: Path, stale_after_seconds: float) -> bool:
 
 
 def _reclaim_stale_lock(path: Path, stale_after_seconds: float) -> None:
+    """Unlink a stale lease. Caller must hold ``_reclaim_gate``."""
     identity = _lock_identity(path)
     if identity is None or not _lock_is_stale(path, stale_after_seconds):
         return
@@ -178,12 +186,69 @@ def _reclaim_stale_lock(path: Path, stale_after_seconds: float) -> None:
 
 
 def _unlink_if_identity(path: Path, identity: tuple[int, int]) -> None:
+    """Unlink ``path`` only if it is still ``identity``. Caller must hold ``_reclaim_gate``."""
     if _lock_identity(path) != identity:
         return
     try:
         os.unlink(path)
     except FileNotFoundError:
         return
+
+
+def _release_acquired_lease(
+    path: Path,
+    fd: int | None,
+    identity: tuple[int, int] | None,
+    *,
+    timeout_seconds: float,
+    poll_seconds: float,
+    pending_exc: BaseException | None,
+) -> None:
+    """Close the lease fd and unlink our inode under the cooperating guard.
+
+    Gate timeout and unsupported flock fail closed: the lease is left in
+    place. Those failures surface only when the critical section itself
+    succeeded, so a body exception is not replaced by a cleanup timeout.
+    Unrelated I/O errors are not swallowed. The lease fd is closed even
+    if gated unlink raises.
+    """
+    if fd is None and identity is None:
+        return
+    if fd is not None and identity is None:
+        try:
+            st = os.fstat(fd)
+            identity = (st.st_dev, st.st_ino)
+        except OSError:
+            identity = None
+    gate_exc: BaseException | None = None
+    close_exc: OSError | None = None
+    try:
+        if identity is not None:
+            release_deadline = time.monotonic() + timeout_seconds
+            try:
+                with _reclaim_gate(
+                    path, deadline=release_deadline, poll_seconds=poll_seconds
+                ):
+                    _unlink_if_identity(path, identity)
+            except _FlockUnsupported as exc:
+                gate_exc = SessionStateError(
+                    f"session lock reclaim is unsupported for {path}"
+                )
+                gate_exc.__cause__ = exc
+            except SessionStateError as exc:
+                gate_exc = exc
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError as exc:
+                close_exc = exc
+    if pending_exc is not None:
+        return
+    if close_exc is not None:
+        raise close_exc
+    if gate_exc is not None:
+        raise gate_exc
 
 
 @contextlib.contextmanager
@@ -198,10 +263,12 @@ def file_lock(
 
     Reclaim and release are serialized under ``{name}.guard``. A waiter
     must re-check inode and mtime under that gate before unlink, and a
-    holder unlinks only its own inode. This is atomic on local POSIX
+    holder unlinks only its own inode. If the gate cannot be obtained,
+    the lease is left in place and the failure is raised; release never
+    falls back to an unguarded unlink. This is atomic on local POSIX
     filesystems for threads and processes that honor the gate. It does
     not claim NFS or cross-host lock coherence; if flock is ENOTSUP,
-    reclaim fails closed and the stale lease is left in place.
+    reclaim and release fail closed and the lease is left in place.
     """
     ensure_state_dir(path.parent)
     deadline = time.monotonic() + timeout_seconds
@@ -212,48 +279,52 @@ def file_lock(
     }
     fd: int | None = None
     identity: tuple[int, int] | None = None
-    while True:
-        try:
-            fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-            os.write(fd, json.dumps(owner, ensure_ascii=False).encode("utf-8"))
-            st = os.fstat(fd)
-            identity = (st.st_dev, st.st_ino)
-            break
-        except FileExistsError:
-            try:
-                # path.stat() is the unguarded verdict; reclaim re-checks
-                # with lstat under the gate so a stale reading cannot
-                # unlink a newer holder's inode.
-                age = time.time() - path.stat().st_mtime
-            except FileNotFoundError:
-                continue
-            if age >= stale_after_seconds:
-                try:
-                    with _reclaim_gate(
-                        path, deadline=deadline, poll_seconds=poll_seconds
-                    ):
-                        _reclaim_stale_lock(path, stale_after_seconds)
-                except _FlockUnsupported:
-                    if time.monotonic() >= deadline:
-                        raise _timed_out(path)
-                    time.sleep(poll_seconds)
-                continue
-            if time.monotonic() >= deadline:
-                raise _timed_out(path)
-            time.sleep(poll_seconds)
+    pending_exc: BaseException | None = None
     try:
-        yield path
-    finally:
-        if fd is not None and identity is not None:
-            release_deadline = time.monotonic() + timeout_seconds
+        while True:
             try:
-                with _reclaim_gate(
-                    path, deadline=release_deadline, poll_seconds=poll_seconds
-                ):
-                    _unlink_if_identity(path, identity)
-            except (_FlockUnsupported, SessionStateError):
-                _unlink_if_identity(path, identity)
-            os.close(fd)
+                fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+                os.write(fd, json.dumps(owner, ensure_ascii=False).encode("utf-8"))
+                st = os.fstat(fd)
+                identity = (st.st_dev, st.st_ino)
+                break
+            except FileExistsError:
+                try:
+                    # path.stat() is the unguarded verdict; reclaim re-checks
+                    # with lstat under the gate so a stale reading cannot
+                    # unlink a newer holder's inode.
+                    age = time.time() - path.stat().st_mtime
+                except FileNotFoundError:
+                    continue
+                if age >= stale_after_seconds:
+                    try:
+                        with _reclaim_gate(
+                            path, deadline=deadline, poll_seconds=poll_seconds
+                        ):
+                            _reclaim_stale_lock(path, stale_after_seconds)
+                    except _FlockUnsupported:
+                        if time.monotonic() >= deadline:
+                            raise _timed_out(path)
+                        time.sleep(poll_seconds)
+                    continue
+                if time.monotonic() >= deadline:
+                    raise _timed_out(path)
+                time.sleep(poll_seconds)
+        try:
+            yield path
+        except BaseException as exc:
+            pending_exc = exc
+            raise
+    finally:
+        if fd is not None or identity is not None:
+            _release_acquired_lease(
+                path,
+                fd,
+                identity,
+                timeout_seconds=timeout_seconds,
+                poll_seconds=poll_seconds,
+                pending_exc=pending_exc,
+            )
 
 
 def sessions_root(repo_root: Path = ROOT) -> Path:

--- a/.agents/lib/vaws_session_state.py
+++ b/.agents/lib/vaws_session_state.py
@@ -209,8 +209,9 @@ def _release_acquired_lease(
     Gate timeout and unsupported flock fail closed: the lease is left in
     place. Those failures surface only when the critical section itself
     succeeded, so a body exception is not replaced by a cleanup timeout.
-    Unrelated I/O errors are not swallowed. The lease fd is closed even
-    if gated unlink raises.
+    Unrelated I/O errors, including lease-fd close failures, are not
+    swallowed even if the body already failed; they chain to the body
+    exception. The lease fd is closed even if gated unlink raises.
     """
     if fd is None and identity is None:
         return
@@ -243,10 +244,12 @@ def _release_acquired_lease(
                 os.close(fd)
             except OSError as exc:
                 close_exc = exc
+    if close_exc is not None:
+        if pending_exc is not None:
+            raise close_exc from pending_exc
+        raise close_exc
     if pending_exc is not None:
         return
-    if close_exc is not None:
-        raise close_exc
     if gate_exc is not None:
         raise gate_exc
 

--- a/.agents/lib/vaws_session_state.py
+++ b/.agents/lib/vaws_session_state.py
@@ -314,9 +314,14 @@ def allocate_session_leases(
             if available_set is not None:
                 missing = sorted(set(requested_devices) - available_set)
                 if missing:
+                    # "Not available" covers both absent and busy on purpose:
+                    # the caller passes free devices, not visible ones, so a
+                    # device that exists but is in use lands here too. Saying
+                    # "not visible" would send the reader looking for a
+                    # hardware or driver problem that is not there.
                     raise SessionStateError(
-                        f"requested NPU devices are not visible on host: {missing}; "
-                        f"available={sorted(available_set)}"
+                        f"requested NPU devices are not available on host (absent or in use "
+                        f"by another process): {missing}; available={sorted(available_set)}"
                     )
             allocated_devices = list(requested_devices)
         elif npu_count:
@@ -336,7 +341,12 @@ def allocate_session_leases(
                 if len(allocated_devices) >= npu_count:
                     break
             if len(allocated_devices) < npu_count:
-                raise SessionStateError(f"not enough locally unleased NPU devices for session {sid}")
+                raise SessionStateError(
+                    f"not enough allocatable NPU devices for session {sid}: "
+                    f"{len(allocated_devices)} of {npu_count} after excluding devices busy on "
+                    f"the host and devices leased in this workspace "
+                    f"(host-free={sorted(available_set)})"
+                )
 
         for dev in allocated_devices:
             _reserve(bucket, "npu_devices", dev, sid)

--- a/.agents/lib/vaws_validate.py
+++ b/.agents/lib/vaws_validate.py
@@ -58,10 +58,15 @@ def parse_device_csv(value: str | None, *, label: str = "devices") -> list[int] 
         token = raw.strip()
         if not token:
             raise ValidationError(f"{label} contains an empty device id")
-        try:
-            device = int(token, 10)
-        except ValueError as exc:
-            raise ValidationError(f"{label} contains a non-integer device id: {token!r}") from exc
+        if token[0] == "-" and token[1:] and all(ch in "0123456789" for ch in token[1:]):
+            raise ValidationError(
+                f"{label} contains a negative device id: {int(token, 10)}"
+            )
+        if not all(ch in "0123456789" for ch in token):
+            raise ValidationError(
+                f"{label} contains a non-integer device id: {token!r}"
+            )
+        device = int(token, 10)
         if device < 0:
             raise ValidationError(f"{label} contains a negative device id: {device}")
         if device in seen:

--- a/.agents/skills/session-management/SKILL.md
+++ b/.agents/skills/session-management/SKILL.md
@@ -79,7 +79,7 @@ does not create another container or duplicate member leases.
 - `session_create.py` creates a fresh generated id when no explicit/env id is provided; it does not reuse `.vaws-local/current-session.json` as a creation default.
 - Existing-session lookup commands may use `.vaws-local/current-session.json` as a convenience fallback.
 - Do not reuse the base machine container for new parallel tasks. New tasks should use `session_create.py`.
-- For NPU work, reserve devices during creation with `--devices` or `--npu-count`; session-aware serving uses that lease by default. `--npu-count` requires a successful host NPU probe (no guessing of device ranges); if the probe fails, fix it or pass explicit `--devices`.
+- For NPU work, reserve devices during creation with `--devices` or `--npu-count`; session-aware serving uses that lease by default. Count-based and explicit-device allocation both require a known occupancy result; unknown occupancy and a known empty free set refuse the request. Port-only creation remains valid without NPUs.
 - `--reuse-existing` probes the existing container's SSH endpoint before reporting the session as reusable; a dead container returns `needs_repair` instead of a stale `ready`.
 - Metadata status changes never release remote leases. Confirmed container removal releases its leases even without `--release-leases`; worktree removal or stopping only the recorded service PID does not prove all remote resources are free.
 - Managed serving requires a nonempty live NPU lease matching the session snapshot. Empty or stale snapshots cannot fall through to idle-card selection.

--- a/.agents/skills/session-management/scripts/session_create.py
+++ b/.agents/skills/session-management/scripts/session_create.py
@@ -104,10 +104,59 @@ def parse_host_npu_devices(stdout: str) -> list[int]:
     Delegates to the shared npu-smi parser: on dual-chip A3 cards the card
     header rows (0-7) undercount the chips vLLM actually sees (0-15), so the
     old header-row regex made TP16 single-node launches impossible to lease.
+
+    Visibility only. Do **not** use this to decide what may be allocated: a
+    device can be visible and in use by somebody else. Use
+    ``parse_host_npu_availability`` for that.
     """
     from vaws_npu_coordination import parse_npu_smi_info  # noqa: PLC0415
 
     return parse_npu_smi_info(stdout).get("devices") or []
+
+
+def parse_host_npu_availability(stdout: str) -> tuple[list[int] | None, dict[str, Any]]:
+    """Which devices are free, or ``None`` when the host cannot tell us.
+
+    Allocation used to be driven by the visible-device list, which is wrong in
+    two separate ways and produced silent double-allocation:
+
+    * A visible device may be busy. The occupancy the parser reports in
+      ``busy``/``free`` was being discarded, so a card another process was
+      already using looked allocatable.
+    * When the parser cannot read the process table it fails closed and
+      reports ``status: failed`` — but it still returns the full ``devices``
+      list with ``busy: {}``. That reads as "every device is free" to a caller
+      that only looks at ``devices``. ``assign_resources`` already refuses to
+      allocate by count when availability is unknown, with a comment saying so;
+      the guard was simply never reachable, because a failed probe produced a
+      full list rather than ``None``.
+
+    So: unknown availability is ``None`` here, which is what makes that guard
+    fire. A probe that cannot establish occupancy must not be treated as an
+    empty occupancy table.
+    """
+    from vaws_npu_coordination import parse_npu_smi_info  # noqa: PLC0415
+
+    info = parse_npu_smi_info(stdout)
+    status = info.get("status")
+    visible = sorted(info.get("devices") or [])
+    busy_map = info.get("busy") or {}
+    diagnostics: dict[str, Any] = {
+        "probe_status": status,
+        "visible_devices": visible,
+        "busy_devices": sorted(int(d) for d in busy_map),
+        "busy_reasons": {str(d): busy_map[d] for d in busy_map},
+    }
+    if status != "ok":
+        diagnostics["availability"] = "unknown"
+        diagnostics["availability_reason"] = (
+            info.get("error") or f"npu-smi occupancy could not be established (status={status!r})"
+        )
+        return None, diagnostics
+    free = sorted(int(d) for d in (info.get("free") or []))
+    diagnostics["availability"] = "known"
+    diagnostics["free_devices"] = free
+    return free, diagnostics
 
 
 def probe_host_npu_devices(record: dict[str, Any]) -> tuple[list[int] | None, dict[str, Any]]:
@@ -139,9 +188,16 @@ def probe_host_npu_devices(record: dict[str, Any]) -> tuple[list[int] | None, di
     if result.returncode != 0:
         payload["status"] = "unavailable"
         return None, payload
-    devices = parse_host_npu_devices(result.stdout)
-    payload.update({"status": "ok" if devices else "unparsed", "devices": devices})
-    return devices or None, payload
+    free, diagnostics = parse_host_npu_availability(result.stdout)
+    payload.update(diagnostics)
+    payload["devices"] = diagnostics["visible_devices"]
+    if free is None:
+        # Availability unknown, not empty. Returning the visible list here is
+        # what allowed a session to be handed a card another process was using.
+        payload["status"] = "occupancy_unknown"
+        return None, payload
+    payload["status"] = "ok" if diagnostics["visible_devices"] else "unparsed"
+    return free or None, payload
 
 
 def host_port_available(record: dict[str, Any]) -> Any:

--- a/.agents/skills/session-management/scripts/session_create.py
+++ b/.agents/skills/session-management/scripts/session_create.py
@@ -197,7 +197,9 @@ def probe_host_npu_devices(record: dict[str, Any]) -> tuple[list[int] | None, di
         payload["status"] = "occupancy_unknown"
         return None, payload
     payload["status"] = "ok" if diagnostics["visible_devices"] else "unparsed"
-    return free or None, payload
+    # A successful parse of an empty free set is `[]`, not unknown occupancy.
+    # `free or None` collapsed that case and skipped the allocator's guard.
+    return free, payload
 
 
 def host_port_available(record: dict[str, Any]) -> Any:
@@ -596,8 +598,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.npu_count is not None and args.npu_count < 1:
             raise SessionStateError("--npu-count must be >= 1")
         available_devices, npu_probe = probe_host_npu_devices(base_record)
+        npu_requested = bool(requested_devices) or args.npu_count is not None
         if available_devices is None:
-            emit_progress("probe-npus", "host NPU device probe unavailable; validating syntax only", **npu_probe)
+            if npu_requested:
+                emit_progress(
+                    "probe-npus",
+                    "host NPU occupancy is unavailable; refusing NPU allocation",
+                    **npu_probe,
+                )
+            else:
+                emit_progress(
+                    "probe-npus",
+                    "host NPU occupancy is unavailable; continuing without NPU leases",
+                    **npu_probe,
+                )
         else:
             emit_progress("probe-npus", "host NPU device probe succeeded", devices=available_devices)
 

--- a/.agents/skills/session-management/tests/test_session_create_probes.py
+++ b/.agents/skills/session-management/tests/test_session_create_probes.py
@@ -3,19 +3,31 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[4]
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
-for _p in (str(SCRIPTS),):
+LIB = ROOT / ".agents" / "lib"
+for _p in (str(LIB), str(SCRIPTS)):
     if _p not in sys.path:
-        sys.path.insert(0, str(_p))
+        sys.path.insert(0, _p)
 
+import session_create  # noqa: E402
 from session_create import (  # noqa: E402
     parse_host_npu_availability,
     parse_host_npu_devices,
+    probe_host_npu_devices,
+)
+from vaws_session_state import (  # noqa: E402
+    SessionStateError,
+    allocate_session_leases,
+    session_leases_path,
+    session_live_leases,
 )
 
 # Dual-chip A3 card layout: 8 cards x 2 chips; chip rows carry Phy-IDs 0-15
@@ -75,6 +87,30 @@ A3_WITH_RUNNING_PROCESS = A3_DUAL_CHIP.replace(
     "| 1       0                 | 3412          | python                   | 41235                   |",
 )
 
+# visible [0,1], busy [0], free [1]
+SINGLE_CHIP_BUSY_0 = SINGLE_CHIP.replace(
+    "| No running processes found                                                          |",
+    "| 0       0                 | 3412          | python                   | 41235                   |",
+)
+
+# visible [0], busy [0], free [], status ok
+SINGLE_DEVICE_ALL_BUSY = """\
++---------------------------+---------------+----------------------------------------------------+
+| NPU   Name                | Health        | Power(W)    Temp(C)           Hugepages-Usage(page)|
+| Chip  Phy-ID              | Bus-Id        | AICore(%)   Memory-Usage(MB)  HBM-Usage(MB)        |
++===========================+===============+====================================================+
+| 0     Ascend910B4         | OK            | 72.6        42                0    / 0             |
+| 0     0                   | 0000:C1:00.0  | 0           0    / 0          1151 / 32768         |
++===========================+===============+====================================================+
+| NPU     Chip              | Process id    | Process name             | Process memory(MB)      |
++===========================+===============+====================================================+
+| 0       0                 | 3412          | python                   | 41235                   |
++------------------------------------------------------------------------------------------------+
+"""
+
+HOST_RECORD = {"host": {"ip": "192.0.2.10", "user": "root", "port": 22}}
+MACHINE = "host"
+
 
 class ParseHostNpuDevicesTests(unittest.TestCase):
     def test_dual_chip_a3_returns_phy_ids(self) -> None:
@@ -88,10 +124,6 @@ class ParseHostNpuDevicesTests(unittest.TestCase):
 
     def test_empty_output(self) -> None:
         self.assertEqual(parse_host_npu_devices(""), [])
-
-
-if __name__ == "__main__":
-    unittest.main()
 
 
 class ParseHostNpuAvailabilityTests(unittest.TestCase):
@@ -133,3 +165,189 @@ class ParseHostNpuAvailabilityTests(unittest.TestCase):
         # allocatable. Callers that need the latter must ask for availability.
         self.assertEqual([0, 1], parse_host_npu_devices(HEADER_ONLY))
         self.assertIsNone(parse_host_npu_availability(HEADER_ONLY)[0])
+
+
+def _probe_host(*, stdout: str = "", returncode: int = 0, timeout: bool = False):
+    if timeout:
+        runner = mock.Mock(
+            side_effect=subprocess.TimeoutExpired(cmd=["ssh"], timeout=30, output="", stderr="")
+        )
+    else:
+        runner = mock.Mock(
+            return_value=subprocess.CompletedProcess(
+                args=["ssh"],
+                returncode=returncode,
+                stdout=stdout,
+                stderr="" if returncode == 0 else "ssh failed",
+            )
+        )
+    with mock.patch.object(session_create.subprocess, "run", runner):
+        return probe_host_npu_devices(HOST_RECORD)
+
+
+def _allocate(root: Path, session_id: str, **kwargs):
+    return allocate_session_leases(
+        repo_root=root,
+        machine_alias=MACHINE,
+        session_id=session_id,
+        port_available=lambda _port: True,
+        **kwargs,
+    )
+
+
+def _live(root: Path, session_id: str) -> dict:
+    return session_live_leases(repo_root=root, machine_alias=MACHINE, session_id=session_id)
+
+
+class ProbeHostNpuDevicesAllocationTests(unittest.TestCase):
+    """Pin the probe wrapper, not just the parser, then feed the allocator."""
+
+    def _assert_no_lease_or_port(self, root: Path, session_id: str) -> None:
+        self.assertFalse(session_leases_path(root).exists())
+        self.assertEqual(
+            _live(root, session_id),
+            {"npu_devices": [], "container_ssh_ports": [], "service_ports": []},
+        )
+
+    def test_partial_busy_allocates_only_the_free_device(self) -> None:
+        free, payload = _probe_host(stdout=SINGLE_CHIP_BUSY_0)
+        self.assertEqual(free, [1])
+        self.assertEqual(payload["availability"], "known")
+        self.assertEqual(payload["visible_devices"], [0, 1])
+        self.assertEqual(payload["busy_devices"], [0])
+        self.assertEqual(payload["free_devices"], [1])
+        self.assertEqual(payload["status"], "ok")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            explicit = _allocate(
+                root, "sess-explicit", requested_devices=[1], available_devices=free, container_ssh_port=46001
+            )
+            self.assertEqual(explicit["npu_devices"], [1])
+            self.assertEqual(_live(root, "sess-explicit")["npu_devices"], [1])
+            self.assertEqual(_live(root, "sess-explicit")["container_ssh_ports"], [46001])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            counted = _allocate(root, "sess-count", npu_count=1, available_devices=free, container_ssh_port=46002)
+            self.assertEqual(counted["npu_devices"], [1])
+            self.assertEqual(_live(root, "sess-count")["npu_devices"], [1])
+            self.assertEqual(_live(root, "sess-count")["container_ssh_ports"], [46002])
+
+    def test_partial_busy_refuses_busy_device_and_oversize_count(self) -> None:
+        free, _payload = _probe_host(stdout=SINGLE_CHIP_BUSY_0)
+        self.assertEqual(free, [1])
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(SessionStateError):
+                _allocate(root, "sess-busy", requested_devices=[0], available_devices=free)
+            self._assert_no_lease_or_port(root, "sess-busy")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(SessionStateError):
+                _allocate(root, "sess-count", npu_count=2, available_devices=free)
+            self._assert_no_lease_or_port(root, "sess-count")
+
+    def test_known_empty_free_set_returns_empty_list_and_refuses_both_modes(self) -> None:
+        free, payload = _probe_host(stdout=SINGLE_DEVICE_ALL_BUSY)
+        self.assertEqual(free, [])
+        self.assertIsNotNone(free)
+        self.assertEqual(payload["availability"], "known")
+        self.assertEqual(payload["visible_devices"], [0])
+        self.assertEqual(payload["busy_devices"], [0])
+        self.assertEqual(payload["free_devices"], [])
+        self.assertEqual(payload["status"], "ok")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(SessionStateError):
+                _allocate(root, "sess-explicit", requested_devices=[0], available_devices=free)
+            with self.assertRaises(SessionStateError):
+                _allocate(root, "sess-count", npu_count=1, available_devices=free)
+            self._assert_no_lease_or_port(root, "sess-explicit")
+            self._assert_no_lease_or_port(root, "sess-count")
+
+    def test_unreadable_process_table_returns_none_and_refuses_both_modes(self) -> None:
+        free, payload = _probe_host(stdout=HEADER_ONLY)
+        self.assertIsNone(free)
+        self.assertEqual(payload["availability"], "unknown")
+        self.assertEqual(payload["status"], "occupancy_unknown")
+        self.assertTrue(payload["availability_reason"])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable"):
+                _allocate(root, "sess-explicit", requested_devices=[0], available_devices=free)
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable"):
+                _allocate(root, "sess-count", npu_count=1, available_devices=free)
+            self._assert_no_lease_or_port(root, "sess-explicit")
+            self._assert_no_lease_or_port(root, "sess-count")
+
+    def test_ssh_failure_returns_none_and_does_not_fall_back_to_visibility(self) -> None:
+        free, payload = _probe_host(stdout=SINGLE_CHIP, returncode=255)
+        self.assertIsNone(free)
+        self.assertEqual(payload["status"], "unavailable")
+        self.assertNotIn("availability", payload)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable"):
+                _allocate(root, "sess-explicit", requested_devices=[0], available_devices=free)
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable"):
+                _allocate(root, "sess-count", npu_count=1, available_devices=free)
+            self._assert_no_lease_or_port(root, "sess-explicit")
+            self._assert_no_lease_or_port(root, "sess-count")
+
+    def test_probe_timeout_returns_none_and_refuses_both_modes(self) -> None:
+        free, payload = _probe_host(timeout=True)
+        self.assertIsNone(free)
+        self.assertEqual(payload["status"], "timeout")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable"):
+                _allocate(root, "sess-explicit", requested_devices=[0], available_devices=free)
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable"):
+                _allocate(root, "sess-count", npu_count=1, available_devices=free)
+            self._assert_no_lease_or_port(root, "sess-explicit")
+            self._assert_no_lease_or_port(root, "sess-count")
+
+    def test_locally_leased_free_device_is_excluded_by_existing_ownership(self) -> None:
+        free, _payload = _probe_host(stdout=SINGLE_CHIP_BUSY_0)
+        self.assertEqual(free, [1])
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            owner = _allocate(
+                root, "sess-owner", requested_devices=[1], available_devices=free, container_ssh_port=46001
+            )
+            self.assertEqual(owner["npu_devices"], [1])
+            with self.assertRaisesRegex(SessionStateError, "already leased"):
+                _allocate(root, "sess-other", requested_devices=[1], available_devices=free)
+            with self.assertRaisesRegex(SessionStateError, "not enough allocatable"):
+                _allocate(root, "sess-count", npu_count=1, available_devices=free)
+            self.assertEqual(_live(root, "sess-owner")["npu_devices"], [1])
+            self.assertEqual(_live(root, "sess-owner")["container_ssh_ports"], [46001])
+            self.assertEqual(
+                _live(root, "sess-other"),
+                {"npu_devices": [], "container_ssh_ports": [], "service_ports": []},
+            )
+            self.assertEqual(
+                _live(root, "sess-count"),
+                {"npu_devices": [], "container_ssh_ports": [], "service_ports": []},
+            )
+
+    def test_no_npu_request_still_allocates_a_port_when_occupancy_is_unknown(self) -> None:
+        free, payload = _probe_host(stdout=HEADER_ONLY)
+        self.assertIsNone(free)
+        self.assertEqual(payload["availability"], "unknown")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            leases = _allocate(root, "sess-port", available_devices=free, container_ssh_port=46009)
+            self.assertEqual(leases["npu_devices"], [])
+            self.assertEqual(leases["container_ssh_port"], 46009)
+            self.assertEqual(_live(root, "sess-port")["npu_devices"], [])
+            self.assertEqual(_live(root, "sess-port")["container_ssh_ports"], [46009])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/session-management/tests/test_session_create_probes.py
+++ b/.agents/skills/session-management/tests/test_session_create_probes.py
@@ -13,7 +13,10 @@ for _p in (str(SCRIPTS),):
     if _p not in sys.path:
         sys.path.insert(0, str(_p))
 
-from session_create import parse_host_npu_devices  # noqa: E402
+from session_create import (  # noqa: E402
+    parse_host_npu_availability,
+    parse_host_npu_devices,
+)
 
 # Dual-chip A3 card layout: 8 cards x 2 chips; chip rows carry Phy-IDs 0-15
 # which are the device ids vLLM / ASCEND_RT_VISIBLE_DEVICES actually use.
@@ -64,6 +67,14 @@ HEADER_ONLY = """\
 | 1     Ascend910           | OK            | 170.9       53                0    / 0             |
 """
 
+# Same A3 layout, but somebody else is already running on Phy-ID 2. This is the
+# case that used to be invisible to allocation: the device is healthy, visible
+# and taken.
+A3_WITH_RUNNING_PROCESS = A3_DUAL_CHIP.replace(
+    "| No running processes found                                                          |",
+    "| 1       0                 | 3412          | python                   | 41235                   |",
+)
+
 
 class ParseHostNpuDevicesTests(unittest.TestCase):
     def test_dual_chip_a3_returns_phy_ids(self) -> None:
@@ -81,3 +92,44 @@ class ParseHostNpuDevicesTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ParseHostNpuAvailabilityTests(unittest.TestCase):
+    """Allocation must never be driven by the visible-device list.
+
+    Two ways that was wrong, both of which handed out cards somebody else was
+    using, and neither of which raised anything:
+
+    * a visible device can be busy, and the parser's occupancy was discarded
+    * a parser that fails closed still reports every device with an empty busy
+      table, which reads as "all free" to a caller that only looks at devices
+    """
+
+    def test_idle_host_offers_every_visible_device(self) -> None:
+        free, diagnostics = parse_host_npu_availability(A3_DUAL_CHIP)
+        self.assertEqual([0, 1, 2, 3], free)
+        self.assertEqual("known", diagnostics["availability"])
+        self.assertEqual([], diagnostics["busy_devices"])
+
+    def test_a_device_in_use_is_not_offered(self) -> None:
+        free, diagnostics = parse_host_npu_availability(A3_WITH_RUNNING_PROCESS)
+        self.assertIsNotNone(free)
+        self.assertNotIn(2, free, "a device with a running process must not be allocatable")
+        self.assertIn(2, diagnostics["busy_devices"])
+        self.assertEqual([0, 1, 2, 3], diagnostics["visible_devices"])
+
+    def test_unreadable_process_table_yields_unknown_not_empty(self) -> None:
+        # HEADER_ONLY has no process table at all, so occupancy cannot be
+        # established. The old code returned [0, 1] here and allocation
+        # proceeded; assign_resources' fail-fast guard for unknown availability
+        # was unreachable because a failed probe never produced None.
+        free, diagnostics = parse_host_npu_availability(HEADER_ONLY)
+        self.assertIsNone(free)
+        self.assertEqual("unknown", diagnostics["availability"])
+        self.assertTrue(diagnostics["availability_reason"])
+
+    def test_visibility_helper_still_reports_visible_devices(self) -> None:
+        # parse_host_npu_devices keeps its meaning: what exists, not what is
+        # allocatable. Callers that need the latter must ask for availability.
+        self.assertEqual([0, 1], parse_host_npu_devices(HEADER_ONLY))
+        self.assertIsNone(parse_host_npu_availability(HEADER_ONLY)[0])

--- a/.agents/tests/test_property_artifact_toolbox.py
+++ b/.agents/tests/test_property_artifact_toolbox.py
@@ -216,7 +216,6 @@ class PullProperties(unittest.TestCase):
 
         run_cases(80, body, label="toolbox pull integrity")
 
-    @unittest.expectedFailure
     def test_known_defect_manifest_relpath_traversal_escapes_the_local_dir(self) -> None:
         """KNOWN DEFECT (medium): ``artifact_pull`` / ``_artifact_pull_single``
         build ``local_dir / relpath`` straight from the remote manifest with no

--- a/.agents/tests/test_property_artifact_toolbox.py
+++ b/.agents/tests/test_property_artifact_toolbox.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Property tests for the managed artifact path in ``vaws_remote_toolbox``.
+
+``.agents/scripts/remote_artifact_{manifest,pull,push}.py`` are thin wrappers
+over ``vaws_remote_toolbox``; the properties therefore target the library:
+
+* the local manifest is deterministic, agrees with an independent reference,
+  and changes for every single-byte flip, truncation, extension, added,
+  removed or renamed file;
+* ``artifact_pull`` never lands a file whose bytes disagree with the manifest,
+  and refuses manifest relpaths that would escape the local directory (the
+  latter is recorded as a known defect: the ``.remote-dev`` port guards it,
+  this path does not).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+import vaws_remote_toolbox as toolbox  # noqa: E402
+from vaws_remote_toolbox import RemoteTarget, SshEndpoint  # noqa: E402
+from test_property_support import DOC_HOSTS, MULTIBYTE, Gen, run_cases  # noqa: E402
+
+NAME_ALPHABET = "abcxyz019_-" + MULTIBYTE
+
+
+def sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def entry_name(gen: Gen, max_len: int = 8) -> str:
+    return gen.text(NAME_ALPHABET, 1, max_len)
+
+
+def build_tree(gen: Gen, root: Path) -> dict[str, bytes]:
+    files: dict[str, bytes] = {}
+    dirs = [""] + ["/".join(entry_name(gen, 6) for _ in range(gen.integer(1, 2))) for _ in range(gen.integer(0, 2))]
+    for _ in range(gen.integer(1, 6)):
+        directory = gen.choice(dirs)
+        rel = f"{directory}/{entry_name(gen)}" if directory else entry_name(gen)
+        if rel in files or any(other.startswith(rel + "/") or rel.startswith(other + "/") for other in files):
+            continue
+        data = gen.one_of(lambda: b"", lambda: gen.raw_bytes(1, 64), lambda: gen.raw_bytes(1000, 2500))
+        (root / rel).parent.mkdir(parents=True, exist_ok=True)
+        (root / rel).write_bytes(data)
+        files[rel] = data
+    return files
+
+
+def view(manifest: dict[str, Any]) -> dict[str, tuple[str, int]]:
+    return {item["relpath"]: (item["sha256"], item["size"]) for item in manifest["files"]}
+
+
+def make_target(base: Path) -> RemoteTarget:
+    return RemoteTarget(
+        mode="session",
+        alias="machine-a",
+        target_id="sess-abc",
+        workspace_id="sess-abc",
+        workspace_root=base,
+        runtime_root="/vllm-workspace",
+        container_name="vaws-test",
+        container_image="image",
+        container_endpoint=SshEndpoint(DOC_HOSTS[0], 46000),
+        host_endpoint=SshEndpoint(DOC_HOSTS[0], 22),
+        state_repo_root=base,
+        record={},
+        session_id="sess-abc",
+        session_file=base / "session.json",
+        session={"session_id": "sess-abc"},
+        leased_devices=[],
+    )
+
+
+class LocalManifestProperties(unittest.TestCase):
+    def test_local_manifest_is_deterministic_and_sensitive_to_every_mutation(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                tree = Path(tmp).resolve() / "out"
+                tree.mkdir()
+                files = build_tree(gen, tree)
+                first = toolbox._local_manifest(tree)
+                self.assertEqual(view(first), {rel: (sha(d), len(d)) for rel, d in files.items()})
+                self.assertEqual(view(toolbox._local_manifest(tree)), view(first))
+                relpaths = [i["relpath"] for i in first["files"]]
+                self.assertEqual(relpaths, sorted(relpaths, key=lambda rel: Path(rel).parts), "entries are ordered by path components")
+                rel = gen.choice(sorted(files))
+                data = files[rel]
+                kind = gen.choice(["append", "add", "remove", "rename"] + (["flip", "truncate"] if data else []))
+                path = tree / rel
+                if kind == "flip":
+                    i = gen.integer(0, len(data) - 1)
+                    path.write_bytes(data[:i] + bytes([data[i] ^ 0x80]) + data[i + 1:])
+                elif kind == "truncate":
+                    path.write_bytes(data[: gen.integer(0, len(data) - 1)])
+                elif kind == "append":
+                    path.write_bytes(data + b"!")
+                elif kind == "add":
+                    (tree / (entry_name(gen) + ".new")).write_bytes(b"new")
+                elif kind == "remove":
+                    path.unlink()
+                else:
+                    path.rename(tree / (rel + ".moved"))
+                second = toolbox._local_manifest(tree)
+                self.assertNotEqual(view(second), view(first), f"manifest did not notice {kind}")
+                if kind in {"flip", "truncate", "append"}:
+                    self.assertEqual(set(view(second)), set(view(first)))
+                    self.assertNotEqual(view(second)[rel], view(first)[rel])
+                else:
+                    self.assertNotEqual(set(view(second)), set(view(first)))
+
+        run_cases(150, body, label="toolbox local manifest")
+
+    def test_symlinks_are_rejected_wherever_they_appear(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                base = Path(tmp).resolve()
+                tree = base / "out"
+                tree.mkdir()
+                files = build_tree(gen, tree)
+                (base / "secret").write_bytes(b"secret")
+                link = tree / gen.choice([str(Path(rel).parent) for rel in files]) / "link"
+                link.symlink_to(gen.choice((base / "secret", tree / gen.choice(sorted(files)))))
+                with self.assertRaises(toolbox.RemoteToolboxError):
+                    toolbox._local_manifest(tree)
+                with self.assertRaises(toolbox.RemoteToolboxError):
+                    toolbox._local_manifest(link)
+
+        run_cases(30, body, label="toolbox manifest symlinks")
+
+
+class PullHarness:
+    def __init__(self, test: unittest.TestCase) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        test.addCleanup(self.tmp.cleanup)
+        self.base = Path(self.tmp.name).resolve()
+        self.remote_tree = self.base / "remote"
+        self.remote_tree.mkdir()
+        self.local_dir = self.base / "local"
+        self.corrupt: dict[str, Any] = {}
+        self.target = make_target(self.base)
+        patchers = [
+            mock.patch.object(toolbox, "remote_manifest", side_effect=self._manifest),
+            mock.patch.object(toolbox, "_remote_tar_available", return_value=False),
+            mock.patch.object(toolbox, "ssh_exec_bytes", side_effect=self._cat),
+        ]
+        for patcher in patchers:
+            patcher.start()
+            test.addCleanup(patcher.stop)
+
+        self.frozen: dict[str, Any] | None = None
+
+    def freeze_manifest(self) -> None:
+        """Snapshot the manifest now, so later disk mutations model remote drift."""
+        self.frozen = self._manifest(self.target, str(self.remote_tree))
+
+    def _manifest(self, _target: RemoteTarget, remote_path: str, timeout: float | None = None) -> dict[str, Any]:
+        if self.frozen is not None:
+            return self.frozen
+        local = toolbox._local_manifest(Path(remote_path))
+        files = [{"relpath": i["relpath"], "path": i["path"], "size": i["size"], "sha256": i["sha256"]} for i in local["files"]]
+        return {"artifacts": {"manifest": {"status": "ok", "remote_path": remote_path, "is_dir": Path(remote_path).is_dir(), "file_count": len(files), "files": files}}}
+
+    def _cat(self, _endpoint: Any, command: str, timeout: float | None = None) -> subprocess.CompletedProcess[bytes]:
+        path = Path(shlex.split(command)[1])
+        if not path.exists():
+            return subprocess.CompletedProcess(args=[], returncode=1, stdout=b"", stderr=b"missing")
+        data = path.read_bytes()
+        mutate = self.corrupt.get(str(path))
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=mutate(data) if mutate else data, stderr=b"")
+
+
+class PullProperties(unittest.TestCase):
+    def test_pull_never_lands_bytes_that_disagree_with_the_manifest(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            harness = PullHarness(self)
+            files = build_tree(gen, harness.remote_tree)
+            harness.freeze_manifest()
+            expected = {rel: sha(d) for rel, d in files.items()}
+            fault = gen.choice(("none", "corrupt", "missing"))
+            victim = gen.choice(sorted(files))
+            if fault == "corrupt":
+                harness.corrupt[str(harness.remote_tree / victim)] = gen.choice((lambda d: d + b"\n", lambda d: d[:-1] if d else b"x", lambda d: b"" if d else b"\x00"))
+            elif fault == "missing":
+                (harness.remote_tree / victim).unlink()
+            result = toolbox.artifact_pull(harness.target, remote_path=str(harness.remote_tree), local_dir=harness.local_dir)
+            landed = {str(p.relative_to(harness.local_dir)): p for p in harness.local_dir.rglob("*") if p.is_file() and p.name != "manifest.json"}
+            self.assertFalse([n for n in landed if n.endswith(".tmp")])
+            for rel, path in landed.items():
+                self.assertIn(rel, expected)
+                self.assertEqual(sha(path.read_bytes()), expected[rel], f"{rel} landed with bytes that disagree with the manifest")
+            if fault == "none":
+                self.assertEqual(result["status"], "ok", result)
+                self.assertEqual(set(landed), set(expected))
+                again = toolbox.artifact_pull(harness.target, remote_path=str(harness.remote_tree), local_dir=harness.local_dir)
+                self.assertEqual(again["artifacts"]["pulled"], [])
+                self.assertEqual(len(again["artifacts"]["skipped"]), len(expected))
+            else:
+                self.assertEqual(result["status"], "failed", result)
+                self.assertNotIn(victim, landed)
+                if fault == "corrupt":
+                    self.assertIn("hash mismatch", result["error"])
+
+        run_cases(80, body, label="toolbox pull integrity")
+
+    @unittest.expectedFailure
+    def test_known_defect_manifest_relpath_traversal_escapes_the_local_dir(self) -> None:
+        """KNOWN DEFECT (medium): ``artifact_pull`` / ``_artifact_pull_single``
+        build ``local_dir / relpath`` straight from the remote manifest with no
+        ``..``/absolute check, unlike ``.remote-dev/core/artifact_ops.py`` which
+        has ``_safe_local_artifact_path``. A manifest entry ``../escaped.txt``
+        is written *outside* ``local_dir`` and the pull reports ``ok``. The
+        manifest normally comes from our own remote script, so this needs a
+        hostile or substituted remote — a defense-in-depth gap, not a remote
+        escape. Evidence: ``escaped.txt`` exists beside ``local_dir``."""
+        harness = PullHarness(self)
+        data = b"escaped\n"
+        manifest = {"status": "ok", "is_dir": True, "remote_path": str(harness.remote_tree), "files": [
+            {"relpath": "../escaped.txt", "path": str(harness.remote_tree / "x"), "size": len(data), "sha256": sha(data)},
+        ]}
+        (harness.remote_tree / "x").write_bytes(data)
+        toolbox.remote_manifest.side_effect = lambda *_a, **_k: {"artifacts": {"manifest": manifest}}  # type: ignore[attr-defined]
+        toolbox.ssh_exec_bytes.side_effect = lambda *_a, **_k: subprocess.CompletedProcess(args=[], returncode=0, stdout=data, stderr=b"")  # type: ignore[attr-defined]
+        result = toolbox.artifact_pull(harness.target, remote_path=str(harness.remote_tree), local_dir=harness.local_dir)
+        self.assertFalse((harness.base / "escaped.txt").exists(), "file written outside local_dir")
+        self.assertNotEqual(result["status"], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_property_run_manifest.py
+++ b/.agents/tests/test_property_run_manifest.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Property tests for Run Manifest v1 (``.agents/lib/vaws_run_manifest.py``).
+
+Properties:
+
+* every generated valid manifest validates, survives ``write_manifest`` /
+  ``load_manifest`` unchanged, and is never silently normalized;
+* corrupting any single top-level field (or any artifact field) is rejected
+  with a message that names the field;
+* the status machine matches its documented transition table exactly;
+* generated run ids are always safe ids;
+* the Python validator agrees with ``run-manifest-v1.schema.json`` on the
+  rules the schema states (known divergences are recorded as defects).
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+import vaws_run_manifest as rm  # noqa: E402
+from vaws_run_manifest import RunManifestError, add_artifact, generate_run_id, load_manifest, new_manifest, transition_status, validate_manifest, write_manifest  # noqa: E402
+from test_property_support import Gen, run_cases  # noqa: E402
+
+SCHEMA = json.loads((ROOT / ".agents" / "schemas" / "run-manifest-v1.schema.json").read_text(encoding="utf-8"))
+SAFE_ID_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789._-"
+SAFE_ENV_WORDS = ("VLLM", "HCCL", "ASCEND", "PATH", "HOME", "RANK", "WORLD", "SIZE", "DEBUG", "LEVEL", "TOKENIZER", "AUTHORITY", "PASSAGE", "KEYRING", "SECRETARY")
+# Words the documented filter must reject when they appear as a whole
+# underscore-delimited component (case-insensitive).
+FORBIDDEN_ENV_WORDS = ("API_KEY", "APIKEY", "ACCESS_KEY", "ACCESSKEY", "AUTH", "CREDENTIAL", "PASS", "PASSWORD", "SECRET", "TOKEN")
+
+
+def safe_id(gen: Gen) -> str:
+    return gen.text("abcdefghijklmnopqrstuvwxyz0123456789", 1, 1) + gen.text(SAFE_ID_ALPHABET, 0, gen.choice((5, 40, 127)))
+
+
+def timestamp(gen: Gen) -> str:
+    base = f"{gen.integer(1970, 2999):04d}-{gen.integer(1, 12):02d}-{gen.integer(1, 28):02d}T{gen.integer(0, 23):02d}:{gen.integer(0, 59):02d}:{gen.integer(0, 59):02d}"
+    if gen.boolean(0.3):
+        base += "." + gen.text("0123456789", 1, 6)
+    return base + "Z"
+
+
+def env_name(gen: Gen) -> str:
+    return "_".join(gen.choice(SAFE_ENV_WORDS) for _ in range(gen.integer(1, 3)))
+
+
+def artifact(gen: Gen, name: str) -> dict[str, Any]:
+    item = {"name": name, "kind": gen.choice(("report", "raw", "log", gen.word(1, 8))), "uri": gen.choice(("report.md", "file:///tmp/x", gen.word(1, 12)))}
+    if gen.boolean(0.5):
+        item["sha256"] = gen.text("0123456789abcdef", 64, 64)
+    return item
+
+
+def valid_manifest(gen: Gen) -> dict[str, Any]:
+    names: list[str] = []
+    while len(names) < gen.integer(0, 4):
+        candidate = gen.word(1, 10)
+        if candidate not in names:
+            names.append(candidate)
+    created = timestamp(gen)
+    return {
+        "schema_version": 1,
+        "run_id": safe_id(gen),
+        "parent_run_id": None if gen.boolean() else safe_id(gen),
+        "run_type": gen.choice(sorted(rm.RUN_TYPES)),
+        "workspace_snapshot": gen.json_object(),
+        "environment": gen.json_object(),
+        "model": gen.json_object(),
+        "topology": gen.json_object(),
+        "command": [gen.word(0, 10) for _ in range(gen.integer(0, 5))],
+        "environment_variables": {env_name(gen): gen.word(0, 10) for _ in range(gen.integer(0, 4))},
+        "artifacts": [artifact(gen, name) for name in names],
+        "status": gen.choice(sorted(rm.RUN_STATUSES)),
+        "created_at": created,
+        "updated_at": created if gen.boolean() else timestamp(gen),
+    }
+
+
+class ValidManifestProperties(unittest.TestCase):
+    def test_generated_manifests_validate_and_round_trip_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            def body(gen: Gen, index: int) -> None:
+                manifest = valid_manifest(gen)
+                frozen = json.dumps(manifest, sort_keys=True)
+                validate_manifest(manifest)
+                self.assertEqual(json.dumps(manifest, sort_keys=True), frozen, "validate_manifest must not mutate")
+                path = Path(tmp) / f"m{index}.json"
+                write_manifest(path, manifest)
+                loaded = load_manifest(path)
+                self.assertEqual(loaded, manifest)
+                self.assertEqual(json.dumps(manifest, sort_keys=True), frozen, "write_manifest must not mutate")
+                self.assertEqual(set(Path(tmp).glob(".m*.tmp")), set(), "no temp files left behind")
+                # The on-disk form is canonical JSON and re-validates as-is.
+                on_disk = json.loads(path.read_text(encoding="utf-8"))
+                validate_manifest(on_disk)
+                self.assertEqual(on_disk, manifest)
+
+            run_cases(200, body, label="manifest round trip")
+
+    def test_new_manifest_matches_its_arguments_and_starts_planned(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            run_type = gen.choice(sorted(rm.RUN_TYPES))
+            created = timestamp(gen)
+            env = {env_name(gen): gen.word(0, 6) for _ in range(gen.integer(0, 3))}
+            manifest = new_manifest(run_type=run_type, environment_variables=env, command=["a", "b"], created_at=created)
+            self.assertEqual(manifest["status"], "planned")
+            self.assertEqual(manifest["run_type"], run_type)
+            self.assertEqual(manifest["created_at"], created)
+            self.assertEqual(manifest["updated_at"], created)
+            self.assertEqual(manifest["environment_variables"], env)
+            self.assertIsNone(manifest["parent_run_id"])
+            self.assertTrue(manifest["run_id"].startswith(run_type + "-"))
+            self.assertRegex(manifest["run_id"], rm.SAFE_ID_RE.pattern)
+
+        run_cases(100, body, label="new_manifest")
+
+    def test_generate_run_id_is_always_a_safe_id(self) -> None:
+        seen: set[str] = set()
+
+        def body(gen: Gen, _index: int) -> None:
+            run_type = gen.choice(sorted(rm.RUN_TYPES))
+            run_id = generate_run_id(run_type, now=timestamp(gen))
+            self.assertRegex(run_id, rm.SAFE_ID_RE.pattern)
+            self.assertRegex(run_id, SCHEMA["properties"]["run_id"]["pattern"])
+            self.assertNotIn(run_id, seen, "run ids must not repeat")
+            seen.add(run_id)
+            with self.assertRaises(RunManifestError):
+                generate_run_id(run_type + "x", now=timestamp(gen))
+
+        run_cases(200, body, label="generate_run_id")
+
+
+class StatusMachineProperties(unittest.TestCase):
+    def test_transition_table_is_exhaustive_and_terminal_states_are_absorbing(self) -> None:
+        for current, target in itertools.product(sorted(rm.RUN_STATUSES), repeat=2):
+            with self.subTest(current=current, target=target):
+                manifest = new_manifest(run_type="debug", run_id="debug-case", created_at="2026-07-25T12:00:00Z")
+                manifest["status"] = current
+                allowed = target in rm.STATUS_TRANSITIONS[current]
+                if allowed:
+                    updated = transition_status(manifest, target, updated_at="2026-07-25T12:00:01Z")
+                    self.assertEqual(updated["status"], target)
+                    self.assertEqual(updated["updated_at"], "2026-07-25T12:00:01Z")
+                    self.assertEqual(manifest["status"], current, "transition must not mutate its input")
+                    self.assertNotEqual(current, target)
+                else:
+                    with self.assertRaisesRegex(RunManifestError, "invalid status transition"):
+                        transition_status(manifest, target, updated_at="2026-07-25T12:00:01Z")
+                if current in rm.TERMINAL_STATUSES:
+                    self.assertFalse(rm.STATUS_TRANSITIONS[current], "terminal states must have no exits")
+
+    def test_every_non_terminal_state_can_reach_every_terminal_state(self) -> None:
+        for terminal in rm.TERMINAL_STATUSES:
+            with self.subTest(terminal=terminal):
+                reachable = {"planned"}
+                frontier = ["planned"]
+                while frontier:
+                    state = frontier.pop()
+                    for nxt in rm.STATUS_TRANSITIONS[state]:
+                        if nxt not in reachable:
+                            reachable.add(nxt)
+                            frontier.append(nxt)
+                self.assertIn(terminal, reachable)
+
+
+CORRUPTIONS: dict[str, list[Any]] = {
+    "schema_version": [2, "1", None, 0],
+    "run_id": ["", "A", "-x", "x/y", "a" * 129, None, 1, "a b"],
+    "parent_run_id": ["", "-x", "a" * 129, 1, "Upper"],
+    "run_type": ["unknown", "", None, "Correctness"],
+    "workspace_snapshot": ["str", [], None, 1],
+    "environment": ["str", [], None],
+    "model": [[], None, 1],
+    "topology": ["x", None],
+    "command": ["str", [1], [None], {"a": 1}, None],
+    "environment_variables": [[], "str", {"A": 1}, {1: "x"}, {"OK": None}],
+    "artifacts": [{}, "str", None, [1], [{"name": "a"}], [{"name": "", "kind": "k", "uri": "u"}], [{"name": " ", "kind": "k", "uri": "u"}], [{"name": "a", "kind": "k", "uri": "u", "sha256": "abc"}], [{"name": "a", "kind": "k", "uri": "u"}, {"name": "a", "kind": "k", "uri": "u"}]],
+    "status": ["done", "", None, "Passed"],
+    "created_at": ["2026-07-25 12:00:00", "2026-07-25T12:00:00", "2026-07-25T12:00:00+00:00", "", None, 1],
+    "updated_at": ["2026-07-25T12:00", "yesterday", None],
+}
+
+
+class InvalidManifestProperties(unittest.TestCase):
+    def test_single_field_corruption_is_rejected_with_a_locatable_message(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            manifest = valid_manifest(gen)
+            field = gen.choice(sorted(CORRUPTIONS))
+            corrupted = dict(manifest)
+            corrupted[field] = gen.choice(CORRUPTIONS[field])
+            with self.assertRaises(RunManifestError) as ctx:
+                validate_manifest(corrupted)
+            message = str(ctx.exception)
+            token = "artifact" if field == "artifacts" else field
+            self.assertIn(token, message, f"error for {field} must name the field: {message}")
+            # A rejected manifest is never written.
+            with tempfile.TemporaryDirectory() as tmp:
+                with self.assertRaises(RunManifestError):
+                    write_manifest(Path(tmp) / "m.json", corrupted)
+                self.assertEqual(list(Path(tmp).iterdir()), [])
+
+        run_cases(400, body, label="single-field corruption")
+
+    def test_missing_and_unknown_fields_are_named(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            manifest = valid_manifest(gen)
+            removed = gen.sample(sorted(manifest), gen.integer(1, 3))
+            extra = [gen.word(1, 8) + "_extra" for _ in range(gen.integer(0, 2))]
+            corrupted = {k: v for k, v in manifest.items() if k not in removed}
+            for key in extra:
+                corrupted[key] = 1
+            with self.assertRaises(RunManifestError) as ctx:
+                validate_manifest(corrupted)
+            message = str(ctx.exception)
+            for key in removed:
+                self.assertIn(key, message)
+            for key in extra:
+                self.assertIn(key, message)
+
+        run_cases(150, body, label="missing/unknown fields")
+
+    def test_secret_like_environment_keys_are_rejected_in_every_position_and_case(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            word = gen.choice(FORBIDDEN_ENV_WORDS)
+            word = "".join(ch.upper() if gen.boolean() else ch.lower() for ch in word)
+            parts = [gen.choice(SAFE_ENV_WORDS) for _ in range(gen.integer(0, 2))]
+            position = gen.integer(0, len(parts))
+            parts.insert(position, word)
+            key = "_".join(parts)
+            with self.assertRaisesRegex(RunManifestError, "secret-like key"):
+                new_manifest(run_type="debug", environment_variables={key: "x"}, created_at="2026-07-25T12:00:00Z")
+            # The same word embedded without delimiters is a different identifier and is allowed.
+            embedded = "MY" + word.upper().replace("_", "") + "S"
+            new_manifest(run_type="debug", environment_variables={embedded: "x"}, created_at="2026-07-25T12:00:00Z")
+
+        run_cases(200, body, label="secret env keys")
+
+    @unittest.expectedFailure
+    def test_known_defect_common_secret_spellings_pass_the_filter(self) -> None:
+        """KNOWN DEFECT (low): the secret-key filter matches PASS/PASSWORD but
+        not ``PASSWD``, and matches API_KEY/ACCESS_KEY but not ``PRIVATE_KEY``
+        or ``SSH_KEY``. Manifests are meant to be shareable evidence, so these
+        spellings let credentials into a tracked artifact.
+        Evidence: ``DB_PASSWD`` and ``SSH_PRIVATE_KEY`` are accepted."""
+        for key in ("DB_PASSWD", "SSH_PRIVATE_KEY", "TLS_KEY", "CLIENT_CERT_KEY"):
+            with self.subTest(key=key):
+                with self.assertRaises(RunManifestError):
+                    new_manifest(run_type="debug", environment_variables={key: "x"}, created_at="2026-07-25T12:00:00Z")
+
+    def test_add_artifact_never_produces_duplicates_or_invalid_hashes(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            manifest = new_manifest(run_type="performance", created_at="2026-07-25T12:00:00Z")
+            names = []
+            for _ in range(gen.integer(1, 4)):
+                name = gen.word(1, 8)
+                sha = gen.text("0123456789abcdef", 64, 64) if gen.boolean() else None
+                if name in names:
+                    with self.assertRaisesRegex(RunManifestError, "duplicated"):
+                        add_artifact(manifest, name=name, kind="k", uri="u", sha256=sha, updated_at="2026-07-25T12:00:01Z")
+                    continue
+                manifest = add_artifact(manifest, name=name, kind="k", uri="u", sha256=sha, updated_at="2026-07-25T12:00:01Z")
+                names.append(name)
+            self.assertEqual([item["name"] for item in manifest["artifacts"]], names)
+            for bad in ("ABC", "0" * 63, "g" * 64, ""):
+                with self.assertRaises(RunManifestError):
+                    add_artifact(manifest, name="fresh-" + bad[:1], kind="k", uri="u", sha256=bad)
+
+        run_cases(100, body, label="add_artifact")
+
+
+class SchemaAgreementProperties(unittest.TestCase):
+    """The Python validator and the JSON schema must draw the same boundary."""
+
+    def test_schema_and_validator_share_patterns_and_enums(self) -> None:
+        props = SCHEMA["properties"]
+        self.assertEqual(props["run_id"]["pattern"], rm.SAFE_ID_RE.pattern)
+        self.assertEqual(props["parent_run_id"]["oneOf"][1]["pattern"], rm.SAFE_ID_RE.pattern)
+        self.assertEqual(set(props["run_type"]["enum"]), set(rm.RUN_TYPES))
+        self.assertEqual(set(props["status"]["enum"]), set(rm.RUN_STATUSES))
+        self.assertEqual(props["created_at"]["pattern"], rm.RFC3339_UTC_RE.pattern)
+        self.assertEqual(props["artifacts"]["items"]["properties"]["sha256"]["pattern"], rm.SHA256_RE.pattern)
+        self.assertEqual(set(SCHEMA["required"]), {
+            "schema_version", "run_id", "parent_run_id", "run_type", "workspace_snapshot", "environment", "model",
+            "topology", "command", "environment_variables", "artifacts", "status", "created_at", "updated_at",
+        })
+
+    def test_manifests_generated_here_satisfy_the_schema_shape(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            manifest = valid_manifest(gen)
+            self.assertEqual(set(manifest), set(SCHEMA["required"]))
+            self.assertEqual(manifest["schema_version"], SCHEMA["properties"]["schema_version"]["const"])
+            for item in manifest["artifacts"]:
+                self.assertTrue(set(item) <= set(SCHEMA["properties"]["artifacts"]["items"]["properties"]))
+
+        run_cases(50, body, label="schema shape")
+
+    @unittest.expectedFailure
+    def test_known_defect_validator_accepts_schema_version_true_and_float(self) -> None:
+        """KNOWN DEFECT (low): the schema says ``schema_version: {const: 1}``;
+        JSON Schema distinguishes ``1`` from ``true`` and (for const) from
+        ``1.0``. The Python check ``!= 1`` accepts ``True`` and ``1.0`` and
+        preserves them on write, so a manifest the library calls valid fails
+        external schema validation. Evidence: ``schema_version=True`` validates."""
+        manifest = new_manifest(run_type="debug", created_at="2026-07-25T12:00:00Z")
+        self.assertEqual(SCHEMA["properties"]["schema_version"], {"const": 1})
+        for value in (True, 1.0):
+            with self.subTest(value=value):
+                bad = dict(manifest, schema_version=value)
+                with self.assertRaises(RunManifestError):
+                    validate_manifest(bad)
+
+    @unittest.expectedFailure
+    def test_known_defect_validator_accepts_artifact_shapes_the_schema_forbids(self) -> None:
+        """KNOWN DEFECT (low-medium): artifacts are ``additionalProperties:
+        false`` with ``sha256: {type: string}`` in the schema, but the Python
+        validator neither rejects unknown artifact keys nor ``sha256: null``.
+        Manifests carrying either are accepted, written and re-loaded here yet
+        rejected by any schema-based consumer. Evidence: both validate."""
+        manifest = new_manifest(run_type="debug", created_at="2026-07-25T12:00:00Z")
+        self.assertFalse(SCHEMA["properties"]["artifacts"]["items"]["additionalProperties"])
+        for item in ({"name": "a", "kind": "k", "uri": "u", "extra": 1}, {"name": "a", "kind": "k", "uri": "u", "sha256": None}):
+            with self.subTest(item=item):
+                with self.assertRaises(RunManifestError):
+                    validate_manifest(dict(manifest, artifacts=[item]))
+
+    @unittest.expectedFailure
+    def test_known_defect_free_form_objects_may_validate_but_not_round_trip(self) -> None:
+        """KNOWN DEFECT (low): ``workspace_snapshot``/``environment``/``model``/
+        ``topology`` are only checked to be mappings, so non-JSON-native content
+        (integer keys, NaN, tuples) validates; ``write_manifest`` then coerces
+        keys to strings and emits non-standard ``NaN``, and ``load_manifest``
+        returns something different from what validated.
+        Evidence: ``{1: 'x'}`` loads back as ``{'1': 'x'}``."""
+        manifest = new_manifest(run_type="debug", environment={1: "x"}, created_at="2026-07-25T12:00:00Z")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "m.json"
+            write_manifest(path, manifest)
+            self.assertEqual(load_manifest(path), manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_property_run_manifest.py
+++ b/.agents/tests/test_property_run_manifest.py
@@ -246,7 +246,6 @@ class InvalidManifestProperties(unittest.TestCase):
 
         run_cases(200, body, label="secret env keys")
 
-    @unittest.expectedFailure
     def test_known_defect_common_secret_spellings_pass_the_filter(self) -> None:
         """KNOWN DEFECT (low): the secret-key filter matches PASS/PASSWORD but
         not ``PASSWD``, and matches API_KEY/ACCESS_KEY but not ``PRIVATE_KEY``

--- a/.agents/tests/test_property_run_manifest.py
+++ b/.agents/tests/test_property_run_manifest.py
@@ -305,7 +305,6 @@ class SchemaAgreementProperties(unittest.TestCase):
 
         run_cases(50, body, label="schema shape")
 
-    @unittest.expectedFailure
     def test_known_defect_validator_accepts_schema_version_true_and_float(self) -> None:
         """KNOWN DEFECT (low): the schema says ``schema_version: {const: 1}``;
         JSON Schema distinguishes ``1`` from ``true`` and (for const) from
@@ -320,7 +319,6 @@ class SchemaAgreementProperties(unittest.TestCase):
                 with self.assertRaises(RunManifestError):
                     validate_manifest(bad)
 
-    @unittest.expectedFailure
     def test_known_defect_validator_accepts_artifact_shapes_the_schema_forbids(self) -> None:
         """KNOWN DEFECT (low-medium): artifacts are ``additionalProperties:
         false`` with ``sha256: {type: string}`` in the schema, but the Python
@@ -334,19 +332,19 @@ class SchemaAgreementProperties(unittest.TestCase):
                 with self.assertRaises(RunManifestError):
                     validate_manifest(dict(manifest, artifacts=[item]))
 
-    @unittest.expectedFailure
     def test_known_defect_free_form_objects_may_validate_but_not_round_trip(self) -> None:
-        """KNOWN DEFECT (low): ``workspace_snapshot``/``environment``/``model``/
-        ``topology`` are only checked to be mappings, so non-JSON-native content
-        (integer keys, NaN, tuples) validates; ``write_manifest`` then coerces
-        keys to strings and emits non-standard ``NaN``, and ``load_manifest``
-        returns something different from what validated.
-        Evidence: ``{1: 'x'}`` loads back as ``{'1': 'x'}``."""
-        manifest = new_manifest(run_type="debug", environment={1: "x"}, created_at="2026-07-25T12:00:00Z")
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "m.json"
-            write_manifest(path, manifest)
-            self.assertEqual(load_manifest(path), manifest)
+        """Free-form objects must be JSON-native so write/load round-trips.
+
+        The schema is the contract; the validator is a strict subset. Integer
+        keys, NaN and tuples cannot serialize without coercion, so they are
+        rejected. Evidence input: ``environment={1: 'x'}``.
+        """
+        with self.assertRaises(RunManifestError):
+            new_manifest(
+                run_type="debug",
+                environment={1: "x"},
+                created_at="2026-07-25T12:00:00Z",
+            )
 
 
 if __name__ == "__main__":

--- a/.agents/tests/test_property_session_state.py
+++ b/.agents/tests/test_property_session_state.py
@@ -18,7 +18,8 @@ Properties:
 * a release-timeout cannot unlink a replacement owner's lease;
 * a sidecar open failure releases the process-local gate and does not leak
   an fd; flock and critical-section failures release acquired resources
-  without unlinking a foreign lease;
+  without unlinking a foreign lease; a body exception does not hide an
+  unrelated lease-close I/O error;
 * unsupported flock and a held gate beyond the deadline fail closed;
 * cooperating processes exclude each other, and a crashed process's stale
   lease is recovered after the stale window.
@@ -635,6 +636,47 @@ class FileLockProperties(unittest.TestCase):
         self.assertTrue(body_exc)
         self.assertIsInstance(body_exc[0], RuntimeError)
         self.assertTrue(self.lock.exists(), "fail-closed release must retain the lease")
+        self.assertFalse(state._thread_gate(self.lock).locked())
+
+    def test_body_exception_does_not_suppress_lease_close_error(self) -> None:
+        real_open = os.open
+        real_close = os.close
+        lease_fds: list[int] = []
+
+        def wrapped_open(path: str | bytes | os.PathLike[str], flags: int, *args: Any, **kwargs: Any) -> int:
+            fd = real_open(path, flags, *args, **kwargs)
+            if os.path.normpath(str(path)) == os.path.normpath(str(self.lock)):
+                lease_fds.append(fd)
+            return fd
+
+        def wrapped_close(fd: int) -> None:
+            real_close(fd)
+            if fd in lease_fds:
+                raise OSError(errno.EIO, "injected-lease-close-error")
+
+        with mock.patch.object(os, "open", wrapped_open), mock.patch.object(os, "close", wrapped_close):
+            with self.assertRaises(BaseException) as raised:
+                with file_lock(self.lock, timeout_seconds=0.05, poll_seconds=0.002):
+                    raise ValueError("body-failure")
+
+        chain: list[BaseException] = []
+        current: BaseException | None = raised.exception
+        seen: set[int] = set()
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            chain.append(current)
+            current = current.__cause__ or current.__context__
+        messages = [str(item) for item in chain]
+        notes = [note for item in chain for note in getattr(item, "__notes__", [])]
+        self.assertTrue(
+            any("injected-lease-close-error" in message for message in messages)
+            or any("injected-lease-close-error" in note for note in notes),
+            f"close error missing from {chain!r}",
+        )
+        self.assertTrue(
+            any(isinstance(item, ValueError) and "body-failure" in str(item) for item in chain),
+            f"body error missing from {chain!r}",
+        )
         self.assertFalse(state._thread_gate(self.lock).locked())
 
     def test_unsupported_flock_fails_closed_on_stale_reclaim(self) -> None:

--- a/.agents/tests/test_property_session_state.py
+++ b/.agents/tests/test_property_session_state.py
@@ -13,15 +13,26 @@ Properties:
 * concurrent allocators (real threads, real file lock) never hand out the
   same device twice;
 * the file lock excludes a live holder, recovers a crashed (stale) holder, and
-  never reads a crashed holder's lock as "available" before the stale window.
+  never reads a crashed holder's lock as "available" before the stale window;
+* two stale waiters never overlap after reclaiming under the sidecar gate;
+* a release-timeout cannot unlink a replacement owner's lease;
+* a sidecar open failure releases the process-local gate and does not leak
+  an fd; flock and critical-section failures release acquired resources
+  without unlinking a foreign lease;
+* unsupported flock and a held gate beyond the deadline fail closed;
+* cooperating processes exclude each other, and a crashed process's stale
+  lease is recovered after the stale window.
 
-The stale-lock recovery race is reproduced deterministically with event
-ordering rather than timing and recorded as a known defect.
+Lock races are reproduced with event ordering rather than timing. NFS and
+cross-host locking are out of scope.
 """
 
 from __future__ import annotations
 
+import errno
+import fcntl
 import os
+import subprocess
 import sys
 import tempfile
 import threading
@@ -259,6 +270,10 @@ class FileLockProperties(unittest.TestCase):
         self.addCleanup(self._tmp.cleanup)
         self.lock = Path(self._tmp.name) / "locks" / "leases.lock"
 
+    def _join(self, thread: threading.Thread, timeout: float = 8) -> None:
+        thread.join(timeout)
+        self.assertFalse(thread.is_alive(), f"{thread.name} did not finish within {timeout}s")
+
     def test_live_holder_excludes_others_until_release(self) -> None:
         with file_lock(self.lock, timeout_seconds=1):
             started = time.monotonic()
@@ -362,9 +377,447 @@ class FileLockProperties(unittest.TestCase):
             for thread in threads:
                 thread.start()
             for thread in threads:
-                thread.join()
+                self._join(thread)
         self.assertEqual(max_in_cs, 1, f"critical section overlapped: {holders}")
         self.assertCountEqual(holders, ["waiter-A", "waiter-B"])
+
+    def test_release_timeout_does_not_unlink_replacement_owner(self) -> None:
+        """A release timeout must not delete a replacement owner's lease.
+
+        Event order uses real threads, a real lease, and a real flock sidecar:
+
+        1. A acquires the lease and finishes its critical-section body.
+        2. B holds the guard; A's lease mtime is made stale.
+        3. A's release waits for the guard and times out.
+        4. If A takes an unguarded identity/unlink fallback, pause after the
+           identity snapshot until B holds a new lease (the old race).
+        5. B reclaims the stale lease under the gate, acquires a new lease,
+           and stays in its critical section.
+        6. A must not unlink B's inode.
+        7. C must not enter while B still holds.
+        """
+        a_in_cs = threading.Event()
+        b_holds_guard = threading.Event()
+        a_releasing = threading.Event()
+        a_release_done = threading.Event()
+        b_in_cs = threading.Event()
+        c_finished = threading.Event()
+        errors: list[str] = []
+        a_release_exc: list[BaseException] = []
+        c_entered = False
+        replacement_after_a = False
+        b_saw_lease_in_cs = False
+        real_lock_identity = state._lock_identity
+
+        def wrapped_lock_identity(path: Path) -> tuple[int, int] | None:
+            ident = real_lock_identity(path)
+            if (
+                threading.current_thread().name == "owner-A"
+                and a_releasing.is_set()
+                and not a_release_done.is_set()
+            ):
+                a_release_done.set()
+                b_in_cs.wait(5)
+            return ident
+
+        def owner_a() -> None:
+            nonlocal replacement_after_a
+            try:
+                with file_lock(
+                    self.lock,
+                    timeout_seconds=0.08,
+                    poll_seconds=0.01,
+                    stale_after_seconds=1,
+                ):
+                    a_in_cs.set()
+                    if not b_holds_guard.wait(5):
+                        errors.append("A: B never took the guard")
+                    a_releasing.set()
+            except SessionStateError as exc:
+                a_release_exc.append(exc)
+            except BaseException as exc:
+                errors.append(f"A: unexpected {exc!r}")
+            finally:
+                replacement_after_a = self.lock.exists()
+                a_release_done.set()
+
+        def waiter_b() -> None:
+            nonlocal b_saw_lease_in_cs
+            try:
+                if not a_in_cs.wait(5):
+                    errors.append("B: A never entered")
+                    return
+                with state._reclaim_gate(
+                    self.lock,
+                    deadline=time.monotonic() + 8,
+                    poll_seconds=0.01,
+                ):
+                    b_holds_guard.set()
+                    past = time.time() - 100
+                    os.utime(self.lock, (past, past))
+                    if not a_release_done.wait(5):
+                        errors.append("B: A never finished release")
+                        return
+                    state._reclaim_stale_lock(self.lock, 1)
+                with file_lock(
+                    self.lock,
+                    timeout_seconds=5,
+                    poll_seconds=0.01,
+                    stale_after_seconds=1,
+                ):
+                    b_in_cs.set()
+                    b_saw_lease_in_cs = self.lock.exists()
+                    if not c_finished.wait(5):
+                        errors.append("B: C never finished")
+            except BaseException as exc:
+                errors.append(f"B: {exc!r}")
+
+        def waiter_c() -> None:
+            nonlocal c_entered
+            try:
+                if not b_in_cs.wait(5):
+                    errors.append("C: B never entered")
+                    return
+                try:
+                    with file_lock(
+                        self.lock,
+                        timeout_seconds=0.3,
+                        poll_seconds=0.02,
+                        stale_after_seconds=1,
+                    ):
+                        c_entered = True
+                except SessionStateError:
+                    pass
+            except BaseException as exc:
+                errors.append(f"C: {exc!r}")
+            finally:
+                c_finished.set()
+
+        with mock.patch.object(state, "_lock_identity", wrapped_lock_identity):
+            threads = [
+                threading.Thread(target=owner_a, name="owner-A"),
+                threading.Thread(target=waiter_b, name="waiter-B"),
+                threading.Thread(target=waiter_c, name="waiter-C"),
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                self._join(thread)
+
+        self.assertEqual(errors, [])
+        self.assertTrue(a_release_exc, "A must fail closed on release timeout")
+        self.assertIsInstance(a_release_exc[0], SessionStateError)
+        self.assertIn("timed out", str(a_release_exc[0]))
+        self.assertTrue(replacement_after_a or b_saw_lease_in_cs, "replacement exists after A release")
+        self.assertTrue(b_in_cs.is_set())
+        self.assertTrue(b_saw_lease_in_cs, "B must still hold its lease in the critical section")
+        self.assertFalse(c_entered, "C in critical section while B still holds")
+        self.assertFalse(state._thread_gate(self.lock).locked())
+
+    def test_sidecar_open_failure_releases_thread_gate(self) -> None:
+        self.lock.parent.mkdir(parents=True, exist_ok=True)
+        guard = state._guard_path(self.lock)
+        opened_guard_fds: list[int] = []
+        real_open = os.open
+        real_close = os.close
+        failed_once = False
+
+        def wrapped_open(path: str | bytes | os.PathLike[str], flags: int, *args: Any, **kwargs: Any) -> int:
+            nonlocal failed_once
+            if os.path.normpath(str(path)) == os.path.normpath(str(guard)) and not failed_once:
+                failed_once = True
+                raise OSError(errno.EMFILE, "Too many open files")
+            fd = real_open(path, flags, *args, **kwargs)
+            if os.path.normpath(str(path)) == os.path.normpath(str(guard)):
+                opened_guard_fds.append(fd)
+            return fd
+
+        def wrapped_close(fd: int) -> None:
+            if fd in opened_guard_fds:
+                opened_guard_fds.remove(fd)
+            real_close(fd)
+
+        gate = state._thread_gate(self.lock)
+        with mock.patch.object(os, "open", wrapped_open), mock.patch.object(os, "close", wrapped_close):
+            with self.assertRaises(OSError) as raised:
+                with state._reclaim_gate(
+                    self.lock, deadline=time.monotonic() + 1, poll_seconds=0.01
+                ):
+                    pass
+            self.assertEqual(raised.exception.errno, errno.EMFILE)
+            self.assertTrue(failed_once)
+            self.assertFalse(gate.locked(), "thread_gate_still_locked")
+            self.assertEqual(opened_guard_fds, [])
+            with state._reclaim_gate(
+                self.lock, deadline=time.monotonic() + 1, poll_seconds=0.01
+            ):
+                self.assertTrue(gate.locked())
+            self.assertFalse(gate.locked())
+            self.assertEqual(opened_guard_fds, [])
+
+    def test_flock_error_during_release_keeps_lease_and_closes_fd(self) -> None:
+        closed: list[int] = []
+        lease_fd: dict[str, int] = {}
+        real_open = os.open
+        real_close = os.close
+        real_flock = fcntl.flock
+
+        def wrapped_open(path: str | bytes | os.PathLike[str], flags: int, *args: Any, **kwargs: Any) -> int:
+            fd = real_open(path, flags, *args, **kwargs)
+            if os.path.normpath(str(path)) == os.path.normpath(str(self.lock)):
+                lease_fd["fd"] = fd
+            return fd
+
+        def wrapped_close(fd: int) -> None:
+            closed.append(fd)
+            real_close(fd)
+
+        def wrapped_flock(fd: int, flags: int) -> None:
+            if flags & fcntl.LOCK_EX:
+                raise OSError(errno.EIO, "injected flock failure")
+            real_flock(fd, flags)
+
+        with mock.patch.object(os, "open", wrapped_open), mock.patch.object(os, "close", wrapped_close), mock.patch.object(fcntl, "flock", wrapped_flock):
+            with self.assertRaises(OSError) as raised:
+                with file_lock(self.lock, timeout_seconds=1, poll_seconds=0.01):
+                    self.assertTrue(self.lock.exists())
+            self.assertEqual(raised.exception.errno, errno.EIO)
+        self.assertTrue(self.lock.exists(), "foreign or own lease must not be unlinked without the gate")
+        self.assertIn(lease_fd["fd"], closed)
+        self.assertFalse(state._thread_gate(self.lock).locked())
+
+    def test_body_exception_preserved_when_release_gate_times_out(self) -> None:
+        a_in_cs = threading.Event()
+        b_holds_guard = threading.Event()
+        a_done = threading.Event()
+        errors: list[str] = []
+        body_exc: list[BaseException] = []
+
+        def owner_a() -> None:
+            try:
+                with file_lock(self.lock, timeout_seconds=0.08, poll_seconds=0.01):
+                    a_in_cs.set()
+                    if not b_holds_guard.wait(5):
+                        errors.append("A: B never took the guard")
+                    raise RuntimeError("boom")
+            except RuntimeError as exc:
+                body_exc.append(exc)
+            except SessionStateError as exc:
+                errors.append(f"A: body error hidden by {exc!r}")
+            finally:
+                a_done.set()
+
+        def holder_b() -> None:
+            try:
+                if not a_in_cs.wait(5):
+                    errors.append("B: A never entered")
+                    return
+                with state._reclaim_gate(
+                    self.lock,
+                    deadline=time.monotonic() + 8,
+                    poll_seconds=0.01,
+                ):
+                    b_holds_guard.set()
+                    if not a_done.wait(5):
+                        errors.append("B: A never finished")
+            except BaseException as exc:
+                errors.append(f"B: {exc!r}")
+
+        threads = [
+            threading.Thread(target=owner_a, name="owner-A"),
+            threading.Thread(target=holder_b, name="holder-B"),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            self._join(thread)
+        self.assertEqual(errors, [])
+        self.assertTrue(body_exc)
+        self.assertIsInstance(body_exc[0], RuntimeError)
+        self.assertTrue(self.lock.exists(), "fail-closed release must retain the lease")
+        self.assertFalse(state._thread_gate(self.lock).locked())
+
+    def test_unsupported_flock_fails_closed_on_stale_reclaim(self) -> None:
+        self.lock.parent.mkdir(parents=True, exist_ok=True)
+        self.lock.write_text("{}", encoding="utf-8")
+        past = time.time() - 100
+        os.utime(self.lock, (past, past))
+
+        def unsupported(_fd: int, _flags: int) -> None:
+            raise OSError(errno.ENOTSUP, "Operation not supported")
+
+        with mock.patch.object(fcntl, "flock", unsupported):
+            with self.assertRaisesRegex(SessionStateError, "timed out"):
+                with file_lock(
+                    self.lock,
+                    timeout_seconds=0.2,
+                    poll_seconds=0.02,
+                    stale_after_seconds=1,
+                ):
+                    pass
+        self.assertTrue(self.lock.exists(), "unsupported flock must leave the stale lease in place")
+        self.assertFalse(state._thread_gate(self.lock).locked())
+
+    def test_unsupported_flock_fails_closed_on_release(self) -> None:
+        def unsupported(_fd: int, _flags: int) -> None:
+            raise OSError(errno.ENOTSUP, "Operation not supported")
+
+        with mock.patch.object(fcntl, "flock", unsupported):
+            with self.assertRaisesRegex(SessionStateError, "unsupported"):
+                with file_lock(self.lock, timeout_seconds=1, poll_seconds=0.01):
+                    self.assertTrue(self.lock.exists())
+        self.assertTrue(self.lock.exists(), "release must not unlink without cooperating flock")
+        self.assertFalse(state._thread_gate(self.lock).locked())
+
+    def test_held_gate_beyond_deadline_leaves_stale_lease(self) -> None:
+        self.lock.parent.mkdir(parents=True, exist_ok=True)
+        self.lock.write_text("{}", encoding="utf-8")
+        past = time.time() - 100
+        os.utime(self.lock, (past, past))
+        b_holds_guard = threading.Event()
+        waiter_done = threading.Event()
+        errors: list[str] = []
+        waiter_exc: list[BaseException] = []
+
+        def holder() -> None:
+            try:
+                with state._reclaim_gate(
+                    self.lock,
+                    deadline=time.monotonic() + 8,
+                    poll_seconds=0.01,
+                ):
+                    b_holds_guard.set()
+                    if not waiter_done.wait(5):
+                        errors.append("holder: waiter never finished")
+            except BaseException as exc:
+                errors.append(f"holder: {exc!r}")
+
+        def waiter() -> None:
+            try:
+                if not b_holds_guard.wait(5):
+                    errors.append("waiter: holder never took the gate")
+                    return
+                with file_lock(
+                    self.lock,
+                    timeout_seconds=0.2,
+                    poll_seconds=0.02,
+                    stale_after_seconds=1,
+                ):
+                    errors.append("waiter: acquired under a held gate")
+            except SessionStateError as exc:
+                waiter_exc.append(exc)
+            except BaseException as exc:
+                errors.append(f"waiter: {exc!r}")
+            finally:
+                waiter_done.set()
+
+        threads = [
+            threading.Thread(target=holder, name="gate-holder"),
+            threading.Thread(target=waiter, name="stale-waiter"),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            self._join(thread)
+        self.assertEqual(errors, [])
+        self.assertTrue(waiter_exc)
+        self.assertIn("timed out", str(waiter_exc[0]))
+        self.assertTrue(self.lock.exists())
+        self.assertFalse(state._thread_gate(self.lock).locked())
+
+    def test_cooperating_processes_exclude_each_other(self) -> None:
+        self.lock.parent.mkdir(parents=True, exist_ok=True)
+        ready = Path(self._tmp.name) / "child.ready"
+        release = Path(self._tmp.name) / "child.release"
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                "--hold-lock",
+                str(self.lock),
+                str(ready),
+                str(release),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    out, err = proc.communicate()
+                    self.fail(f"child exited early rc={proc.returncode} stdout={out!r} stderr={err!r}")
+                if ready.exists() and self.lock.exists():
+                    break
+                time.sleep(0.01)
+            else:
+                self.fail("child did not acquire the lease")
+            with self.assertRaisesRegex(SessionStateError, "timed out"):
+                with file_lock(self.lock, timeout_seconds=0.3, poll_seconds=0.02):
+                    pass
+            self.assertTrue(self.lock.exists())
+            release.write_text("1", encoding="utf-8")
+            self.assertEqual(proc.wait(timeout=5), 0)
+            proc.communicate()
+            with file_lock(self.lock, timeout_seconds=1, poll_seconds=0.01):
+                self.assertTrue(self.lock.exists())
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.communicate(timeout=5)
+
+    def test_crashed_process_fresh_lease_excludes_then_stale_recovers(self) -> None:
+        self.lock.parent.mkdir(parents=True, exist_ok=True)
+        ready = Path(self._tmp.name) / "crash.ready"
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                "--crash-hold-lock",
+                str(self.lock),
+                str(ready),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                if ready.exists() and self.lock.exists():
+                    break
+                if proc.poll() is not None and not ready.exists():
+                    out, err = proc.communicate()
+                    self.fail(f"child exited before ready rc={proc.returncode} stdout={out!r} stderr={err!r}")
+                time.sleep(0.01)
+            else:
+                self.fail("child did not create a lease")
+            self.assertEqual(proc.wait(timeout=5), 0)
+            proc.communicate()
+            with self.assertRaisesRegex(SessionStateError, "timed out"):
+                with file_lock(
+                    self.lock,
+                    timeout_seconds=0.15,
+                    poll_seconds=0.02,
+                    stale_after_seconds=60,
+                ):
+                    pass
+            self.assertTrue(self.lock.exists(), "a fresh crashed holder's lock must not be removed")
+            past = time.time() - 100
+            os.utime(self.lock, (past, past))
+            with file_lock(
+                self.lock,
+                timeout_seconds=1,
+                poll_seconds=0.01,
+                stale_after_seconds=1,
+            ):
+                self.assertTrue(self.lock.exists())
+            self.assertFalse(self.lock.exists())
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.communicate(timeout=5)
 
 
 class TokenProperties(unittest.TestCase):
@@ -399,5 +852,24 @@ class TokenProperties(unittest.TestCase):
         run_cases(300, body, label="container names")
 
 
+def _lock_worker(mode: str, lock: Path, ready: Path, release: Path | None) -> None:
+    if mode == "--crash-hold-lock":
+        with file_lock(lock, timeout_seconds=5, poll_seconds=0.01):
+            ready.write_text("1", encoding="utf-8")
+            os._exit(0)
+    with file_lock(lock, timeout_seconds=5, poll_seconds=0.01):
+        ready.write_text("1", encoding="utf-8")
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if release is not None and release.exists():
+                return
+            time.sleep(0.01)
+        raise SystemExit("release signal not seen")
+
+
 if __name__ == "__main__":
+    if len(sys.argv) >= 2 and sys.argv[1] in {"--hold-lock", "--crash-hold-lock"}:
+        release_path = Path(sys.argv[4]) if len(sys.argv) > 4 else None
+        _lock_worker(sys.argv[1], Path(sys.argv[2]), Path(sys.argv[3]), release_path)
+        raise SystemExit(0)
     unittest.main()

--- a/.agents/tests/test_property_session_state.py
+++ b/.agents/tests/test_property_session_state.py
@@ -298,57 +298,73 @@ class FileLockProperties(unittest.TestCase):
                 raise RuntimeError("boom")
         self.assertFalse(self.lock.exists())
 
-    @unittest.expectedFailure
     def test_known_defect_two_waiters_can_both_acquire_after_removing_a_stale_lock(self) -> None:
-        """KNOWN DEFECT (medium): stale-lock recovery is check-then-unlink
-        without atomicity. Interleaving: A and B both stat the stale lock; A
-        unlinks it and creates a fresh lock; B (still acting on its stale
-        verdict) unlinks *A's* fresh lock and creates its own. Both are now
-        inside ``file_lock`` at once, so two ``allocate_session_leases`` calls
-        can hand the same NPU device to two sessions. Requires a crashed
-        holder (>= 6h by default) plus concurrent recovery; consequence is a
-        double lease. Reproduced with event ordering, not timing.
-        Evidence: ``holders == ['A', 'B']`` before either release."""
+        """Two waiters that both judge a lease stale must not overlap.
+
+        The unguarded ``Path.stat`` verdict is still racy; reclaim re-checks
+        inode and mtime under the sidecar gate, so a waiter that saw stale
+        cannot unlink a newer holder's file. Hook ``Path.stat`` (not unlink)
+        so B records a stale reading and waits until A holds; under the old
+        check-then-unlink code both entered the section. NFS / cross-host
+        locking is out of scope.
+        """
         self.lock.parent.mkdir(parents=True, exist_ok=True)
         self.lock.write_text("{}", encoding="utf-8")
         old = time.time() - 7 * 3600
         os.utime(self.lock, (old, old))
-        b_at_unlink = threading.Event()
+        b_judged_stale = threading.Event()
         a_holds = threading.Event()
+        in_cs = 0
+        max_in_cs = 0
+        cs_lock = threading.Lock()
         holders: list[str] = []
-        overlap: list[bool] = []
-        real_unlink = Path.unlink
+        real_stat = Path.stat
+        b_stat_count = 0
+        count_lock = threading.Lock()
 
-        # Patch the pathlib method (not os.unlink) so the hook works on every
-        # Python version; before 3.11 pathlib bound os.unlink at import time.
-        def patched_unlink(path: Path, *args: Any, **kwargs: Any) -> None:
-            if str(path) == str(self.lock):
-                name = threading.current_thread().name
-                if name == "waiter-B":
-                    b_at_unlink.set()
+        def patched_stat(path: Path, *args: Any, **kwargs: Any) -> os.stat_result:
+            nonlocal b_stat_count
+            result = real_stat(path, *args, **kwargs)
+            if str(path) != str(self.lock):
+                return result
+            name = threading.current_thread().name
+            if name == "waiter-B":
+                with count_lock:
+                    b_stat_count += 1
+                    first = b_stat_count == 1
+                if first:
+                    b_judged_stale.set()
                     a_holds.wait(5)
-                elif name == "waiter-A":
-                    b_at_unlink.wait(5)
-            return real_unlink(path, *args, **kwargs)
+            elif name == "waiter-A":
+                b_judged_stale.wait(5)
+            return result
 
         def worker(name: str) -> None:
+            nonlocal in_cs, max_in_cs
             with file_lock(self.lock, timeout_seconds=5, poll_seconds=0.01):
-                holders.append(name)
+                with cs_lock:
+                    in_cs += 1
+                    max_in_cs = max(max_in_cs, in_cs)
+                    holders.append(name)
                 if name == "waiter-A":
                     a_holds.set()
-                    time.sleep(0.3)
-                    overlap.append("waiter-B" in holders)
+                    time.sleep(0.2)
                 else:
-                    time.sleep(0.1)
+                    time.sleep(0.05)
+                with cs_lock:
+                    in_cs -= 1
 
-        with mock.patch.object(Path, "unlink", patched_unlink):
-            threads = [threading.Thread(target=worker, args=(n,), name=n) for n in ("waiter-A", "waiter-B")]
+        with mock.patch.object(Path, "stat", patched_stat):
+            threads = [
+                threading.Thread(target=worker, args=(n,), name=n)
+                for n in ("waiter-A", "waiter-B")
+            ]
             for thread in threads:
                 thread.start()
             for thread in threads:
                 thread.join()
-        self.assertEqual(holders, ["waiter-A", "waiter-B"])
-        self.assertEqual(overlap, [False], "B entered the critical section while A still held the lock")
+        self.assertEqual(max_in_cs, 1, f"critical section overlapped: {holders}")
+        self.assertCountEqual(holders, ["waiter-A", "waiter-B"])
 
 
 class TokenProperties(unittest.TestCase):

--- a/.agents/tests/test_property_session_state.py
+++ b/.agents/tests/test_property_session_state.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Property tests for session identity, leases and locks.
+
+Modules: ``.agents/lib/vaws_session_id.py`` and ``vaws_session_state.py``.
+
+Properties:
+
+* ``normalize_session_id`` is total, idempotent, deterministic, bounded and
+  keeps distinct long inputs distinct;
+* lease allocation agrees with a reference model over random operation
+  sequences: no NPU device or port is ever owned by two sessions, releases
+  only affect the caller's resources, and live leases equal the model;
+* concurrent allocators (real threads, real file lock) never hand out the
+  same device twice;
+* the file lock excludes a live holder, recovers a crashed (stale) holder, and
+  never reads a crashed holder's lock as "available" before the stale window.
+
+The stale-lock recovery race is reproduced deterministically with event
+ordering rather than timing and recorded as a known defect.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+import vaws_session_state as state  # noqa: E402
+from vaws_session_id import derive_from_branch, normalize_session_id  # noqa: E402
+from vaws_session_state import SessionStateError, allocate_service_port, allocate_session_leases, file_lock, parse_port_range, release_all_session_leases, release_service_port, safe_token, session_container_name, session_live_leases  # noqa: E402
+from vaws_validate import ValidationError  # noqa: E402
+from test_property_support import MULTIBYTE, Gen, run_cases  # noqa: E402
+
+ID_CHARS = "abcXYZ019._-/ \t:@#" + MULTIBYTE
+VALID_SHAPE = r"^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]{3}$"
+
+
+class NormalizeSessionIdProperties(unittest.TestCase):
+    def test_output_is_none_or_a_bounded_canonical_id(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            raw = gen.one_of(
+                lambda: gen.text(ID_CHARS, 0, 30),
+                lambda: gen.text(ID_CHARS, 60, 200),
+                lambda: gen.choice(("", "..", "---", "a", "ab", "abc", "A-B_C.d", "  x y z  ", "pr/12", "\u0130stanbul", "\u212aelvin")),
+            )
+            result = normalize_session_id(raw)
+            if result is None:
+                return
+            self.assertTrue(3 <= len(result) <= 64, result)
+            self.assertRegex(result, r"^[a-z0-9._-]+$")
+            self.assertNotIn(result[0], ".-_")
+            self.assertNotIn(result[-1], ".-_")
+            self.assertNotIn("--", result)
+            self.assertEqual(normalize_session_id(result), result, "normalization must be idempotent")
+            self.assertEqual(normalize_session_id(raw), result, "normalization must be deterministic")
+            self.assertTrue(result.isascii())
+
+        run_cases(1500, body, label="normalize_session_id")
+
+    def test_canonical_ids_are_fixed_points(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            middle = gen.text("abcxyz019._-", 1, 62).replace("--", "-x")
+            value = gen.text("abcxyz019", 1, 1) + middle + gen.text("abcxyz019", 1, 1)
+            self.assertEqual(normalize_session_id(value), value)
+
+        run_cases(400, body, label="fixed points")
+
+    def test_long_inputs_that_share_a_prefix_stay_distinct(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            prefix = gen.text("abcxyz019", 70, 90)
+            a = normalize_session_id(prefix + gen.text("abc", 1, 4))
+            b = normalize_session_id(prefix + gen.text("xyz", 1, 4))
+            self.assertIsNotNone(a)
+            self.assertIsNotNone(b)
+            self.assertNotEqual(a, b)
+            self.assertLessEqual(len(a or ""), 64)
+
+        run_cases(200, body, label="long id distinctness")
+
+    def test_branch_derivation_yields_only_canonical_ids(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            tail = gen.text(ID_CHARS, 0, 40)
+            branch = gen.choice((f"session/{tail}", f"task/{tail}", f"pr/{tail}", f"feature/{tail}", tail, None))
+            derived = derive_from_branch(branch)
+            if derived is None:
+                self.assertTrue(branch is None or not branch.startswith(("session/", "task/", "pr/")) or normalize_session_id(branch.split("/", 1)[1]) is None or (branch.startswith("pr/")))
+                return
+            self.assertEqual(normalize_session_id(derived), derived)
+            if branch and branch.startswith("pr/"):
+                self.assertTrue(derived.startswith("pr-"))
+
+        run_cases(400, body, label="derive_from_branch")
+
+
+class LeaseModel:
+    """Reference model: resource -> owning session, per machine."""
+
+    def __init__(self) -> None:
+        self.devices: dict[int, str] = {}
+        self.ssh_ports: dict[int, str] = {}
+        self.service_ports: dict[int, str] = {}
+
+    def live(self, sid: str) -> dict[str, list[int]]:
+        return {
+            "npu_devices": sorted(d for d, o in self.devices.items() if o == sid),
+            "container_ssh_ports": sorted(p for p, o in self.ssh_ports.items() if o == sid),
+            "service_ports": sorted(p for p, o in self.service_ports.items() if o == sid),
+        }
+
+
+class LeaseModelProperties(unittest.TestCase):
+    SESSIONS = ("sess-a", "sess-b", "sess-c")
+    AVAILABLE = [0, 1, 2, 3]
+    SSH_RANGE = "46000:46003"
+    SERVICE_RANGE = "30000:30003"
+
+    def test_random_operation_sequences_agree_with_the_model(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                repo = Path(tmp)
+                model = LeaseModel()
+                for _step in range(gen.integer(3, 10)):
+                    sid = gen.choice(self.SESSIONS)
+                    op = gen.choice(("alloc-devices", "alloc-count", "alloc-service", "release-service", "release-all"))
+                    if op == "alloc-devices":
+                        requested = sorted(gen.sample(self.AVAILABLE, gen.integer(1, 3)))
+                        conflict = [d for d in requested if model.devices.get(d, sid) != sid]
+                        port_taken_by_other = [p for p in range(46000, 46004) if model.ssh_ports.get(p, sid) != sid]
+                        free_port_exists = any(model.ssh_ports.get(p, sid) == sid for p in range(46000, 46004))
+                        try:
+                            result = allocate_session_leases(repo_root=repo, machine_alias="m", session_id=sid, requested_devices=requested, available_devices=self.AVAILABLE, container_ssh_port_range=self.SSH_RANGE, port_available=lambda _p: True)
+                        except SessionStateError as exc:
+                            self.assertTrue(conflict or not free_port_exists, f"allocation rejected without a modelled conflict: {exc}")
+                            if conflict:
+                                self.assertIn("already leased", str(exc))
+                            continue
+                        self.assertEqual(conflict, [], "allocation succeeded despite a device owned by another session")
+                        self.assertEqual(result["npu_devices"], requested)
+                        for d in requested:
+                            model.devices[d] = sid
+                        port = result["container_ssh_port"]
+                        self.assertIn(port, range(46000, 46004))
+                        self.assertNotIn(port, port_taken_by_other)
+                        model.ssh_ports[port] = sid
+                    elif op == "alloc-count":
+                        count = gen.integer(1, 3)
+                        free = [d for d in self.AVAILABLE if model.devices.get(d, sid) == sid]
+                        free_port_exists = any(model.ssh_ports.get(p, sid) == sid for p in range(46000, 46004))
+                        try:
+                            result = allocate_session_leases(repo_root=repo, machine_alias="m", session_id=sid, npu_count=count, available_devices=self.AVAILABLE, container_ssh_port_range=self.SSH_RANGE, port_available=lambda _p: True)
+                        except SessionStateError:
+                            self.assertTrue(len(free) < count or not free_port_exists)
+                            continue
+                        self.assertGreaterEqual(len(free), count)
+                        self.assertEqual(result["npu_devices"], free[:count])
+                        for d in result["npu_devices"]:
+                            model.devices[d] = sid
+                        model.ssh_ports[result["container_ssh_port"]] = sid
+                    elif op == "alloc-service":
+                        requested_port = gen.choice((None, gen.integer(30000, 30003), 29999))
+                        try:
+                            port = allocate_service_port(repo_root=repo, machine_alias="m", session_id=sid, requested_port=requested_port, serving_port_range=self.SERVICE_RANGE, port_available=lambda _p: True)
+                        except SessionStateError:
+                            if requested_port is None:
+                                self.assertFalse(any(model.service_ports.get(p, sid) == sid for p in range(30000, 30004)))
+                            else:
+                                self.assertTrue(requested_port == 29999 or model.service_ports.get(requested_port, sid) != sid)
+                            continue
+                        self.assertIn(port, range(30000, 30004))
+                        self.assertEqual(model.service_ports.get(port, sid), sid, "service port handed out while owned by another session")
+                        if requested_port is not None:
+                            self.assertEqual(port, requested_port)
+                        model.service_ports[port] = sid
+                    elif op == "release-service":
+                        port = gen.choice((30000, 30001, 30002, 30003, None))
+                        release_service_port(repo_root=repo, machine_alias="m", session_id=sid, port=port)
+                        if port is not None and model.service_ports.get(port) == sid:
+                            del model.service_ports[port]
+                    else:
+                        release_all_session_leases(repo_root=repo, session_id=sid)
+                        for table in (model.devices, model.ssh_ports, model.service_ports):
+                            for key in [k for k, o in table.items() if o == sid]:
+                                del table[key]
+                    for other in self.SESSIONS:
+                        self.assertEqual(session_live_leases(repo_root=repo, machine_alias="m", session_id=other), model.live(other), f"live leases for {other} diverge from the model")
+                # Global invariant: no resource has two owners.
+                seen: dict[tuple[str, int], str] = {}
+                for other in self.SESSIONS:
+                    for kind, values in session_live_leases(repo_root=repo, machine_alias="m", session_id=other).items():
+                        for value in values:
+                            self.assertNotIn((kind, value), seen, f"{kind} {value} owned by {seen.get((kind, value))} and {other}")
+                            seen[(kind, value)] = other
+
+        run_cases(120, body, label="lease model")
+
+    def test_invalid_requests_are_rejected_before_touching_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            with self.assertRaises(SessionStateError):
+                allocate_session_leases(repo_root=repo, machine_alias="m", session_id="sess-a", requested_devices=[0], npu_count=1, available_devices=[0])
+            with self.assertRaises(SessionStateError):
+                allocate_session_leases(repo_root=repo, machine_alias="m", session_id="sess-a", npu_count=1, available_devices=None)
+            with self.assertRaises((SessionStateError, ValidationError)):
+                allocate_session_leases(repo_root=repo, machine_alias="m", session_id="sess-a", requested_devices=[-1], available_devices=[0])
+            with self.assertRaises(SessionStateError):
+                allocate_session_leases(repo_root=repo, machine_alias="m", session_id="!!", requested_devices=[0], available_devices=[0])
+            self.assertFalse((repo / ".vaws-local" / "sessions" / "leases.json").exists(), "rejected requests must not create lease state")
+
+
+class ConcurrentAllocationProperties(unittest.TestCase):
+    def test_threads_never_receive_the_same_device(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                repo = Path(tmp)
+                devices = list(range(gen.integer(1, 4)))
+                sessions = [f"sess-{i}" for i in range(len(devices) + gen.integer(1, 2))]
+                results: dict[str, Any] = {}
+
+                def worker(sid: str) -> None:
+                    try:
+                        results[sid] = allocate_session_leases(repo_root=repo, machine_alias="m", session_id=sid, npu_count=1, available_devices=devices, port_available=lambda _p: True)
+                    except SessionStateError as exc:
+                        results[sid] = exc
+
+                threads = [threading.Thread(target=worker, args=(sid,)) for sid in sessions]
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join()
+                winners = {sid: r for sid, r in results.items() if isinstance(r, dict)}
+                losers = {sid: r for sid, r in results.items() if not isinstance(r, dict)}
+                self.assertEqual(len(winners), len(devices), f"exactly one winner per device expected: {results}")
+                self.assertEqual(len(losers), len(sessions) - len(devices))
+                allocated = sorted(d for r in winners.values() for d in r["npu_devices"])
+                self.assertEqual(allocated, devices, "every device handed out exactly once")
+                ports = [r["container_ssh_port"] for r in winners.values()]
+                self.assertEqual(len(set(ports)), len(ports), "ssh ports must be unique")
+                for sid in winners:
+                    self.assertEqual(session_live_leases(repo_root=repo, machine_alias="m", session_id=sid)["npu_devices"], winners[sid]["npu_devices"])
+                self.assertFalse(list((repo / ".vaws-local" / "sessions" / "locks").glob("*.lock")), "no lock left behind")
+
+        run_cases(6, body, label="concurrent allocation")
+
+
+class FileLockProperties(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.lock = Path(self._tmp.name) / "locks" / "leases.lock"
+
+    def test_live_holder_excludes_others_until_release(self) -> None:
+        with file_lock(self.lock, timeout_seconds=1):
+            started = time.monotonic()
+            with self.assertRaisesRegex(SessionStateError, "timed out"):
+                with file_lock(self.lock, timeout_seconds=0.3, poll_seconds=0.02):
+                    pass
+            self.assertGreaterEqual(time.monotonic() - started, 0.25)
+            self.assertTrue(self.lock.exists())
+        self.assertFalse(self.lock.exists(), "lock must be released on exit")
+        with file_lock(self.lock, timeout_seconds=1):
+            pass
+
+    def test_crashed_holder_is_unavailable_before_and_recovered_after_the_stale_window(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            self.lock.parent.mkdir(parents=True, exist_ok=True)
+            self.lock.write_text('{"pid": 999999, "hostname": "example.invalid"}', encoding="utf-8")
+            stale_after = gen.integer(2, 3600)
+            age = gen.integer(0, 2 * stale_after)
+            past = time.time() - age
+            os.utime(self.lock, (past, past))
+            if age >= stale_after:
+                with file_lock(self.lock, timeout_seconds=0.2, poll_seconds=0.01, stale_after_seconds=stale_after):
+                    self.assertTrue(self.lock.exists())
+                self.assertFalse(self.lock.exists())
+            else:
+                with self.assertRaisesRegex(SessionStateError, "timed out"):
+                    with file_lock(self.lock, timeout_seconds=0.05, poll_seconds=0.01, stale_after_seconds=stale_after):
+                        pass
+                self.assertTrue(self.lock.exists(), "a fresh crashed holder's lock must not be removed")
+                self.lock.unlink()
+
+        run_cases(40, body, label="stale lock window")
+
+    def test_exception_inside_the_critical_section_releases_the_lock(self) -> None:
+        with self.assertRaises(RuntimeError):
+            with file_lock(self.lock, timeout_seconds=1):
+                raise RuntimeError("boom")
+        self.assertFalse(self.lock.exists())
+
+    @unittest.expectedFailure
+    def test_known_defect_two_waiters_can_both_acquire_after_removing_a_stale_lock(self) -> None:
+        """KNOWN DEFECT (medium): stale-lock recovery is check-then-unlink
+        without atomicity. Interleaving: A and B both stat the stale lock; A
+        unlinks it and creates a fresh lock; B (still acting on its stale
+        verdict) unlinks *A's* fresh lock and creates its own. Both are now
+        inside ``file_lock`` at once, so two ``allocate_session_leases`` calls
+        can hand the same NPU device to two sessions. Requires a crashed
+        holder (>= 6h by default) plus concurrent recovery; consequence is a
+        double lease. Reproduced with event ordering, not timing.
+        Evidence: ``holders == ['A', 'B']`` before either release."""
+        self.lock.parent.mkdir(parents=True, exist_ok=True)
+        self.lock.write_text("{}", encoding="utf-8")
+        old = time.time() - 7 * 3600
+        os.utime(self.lock, (old, old))
+        b_at_unlink = threading.Event()
+        a_holds = threading.Event()
+        holders: list[str] = []
+        overlap: list[bool] = []
+        real_unlink = Path.unlink
+
+        # Patch the pathlib method (not os.unlink) so the hook works on every
+        # Python version; before 3.11 pathlib bound os.unlink at import time.
+        def patched_unlink(path: Path, *args: Any, **kwargs: Any) -> None:
+            if str(path) == str(self.lock):
+                name = threading.current_thread().name
+                if name == "waiter-B":
+                    b_at_unlink.set()
+                    a_holds.wait(5)
+                elif name == "waiter-A":
+                    b_at_unlink.wait(5)
+            return real_unlink(path, *args, **kwargs)
+
+        def worker(name: str) -> None:
+            with file_lock(self.lock, timeout_seconds=5, poll_seconds=0.01):
+                holders.append(name)
+                if name == "waiter-A":
+                    a_holds.set()
+                    time.sleep(0.3)
+                    overlap.append("waiter-B" in holders)
+                else:
+                    time.sleep(0.1)
+
+        with mock.patch.object(Path, "unlink", patched_unlink):
+            threads = [threading.Thread(target=worker, args=(n,), name=n) for n in ("waiter-A", "waiter-B")]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+        self.assertEqual(holders, ["waiter-A", "waiter-B"])
+        self.assertEqual(overlap, [False], "B entered the critical section while A still held the lock")
+
+
+class TokenProperties(unittest.TestCase):
+    def test_port_range_parsing_boundary(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            start = gen.integer(-5, 70000)
+            end = gen.integer(-5, 70000)
+            value = f"{start}:{end}"
+            valid = 0 < start <= end <= 65535
+            if valid:
+                self.assertEqual(parse_port_range(value), (start, end))
+            else:
+                with self.assertRaises(SessionStateError):
+                    parse_port_range(value)
+            with self.assertRaises((SessionStateError, ValueError)):
+                parse_port_range(gen.choice((f"{start}", f"{start}-{end}", "", "a:b", f"{start}:{end}:1")))
+
+        run_cases(300, body, label="parse_port_range")
+
+    def test_container_names_are_docker_safe_and_bounded(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            namespace = gen.choice((None, gen.text(ID_CHARS, 0, 40)))
+            sid = normalize_session_id(gen.text(ID_CHARS, 3, 90)) or "sess-fallback"
+            name = session_container_name(namespace, sid)
+            self.assertLessEqual(len(name), 63)
+            self.assertRegex(name, r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+            self.assertTrue(name.startswith("vaws-"))
+            self.assertEqual(session_container_name(namespace, sid), name)
+            token = safe_token(gen.text(ID_CHARS, 0, 120), max_len=gen.integer(1, 63))
+            self.assertRegex(token, r"^[A-Za-z0-9_.-]+$")
+
+        run_cases(300, body, label="container names")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_property_support.py
+++ b/.agents/tests/test_property_support.py
@@ -1,0 +1,229 @@
+"""Seeded, dependency-free support for the ``test_property_*`` suites.
+
+This file intentionally duplicates (apart from this note)
+``.remote-dev/tests/test_property_support.py``: the two test trees are
+discovered independently and ``.remote-dev`` is being extracted into its own
+repository, so neither tree may import from the other. Keep both in sync.
+
+``hypothesis`` is deliberately not a dependency of this repository, so the
+property suites use this small generator instead. Two rules make failures
+reproducible:
+
+* Every case derives its own ``random.Random`` seed from the suite seed and
+  the case index, so a failing case can be re-run in isolation.
+* The suite seed and the case-count scale are read from the environment
+  (``VAWS_PROPTEST_SEED``, ``VAWS_PROPTEST_SCALE``) and printed in every
+  failure message.
+
+The module also carries a self-test so that a regression in the generator
+itself is caught by the same ``unittest discover`` invocation.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import json
+import os
+import random
+import sys
+import unittest
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+DEFAULT_SEED = 20260907
+SEED = int(os.environ.get("VAWS_PROPTEST_SEED", str(DEFAULT_SEED)))
+SCALE = float(os.environ.get("VAWS_PROPTEST_SCALE", "1"))
+
+# Reserved documentation values only (RFC 5737 / RFC 2606); never real hosts.
+DOC_HOSTS = ("192.0.2.10", "198.51.100.7", "203.0.113.5", "npu-a.example.invalid")
+
+ASCII_WORD = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+ASCII_PUNCT = "!\"#$%&'()*+,-./:;<=>?@[\\]^`{|}~ "
+# Characters that ``str.splitlines`` treats as line boundaries besides ``\n``.
+SPLITLINES_EXTRA = "\r\x0b\x0c\x1c\x1d\x1e\x85\u2028\u2029"
+MULTIBYTE = "é漢字🙂\u0301\u200d"
+
+
+def case_count(base: int) -> int:
+    return max(1, int(round(base * SCALE)))
+
+
+class Gen:
+    """Thin wrapper over ``random.Random`` with generators used by the suites."""
+
+    def __init__(self, seed: int) -> None:
+        self.seed = seed
+        self.rng = random.Random(seed)
+
+    def integer(self, low: int, high: int) -> int:
+        return self.rng.randint(low, high)
+
+    def boolean(self, probability: float = 0.5) -> bool:
+        return self.rng.random() < probability
+
+    def choice(self, values: Sequence[Any]) -> Any:
+        return self.rng.choice(list(values))
+
+    def sample(self, values: Sequence[Any], k: int) -> list[Any]:
+        return self.rng.sample(list(values), k)
+
+    def shuffled(self, values: Sequence[Any]) -> list[Any]:
+        items = list(values)
+        self.rng.shuffle(items)
+        return items
+
+    def subset(self, values: Sequence[Any]) -> list[Any]:
+        return [item for item in values if self.boolean()]
+
+    def text(self, alphabet: str, min_len: int, max_len: int) -> str:
+        length = self.integer(min_len, max_len)
+        return "".join(self.rng.choice(alphabet) for _ in range(length))
+
+    def word(self, min_len: int = 1, max_len: int = 8) -> str:
+        return self.text(ASCII_WORD, min_len, max_len)
+
+    def lines(self, count: int, *, alphabet: str = ASCII_WORD + " ", max_len: int = 12) -> list[str]:
+        return [self.text(alphabet, 0, max_len) + "\n" for _ in range(count)]
+
+    def raw_bytes(self, min_len: int, max_len: int) -> bytes:
+        return self.rng.randbytes(self.integer(min_len, max_len))
+
+    def one_of(self, *makers: Callable[[], Any]) -> Any:
+        return self.rng.choice(makers)()
+
+    def json_scalar(self) -> Any:
+        return self.one_of(
+            lambda: self.word(0, 6),
+            lambda: self.integer(-1000, 1000),
+            lambda: self.boolean(),
+            lambda: None,
+        )
+
+    def json_object(self, depth: int = 2, max_keys: int = 4) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for _ in range(self.integer(0, max_keys)):
+            key = self.word(1, 6)
+            if depth > 0 and self.boolean(0.3):
+                result[key] = self.json_object(depth - 1, max_keys)
+            elif depth > 0 and self.boolean(0.2):
+                result[key] = [self.json_scalar() for _ in range(self.integer(0, 3))]
+            else:
+                result[key] = self.json_scalar()
+        return result
+
+
+def case_seed(index: int, *, seed: int = SEED) -> int:
+    digest = hashlib.sha256(f"{seed}:{index}".encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big")
+
+
+def run_cases(
+    count: int,
+    body: Callable[[Gen, int], None],
+    *,
+    seed: int = SEED,
+    label: str = "property",
+) -> int:
+    """Run ``body(gen, index)`` for ``case_count(count)`` seeded cases.
+
+    Failures are re-raised with the suite seed and the per-case seed so the
+    exact case can be reproduced with ``VAWS_PROPTEST_SEED``.
+    """
+    total = case_count(count)
+    for index in range(total):
+        current = case_seed(index, seed=seed)
+        try:
+            body(Gen(current), index)
+        except Exception as exc:  # noqa: BLE001 - re-raise with reproduction info
+            raise AssertionError(
+                f"{label}: case #{index}/{total} failed "
+                f"(VAWS_PROPTEST_SEED={seed}, case_seed={current}): "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+    return total
+
+
+def run_remote_script(code: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Execute one of the remote-side executor scripts in-process.
+
+    The ``REMOTE_*_PY`` scripts read a JSON payload from stdin, print one JSON
+    object and exit via ``SystemExit(0)``. Running them in-process (instead of
+    through ``python3 -c``) keeps property suites fast while exercising the
+    exact code that runs on the remote host.
+    """
+    stdout = io.StringIO()
+    stdin = io.StringIO(json.dumps(payload))
+    namespace: dict[str, Any] = {"__name__": "__remote_dev_script__"}
+    original_stdin = sys.stdin
+    sys.stdin = stdin
+    try:
+        with contextlib.redirect_stdout(stdout):
+            try:
+                exec(compile(code, "<remote-dev-script>", "exec"), namespace)
+            except SystemExit as exc:
+                if exc.code not in (0, None):
+                    raise AssertionError(f"remote script exited with {exc.code}: {stdout.getvalue()}") from exc
+    finally:
+        sys.stdin = original_stdin
+    lines = stdout.getvalue().strip().splitlines()
+    if not lines:
+        raise AssertionError("remote script produced no output")
+    data = json.loads(lines[-1])
+    if not isinstance(data, dict):
+        raise AssertionError(f"remote script returned non-object: {data!r}")
+    return data
+
+
+def snapshot_tree(root: Path) -> dict[str, tuple[str, Any]]:
+    """Return ``{relpath: (kind, payload)}`` for every entry below ``root``.
+
+    Symlinks are recorded by their target, files by their bytes, directories by
+    a marker, so two snapshots compare equal only when the trees are identical.
+    """
+    result: dict[str, tuple[str, Any]] = {}
+    for path in sorted(root.rglob("*")):
+        rel = str(path.relative_to(root))
+        if path.is_symlink():
+            result[rel] = ("symlink", os.readlink(path))
+        elif path.is_dir():
+            result[rel] = ("dir", None)
+        elif path.is_file():
+            result[rel] = ("file", path.read_bytes())
+        else:
+            result[rel] = ("other", None)
+    return result
+
+
+class GeneratorSelfTests(unittest.TestCase):
+    def test_case_seed_is_deterministic_and_distinct_per_index(self) -> None:
+        seeds = [case_seed(i, seed=123) for i in range(50)]
+        self.assertEqual(seeds, [case_seed(i, seed=123) for i in range(50)])
+        self.assertEqual(len(set(seeds)), 50)
+        self.assertNotEqual(case_seed(0, seed=1), case_seed(0, seed=2))
+
+    def test_same_seed_replays_same_values(self) -> None:
+        first = Gen(7)
+        second = Gen(7)
+        for _ in range(20):
+            self.assertEqual(first.text(ASCII_WORD, 0, 10), second.text(ASCII_WORD, 0, 10))
+            self.assertEqual(first.integer(0, 1000), second.integer(0, 1000))
+            self.assertEqual(first.json_object(), second.json_object())
+
+    def test_run_cases_reports_seed_in_failure(self) -> None:
+        def body(gen: Gen, index: int) -> None:
+            if index == 3:
+                raise AssertionError("boom")
+
+        with self.assertRaisesRegex(AssertionError, r"case #3/.*VAWS_PROPTEST_SEED=99.*case_seed=\d+.*boom"):
+            run_cases(10, body, seed=99, label="self-test")
+
+    def test_run_remote_script_round_trips_json(self) -> None:
+        code = "import json, sys\npayload = json.loads(sys.stdin.read())\nprint(json.dumps({'echo': payload}))\nraise SystemExit(0)\n"
+        self.assertEqual(run_remote_script(code, {"k": "v"}), {"echo": {"k": "v"}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_property_validate.py
+++ b/.agents/tests/test_property_validate.py
@@ -162,7 +162,6 @@ class DeviceCsvProperties(unittest.TestCase):
 
         run_cases(1200, body, label="parse_device_csv")
 
-    @unittest.expectedFailure
     def test_known_defect_int_parsing_accepts_more_than_decimal_ascii_digits(self) -> None:
         """KNOWN DEFECT (low): tokens are parsed with ``int(token, 10)``, which
         also accepts a leading ``+``, digit-group underscores (``1_0`` -> 10)

--- a/.agents/tests/test_property_validate.py
+++ b/.agents/tests/test_property_validate.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Property tests for the shared validators (``.agents/lib/vaws_validate.py``).
+
+Property: the accept/reject boundary is exactly where the docstrings and
+error messages say it is. Each validator is compared against an independent
+reference predicate over generated inputs that include the shapes an injection
+would take (path separators, traversal, whitespace, shell metacharacters,
+NUL, newlines, Unicode look-alikes, full-width and non-ASCII digits).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_validate import ValidationError, ensure_child_path, parse_device_csv, require_env_name, require_remote_leaf, require_safe_id  # noqa: E402
+from test_property_support import MULTIBYTE, Gen, run_cases  # noqa: E402
+
+ASCII_ALNUM = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+SAFE_ID_EXTRA = "_.-"
+HOSTILE = "/\\ \t\n\r\x00;$`'\"|&<>*?~()[]{}!#%^=+,:@" + MULTIBYTE + "\u0661\uff11\u212a\u0130\u00df"
+UNICODE_DIGITS = "\u0660\u0661\u0662\u06f1\u0967\uff10\uff11\uff12\u0be7"
+
+
+def reference_safe_id(value: object) -> bool:
+    if not isinstance(value, str) or not 3 <= len(value) <= 64:
+        return False
+    if value[0] not in ASCII_ALNUM:
+        return False
+    return all(ch in ASCII_ALNUM or ch in SAFE_ID_EXTRA for ch in value[1:])
+
+
+def reference_env_name(value: object) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    if value[0] not in ASCII_ALNUM[:52] + "_":
+        return False
+    return all(ch in ASCII_ALNUM or ch == "_" for ch in value)
+
+
+def reference_devices(value: object) -> list[int] | None | str:
+    """Return the parsed list, None for None, or the string 'reject'."""
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        return "reject"
+    seen: set[int] = set()
+    for token in value.split(","):
+        token = token.strip()
+        if not token or not all(ch in "0123456789" for ch in token):
+            return "reject"
+        device = int(token)
+        if device in seen:
+            return "reject"
+        seen.add(device)
+    return sorted(seen)
+
+
+def hostile_string(gen: Gen) -> str:
+    return gen.one_of(
+        lambda: gen.text(ASCII_ALNUM + SAFE_ID_EXTRA, 0, 70),
+        lambda: gen.text(ASCII_ALNUM + SAFE_ID_EXTRA + HOSTILE, 0, 70),
+        lambda: gen.text(ASCII_ALNUM, 1, 5) + gen.choice(HOSTILE) + gen.text(ASCII_ALNUM, 0, 5),
+        lambda: gen.choice(("", "..", ".", "...", "a/b", "../x", "/tmp/x", "a b", "abc\n", "abc\x00", "a" * 64, "a" * 65, "-abc", "_abc", ".abc", "ab", "abc")),
+    )
+
+
+class SafeIdProperties(unittest.TestCase):
+    def test_safe_id_boundary_matches_reference(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            value = hostile_string(gen)
+            expected = reference_safe_id(value)
+            try:
+                result = require_safe_id(value, label="job id")
+            except ValidationError as exc:
+                self.assertFalse(expected, f"reference accepts {value!r} but validator rejected")
+                self.assertIn("job id", str(exc))
+                return
+            self.assertTrue(expected, f"validator accepted {value!r} but reference rejects")
+            self.assertEqual(result, value, "accepted ids are returned unchanged, never normalized")
+
+        run_cases(1500, body, label="require_safe_id")
+
+    def test_safe_ids_are_single_path_segments_without_traversal(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            value = hostile_string(gen)
+            try:
+                require_safe_id(value)
+            except ValidationError:
+                return
+            self.assertNotIn("/", value)
+            self.assertNotIn("\\", value)
+            self.assertNotIn("\x00", value)
+            self.assertNotIn(value, {".", ".."})
+            self.assertEqual(require_remote_leaf(value), value, "every safe id is a valid remote leaf")
+            self.assertEqual(Path("/state") / value, Path("/state", value))
+            self.assertEqual((Path("/state") / value).parent, Path("/state"))
+
+        run_cases(800, body, label="safe id as path segment")
+
+    def test_non_string_inputs_are_rejected(self) -> None:
+        for value in (None, 123, b"abc", ["abc"], {"a": 1}, 3.5):
+            with self.subTest(value=value):
+                with self.assertRaises(ValidationError):
+                    require_safe_id(value)  # type: ignore[arg-type]
+                with self.assertRaises(ValidationError):
+                    require_env_name(value)  # type: ignore[arg-type]
+
+
+class EnvNameProperties(unittest.TestCase):
+    def test_env_name_boundary_matches_reference(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            value = gen.one_of(
+                lambda: hostile_string(gen),
+                lambda: gen.text(ASCII_ALNUM + "_", 0, 20),
+                lambda: gen.choice(("VLLM_USE_V1", "_", "__", "A", "1A", "A-B", "A B", "A=B", "A;echo", "ÄB", "A\u200bB", "A\n", "\nA", "A" * 200)),
+            )
+            expected = reference_env_name(value)
+            try:
+                result = require_env_name(value)
+            except ValidationError:
+                self.assertFalse(expected, f"reference accepts {value!r} but validator rejected")
+                return
+            self.assertTrue(expected, f"validator accepted {value!r} but reference rejects")
+            self.assertEqual(result, value)
+            self.assertTrue(value.isidentifier() and value.isascii())
+
+        run_cases(1500, body, label="require_env_name")
+
+
+class DeviceCsvProperties(unittest.TestCase):
+    def test_device_csv_boundary_matches_reference_on_ascii_inputs(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            tokens = []
+            for _ in range(gen.integer(0, 5)):
+                tokens.append(gen.one_of(
+                    lambda: str(gen.integer(0, 15)),
+                    lambda: str(gen.integer(0, 15)) + gen.choice(("", " ", "\t")),
+                    lambda: gen.choice(("", " ", "-1", "abc", "0x1", "1.0", "1e2", "00", "007", " 3 ")),
+                ))
+            value = gen.choice((",".join(tokens), None, "", "   ", ","))
+            expected = reference_devices(value)
+            try:
+                result = parse_device_csv(value)
+            except ValidationError as exc:
+                self.assertEqual(expected, "reject", f"reference accepts {value!r} but parser rejected: {exc}")
+                self.assertIn("devices", str(exc))
+                return
+            self.assertNotEqual(expected, "reject", f"parser accepted {value!r} -> {result} but reference rejects")
+            self.assertEqual(result, expected)
+            if result is not None:
+                self.assertEqual(result, sorted(set(result)))
+                self.assertTrue(all(isinstance(d, int) and d >= 0 for d in result))
+
+        run_cases(1200, body, label="parse_device_csv")
+
+    @unittest.expectedFailure
+    def test_known_defect_int_parsing_accepts_more_than_decimal_ascii_digits(self) -> None:
+        """KNOWN DEFECT (low): tokens are parsed with ``int(token, 10)``, which
+        also accepts a leading ``+``, digit-group underscores (``1_0`` -> 10)
+        and any Unicode decimal digit (Arabic-Indic ``\u0661``, full-width
+        ``\uff11`` -> 1). The documented boundary is "comma-separated device
+        ids"; ``1_0`` silently becomes device 10.
+        Evidence: ``parse_device_csv('1_0') == [10]``."""
+        for value in ("1_0", "+1", "\u0661", "\uff11", "\u0660,\u0661"):
+            with self.subTest(value=value):
+                with self.assertRaises(ValidationError):
+                    parse_device_csv(value)
+
+    def test_unicode_digit_inputs_never_crash(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            value = ",".join(gen.text(UNICODE_DIGITS + "0123456789_+", 1, 3) for _ in range(gen.integer(1, 3)))
+            try:
+                result = parse_device_csv(value)
+            except ValidationError:
+                return
+            self.assertTrue(all(isinstance(d, int) and d >= 0 for d in result or []))
+
+        run_cases(200, body, label="unicode device tokens")
+
+
+class ChildPathProperties(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        base = Path(self._tmp.name).resolve()
+        self.root = base / "state"
+        self.outside = base / "outside"
+        (self.root / "a" / "b").mkdir(parents=True)
+        self.outside.mkdir()
+        (self.root / "escape_link").symlink_to(self.outside)
+        (self.root / "inner_link").symlink_to(self.root / "a")
+
+    def test_child_accepted_iff_its_resolved_location_is_under_root(self) -> None:
+        def body(gen: Gen, _index: int) -> None:
+            parts = [gen.choice(("a", "b", "..", ".", "escape_link", "inner_link", "new", gen.text(ASCII_ALNUM, 1, 5))) for _ in range(gen.integer(0, 5))]
+            child = self.root.joinpath(*parts) if parts else self.root
+            if gen.boolean(0.15):
+                child = self.outside.joinpath(*parts)
+            resolved = child.resolve()
+            expected = resolved == self.root or self.root in resolved.parents
+            try:
+                result = ensure_child_path(self.root, child)
+            except ValidationError:
+                self.assertFalse(expected, f"{child} resolves to {resolved} under root but was rejected")
+                return
+            self.assertTrue(expected, f"{child} -> {resolved} escapes {self.root} but was accepted")
+            self.assertEqual(result, resolved)
+            self.assertTrue(result.is_absolute())
+
+        run_cases(600, body, label="ensure_child_path")
+
+    def test_relative_children_resolve_against_cwd_not_root(self) -> None:
+        # Documented contract: ``ensure_child_path`` resolves both sides with
+        # ``Path.resolve``; a *relative* child is relative to the process cwd.
+        original = os.getcwd()
+        try:
+            os.chdir(self.root)
+            self.assertEqual(ensure_child_path(self.root, Path("a/b")), self.root / "a" / "b")
+            with self.assertRaises(ValidationError):
+                ensure_child_path(self.root, Path("../outside"))
+            os.chdir(self.outside)
+            with self.assertRaises(ValidationError):
+                ensure_child_path(self.root, Path("x"))
+        finally:
+            os.chdir(original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_vaws_scaffold_safety.py
+++ b/.agents/tests/test_vaws_scaffold_safety.py
@@ -25,6 +25,7 @@ from vaws_session_state import (  # noqa: E402
     allocate_service_port,
     allocate_session_leases,
     release_service_port,
+    session_leases_path,
     session_live_leases,
     require_session_npu_lease,
     release_all_session_leases,
@@ -260,6 +261,65 @@ class LeaseValidationTests(unittest.TestCase):
                 )["service_ports"],
                 [],
             )
+
+    def test_unknown_occupancy_refuses_npu_requests_but_allows_port_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable") as explicit:
+                allocate_session_leases(
+                    repo_root=root,
+                    machine_alias="host",
+                    session_id="sess-explicit",
+                    requested_devices=[0],
+                    port_available=lambda _port: True,
+                )
+            self.assertNotIn("--devices", str(explicit.exception))
+            with self.assertRaisesRegex(SessionStateError, "occupancy is unavailable") as counted:
+                allocate_session_leases(
+                    repo_root=root,
+                    machine_alias="host",
+                    session_id="sess-count",
+                    npu_count=1,
+                    port_available=lambda _port: True,
+                )
+            self.assertNotIn("--devices", str(counted.exception))
+            self.assertFalse(session_leases_path(root).exists())
+            leases = allocate_session_leases(
+                repo_root=root,
+                machine_alias="host",
+                session_id="sess-port",
+                container_ssh_port=46009,
+                port_available=lambda _port: True,
+            )
+            self.assertEqual(leases["npu_devices"], [])
+            self.assertEqual(leases["container_ssh_port"], 46009)
+            self.assertEqual(
+                session_live_leases(repo_root=root, machine_alias="host", session_id="sess-port"),
+                {"npu_devices": [], "container_ssh_ports": [46009], "service_ports": []},
+            )
+
+    def test_known_empty_free_set_refuses_explicit_and_count_requests(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(SessionStateError):
+                allocate_session_leases(
+                    repo_root=root,
+                    machine_alias="host",
+                    session_id="sess-explicit",
+                    requested_devices=[0],
+                    available_devices=[],
+                    port_available=lambda _port: True,
+                )
+            with self.assertRaises(SessionStateError):
+                allocate_session_leases(
+                    repo_root=root,
+                    machine_alias="host",
+                    session_id="sess-count",
+                    npu_count=1,
+                    available_devices=[],
+                    port_available=lambda _port: True,
+                )
+            self.assertFalse(session_leases_path(root).exists())
 
 
 class WorktreeCreateTests(unittest.TestCase):


### PR DESCRIPTION
Lease reclaim and release now use the same cooperating guard protocol, preventing a releasing process from deleting a replacement owner’s lease after a timeout. Sidecar-open and flock failures release local locks and descriptors, and a lease-close I/O error remains visible alongside an exception from the critical section. The guard fails closed when safe cleanup cannot complete.

The property-campaign fixes also retain artifact path validation, manifest secret filtering, finite-number validation and device parsing as ordinary passing regressions. This continuation includes the already merged #87 in its ancestry; the current PR diff contains only the #94 changes.

Independent validation on combined head `9320aa1f76598417e9c3ebf1f58ca93188af879e`:

- Shared pure-Python suite: 113 passed; session-management suite: 81 passed; zero skipped.
- Eleven independent NPU allocation cases, seven lock/ownership cases, and the close-EIO exception-chain check passed on the combined source.
- Deterministic replacement-owner and independent-process contention/crash tests passed without expected-failure conversions.
- The prospective merge with actual main `df1ac3de625df9f1efaae1d432dd432d8b3f93b2` has exactly the independently tested tree; diff checks passed.

Evidence is local POSIX and deterministic. NFS/cross-host coherence, real remote services and NPU behavior are not established by these checks. A fail-closed release can leave an abandoned lease until the existing stale window. #89 will retain the remaining property documentation while standalone remote-dev owns its property tests.
