### PR TITLE
chore: follow vaws-knowledge 0.1.1; restamp r1 provenance; fix vaws-top surface declaration

### DIFF
--- a/.agents/knowledge/known-failure-signatures.v2.yaml
+++ b/.agents/knowledge/known-failure-signatures.v2.yaml
@@ -12,7 +12,7 @@
       "provenance": {
         "contributor": "maoxx241",
         "origin_repo": "maoxx241/vllm-ascend-workspace",
-        "redaction_profile": "r1",
+        "redaction_profile": "r2",
         "submitted_at": "2026-09-07"
       },
       "rule": {
@@ -100,7 +100,7 @@
       "provenance": {
         "contributor": "maoxx241",
         "origin_repo": "maoxx241/vllm-ascend-workspace",
-        "redaction_profile": "r1",
+        "redaction_profile": "r2",
         "submitted_at": "2026-09-07"
       },
       "rule": {

--- a/.agents/lib/vaws_knowledge_v2.py
+++ b/.agents/lib/vaws_knowledge_v2.py
@@ -859,7 +859,7 @@ def _validate_provenance(value: Any, path: str, errors: list[str]) -> None:
         errors.append(f"{path}.submitted_at must use YYYY-MM-DD")
     profile = value.get("redaction_profile")
     if not isinstance(profile, str) or not REDACTION_PROFILE_RE.fullmatch(profile):
-        errors.append(f"{path}.redaction_profile must look like r1")
+        errors.append(f"{path}.redaction_profile must look like r<N>")
     unknown = sorted(
         set(value) - {"contributor", "origin_repo", "submitted_at", "redaction_profile"}
     )

--- a/.agents/policy/cli-surface-inventory.json
+++ b/.agents/policy/cli-surface-inventory.json
@@ -12,7 +12,8 @@
     },
     {
       "id": "vaws-top",
-      "package": "vaws-top"
+      "package": "vaws-top",
+      "declaration": "npu-fleet-monitor uvx release wheel"
     },
     {
       "id": "vaws-knowledge",

--- a/.agents/scripts/cli_surface_inventory.py
+++ b/.agents/scripts/cli_surface_inventory.py
@@ -173,6 +173,7 @@ def load_catalog(path: Path | None = None) -> dict:
             raise CatalogError(f"CLI surface catalog entry {key!r} is missing overlay fields: {catalog_path}")
         parsed[key] = {str(field): str(value) for field, value in meta.items()}
     deps: list[tuple[str, str]] = []
+    labels: dict[str, str] = {}
     for item in declarations:
         if not isinstance(item, dict):
             raise CatalogError(f"CLI surface catalog dep_declarations entries must be objects: {catalog_path}")
@@ -181,14 +182,20 @@ def load_catalog(path: Path | None = None) -> dict:
         if not isinstance(ident, str) or not ident or not isinstance(package, str) or not package:
             raise CatalogError(f"CLI surface catalog dep_declarations requires id and package: {catalog_path}")
         deps.append((ident, package))
+        declaration = item.get("declaration")
+        if isinstance(declaration, str) and declaration.strip():
+            labels[ident] = declaration.strip()
+            labels[package] = declaration.strip()
     loaded = dict(data)
     loaded["classification"] = parsed
     loaded["dep_declarations"] = deps
+    loaded["dep_declaration_labels"] = labels
     return loaded
 
 
 _CATALOG = load_catalog()
 DEP_DECLARATIONS = tuple(_CATALOG["dep_declarations"])
+DEP_DECLARATION_LABELS = dict(_CATALOG["dep_declaration_labels"])
 CLASSIFICATION = dict(_CATALOG["classification"])
 
 
@@ -647,7 +654,9 @@ def load_external_owners(repo_root: Path) -> dict[str, dict]:
     for ident, package in DEP_DECLARATIONS:
         row = locked.get(package) or locked.get(ident) or {}
         owners[ident] = {
-            "declaration": "pyproject.toml",
+            "declaration": DEP_DECLARATION_LABELS.get(ident)
+            or DEP_DECLARATION_LABELS.get(package)
+            or "pyproject.toml",
             "name": package,
             "repository": repos.get(ident) or repos.get(package),
             "commit": row.get("commit"),

--- a/.agents/tests/test_cli_surface_inventory.py
+++ b/.agents/tests/test_cli_surface_inventory.py
@@ -314,8 +314,12 @@ class RepositoryCoherenceTests(unittest.TestCase):
         )
         self.assertIsNone(by_repository["vllm-ascend-workspace/vaws-top"]["commit"])
         self.assertEqual(
+            by_repository["vllm-ascend-workspace/vaws-top"]["declaration"],
+            "npu-fleet-monitor uvx release wheel",
+        )
+        self.assertEqual(
             by_repository["vllm-ascend-workspace/vaws-knowledge"]["commit"],
-            "afe396071540ff28623a53c3edd22fca6de011af",
+            "93be969f04a5f681fee1686bfd1f2bf319a90f12",
         )
         for meta in owners.values():
             self.assertEqual(meta["source_availability"], "uninspected")

--- a/.agents/tests/test_cli_surface_inventory.py
+++ b/.agents/tests/test_cli_surface_inventory.py
@@ -319,7 +319,7 @@ class RepositoryCoherenceTests(unittest.TestCase):
         )
         self.assertEqual(
             by_repository["vllm-ascend-workspace/vaws-knowledge"]["commit"],
-            "93be969f04a5f681fee1686bfd1f2bf319a90f12",
+            "2a89241b83e6ae85deb99926088d9c9c6d07364b",
         )
         for meta in owners.values():
             self.assertEqual(meta["source_availability"], "uninspected")

--- a/.agents/tests/test_cli_surface_inventory.py
+++ b/.agents/tests/test_cli_surface_inventory.py
@@ -319,7 +319,7 @@ class RepositoryCoherenceTests(unittest.TestCase):
         )
         self.assertEqual(
             by_repository["vllm-ascend-workspace/vaws-knowledge"]["commit"],
-            "2a89241b83e6ae85deb99926088d9c9c6d07364b",
+            "19b60cb1538691880a05925305d85108acd7ee0f",
         )
         for meta in owners.values():
             self.assertEqual(meta["source_availability"], "uninspected")

