### PR TITLE
build: generate the Trae ModelScope package from the canonical skill

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -294,6 +294,7 @@ If you change `modelscope`, update these together:
 - `.agents/skills/modelscope/SKILL.md`
 - `.agents/skills/modelscope/scripts/`
 - `.agents/skills/modelscope/agents/`
+- `.trae/skills/modelscope` via `python3 .agents/scripts/sync_claude_skills.py`
 - `AGENTS.md`, `README.md`, and this file when routing or output contract changes
 
 Keep the files under `.agents/skills/` as the canonical supporting files for repo-local skills.

--- a/.agents/scripts/sync_claude_skills.py
+++ b/.agents/scripts/sync_claude_skills.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Generate the lightweight `.claude/skills/<name>/SKILL.md` shims from `.agents/skills`.
+"""Generate Claude Code skill shims and the ModelScope Trae projection.
 
-Moved here from the remote-dev substrate's `tools/` directory when that
-substrate became its own repository: the shims are scaffold work (they read
-`.agents/skills` and write `.claude/skills`), not remote development.
+`.claude/skills/<name>/SKILL.md` shims come from `.agents/skills`. The six
+`.trae/skills/modelscope` files are copied byte-for-byte from
+`.agents/skills/modelscope`. Edit ModelScope only in that canonical package;
+this command regenerates the Trae projection.
 
     python3 .agents/scripts/sync_claude_skills.py          # regenerate
     python3 .agents/scripts/sync_claude_skills.py --check  # verify, exit 1 on drift
@@ -18,7 +19,17 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 AGENTS_SKILLS = ROOT / ".agents" / "skills"
 CLAUDE_SKILLS = ROOT / ".claude" / "skills"
+TRAE_SKILLS = ROOT / ".trae" / "skills"
 MAX_SHIM_LINES = 60
+MODELSCOPE_SKILL = "modelscope"
+MODELSCOPE_TRAE_PATHS = (
+    "SKILL.md",
+    "agents/openai.yaml",
+    "scripts/download_from_modelscope.py",
+    "scripts/modelscope_auto.py",
+    "scripts/modelscope_download_status.py",
+    "scripts/verify_modelscope_sha256.py",
+)
 
 
 def parse_frontmatter(source: Path) -> dict[str, str]:
@@ -74,6 +85,37 @@ def source_skill_dirs() -> list[Path]:
     return sorted(path for path in AGENTS_SKILLS.iterdir() if path.is_dir() and (path / "SKILL.md").exists())
 
 
+def modelscope_source_dir() -> Path:
+    return AGENTS_SKILLS / MODELSCOPE_SKILL
+
+
+def modelscope_trae_dir() -> Path:
+    return TRAE_SKILLS / MODELSCOPE_SKILL
+
+
+def _exec_bits(path: Path) -> int:
+    return path.stat().st_mode & 0o111
+
+
+def _copy_projected_file(source: Path, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(source.read_bytes())
+    updated_mode = (target.stat().st_mode & ~0o111) | _exec_bits(source)
+    if updated_mode != target.stat().st_mode:
+        target.chmod(updated_mode)
+
+
+def _projected_file_relpaths(root: Path) -> list[str]:
+    if not root.is_dir():
+        return []
+    relative: list[str] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or "__pycache__" in path.parts:
+            continue
+        relative.append(path.relative_to(root).as_posix())
+    return relative
+
+
 def check_shims() -> list[str]:
     errors: list[str] = []
     expected_names = {path.name for path in source_skill_dirs()}
@@ -99,6 +141,32 @@ def check_shims() -> list[str]:
     return errors
 
 
+def check_modelscope_trae() -> list[str]:
+    errors: list[str] = []
+    source_root = modelscope_source_dir()
+    target_root = modelscope_trae_dir()
+    owned = set(MODELSCOPE_TRAE_PATHS)
+    for relative in MODELSCOPE_TRAE_PATHS:
+        source = source_root / relative
+        target = target_root / relative
+        if not source.is_file():
+            errors.append(f"missing canonical modelscope source: {relative}")
+            continue
+        if not target.is_file():
+            errors.append(f"missing Trae modelscope projection: {relative}")
+            continue
+        if source.read_bytes() != target.read_bytes() or _exec_bits(source) != _exec_bits(target):
+            errors.append(f"stale Trae modelscope projection: {relative}")
+    for relative in _projected_file_relpaths(target_root):
+        if relative not in owned:
+            errors.append(f"unexpected file in Trae modelscope projection: {relative}")
+    return errors
+
+
+def check_generated() -> list[str]:
+    return check_shims() + check_modelscope_trae()
+
+
 def sync_shims() -> None:
     CLAUDE_SKILLS.mkdir(parents=True, exist_ok=True)
     for skill_dir in source_skill_dirs():
@@ -111,16 +179,43 @@ def sync_shims() -> None:
             shutil.rmtree(existing)
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description="Sync generated Claude Code skill shims from .agents/skills.")
-    parser.add_argument("--check", action="store_true", help="Only verify that .claude/skills is synchronized.")
-    args = parser.parse_args()
+def sync_modelscope_trae() -> None:
+    source_root = modelscope_source_dir()
+    target_root = modelscope_trae_dir()
+    for relative in MODELSCOPE_TRAE_PATHS:
+        source = source_root / relative
+        if not source.is_file():
+            raise FileNotFoundError(f"missing canonical modelscope source: {relative}")
+        _copy_projected_file(source, target_root / relative)
+
+
+def sync_generated() -> None:
+    sync_shims()
+    sync_modelscope_trae()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Sync generated Claude Code skill shims and the ModelScope Trae "
+            "projection from .agents/skills."
+        )
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Only verify that .claude/skills shims and the "
+            ".trae/skills/modelscope projection are synchronized."
+        ),
+    )
+    args = parser.parse_args(argv)
     if args.check:
-        errors = check_shims()
+        errors = check_generated()
         for error in errors:
             print(error)
         return 1 if errors else 0
-    sync_shims()
+    sync_generated()
     return 0
 
 

--- a/.agents/skills/modelscope/SKILL.md
+++ b/.agents/skills/modelscope/SKILL.md
@@ -14,6 +14,8 @@ Use the bundled scripts from this skill directory. Prefer the compact manager fi
 
 Do not inline long `nohup`/`setsid` shell blocks. Do not read or tail large logs unless a task fails or the user asks.
 
+Edit only `.agents/skills/modelscope`. `python3 .agents/scripts/sync_claude_skills.py` regenerates `.trae/skills/modelscope` from this package.
+
 ## Model Mapping
 
 Represent every model as `MODEL_ID=LOCAL_DIR`.

--- a/.agents/tests/test_sync_claude_skills.py
+++ b/.agents/tests/test_sync_claude_skills.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Tests for generated Claude shims and the ModelScope Trae projection."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / ".agents" / "scripts" / "sync_claude_skills.py"
+CATALOG_SCRIPT = ROOT / ".agents" / "scripts" / "skill_catalog.py"
+CANONICAL_MODELSCOPE = ROOT / ".agents" / "skills" / "modelscope"
+TRAE_MODELSCOPE = ROOT / ".trae" / "skills" / "modelscope"
+FOREIGN_TRAE_SKILL = ROOT / ".trae" / "skills" / "machine-management" / "SKILL.md"
+MODELSCOPE_SCRIPTS = (
+    "modelscope_auto.py",
+    "download_from_modelscope.py",
+    "modelscope_download_status.py",
+    "verify_modelscope_sha256.py",
+)
+HELP_MARKERS = {
+    "modelscope_auto.py": ("ensure", "status", "verify", "worker"),
+    "download_from_modelscope.py": ("--model-id", "--local-dir", "--revision"),
+    "modelscope_download_status.py": ("--model", "--revision"),
+    "verify_modelscope_sha256.py": ("--model", "--output-dir"),
+}
+
+
+def load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sync = load_module(SCRIPT, "_sync_claude_skills_test")
+catalog = load_module(CATALOG_SCRIPT, "_skill_catalog_for_sync_test")
+
+
+def _unquote_yaml_scalar(raw: str) -> object:
+    if raw in {"true", "True"}:
+        return True
+    if raw in {"false", "False"}:
+        return False
+    if raw in {"null", "Null", "~"}:
+        return None
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {'"', "'"}:
+        return raw[1:-1]
+    return raw
+
+
+def parse_yaml_mapping(text: str) -> dict[str, object]:
+    """Parse a nested block mapping. Used when PyYAML is not a package dependency."""
+    root: dict[str, object] = {}
+    stack: list[tuple[int, dict[str, object]]] = [(-1, root)]
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        if ":" not in stripped:
+            raise ValueError(f"invalid YAML mapping line: {raw_line!r}")
+        key, remainder = stripped.split(":", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"invalid YAML key: {raw_line!r}")
+        value_text = remainder.strip()
+        while indent <= stack[-1][0]:
+            stack.pop()
+        parent = stack[-1][1]
+        if value_text == "":
+            nested: dict[str, object] = {}
+            parent[key] = nested
+            stack.append((indent, nested))
+        else:
+            parent[key] = _unquote_yaml_scalar(value_text)
+    return root
+
+
+def frontmatter_yaml(text: str) -> str:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        raise ValueError("missing opening YAML frontmatter delimiter")
+    try:
+        end = next(
+            index
+            for index, line in enumerate(lines[1:], start=1)
+            if line.strip() == "---"
+        )
+    except StopIteration as exc:
+        raise ValueError("missing closing YAML frontmatter delimiter") from exc
+    return "\n".join(lines[1:end]) + "\n"
+
+
+def write_owned_modelscope(package: Path, payload_prefix: str) -> None:
+    for relative in sync.MODELSCOPE_TRAE_PATHS:
+        path = package / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"{payload_prefix}:{relative}\n", encoding="utf-8")
+        if relative.endswith(".py"):
+            path.chmod(path.stat().st_mode | 0o111)
+
+
+def snapshot_package(package: Path) -> dict[str, tuple[bytes, int]]:
+    snapshot: dict[str, tuple[bytes, int]] = {}
+    for relative in sync.MODELSCOPE_TRAE_PATHS:
+        path = package / relative
+        snapshot[relative] = (path.read_bytes(), path.stat().st_mode & 0o111)
+    return snapshot
+
+
+def deny_network_pythonpath(root: Path) -> str:
+    package = root / "requests"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "class Session:\n"
+        "    def get(self, *args, **kwargs):\n"
+        "        raise RuntimeError("
+        "'network and ModelScope provider calls are denied in this fixture')\n",
+        encoding="utf-8",
+    )
+    return str(root)
+
+
+class ModelScopeTraeProjectionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.agents_skills = self.root / "agents-skills"
+        self.claude_skills = self.root / "claude-skills"
+        self.trae_skills = self.root / "trae-skills"
+        self.canonical = self.agents_skills / "modelscope"
+        self.projected = self.trae_skills / "modelscope"
+        self.foreign = self.trae_skills / "other-skill" / "SKILL.md"
+        self.agents_skills.mkdir()
+        self.claude_skills.mkdir()
+        self.trae_skills.mkdir()
+        write_owned_modelscope(self.canonical, "canonical")
+        self.foreign.parent.mkdir()
+        self.foreign.write_text("foreign-skill-body\n", encoding="utf-8")
+        sync.AGENTS_SKILLS = self.agents_skills
+        sync.CLAUDE_SKILLS = self.claude_skills
+        sync.TRAE_SKILLS = self.trae_skills
+        shim_dir = self.claude_skills / "modelscope"
+        shim_dir.mkdir()
+        (shim_dir / "SKILL.md").write_text(
+            sync.expected_skill_body(self.canonical),
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        sync.AGENTS_SKILLS = ROOT / ".agents" / "skills"
+        sync.CLAUDE_SKILLS = ROOT / ".claude" / "skills"
+        sync.TRAE_SKILLS = ROOT / ".trae" / "skills"
+        self._tmp.cleanup()
+
+    def test_mapping_is_the_six_modelscope_outputs(self) -> None:
+        self.assertEqual(
+            sync.MODELSCOPE_TRAE_PATHS,
+            (
+                "SKILL.md",
+                "agents/openai.yaml",
+                "scripts/download_from_modelscope.py",
+                "scripts/modelscope_auto.py",
+                "scripts/modelscope_download_status.py",
+                "scripts/verify_modelscope_sha256.py",
+            ),
+        )
+
+    def test_generate_copies_exact_bytes_and_preserves_foreign_package(self) -> None:
+        self.assertEqual(sync.sync_modelscope_trae(), None)
+        for relative in sync.MODELSCOPE_TRAE_PATHS:
+            source = self.canonical / relative
+            target = self.projected / relative
+            self.assertEqual(source.read_bytes(), target.read_bytes(), relative)
+            self.assertEqual(
+                source.stat().st_mode & 0o111,
+                target.stat().st_mode & 0o111,
+                relative,
+            )
+        self.assertEqual(self.foreign.read_text(encoding="utf-8"), "foreign-skill-body\n")
+        self.assertEqual(sync.check_modelscope_trae(), [])
+
+    def test_generate_is_idempotent(self) -> None:
+        sync.sync_modelscope_trae()
+        first = snapshot_package(self.projected)
+        sync.sync_modelscope_trae()
+        second = snapshot_package(self.projected)
+        self.assertEqual(first, second)
+        self.assertEqual(sync.check_modelscope_trae(), [])
+        with redirect_stdout(io.StringIO()) as captured:
+            self.assertEqual(sync.main(["--check"]), 0)
+        self.assertEqual(captured.getvalue(), "")
+
+    def test_check_detects_projected_file_drift_then_regenerate_restores(self) -> None:
+        sync.sync_modelscope_trae()
+        drifted = self.projected / "SKILL.md"
+        drifted.write_text("projected-drift\n", encoding="utf-8")
+        errors = sync.check_modelscope_trae()
+        self.assertIn("stale Trae modelscope projection: SKILL.md", errors)
+        with redirect_stdout(io.StringIO()) as captured:
+            self.assertEqual(sync.main(["--check"]), 1)
+        self.assertIn("stale Trae modelscope projection: SKILL.md", captured.getvalue())
+        sync.sync_modelscope_trae()
+        self.assertEqual((self.canonical / "SKILL.md").read_bytes(), drifted.read_bytes())
+        self.assertEqual(sync.check_modelscope_trae(), [])
+
+    def test_check_detects_canonical_edit_until_regenerated(self) -> None:
+        sync.sync_modelscope_trae()
+        canonical_script = self.canonical / "scripts" / "modelscope_auto.py"
+        canonical_script.write_text("canonical-edit:modelscope_auto.py\n", encoding="utf-8")
+        canonical_script.chmod(canonical_script.stat().st_mode | 0o111)
+        errors = sync.check_modelscope_trae()
+        self.assertIn(
+            "stale Trae modelscope projection: scripts/modelscope_auto.py",
+            errors,
+        )
+        sync.sync_modelscope_trae()
+        self.assertEqual(
+            canonical_script.read_bytes(),
+            (self.projected / "scripts" / "modelscope_auto.py").read_bytes(),
+        )
+        self.assertEqual(sync.check_modelscope_trae(), [])
+
+    def test_check_detects_missing_projected_file(self) -> None:
+        sync.sync_modelscope_trae()
+        (self.projected / "agents" / "openai.yaml").unlink()
+        errors = sync.check_modelscope_trae()
+        self.assertIn("missing Trae modelscope projection: agents/openai.yaml", errors)
+
+    def test_unexpected_projection_file_is_reported_and_not_deleted(self) -> None:
+        sync.sync_modelscope_trae()
+        extra = self.projected / "notes.txt"
+        extra.write_text("user-owned extra\n", encoding="utf-8")
+        errors = sync.check_modelscope_trae()
+        self.assertIn("unexpected file in Trae modelscope projection: notes.txt", errors)
+        sync.sync_modelscope_trae()
+        self.assertEqual(extra.read_text(encoding="utf-8"), "user-owned extra\n")
+        self.assertEqual(self.foreign.read_text(encoding="utf-8"), "foreign-skill-body\n")
+        self.assertIn(
+            "unexpected file in Trae modelscope projection: notes.txt",
+            sync.check_modelscope_trae(),
+        )
+
+
+class CurrentTreeProjectionTests(unittest.TestCase):
+    def test_canonical_and_trae_payloads_match(self) -> None:
+        owned = set(sync.MODELSCOPE_TRAE_PATHS)
+        observed = {
+            path.relative_to(TRAE_MODELSCOPE).as_posix()
+            for path in TRAE_MODELSCOPE.rglob("*")
+            if path.is_file() and "__pycache__" not in path.parts
+        }
+        self.assertEqual(observed, owned)
+        for relative in sync.MODELSCOPE_TRAE_PATHS:
+            source = CANONICAL_MODELSCOPE / relative
+            target = TRAE_MODELSCOPE / relative
+            self.assertEqual(source.read_bytes(), target.read_bytes(), relative)
+            self.assertEqual(
+                source.stat().st_mode & 0o111,
+                target.stat().st_mode & 0o111,
+                relative,
+            )
+
+    def test_check_passes_on_current_tree(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--check"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertEqual(proc.stdout, "")
+
+    def test_foreign_trae_package_remains_on_current_tree(self) -> None:
+        self.assertTrue(FOREIGN_TRAE_SKILL.is_file())
+        body = FOREIGN_TRAE_SKILL.read_text(encoding="utf-8")
+        self.assertIn("machine-management", body)
+        self.assertNotEqual(body, (CANONICAL_MODELSCOPE / "SKILL.md").read_text(encoding="utf-8"))
+
+    def test_skill_frontmatter_parses_through_catalog(self) -> None:
+        for skill_file in (
+            CANONICAL_MODELSCOPE / "SKILL.md",
+            TRAE_MODELSCOPE / "SKILL.md",
+        ):
+            record = catalog.parse_skill(skill_file, ROOT)
+            self.assertEqual(record.name, "modelscope")
+            self.assertIn("ModelScope", record.description)
+            self.assertGreater(len(record.description), 20)
+
+    def test_modelscope_yaml_documents_parse(self) -> None:
+        try:
+            import yaml
+        except ImportError:
+            yaml = None
+        for skill_file in (
+            CANONICAL_MODELSCOPE / "SKILL.md",
+            TRAE_MODELSCOPE / "SKILL.md",
+        ):
+            frontmatter = frontmatter_yaml(skill_file.read_text(encoding="utf-8"))
+            metadata = parse_yaml_mapping(frontmatter)
+            self.assertEqual(metadata["name"], "modelscope")
+            self.assertIsInstance(metadata["description"], str)
+            self.assertIn("ModelScope", metadata["description"])
+            if yaml is not None:
+                loaded = yaml.safe_load(frontmatter)
+                self.assertEqual(loaded["name"], metadata["name"])
+                self.assertEqual(loaded["description"], metadata["description"])
+        for yaml_file in (
+            CANONICAL_MODELSCOPE / "agents" / "openai.yaml",
+            TRAE_MODELSCOPE / "agents" / "openai.yaml",
+        ):
+            text = yaml_file.read_text(encoding="utf-8")
+            document = parse_yaml_mapping(text)
+            interface = document["interface"]
+            self.assertIsInstance(interface, dict)
+            self.assertEqual(interface["display_name"], "ModelScope")
+            self.assertIn("ModelScope", interface["short_description"])
+            self.assertIn("$modelscope", interface["default_prompt"])
+            if yaml is not None:
+                loaded = yaml.safe_load(text)
+                self.assertEqual(loaded["interface"]["display_name"], interface["display_name"])
+                self.assertEqual(
+                    loaded["interface"]["short_description"],
+                    interface["short_description"],
+                )
+                self.assertEqual(
+                    loaded["interface"]["default_prompt"],
+                    interface["default_prompt"],
+                )
+
+    def test_generator_help_names_trae_output(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("ModelScope Trae", proc.stdout)
+        self.assertIn(".trae/skills/modelscope", proc.stdout)
+        self.assertIn("--check", proc.stdout)
+
+
+class ModelScopeHelpTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._tmpdir = tempfile.TemporaryDirectory()
+        cls.pythonpath = deny_network_pythonpath(Path(cls._tmpdir.name))
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._tmpdir.cleanup()
+
+    def _run_help(
+        self, script: Path, *args: str
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        existing = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = (
+            self.pythonpath if not existing else self.pythonpath + os.pathsep + existing
+        )
+        for name in (
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "ALL_PROXY",
+            "http_proxy",
+            "https_proxy",
+            "all_proxy",
+            "MODELSCOPE_TOKEN",
+            "MODELSCOPE_API_TOKEN",
+        ):
+            env.pop(name, None)
+        return subprocess.run(
+            [sys.executable, str(script), *args],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+            timeout=20,
+        )
+
+    def test_canonical_and_trae_help_match(self) -> None:
+        for name in MODELSCOPE_SCRIPTS:
+            with self.subTest(script=name):
+                canonical = self._run_help(
+                    CANONICAL_MODELSCOPE / "scripts" / name, "--help"
+                )
+                trae = self._run_help(TRAE_MODELSCOPE / "scripts" / name, "--help")
+                self.assertEqual(canonical.returncode, 0, canonical.stderr)
+                self.assertEqual(trae.returncode, 0, trae.stderr)
+                self.assertEqual(canonical.stdout, trae.stdout)
+                self.assertEqual(canonical.stderr, trae.stderr)
+                self.assertIn("usage:", canonical.stdout)
+                for marker in HELP_MARKERS[name]:
+                    self.assertIn(marker, canonical.stdout)
+                if name == "modelscope_auto.py":
+                    for command in ("ensure", "status", "verify"):
+                        canonical_sub = self._run_help(
+                            CANONICAL_MODELSCOPE / "scripts" / name,
+                            command,
+                            "--help",
+                        )
+                        trae_sub = self._run_help(
+                            TRAE_MODELSCOPE / "scripts" / name,
+                            command,
+                            "--help",
+                        )
+                        self.assertEqual(canonical_sub.returncode, 0, canonical_sub.stderr)
+                        self.assertEqual(trae_sub.stdout, canonical_sub.stdout)
+                        self.assertIn("--model", canonical_sub.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/coordinator.yml
+++ b/.github/workflows/coordinator.yml
@@ -82,5 +82,5 @@ jobs:
         env:
           VAWS_COORDINATOR_ROOT: ${{ runner.temp }}/vaws-coordinator
         run: python -B .agents/scripts/vaws.py status
-      - name: Claude skill shims are in sync
+      - name: Generated Claude shims and ModelScope Trae projection are in sync
         run: python -B .agents/scripts/sync_claude_skills.py --check

--- a/.github/workflows/remote-dev.yml
+++ b/.github/workflows/remote-dev.yml
@@ -85,5 +85,5 @@ jobs:
         # Exit 1 (no checkout) is expected without the token; the JSON is the
         # useful artifact either way.
         run: python -B .agents/scripts/remote_dev.py status || true
-      - name: Claude skill shims are in sync
+      - name: Generated Claude shims and ModelScope Trae projection are in sync
         run: python -B .agents/scripts/sync_claude_skills.py --check

--- a/.github/workflows/skill-catalog.yml
+++ b/.github/workflows/skill-catalog.yml
@@ -7,6 +7,7 @@ on:
       - "AGENTS.md"
       - "README.md"
       - "README.en.md"
+      - ".trae/skills/modelscope/**"
       - ".github/workflows/skill-catalog.yml"
   push:
     branches:
@@ -16,6 +17,7 @@ on:
       - "AGENTS.md"
       - "README.md"
       - "README.en.md"
+      - ".trae/skills/modelscope/**"
       - ".github/workflows/skill-catalog.yml"
 
 permissions:
@@ -45,6 +47,10 @@ jobs:
           python -B -m unittest discover -s .agents/tests -p "test_repo_boundary_check.py"
       - name: Run catalog tests
         run: python -B -m unittest discover -s .agents/tests -p "test_*catalog.py"
+      - name: Run generated skill projection tests
+        run: python -B -m unittest discover -s .agents/tests -p "test_sync_claude_skills.py"
+      - name: Check generated Claude shims and ModelScope Trae projection
+        run: python -B .agents/scripts/sync_claude_skills.py --check
       - name: Run manifest and knowledge tests
         run: python -B -m unittest discover -s .agents/tests -p "test_run_manifest.py"
       - name: Run knowledge evidence-chain tests

--- a/.trae/skills/modelscope/SKILL.md
+++ b/.trae/skills/modelscope/SKILL.md
@@ -14,6 +14,8 @@ Use the bundled scripts from this skill directory. Prefer the compact manager fi
 
 Do not inline long `nohup`/`setsid` shell blocks. Do not read or tail large logs unless a task fails or the user asks.
 
+Edit only `.agents/skills/modelscope`. `python3 .agents/scripts/sync_claude_skills.py` regenerates `.trae/skills/modelscope` from this package.
+
 ## Model Mapping
 
 Represent every model as `MODEL_ID=LOCAL_DIR`.


### PR DESCRIPTION
The Trae ModelScope package was a separate handwritten copy of the canonical skill. The existing skill sync/check command now generates and verifies its six fixed files, so canonical changes have one maintenance path. It preserves foreign Trae packages and reports unexpected ModelScope files without deleting them; CI tracks the affected paths.

Independent validation: 14 generator tests and 11 additional drift/idempotence/ownership cases; real YAML parsing; all eight script help entrypoints with existing real requests dependencies and no network or child-process calls. Business scripts and agent metadata are byte-identical. The final ordinary merge with current main passes generator/catalog checks and strict tracked-leak scanning with zero findings or unused allowances. No downloads or live client changes.
