### PR TITLE
fix: correct mux-stream knowledge to name profiling files

### DIFF
--- a/.agents/knowledge/known-failure-signatures.yaml
+++ b/.agents/knowledge/known-failure-signatures.yaml
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "kind": "known-failure-signatures",
-  "updated_at": "2026-09-03",
+  "updated_at": "2026-09-07",
   "entries": [
     {
       "id": "gloo-init-container-hostname-missing-from-etc-hosts",
@@ -37,7 +37,7 @@
       "status": "active",
       "source": "promoted from local candidate remote-toolbox-ssh-stream-through-the-shared-controlmaster-mux--fbff8c67cb (PR #70)",
       "applicable_versions": "Verified 2026-09-02 on macOS client + VAWS containers, OpenSSH ControlMaster shared connections.",
-      "updated_at": "2026-09-03",
+      "updated_at": "2026-09-07",
       "first_seen": "2026-09-03",
       "scope": {
         "component": "ssh transport",
@@ -48,8 +48,8 @@
         "summary": "ssh_stream through the shared ControlMaster mux fails on long-running remote commands; run stream/tunnel off the mux",
         "symptom": "Long-lived SSH streaming commands (service logs, analyse progress, tunnels) die or hang immediately / return early when issued over the shared ControlMaster connection; MCP remote_bash separately reported instant 'timeout' for any command while remote_probe/remote_ls kept working.",
         "root_cause": "The shared ControlMaster mux channel does not reliably carry long-lived stream sessions in this environment; stream-type invocations must bypass the mux (dedicated connection) instead of multiplexing over it.",
-        "resolution": "Use base_ssh_options(mux=False) for ssh_stream and for any long-lived tunnel/stream command (fixed in remote-code-parity + vllm-ascend-serving ssh helpers, PR #70). Fall back to direct 'ssh -o BatchMode=yes -p <port> root@<host>' when MCP remote_bash misbehaves.",
-        "avoidance": "Do not retry the same stream command on the mux hoping for a different result; check mux options first. Treat instant 'timeout' from MCP remote_bash as a tool-service fault signature, not a remote command fault.",
+        "resolution": "Use base_ssh_options(mux=False) only for long-lived stream/tunnel commands. The helpers that actually do this are .agents/skills/ascend-profiling-analysis/scripts/_common.py `_ssh_base_cmd` (ssh_stream) and .agents/skills/ascend-profiling-collection/scripts/_common.py `open_local_tunnel` (ssh -N -L), both from PR #70. remote-code-parity and vllm-ascend-serving still call base_ssh_options() with default mux=True for short captured SSH and stdin uploads; they were not switched off the mux. Fall back to direct 'ssh -o BatchMode=yes -p <port> root@<host>' when MCP remote_bash misbehaves.",
+        "avoidance": "Do not retry a long-lived stream/tunnel on the mux hoping for a different result; check whether that command actually passes mux=False. Do not flip serving ssh_exec or parity stdin-upload helpers to mux=False — those are short round-trips and should keep the mux. Treat instant 'timeout' from MCP remote_bash as a tool-service fault signature, not a remote command fault.",
         "fingerprints": [
           "ssh_stream instant timeout controlmaster",
           "remote_bash instant timeout any command",
@@ -57,7 +57,7 @@
         ],
         "candidate_id": "remote-toolbox-ssh-stream-through-the-shared-controlmaster-mux--fbff8c67cb",
         "verification": [
-          "serve_start log streaming and long analyse runs completed after switching stream commands to base_ssh_options(mux=False) (2026-09-02, PR #70 head commits)."
+          "Long analyse runs and collection -N -L tunnels completed after those two profiling helpers switched to base_ssh_options(mux=False) (2026-09-02, PR #70). Evidence is profiling-only; serving and parity SSH were not changed and were not re-proven."
         ]
       }
     }


### PR DESCRIPTION
## Summary

- The verified entry `ssh-stream-over-shared-controlmaster-mux-dies-early` claimed serving and parity SSH helpers were switched to `mux=False` in PR #70. That is false today. The phenomenon (long-lived stream/tunnel over ControlMaster dies early) is still real; only the resolution/avoidance/evidence text was wrong.
- PR #93's 2216-trial hardware pass did not re-prove the stream-over-mux bug. It proved a sibling: killing an `ssh` child that is (or becomes) the ControlMaster master wedges later commands on that endpoint. Uninterrupted artifact round-trips were 120/120. A candidate was captured and left unpromoted.

## Old claim

> Use `base_ssh_options(mux=False)` for ssh_stream and for any long-lived tunnel/stream command (**fixed in remote-code-parity + vllm-ascend-serving ssh helpers, PR #70**).

Verification also claimed "serve_start log streaming" was fixed. It was not.

## Files read

- `.agents/skills/vllm-ascend-serving/scripts/_common.py` — `_ssh_base_cmd` calls `base_ssh_options(connect_timeout=...)` (default `mux=True`). `ssh_exec` is a captured 180s round-trip, not a stream.
- `.agents/skills/remote-code-parity/scripts/common.py` — `_ssh_base_cmd` calls `base_ssh_options()` (default `mux=True`). `ssh_stream_to_file` / `ssh_stream_bytes_to_file` are stdin uploads, not long-lived streams.
- `.agents/skills/ascend-profiling-analysis/scripts/_common.py` — `_ssh_base_cmd` (used by `ssh_stream`) already passes `mux=False`. `_ssh_pipe_cmd` at line 378 uses default `mux=True`; that path is a bounded tar-over-ssh sync (`communicate()`), not a long-lived stream, so it was left alone. No `base_ssh_options` call was changed.
- `.agents/skills/ascend-profiling-collection/scripts/_common.py` — `open_local_tunnel` (`ssh -N -L`) already passes `mux=False`.
- `.agents/lib/vaws_ssh.py` — documents `mux=False` for long-lived tunnels/streams; default remains `mux=True`.

## Corrected text

**resolution:** Use `base_ssh_options(mux=False)` only for long-lived stream/tunnel commands. The helpers that actually do this are `.agents/skills/ascend-profiling-analysis/scripts/_common.py` `_ssh_base_cmd` (`ssh_stream`) and `.agents/skills/ascend-profiling-collection/scripts/_common.py` `open_local_tunnel` (`ssh -N -L`), both from PR #70. remote-code-parity and vllm-ascend-serving still call `base_ssh_options()` with default `mux=True` for short captured SSH and stdin uploads; they were not switched off the mux.

**avoidance:** Do not retry a long-lived stream/tunnel on the mux hoping for a different result; check whether that command actually passes `mux=False`. Do not flip serving `ssh_exec` or parity stdin-upload helpers to `mux=False` — those are short round-trips and should keep the mux.

**verification:** Long analyse runs and collection `-N -L` tunnels completed after those two profiling helpers switched to `base_ssh_options(mux=False)` (2026-09-02, PR #70). Evidence is profiling-only; serving and parity SSH were not changed and were not re-proven.

Verification date stays 2026-09-02. Document/entry `updated_at` is 2026-09-07 for the text correction only.

## New candidate (not promoted)

- **id:** `remote-toolbox-killing-a-controlmaster-ssh-master-wedges-later--06fff44d8e`
- **path:** `.vaws-local/knowledge/candidates/remote-toolbox-killing-a-controlmaster-ssh-master-wedges-later--06fff44d8e.json` (untracked; captured via `.agents/scripts/knowledge_capture.py` in this worktree)
- **evidence:** https://github.com/maoxx241/vllm-ascend-workspace/pull/93
- Left as `status: candidate`. Not merged into the formal entry.

## Serving / parity mux (intentional)

**Serving and parity SSH still use the ControlMaster mux on purpose.** They are short captured commands / stdin uploads, not long-lived streams. Flipping them to `mux=False` would slow every short SSH and would not match #93 (uninterrupted artifact transfers 120/120 on the mux). No serving or parity SSH helper was changed in this PR.

## Test plan

- [x] `python3 -m compileall -q .agents`
- [x] `python3 .agents/scripts/knowledge_validate.py`
- [x] `python3 -m unittest discover -s .agents/tests -p 'test_knowledge*.py'`
- [x] `python3 -m unittest discover -s .agents/skills/curate-workspace-knowledge/tests`
- [x] Confirmed no `base_ssh_options` call was flipped


Made with [Cursor](https://cursor.com)