### PR TITLE
chore: pin npu-fleet-monitor to vaws-top v0.1.1

### DIFF
--- a/.agents/skills/npu-fleet-monitor/SKILL.md
+++ b/.agents/skills/npu-fleet-monitor/SKILL.md
@@ -7,13 +7,13 @@ description: Start, inspect, restart, or stop the loopback-only vaws-top NPU fle
 
 The dashboard, its runtime, and its complete Agent instructions live in the published package `vaws-top` from `vllm-ascend-workspace/vaws-top`. This scaffold Skill only launches that package through `uvx` as a local background process and hands off to its CLI/MCP.
 
-The pinned revision is the single constant `VAWS_TOP_REF` in `scripts/manage_monitor.py` (currently `v0.1.0`); the wheel filename is derived from it. Every invocation uses the GitHub Release wheel:
+The pinned revision is the single constant `VAWS_TOP_REF` in `scripts/manage_monitor.py` (currently `v0.1.1`); the wheel filename is derived from it. Every invocation uses the GitHub Release wheel:
 
 ```bash
-uvx --from "https://github.com/vllm-ascend-workspace/vaws-top/releases/download/v0.1.0/vaws_top-0.1.0-py3-none-any.whl" vaws-top ...
+uvx --from "https://github.com/vllm-ascend-workspace/vaws-top/releases/download/v0.1.1/vaws_top-0.1.1-py3-none-any.whl" vaws-top ...
 ```
 
-Why the wheel and not `git+https://...@v0.1.0`: vaws-top ships a JS frontend whose build output exists only in the released wheel. Installing from git runs a hatch hook that needs Node.js; on a host without Node it silently produces a wheel with no frontend and `serve` fails at startup. This is specific to vaws-top; pure-Python sibling packages keep `git+tag`. Operational contract: **every new vaws-top release must upload its wheel as a Release asset, otherwise the monitor cannot be installed** by this Skill.
+Why the wheel and not `git+https://...@v0.1.1`: vaws-top ships a JS frontend whose build output exists only in the released wheel. Installing from git runs a hatch hook that needs Node.js; on a host without Node it silently produces a wheel with no frontend and `serve` fails at startup. This is specific to vaws-top; pure-Python sibling packages keep `git+tag`. Operational contract: **every new vaws-top release must upload its wheel as a Release asset, otherwise the monitor cannot be installed** by this Skill.
 
 Developers may override the install source with `--from <spec>` or `VAWS_TOP_FROM=<spec>` (a local wheel, a source tree, or `git+https://...`, which needs Node.js 22.13+). The default is always the wheel. `uvx` fetches and caches the package; there is no checkout, no pin file, and no service manager.
 
@@ -44,7 +44,7 @@ The helper always passes `--bind 127.0.0.1` and sets `NFM_BIND=127.0.0.1`; there
 Use the `cli_prefix` from the JSON, which is the `uvx` command above:
 
 ```bash
-WHEEL="https://github.com/vllm-ascend-workspace/vaws-top/releases/download/v0.1.0/vaws_top-0.1.0-py3-none-any.whl"
+WHEEL="https://github.com/vllm-ascend-workspace/vaws-top/releases/download/v0.1.1/vaws_top-0.1.1-py3-none-any.whl"
 uvx --from "$WHEEL" vaws-top servers
 uvx --from "$WHEEL" vaws-top capacity --min-idle 4 --max-age 180
 uvx --from "$WHEEL" vaws-top status HOST
@@ -64,7 +64,7 @@ Register the stdio server with the `mcp_command` from the JSON:
   "mcpServers": {
     "vaws-top": {
       "command": "uvx",
-      "args": ["--from", "https://github.com/vllm-ascend-workspace/vaws-top/releases/download/v0.1.0/vaws_top-0.1.0-py3-none-any.whl", "vaws-top", "mcp"],
+      "args": ["--from", "https://github.com/vllm-ascend-workspace/vaws-top/releases/download/v0.1.1/vaws_top-0.1.1-py3-none-any.whl", "vaws-top", "mcp"],
       "env": { "VAWS_TOP_URL": "http://127.0.0.1:8788" }
     }
   }
@@ -77,7 +77,7 @@ The basic tools are `list_npu_servers`, `find_npu_capacity`, `server_status`, `n
 
 Before advanced fleet selection, process attribution, mount discovery, or operational changes, read the standalone repository's skill and Agent contract at the pinned tag and follow them:
 
-- <https://github.com/vllm-ascend-workspace/vaws-top/blob/v0.1.0/.agents/skills/vaws-top/SKILL.md>
-- <https://github.com/vllm-ascend-workspace/vaws-top/blob/v0.1.0/docs/agent-access.md>
+- <https://github.com/vllm-ascend-workspace/vaws-top/blob/v0.1.1/.agents/skills/vaws-top/SKILL.md>
+- <https://github.com/vllm-ascend-workspace/vaws-top/blob/v0.1.1/docs/agent-access.md>
 
 Do not copy that skill into the scaffold. Never use this entry to launch workloads or reserve NPUs.

