### PR TITLE
chore: bump vaws-coordinator pin to a7d5005 (integer service_api_version)

### DIFF
--- a/.agents/deps/coordinator.json
+++ b/.agents/deps/coordinator.json
@@ -5,7 +5,7 @@
   "url": "https://github.com/vllm-ascend-workspace/vaws-coordinator.git",
   "visibility": "public",
   "ref": "main",
-  "commit": "d3c4e82a3c0e3f0be31727abf17b7863bcedba77",
+  "commit": "a7d5005a4df6ab8adf5b16a965127e81a30ee3fc",
   "root_env": "VAWS_COORDINATOR_ROOT",
   "default_checkout": "{shared_workspace_root}/.vaws-local/vaws-coordinator",
   "bootstrap": "python3 .agents/scripts/vaws.py bootstrap",
@@ -39,7 +39,7 @@
   },
   "note": "vaws-coordinator is consumed as an external checkout, not a submodule and not a vendored copy. Locate it through VAWS_COORDINATOR_ROOT or the default path above. Bump `commit` deliberately; `vaws.py status` reports drift. This pin is the independently accepted merged main. It does not change the remote-dev pin in remote-dev.json. identity.canonical_origin is true so a fork is reported as wrong_origin (usable, always warned). false would drop origin from identity and never emit wrong_origin.",
   "extensions": {
-    "tree": "d3f91bc6375a876fc01d46b1835feabd61db2729",
+    "tree": "2660b7fe09c660b8827444753a87ec3bf554d551",
     "pinned_mirrors": {
       "vaws_build_inputs": {
         "scaffold_path": ".agents/lib/vaws_build_inputs.py",
@@ -56,7 +56,7 @@
       "lib/vaws_runtime_profile.py": "14e0e0e9afd7171119f8f3d09472f69488235b51",
       "lib/vaws_ops.py": "ec175c382edfe0baf0806b0f3572f572c1d35ff6",
       "lib/vaws_build_inputs.py": "426c97a47de22d110b2e827257fc79eeba544d85",
-      "task_server.py": "f59a9a8cde60193b10d6ddda3ef4a43b5fe337fe",
+      "task_server.py": "1d77f7de536f01c0a158099d6f211a24b624432b",
       "scripts/vaws.py": "c712c200aeab867f217ea069f6a670a513dc108b",
       "hooks/vaws_session.py": "8e9b796b3dd98c65666bd465f748eb7cfcce6b58",
       "workers/managed_jobs.py": "ddb6811c4d28d5add31973e4bf8731909b0a9783",

--- a/.agents/tests/test_cli_surface_inventory.py
+++ b/.agents/tests/test_cli_surface_inventory.py
@@ -298,7 +298,7 @@ class RepositoryCoherenceTests(unittest.TestCase):
         )
         self.assertEqual(
             by_repository["vllm-ascend-workspace/vaws-coordinator"]["commit"],
-            "d3c4e82a3c0e3f0be31727abf17b7863bcedba77",
+            "a7d5005a4df6ab8adf5b16a965127e81a30ee3fc",
         )
         self.assertEqual(
             by_repository["vllm-ascend-workspace/vaws-top"]["commit"],

--- a/.agents/tests/test_coordinator_consumer.py
+++ b/.agents/tests/test_coordinator_consumer.py
@@ -111,8 +111,8 @@ class LocatorTests(unittest.TestCase):
     def test_dependency_pin_names_the_accepted_main(self) -> None:
         pin = coordinator.load_dependency()
         self.assertEqual(pin["repository"], "vllm-ascend-workspace/vaws-coordinator")
-        self.assertEqual(pin["commit"], "d3c4e82a3c0e3f0be31727abf17b7863bcedba77")
-        self.assertEqual(pin["tree"], "d3f91bc6375a876fc01d46b1835feabd61db2729")
+        self.assertEqual(pin["commit"], "a7d5005a4df6ab8adf5b16a965127e81a30ee3fc")
+        self.assertEqual(pin["tree"], "2660b7fe09c660b8827444753a87ec3bf554d551")
         self.assertEqual(pin["visibility"], "public")
         self.assertEqual(
             pin["pinned_mirrors"]["vaws_build_inputs"]["sha256"],
@@ -611,7 +611,13 @@ class CoordinatorCheckoutTests(unittest.TestCase):
         self.assertEqual(status["commit"], pin["commit"])
 
     def test_arrival_blobs_match_the_pin(self) -> None:
+        status = coordinator.checkout_status()
         pin = coordinator.load_dependency()
+        if status["pin_matches"] is False:
+            message = f"checkout {status['commit']} is not the pinned {pin['commit']}"
+            if os.environ.get("CI"):
+                self.fail(message)
+            self.skipTest(message)
         for relative, blob in pin["arrival_blobs"].items():
             result = subprocess.run(
                 ["git", "-C", str(CHECKOUT), "rev-parse", f"HEAD:{relative}"],

--- a/.agents/tests/test_coordinator_official_stdio.py
+++ b/.agents/tests/test_coordinator_official_stdio.py
@@ -47,6 +47,15 @@ def have_sdk() -> bool:
 @unittest.skipUnless(CHECKOUT, "no vaws-coordinator checkout (set VAWS_COORDINATOR_ROOT)")
 @unittest.skipUnless(have_sdk(), "official MCP SDK 2.1.1 is not installed")
 class OfficialStdioTests(unittest.TestCase):
+    def setUp(self) -> None:
+        status = coordinator.checkout_status()
+        pin = coordinator.load_dependency()
+        if status["pin_matches"] is False:
+            message = f"checkout {status['commit']} is not the pinned {pin['commit']}"
+            if os.environ.get("CI"):
+                self.fail(message)
+            self.skipTest(message)
+
     def test_local_only_task_lifecycle(self) -> None:
         asyncio.run(self._run())
 
@@ -126,7 +135,8 @@ class OfficialStdioTests(unittest.TestCase):
                     async with ClientSession(read, write) as client:
                         initialized = (await client.initialize()).model_dump(by_alias=True)
                         capability = initialized["capabilities"]["experimental"]["vaws-coordinator-task"]
-                        self.assertEqual(capability["service_api_version"], "1")
+                        self.assertEqual(capability["service_api_version"], 1)
+                        self.assertIsInstance(capability["service_api_version"], int)
                         names = [tool.name for tool in (await client.list_tools()).tools]
                         self.assertEqual(set(names), {"vaws_session", "vaws_run", "vaws_execution", "vaws_finish"})
 

--- a/.agents/tests/test_dependency.py
+++ b/.agents/tests/test_dependency.py
@@ -116,12 +116,12 @@ class PinSchemaTests(unittest.TestCase):
     def test_coordinator_pin_consumes_the_bundled_host_queue(self) -> None:
         raw = json.loads((ROOT / ".agents/deps/coordinator.json").read_text(encoding="utf-8"))
         pin = deps.load_pin("vaws-coordinator")
-        self.assertEqual(pin["commit"], "d3c4e82a3c0e3f0be31727abf17b7863bcedba77")
+        self.assertEqual(pin["commit"], "a7d5005a4df6ab8adf5b16a965127e81a30ee3fc")
         self.assertEqual(pin["consumed_surface"]["host_queue_module"], "host/vaws_npu_coordination.py")
         self.assertNotIn("scaffold", pin["consumed_surface"]["host_queue_interface"])
         self.assertIn("host/vaws_npu_coordination.py", pin["identity"]["required_files"])
         self.assertIn("service-api.json", pin["identity"]["required_files"])
-        self.assertEqual(pin["extensions"]["tree"], "d3f91bc6375a876fc01d46b1835feabd61db2729")
+        self.assertEqual(pin["extensions"]["tree"], "2660b7fe09c660b8827444753a87ec3bf554d551")
         self.assertEqual(
             pin["extensions"]["arrival_blobs"]["host/vaws_npu_coordination.py"],
             "00f81e8300717307da06556f7c2cbdebf6b14ed7",

--- a/docs/coordinator-consumption.md
+++ b/docs/coordinator-consumption.md
@@ -6,8 +6,8 @@ The shared runtime pool, local task registry and four `vaws_*` tools used to
 live in this repository under `.agents/coordinator/` and a handful of
 `.agents/lib` modules. They now live in
 [`vllm-ascend-workspace/vaws-coordinator`](https://github.com/vllm-ascend-workspace/vaws-coordinator)
-at accepted main `d3c4e82a3c0e3f0be31727abf17b7863bcedba77` (tree
-`d3f91bc6375a876fc01d46b1835feabd61db2729`). This scaffold consumes that
+at accepted main `a7d5005a4df6ab8adf5b16a965127e81a30ee3fc` (tree
+`2660b7fe09c660b8827444753a87ec3bf554d551`). This scaffold consumes that
 checkout as an **external checkout**, matching the remote-dev pin/install
 pattern from #90.
 

--- a/docs/repo-boundaries.md
+++ b/docs/repo-boundaries.md
@@ -49,7 +49,7 @@ The coordinator consumer now **exists** in this combined tree: pin, locator,
 launcher, dual-provider client setup, owned-hook preservation, and residual
 compatibility adapters. Arrival evidence and the deleted in-tree writers are
 in [coordinator-consumption.md](coordinator-consumption.md). The pin is
-`d3c4e82a3c0e3f0be31727abf17b7863bcedba77`. Task tools, registry writes, and
+`a7d5005a4df6ab8adf5b16a965127e81a30ee3fc`. Task tools, registry writes, and
 the managed supervisor are not reimplemented here.
 
 The first-stage vaws-top consumer now **exists** in this combined tree:
@@ -70,7 +70,7 @@ current tree.
 
 | Repository | Role | Exact SHA |
 |---|---|---|
-| `vaws-coordinator` | accepted actual main after independent #1/#2 | `d3c4e82a3c0e3f0be31727abf17b7863bcedba77` |
+| `vaws-coordinator` | accepted actual main after independent #1/#2/#4 | `a7d5005a4df6ab8adf5b16a965127e81a30ee3fc` |
 | `remote-dev` | ledger + glob + mux accepted actual provider main | `62045af1f76c803ca392ae413b56bcfe290e6450` |
 | `vaws-top` | independently inspected standalone main consumed by this first-stage locator | `e7af28e629e7fd79c47e9b096f1dc1fd94f665ab` |
 
@@ -98,7 +98,7 @@ metadata; current visibility comes from the organization inventory.
 |---|---:|---|---|---|
 | `vllm-ascend-workspace/vllm-ascend-workspace` | 1196723340 | public, non-fork | `7af4ac3106649d2dbbed712c780a14db8bf25113` | canonical scaffold |
 | `vllm-ascend-workspace/remote-dev` | 1360023179 | private | `62045af1f76c803ca392ae413b56bcfe290e6450` | transport and explicit endpoints |
-| `vllm-ascend-workspace/vaws-coordinator` | 1360026044 | public | `d3c4e82a3c0e3f0be31727abf17b7863bcedba77` | task/provider/pool protocol and managed worker |
+| `vllm-ascend-workspace/vaws-coordinator` | 1360026044 | public | `a7d5005a4df6ab8adf5b16a965127e81a30ee3fc` | task/provider/pool protocol and managed worker |
 | `vllm-ascend-workspace/vaws-knowledge` | 1359978527 | public | `1eac65cf2f8ff4f1451c788f0964005ea0dfdee2` | formal knowledge corpus and source identity |
 | `vllm-ascend-workspace/vaws-top` | 1360023247 | private | `e7af28e629e7fd79c47e9b096f1dc1fd94f665ab` | fleet monitoring; observation only |
 | `vllm-ascend-workspace/.github` | 1360014025 | public | `fc6a1929fc13b2844f47012a1dec296daff09936` | organization landing metadata, not a runtime provider |


### PR DESCRIPTION
## Summary
- Bump the coordinator pin to `a7d5005a4df6ab8adf5b16a965127e81a30ee3fc` (tree `2660b7fe09c660b8827444753a87ec3bf554d551`), the merge of coordinator PR #4 that advertises `service_api_version` as an integer.
- Recomputed `arrival_blobs`: only `task_server.py` changed. `host/vaws_npu_coordination.py` is still `00f81e8300717307da06556f7c2cbdebf6b14ed7`. `service_api` stays `{min:1,max:1}`.
- Current-pin docs and hardcoded pin assertions moved with the new values. Arrival-evidence SHAs in `coordinator-consumption.md` §5 stay as dated facts. Integration tests skip (not fail) when the live checkout is one pin behind.

## Test plan
- [x] `git rev-parse a7d5005^{tree}` = `2660b7fe09c660b8827444753a87ec3bf554d551`
- [x] `VAWS_COORDINATOR_ROOT=<a7d5005 clone>` → `vaws_deps.py status` = `ready` + `service_api.compatible`; task-server `initialize` has integer `service_api_version: 1`
- [x] Suite A (live `.vaws-local` at old pin): `OK (skipped=9)` — coordinator checkout tests skip on `off_pin`
- [x] Suite B (`VAWS_*_ROOT=/nonexistent`): `OK (skipped=27)`
- [x] `tracked_path_check`, `tracked_leak_scan --commit-range`, `cli_surface_inventory --quiet`


Made with [Cursor](https://cursor.com)