--- a/.agents/tests/test_dependency.py
+++ b/.agents/tests/test_dependency.py
@@ -39,7 +39,7 @@ class SpecLockTests(unittest.TestCase):
         )
         self.assertEqual(
             locked["vaws-knowledge"]["commit"],
-            "2a89241b83e6ae85deb99926088d9c9c6d07364b",
+            "19b60cb1538691880a05925305d85108acd7ee0f",
         )
         self.assertEqual(
             locked["vaws-remote-dev"]["commit"],

--- a/.agents/tests/test_dependency.py
+++ b/.agents/tests/test_dependency.py
@@ -24,7 +24,7 @@ class SpecLockTests(unittest.TestCase):
         versions = deps.required_versions()
         self.assertEqual(versions["vaws-remote-dev"], "0.1.0")
         self.assertEqual(versions["vaws-coordinator"], "0.1.0")
-        self.assertEqual(versions["vaws-knowledge"], "0.1.0")
+        self.assertEqual(versions["vaws-knowledge"], "0.1.1")
         self.assertNotIn(deps.VAWS_TOP_NAME, versions)
 
     def test_status_tracks_only_the_three_packages(self) -> None:
@@ -39,14 +39,15 @@ class SpecLockTests(unittest.TestCase):
         )
         self.assertEqual(
             locked["vaws-knowledge"]["commit"],
-            "afe396071540ff28623a53c3edd22fca6de011af",
+            "93be969f04a5f681fee1686bfd1f2bf319a90f12",
         )
         self.assertEqual(
             locked["vaws-remote-dev"]["commit"],
             "2d2d9297fbf74259f6733b3f4a0ab35150608d56",
         )
