### PR TITLE
test: drop the vaws-top wrapper-list assertion the uvx monitor removed

### DIFF
--- a/.agents/tests/test_dependency.py
+++ b/.agents/tests/test_dependency.py
@@ -99,15 +99,9 @@ class PinSchemaTests(unittest.TestCase):
             tuple(deps.load_pin("remote-dev")["identity"]["required_files"]),
             remote_dev.REQUIRED_FILES,
         )
-        scripts = ROOT / ".agents" / "skills" / "npu-fleet-monitor" / "scripts"
-        if str(scripts) not in sys.path:
-            sys.path.insert(0, str(scripts))
-        import manage_monitor  # noqa: E402
-
-        self.assertEqual(
-            tuple(deps.load_pin(deps.VAWS_TOP_NAME)["identity"]["required_files"]),
-            manage_monitor.REQUIRED_FILES,
-        )
+        # npu-fleet-monitor no longer consumes a vaws-top checkout: it installs
+        # the released wheel through uvx, so there is no wrapper file list to
+        # match against the pin.
         self.assertIn(
             "task_server.py",
             deps.load_pin("vaws-coordinator")["identity"]["required_files"],


### PR DESCRIPTION
`.agents/tests/test_dependency.py::test_pin_required_files_match_wrapper_lists` asserts the vaws-top pin's `identity.required_files` equals `manage_monitor.REQUIRED_FILES`. [#110](https://github.com/vllm-ascend-workspace/vllm-ascend-workspace/pull/110) replaced the pinned checkout with a uvx install and removed that constant, so the assertion fails on `main`.

CI stayed green because no workflow runs `.agents/tests` wholesale — only selected `-p` patterns. That gap is being addressed in the dependency-plane work.

Only the vaws-top third of the assertion is dropped; the coordinator and remote-dev halves still hold.

```
$ python3 -B -m pytest .agents/tests -q
657 passed, 7 skipped, 315 subtests passed in 68.97s
```

Made with [Cursor](https://cursor.com)