### PR TITLE
fix: report --reset remedy for incomplete dependency checkouts

### DIFF
--- a/.agents/lib/vaws_dependency.py
+++ b/.agents/lib/vaws_dependency.py
@@ -661,7 +661,7 @@ def bootstrap(
     dry_run: bool = False,
     repo_root: Path = ROOT,
 ) -> dict[str, Any]:
-    """Clone ``url`` at ``commit``. Never resets an off_pin tree unless asked."""
+    """Clone ``url`` at ``commit``. Never resets an off_pin or incomplete tree unless asked."""
     if dry_run:
         return bootstrap_plan(name, dest=dest, env=env, repo_root=repo_root)
     pin = load_pin(name)
@@ -697,6 +697,24 @@ def bootstrap(
                 pin_matches=False,
                 remedy=(
                     f"checkout is at {info['commit']}, pin is {commit}; "
+                    "pass --reset to fetch and checkout the pin when the working tree is clean"
+                ),
+            )
+            return payload
+        if info["state"] == "incomplete" and not reset:
+            missing = [
+                rel
+                for rel in (pin.get("identity") or {}).get("required_files") or []
+                if not (dest / rel).is_file()
+            ]
+            payload.update(
+                state="incomplete",
+                commit=info["commit"],
+                pin_matches=False,
+                problems=info["problems"],
+                remedy=(
+                    f"checkout is at {info['commit']} and is missing {', '.join(missing)}; "
+                    f"pin is {commit}; "
                     "pass --reset to fetch and checkout the pin when the working tree is clean"
                 ),
             )

--- a/.agents/tests/test_dependency.py
+++ b/.agents/tests/test_dependency.py
@@ -483,6 +483,61 @@ class BootstrapPlanAndAllTests(unittest.TestCase):
         self.assertEqual(payload["state"], "access-denied")
         self.assertEqual(payload["remedy"], "gh auth login")
 
+    def test_bootstrap_incomplete_reports_reset_remedy_and_reset_lands_ready(self) -> None:
+        pin = deps.load_pin("vaws-coordinator")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "coord"
+            root.mkdir()
+            _synthetic_off_pin(root, pin)
+            complete = subprocess.run(
+                ["git", "rev-list", "--max-parents=0", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            missing = "service-api.json"
+            (root / missing).unlink()
+            _git(root, "add", "-A")
+            _git(root, "commit", "-m", "drop required file")
+            env = {"VAWS_COORDINATOR_ROOT": str(root)}
+            original_load = deps.load_pin
+
+            def load_with_local_pin(name: str, *args: object, **kwargs: object) -> dict:
+                loaded = original_load(name, *args, **kwargs)
+                if name == "vaws-coordinator":
+                    loaded = dict(loaded)
+                    loaded["commit"] = complete
+                return loaded
+
+            deps.load_pin = load_with_local_pin  # type: ignore[method-assign]
+            try:
+                payload = deps.bootstrap("vaws-coordinator", env=env, reset=False)
+                self.assertEqual(payload["state"], "incomplete")
+                self.assertFalse(payload["pin_matches"])
+                self.assertIn("--reset", payload["remedy"])
+                self.assertTrue(payload.get("problems"))
+                self.assertIn(missing, payload["remedy"])
+                self.assertTrue(deps.bootstrap_public_failed(payload))
+
+                original_git = deps._git
+
+                def git_skip_network_fetch(*argv: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+                    if argv and argv[0] == "fetch":
+                        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+                    return original_git(*argv, **kwargs)
+
+                deps._git = git_skip_network_fetch  # type: ignore[method-assign]
+                try:
+                    reset_payload = deps.bootstrap("vaws-coordinator", env=env, reset=True)
+                finally:
+                    deps._git = original_git  # type: ignore[method-assign]
+                self.assertEqual(reset_payload["state"], "ready")
+                self.assertTrue(reset_payload["pin_matches"])
+                self.assertTrue((root / missing).is_file())
+            finally:
+                deps.load_pin = original_load  # type: ignore[method-assign]
+
     def test_bootstrap_all_cli_dry_run_prints_one_payload(self) -> None:
         env = {key: value for key, value in os.environ.items() if not key.startswith("VAWS_")}
         env.update(

--- a/docs/dependency-plane.md
+++ b/docs/dependency-plane.md
@@ -159,7 +159,8 @@ python3 .agents/scripts/vaws_deps.py doctor
 ```
 
 `--reset` fetches and checks out the pin only when the working tree is clean.
-An `off_pin` dest is never reset without that flag. A `wrong_origin` dest is
+An `off_pin` dest is never reset without that flag. An `incomplete` checkout,
+like `off_pin`, is never rewritten without `--reset`. A `wrong_origin` dest is
 never overwritten by bootstrap; choose a different dest.
 
 `--dry-run` prints one JSON object of planned destinations and does not


### PR DESCRIPTION
## Summary
- `bootstrap()` now treats an existing `incomplete` checkout like `off_pin`: it reports `state`, `commit`, `pin_matches=False`, inspect `problems`, and a `--reset` remedy instead of silently returning the inspect record.
- `--reset` is unchanged: a clean tree still fetches and checks out the pin.
- `bootstrap all` already walks every pin (there is no `should_bootstrap()` filter); `incomplete` is included and still fails the public-pin exit path until `--reset`.

## Test plan
- [x] `.agents/tests/test_dependency.py` — incomplete checkout without `--reset` reports `state == "incomplete"` and `"--reset" in remedy`; with `reset=True` it lands `ready`
- [x] `python3 -B -m unittest discover -s .agents/tests -p "test_dependency.py"`
- [x] `python3 .agents/scripts/tracked_path_check.py --mode enforce`
- [x] `python3 .agents/scripts/tracked_leak_scan.py --commit-range origin/main..HEAD` (0 findings)


Made with [Cursor](https://cursor.com)