--- a/.agents/skills/npu-fleet-monitor/scripts/manage_monitor.py
+++ b/.agents/skills/npu-fleet-monitor/scripts/manage_monitor.py
@@ -36,7 +36,7 @@ from vaws_local_state import STATE_DIRNAME, shared_inventory_path, shared_worksp
 VAWS_TOP_REPO = "vllm-ascend-workspace/vaws-top"
 # Single version constant: the release tag. The wheel filename below is derived
 # from it so the tag and the wheel version cannot drift apart.
-VAWS_TOP_REF = "v0.1.0"
+VAWS_TOP_REF = "v0.1.1"
 VAWS_TOP_VERSION = VAWS_TOP_REF.removeprefix("v")
 # The console script is named after the repository and the import package uses
 # underscores; derive both so the only literal naming the extracted project is

--- a/docs/npu-fleet-monitor.md
+++ b/docs/npu-fleet-monitor.md
@@ -9,12 +9,12 @@ Status: current
 所有调用都固定为 GitHub Release wheel：
 
 ```bash
-uvx --from "https://github.com/vllm-ascend-workspace/vaws-top/releases/download/v0.1.0/vaws_top-0.1.0-py3-none-any.whl" vaws-top <子命令>
+uvx --from "https://github.com/vllm-ascend-workspace/vaws-top/releases/download/v0.1.1/vaws_top-0.1.1-py3-none-any.whl" vaws-top <子命令>
 ```
 
 版本只有一个常量：`.agents/skills/npu-fleet-monitor/scripts/manage_monitor.py` 里的 `VAWS_TOP_REF`（tag），wheel 文件名和下载 URL 都从它派生，不会出现 tag 与 wheel 版本各写各的。升级监控就是改这一个常量。不再有依赖 pin 文件、本地 checkout、`npm` 构建或用户级服务单元。
 
-**为什么是 wheel 而不是 `git+https://…@v0.1.0`**：vaws-top 带 JS 前端，构建产物只存在于 Release wheel 里（`vaws_top/static` 不入库）。从 git 安装会在本机跑 hatch 构建 hook，需要 Node.js 22.13+；机器上没有 Node 时它会**静默**构建出一个没有前端的 wheel，直到 `serve` 才报错。这一条只针对 vaws-top；其余纯 Python 的外部包继续用 `git+tag`。
+**为什么是 wheel 而不是 `git+https://…@v0.1.1`**：vaws-top 带 JS 前端，构建产物只存在于 Release wheel 里（`vaws_top/static` 不入库）。从 git 安装会在本机跑 hatch 构建 hook，需要 Node.js 22.13+；机器上没有 Node 时它会**静默**构建出一个没有前端的 wheel，直到 `serve` 才报错。这一条只针对 vaws-top；其余纯 Python 的外部包继续用 `git+tag`。
 
 **运维契约**：vaws-top 发布新版本时必须把 wheel 上传为 Release 资产，否则本入口装不上监控。改 `VAWS_TOP_REF` 之前先确认对应 tag 的 Release 里有 `vaws_top-<版本>-py3-none-any.whl`。
 
@@ -65,6 +65,6 @@ python3 .agents/skills/npu-fleet-monitor/scripts/manage_monitor.py stop
 
 ## Agent 查询入口
 
-JSON 结果里的 `cli_prefix` 即上面的 `uvx` 命令前缀，`mcp_command` 是对应的 stdio MCP 命令（`… vaws-top mcp`，通过 `VAWS_TOP_URL` 指向 `http://127.0.0.1:8788`）。完整的 CLI/MCP 参数、`observation` 信封和高级选机指引见独立仓库 pinned tag 下的 [Agent CLI 与 MCP 文档](https://github.com/vllm-ascend-workspace/vaws-top/blob/v0.1.0/docs/agent-access.md) 与 [vaws-top Agent Skill](https://github.com/vllm-ascend-workspace/vaws-top/blob/v0.1.0/.agents/skills/vaws-top/SKILL.md)。
+JSON 结果里的 `cli_prefix` 即上面的 `uvx` 命令前缀，`mcp_command` 是对应的 stdio MCP 命令（`… vaws-top mcp`，通过 `VAWS_TOP_URL` 指向 `http://127.0.0.1:8788`）。完整的 CLI/MCP 参数、`observation` 信封和高级选机指引见独立仓库 pinned tag 下的 [Agent CLI 与 MCP 文档](https://github.com/vllm-ascend-workspace/vaws-top/blob/v0.1.1/docs/agent-access.md) 与 [vaws-top Agent Skill](https://github.com/vllm-ascend-workspace/vaws-top/blob/v0.1.1/.agents/skills/vaws-top/SKILL.md)。
 
 需要新增、修复或移除远程服务器时使用 `machine-management`，监控服务本身不创建远程容器、不启动任务，也不占用 NPU lease。


### PR DESCRIPTION
Follows vaws-top v0.1.1 (loopback-only bind refusal from vaws-top #3). Release wheel confirmed uploaded. Monitor tests 28 pass; six guards 0.

Made with [Cursor](https://cursor.com)