+        expected_versions = deps.required_versions()
         for name in deps.PACKAGE_NAMES:
-            self.assertEqual(locked[name]["version"], "0.1.0", name)
+            self.assertEqual(locked[name]["version"], expected_versions[name], name)
             self.assertIn("github.com/vllm-ascend-workspace", locked[name]["url"] or "")
 
     def test_inspect_ready_when_installed_matches_lock(self) -> None:
@@ -58,7 +59,7 @@ class SpecLockTests(unittest.TestCase):
             self.assertEqual(info["name"], name)
             self.assertIn(info["state"], deps.STATES)
             if info["state"] == "ready":
-                self.assertEqual(info["installed_version"], "0.1.0")
+                self.assertEqual(info["installed_version"], deps.locked_packages()[name]["version"])
                 self.assertEqual(info["installed_commit"], deps.locked_packages()[name]["commit"])
                 self.assertEqual(info["remedy"], "uv sync")
 

--- a/.agents/tests/test_dependency.py
+++ b/.agents/tests/test_dependency.py
@@ -39,7 +39,7 @@ class SpecLockTests(unittest.TestCase):
         )
         self.assertEqual(
             locked["vaws-knowledge"]["commit"],
-            "93be969f04a5f681fee1686bfd1f2bf319a90f12",
+            "2a89241b83e6ae85deb99926088d9c9c6d07364b",
         )
         self.assertEqual(
             locked["vaws-remote-dev"]["commit"],

--- a/docs/dependency-plane.md
+++ b/docs/dependency-plane.md
@@ -17,7 +17,7 @@ must name git+https tag sources because `vaws-coordinator` depends on
 |---|---|---|---|
 | `vaws-remote-dev` | `remote_dev` | `v0.1.0` | process-in import + MCP server |
 | `vaws-coordinator` | `vaws_coordinator` | `v0.1.0` | process-in import + stdio MCP |
-| `vaws-knowledge` | `vaws_knowledge` | `v0.1.0` | process-in import + MCP |
+| `vaws-knowledge` | `vaws_knowledge` | `==0.1.1` (git rev until `v0.1.1` is tagged) | process-in import + MCP |
 | `vaws-top` | — | uvx only | fleet dashboard; not imported |
 
 `uv sync` writes `.venv` and records the resolved git commits in `uv.lock`.

--- a/docs/dependency-plane.md
+++ b/docs/dependency-plane.md
@@ -17,7 +17,7 @@ must name git+https tag sources because `vaws-coordinator` depends on
 |---|---|---|---|
 | `vaws-remote-dev` | `remote_dev` | `v0.1.0` | process-in import + MCP server |
 | `vaws-coordinator` | `vaws_coordinator` | `v0.1.0` | process-in import + stdio MCP |
-| `vaws-knowledge` | `vaws_knowledge` | `==0.1.1` (git rev until `v0.1.1` is tagged) | process-in import + MCP |
+| `vaws-knowledge` | `vaws_knowledge` | `v0.1.1` | process-in import + MCP |
 | `vaws-top` | — | uvx only | fleet dashboard; not imported |
 
 `uv sync` writes `.venv` and records the resolved git commits in `uv.lock`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ package = false
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", tag = "v0.1.0" }
 vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", tag = "v0.1.0" }
-vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "93be969f04a5f681fee1686bfd1f2bf319a90f12" }
+vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "2a89241b83e6ae85deb99926088d9c9c6d07364b" }
 
 [tool.pytest.ini_options]
 pythonpath = [".agents/lib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.11"
 dependencies = [
   "vaws-remote-dev==0.1.0",
   "vaws-coordinator==0.1.0",
-  "vaws-knowledge==0.1.0",
+  "vaws-knowledge==0.1.1",
 ]
 
 [dependency-groups]
@@ -22,7 +22,7 @@ package = false
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", tag = "v0.1.0" }
 vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", tag = "v0.1.0" }
-vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", tag = "v0.1.0" }
+vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "93be969f04a5f681fee1686bfd1f2bf319a90f12" }
 
 [tool.pytest.ini_options]
 pythonpath = [".agents/lib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ package = false
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", tag = "v0.1.0" }
 vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", tag = "v0.1.0" }
-vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "2a89241b83e6ae85deb99926088d9c9c6d07364b" }
+vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", tag = "v0.1.1" }
 
 [tool.pytest.ini_options]
 pythonpath = [".agents/lib"]

--- a/uv.lock
+++ b/uv.lock
@@ -820,8 +820,8 @@ name = "uvicorn"
 version = "0.52.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
 wheels = [
@@ -838,8 +838,8 @@ dependencies = [
 
 [[package]]
 name = "vaws-knowledge"
-version = "0.1.0"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?tag=v0.1.0#afe396071540ff28623a53c3edd22fca6de011af" }
+version = "0.1.1"
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=93be969f04a5f681fee1686bfd1f2bf319a90f12#93be969f04a5f681fee1686bfd1f2bf319a90f12" }
 dependencies = [
     { name = "jsonschema" },
     { name = "packaging" },
@@ -872,7 +872,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?tag=v0.1.0" },
-    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?tag=v0.1.0" },
+    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=93be969f04a5f681fee1686bfd1f2bf319a90f12" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?tag=v0.1.0" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "vaws-knowledge"
 version = "0.1.1"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=93be969f04a5f681fee1686bfd1f2bf319a90f12#93be969f04a5f681fee1686bfd1f2bf319a90f12" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=2a89241b83e6ae85deb99926088d9c9c6d07364b#2a89241b83e6ae85deb99926088d9c9c6d07364b" }
 dependencies = [
     { name = "jsonschema" },
     { name = "packaging" },
@@ -872,7 +872,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?tag=v0.1.0" },
-    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=93be969f04a5f681fee1686bfd1f2bf319a90f12" },
+    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=2a89241b83e6ae85deb99926088d9c9c6d07364b" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?tag=v0.1.0" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "vaws-knowledge"
 version = "0.1.1"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=2a89241b83e6ae85deb99926088d9c9c6d07364b#2a89241b83e6ae85deb99926088d9c9c6d07364b" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?tag=v0.1.1#19b60cb1538691880a05925305d85108acd7ee0f" }
 dependencies = [
     { name = "jsonschema" },
     { name = "packaging" },
@@ -872,7 +872,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?tag=v0.1.0" },
-    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=2a89241b83e6ae85deb99926088d9c9c6d07364b" },
+    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?tag=v0.1.1" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?tag=v0.1.0" },
 ]
 


### PR DESCRIPTION
## Summary

- Follow `vaws-knowledge==0.1.1` from tag `v0.1.1` (`19b60cb1538691880a05925305d85108acd7ee0f`) (https://github.com/vllm-ascend-workspace/vaws-knowledge/pull/13). `[tool.uv.sources]` is `tag = "v0.1.1"`.
- Restamp the two project-layer `provenance.redaction_profile: "r1"` rows to `"r2"`. Commons r2 already reports zero findings on `.agents/knowledge/*.yaml`; `content_hash` covers scope+body only, so the hashes are unchanged.
- `redaction_profile` format check now says `must look like r<N>` (it is a shape check, not a pinned value).
- CLI-surface overlay now declares `vaws-top` as `npu-fleet-monitor uvx release wheel` instead of `pyproject.toml`. Regenerating `docs/cli-surface.md` left the current table unchanged (declaration is not a table column; section 6 already said uvx only).


## Redaction through `vaws_redaction.scan`

```
profile r2
-- should be clean --
'worker-pool-size-32': clean
'compute-bound-step-3': clean
'master-branch-2026': clean
'node-count-8': clean
'remote-code-parity-sync-27a5373f7a': clean
-- should hit hostname-numbered --
'node-01': [('hostname-numbered', 'block')]
'worker3': [('hostname-numbered', 'block')]
'remote_131': [('hostname-numbered', 'block')]
'remote-131': [('hostname-numbered', 'block')]
'k8s-3': [('hostname-numbered', 'block')]
'master01': [('hostname-numbered', 'block')]
```

20 `generate_candidate_id({'owner_skill':'remote-code-parity','summary':…,'kind':'k','scope':{}})` ids, all clean:

```
remote-code-parity-sync-failed-on-first-retry-87112e9902: clean
remote-code-parity-parity-checksum-mismatch-after-pull-87112e9902: clean
remote-code-parity-container-hostname-missing-from-hosts-87112e9902: clean
remote-code-parity-graph-compile-abort-on-capture-87112e9902: clean
remote-code-parity-eager-graph-numeric-drift-87112e9902: clean
remote-code-parity-npu-memory-fragmentation-under-load-87112e9902: clean
remote-code-parity-hccl-timeout-during-allreduce-87112e9902: clean
remote-code-parity-kv-cache-block-size-mismatch-87112e9902: clean
remote-code-parity-tokenizer-vocab-pad-id-conflict-87112e9902: clean
remote-code-parity-speculative-decode-reject-rate-spike-87112e9902: clean
remote-code-parity-prefill-decode-connector-hang-87112e9902: clean
remote-code-parity-lora-adapter-load-path-miss-87112e9902: clean
remote-code-parity-quant-scale-dump-overflow-87112e9902: clean
remote-code-parity-attention-backend-fallback-87112e9902: clean
remote-code-parity-chunked-prefill-schedule-stall-87112e9902: clean
remote-code-parity-prefix-cache-hit-rate-collapse-87112e9902: clean
remote-code-parity-multimodal-image-token-inflate-87112e9902: clean
remote-code-parity-guided-decoding-fsm-compile-fail-87112e9902: clean
remote-code-parity-logprobs-rank-permutation-87112e9902: clean
remote-code-parity-streaming-sse-disconnect-mid-token-87112e9902: clean
unique 20 all_clean True
```

(`summary` is not part of the digest; the 10-hex suffix is therefore identical. The suffix still starts with digits, which is the old false-positive shape.)

## content_hash unchanged after r1 → r2

```
gloo-init-container-hostname-missing-from-etc-hosts
  stored      sha256:82a834b64884aab039410361823287f2b64973e827556a83630d74e1573ccc2c
  after r2    sha256:82a834b64884aab039410361823287f2b64973e827556a83630d74e1573ccc2c
  with r1     sha256:82a834b64884aab039410361823287f2b64973e827556a83630d74e1573ccc2c
ssh-stream-over-shared-controlmaster-mux-dies-early
  stored      sha256:d6e581d3393d72a081ec648e227e675bf7175b95a8f90c023d211aff57d696b0
  after r2    sha256:d6e581d3393d72a081ec648e227e675bf7175b95a8f90c023d211aff57d696b0
  with r1     sha256:d6e581d3393d72a081ec648e227e675bf7175b95a8f90c023d211aff57d696b0
```

## Acceptance

```
uv run python -B -m pytest .agents/tests -q
# 639 passed, 5 skipped, 313 subtests passed in 55.09s

uv run python -B .agents/tests/knowledge_kit.py
# 41 passed, 0 failed, 0 skipped, 41 total

uv run python -B .agents/scripts/skill_catalog.py                          # exit 0
uv run python -B .agents/scripts/tracked_path_check.py --mode enforce      # exit 0
uv run python -B .agents/scripts/cli_surface_inventory.py --quiet          # exit 0
uv run python -B .agents/scripts/repo_boundary_check.py --mode enforce     # exit 0
uv run python -B .agents/scripts/tracked_leak_scan.py                      # exit 0
uv run python -B .agents/scripts/sync_claude_skills.py --check             # exit 0
uv lock --check                                                            # exit 0
```


Made with [Cursor](https://cursor.com)

