### PR TITLE
feat: satisfy P9/P10/P19 and pin vaws-knowledge 0.1.4

### DIFF
--- a/.agents/policy/cli-surface-inventory.json
+++ b/.agents/policy/cli-surface-inventory.json
@@ -596,9 +596,10 @@
     },
     ".agents/skills/remote-code-parity/scripts/remote_code_parity.py": {
       "responsibility": "mechanics",
-      "support_role": "payload",
+      "support_role": "supported",
       "target_kind": "self",
-      "note": "thin CLI over vaws_coordinator.parity; spawned by parity_sync, toolbox adapters and the coordinator"
+      "note": "thin local CLI over vaws_coordinator.parity; spawned by parity_sync and the coordinator on the workstation, not on the NPU container",
+      "proposed_target": "vaws sync"
     },
     ".agents/skills/remote-code-parity/scripts/transport_benchmark.py": {
       "responsibility": "mechanics",
@@ -796,9 +797,9 @@
     },
     ".trae/skills/modelscope/scripts/download_from_modelscope.py": {
       "responsibility": "mechanics",
-      "support_role": "generated",
+      "support_role": "payload",
       "target_kind": "local-entry",
-      "note": "Trae projection generated from the canonical download script by sync_claude_skills.py",
+      "note": "Trae byte-copy of the canonical payload download script; inherits payload (no shim, no .agents/lib)",
       "target": ".agents/skills/modelscope/scripts/download_from_modelscope.py"
     },
     ".trae/skills/modelscope/scripts/modelscope_auto.py": {
@@ -817,9 +818,9 @@
     },
     ".trae/skills/modelscope/scripts/verify_modelscope_sha256.py": {
       "responsibility": "mechanics",
-      "support_role": "generated",
+      "support_role": "payload",
       "target_kind": "local-entry",
-      "note": "Trae projection generated from the canonical verify script",
+      "note": "Trae byte-copy of the canonical payload verify script; inherits payload (no shim, no .agents/lib)",
       "target": ".agents/skills/modelscope/scripts/verify_modelscope_sha256.py"
     }
   }

--- a/.agents/policy/repo-boundaries.json
+++ b/.agents/policy/repo-boundaries.json
@@ -110,8 +110,10 @@
       "layer": 30,
       "summary": "The domain layer that stays: 24 skills, shared libraries, helper scripts. May depend on every extracted subsystem; none of them may depend on it.",
       "roots": [
-        ".agents"
+        ".agents",
+        ".trae/skills/modelscope"
       ],
+      "roots_note": "The ModelScope Trae projection is a byte-identical twin of `.agents/skills/modelscope`. Local facades carry `ensure_workspace_interpreter` and therefore name `.agents/lib`; they are the same skill, not a workspace-root consumer of scaffold internals.",
       "public_paths": [],
       "public_paths_note": "Deliberately empty. The scaffold publishes nothing downward: a lower layer that needs scaffold data must receive it through an interface the lower layer owns, not read it.",
       "private_paths": [

--- a/.agents/scripts/cli_surface_inventory.py
+++ b/.agents/scripts/cli_surface_inventory.py
@@ -51,6 +51,16 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Iterable
 
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 SUBMODULES = ("vllm", "vllm-ascend")
 IGNORED_PREFIXES = (".git/", ".vaws-local/", ".remote-dev/state/")
 TEST_FILE_RE = re.compile(r"^(test_.*|.*_test|selftest_.*|conftest)\.py$")

--- a/.agents/scripts/knowledge_query.py
+++ b/.agents/scripts/knowledge_query.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -26,6 +27,50 @@ from vaws_knowledge.server.layers import LAYERS, load_entries  # noqa: E402
 from vaws_knowledge.server.query import explain, query  # noqa: E402
 from vaws_knowledge_service import infer_repo_root, service_config  # noqa: E402
 
+REQUIRED_KNOWLEDGE = "0.1.4"
+
+
+def _version_core(raw: str) -> tuple[int, ...]:
+    core = raw.split("+", 1)[0]
+    for marker in ("a", "b", "rc", ".dev"):
+        idx = core.find(marker)
+        if idx != -1:
+            core = core[:idx]
+    parts: list[int] = []
+    for item in core.split("."):
+        if item.isdigit():
+            parts.append(int(item))
+        else:
+            break
+    return tuple(parts) or (0,)
+
+
+def require_knowledge_reader_cli() -> None:
+    """Fail with cause and remedy when the coordinate CLI helpers are absent."""
+    try:
+        installed = version("vaws-knowledge")
+    except PackageNotFoundError as exc:
+        raise SystemExit(
+            "vaws-knowledge is not installed; reader-coordinate flags cannot "
+            "run. Install it with `uv sync`."
+        ) from exc
+    if _version_core(installed) < _version_core(REQUIRED_KNOWLEDGE):
+        raise SystemExit(
+            f"vaws-knowledge {installed} is too old for reader-coordinate "
+            f"flags (need >={REQUIRED_KNOWLEDGE}). Run `uv sync`."
+        )
+    try:
+        from vaws_knowledge.server.query import (  # noqa: F401
+            add_reader_coordinate_arguments,
+            reader_coordinate_from_args,
+        )
+    except ImportError as exc:
+        raise SystemExit(
+            "this vaws-knowledge install does not export the reader-coordinate "
+            f"CLI helpers ({type(exc).__name__}: {exc}). Need "
+            f">={REQUIRED_KNOWLEDGE}; run `uv sync`."
+        ) from exc
+
 
 def _explain(config, ident: str, layers: list[str] | None) -> dict:
     wanted = layers or list(LAYERS)
@@ -37,6 +82,12 @@ def _explain(config, ident: str, layers: list[str] | None) -> dict:
 
 
 def main(argv: list[str] | None = None) -> int:
+    require_knowledge_reader_cli()
+    from vaws_knowledge.server.query import (
+        add_reader_coordinate_arguments,
+        reader_coordinate_from_args,
+    )
+
     parser = argparse.ArgumentParser(description=__doc__)
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--query")
@@ -70,6 +121,7 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         default=ROOT / ".vaws-local" / "knowledge" / "candidate",
     )
+    add_reader_coordinate_arguments(parser)
     args = parser.parse_args(argv)
     bodies = (
         [item.strip() for item in args.bodies.split(",") if item.strip()]
@@ -83,6 +135,7 @@ def main(argv: list[str] | None = None) -> int:
         project_root=knowledge_dir,
         candidate_root=args.candidate_dir.resolve(),
     )
+    reader_coordinate = reader_coordinate_from_args(args)
     if args.id:
         payload = _explain(config, args.id, args.layers)
     else:
@@ -94,6 +147,7 @@ def main(argv: list[str] | None = None) -> int:
             kind=args.kind,
             bodies=bodies,
             limit=args.limit,
+            reader_coordinate=reader_coordinate,
         ).to_dict()
     print(json.dumps(payload, ensure_ascii=False))
     return 0

--- a/.agents/scripts/repo_boundary_check.py
+++ b/.agents/scripts/repo_boundary_check.py
@@ -42,6 +42,16 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, Iterator, Sequence
 
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 DEFAULT_POLICY = ".agents/policy/repo-boundaries.json"
 DEFAULT_BASELINE = ".agents/policy/repo-boundaries-baseline.json"
 UNATTRIBUTED = "unassigned"

--- a/.agents/scripts/skill_catalog.py
+++ b/.agents/scripts/skill_catalog.py
@@ -11,6 +11,16 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Iterable
 
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 README_SKILL_RE = re.compile(r"^\|\s*\*\*([a-z0-9-]+)\*\*\s*\|", re.MULTILINE)

--- a/.agents/scripts/sync_claude_skills.py
+++ b/.agents/scripts/sync_claude_skills.py
@@ -11,12 +11,21 @@ this command regenerates the Trae projection.
 """
 from __future__ import annotations
 
+import sys
+
 import argparse
 import shutil
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 AGENTS_SKILLS = ROOT / ".agents" / "skills"
 CLAUDE_SKILLS = ROOT / ".claude" / "skills"
 TRAE_SKILLS = ROOT / ".trae" / "skills"

--- a/.agents/scripts/tracked_path_check.py
+++ b/.agents/scripts/tracked_path_check.py
@@ -40,6 +40,16 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 DEFAULT_POLICY = ".agents/policy/tracked-paths.json"
 DEFAULT_BASELINE = ".agents/policy/tracked-paths-baseline.json"
 UNATTRIBUTED = "unassigned"
@@ -214,21 +224,52 @@ def load_policy(path: Path, repo_root: Path) -> Policy:
     )
 
 
-def tracked_files(repo_root: Path, policy: Policy) -> list[str]:
+def git_ls_files(repo_root: Path) -> list[str]:
+    """Return the tracked tree as ``git ls-files`` sees it.
+
+    Existence for this guard is that listing, not the working tree. An
+    untracked leftover must not hide a dead reference or turn a baseline
+    row stale. Rebuilt on every call; do not cache by ``repo_root``.
+    """
     try:
-        output = subprocess.check_output(
+        completed = subprocess.run(
             ["git", "ls-files", "-z"],
             cwd=repo_root,
-            stderr=subprocess.DEVNULL,
+            check=True,
+            capture_output=True,
         )
-    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
-        raise TrackedPathError(f"cannot list tracked files under {repo_root}: {exc}") from exc
-    suffixes = set(policy.include_suffixes)
+    except FileNotFoundError as exc:
+        raise TrackedPathError(
+            f"git is not available; cannot decide tracked-tree existence under {repo_root}"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        err = (exc.stderr or b"").decode("utf-8", errors="replace").strip()
+        raise TrackedPathError(
+            f"git ls-files failed under {repo_root}: {err or exc}"
+        ) from exc
     files: list[str] = []
-    for raw in output.split(b"\0"):
+    for raw in completed.stdout.split(b"\0"):
         if not raw:
             continue
-        rel = raw.decode("utf-8", errors="replace")
+        files.append(raw.decode("utf-8", errors="replace"))
+    return files
+
+
+def tracked_tree_index(repo_root: Path) -> frozenset[str]:
+    """Tracked files plus every directory prefix that contains one."""
+    paths: set[str] = set()
+    for rel in git_ls_files(repo_root):
+        paths.add(rel)
+        parts = rel.split("/")
+        for index in range(1, len(parts)):
+            paths.add("/".join(parts[:index]))
+    return frozenset(paths)
+
+
+def tracked_files(repo_root: Path, policy: Policy) -> list[str]:
+    suffixes = set(policy.include_suffixes)
+    files: list[str] = []
+    for rel in git_ls_files(repo_root):
         if any(rel == root or rel.startswith(root + "/") for root in policy.skip_roots):
             continue
         if rel in policy.fixture_paths or rel in policy.skip_paths:
@@ -273,23 +314,31 @@ def is_allowed(token: str, allow_prefixes: Iterable[str]) -> bool:
     return False
 
 
-def path_exists(repo_root: Path, rel: str) -> bool:
+def path_exists(
+    repo_root: Path, rel: str, tracked: frozenset[str] | None = None
+) -> bool:
     if not rel:
         return True
-    return (repo_root / rel).exists()
+    index = tracked if tracked is not None else tracked_tree_index(repo_root)
+    return rel.rstrip("/") in index
 
 
-def scripts_exists(repo_root: Path, token: str, referring: str) -> bool:
+def scripts_exists(
+    repo_root: Path,
+    token: str,
+    referring: str,
+    tracked: frozenset[str] | None = None,
+) -> bool:
     """``scripts/foo.py`` may be repo-root, ``.agents/scripts/``, or skill-local."""
-    if path_exists(repo_root, token):
+    if path_exists(repo_root, token, tracked):
         return True
     if not token.startswith("scripts/"):
         return False
-    if path_exists(repo_root, ".agents/" + token):
+    if path_exists(repo_root, ".agents/" + token, tracked):
         return True
     parts = Path(referring).parts
     if len(parts) >= 3 and parts[0] in {".agents", ".trae"} and parts[1] == "skills":
-        return path_exists(repo_root, f"{parts[0]}/skills/{parts[2]}/{token}")
+        return path_exists(repo_root, f"{parts[0]}/skills/{parts[2]}/{token}", tracked)
     return False
 
 
@@ -335,6 +384,7 @@ def os_normpath(value: str) -> str:
 def collect_violations(repo_root: Path, policy: Policy, scanned: list[str]) -> list[Violation]:
     rule = policy.rule("missing-in-tree-path")
     token_re = _token_regex(policy.token_prefixes)
+    tracked = tracked_tree_index(repo_root)
     merged: dict[str, Violation] = {}
 
     def record(path: str, token: str, resolved: str, line: int, message: str) -> None:
@@ -366,7 +416,9 @@ def collect_violations(repo_root: Path, policy: Policy, scanned: list[str]) -> l
                     continue
                 if is_allowed(cleaned, policy.allow_prefixes) or is_allowed(check, policy.allow_prefixes):
                     continue
-                if scripts_exists(repo_root, check, relpath) or path_exists(repo_root, check):
+                if scripts_exists(repo_root, check, relpath, tracked) or path_exists(
+                    repo_root, check, tracked
+                ):
                     continue
                 record(
                     relpath,
@@ -385,7 +437,9 @@ def collect_violations(repo_root: Path, policy: Policy, scanned: list[str]) -> l
                 token = href.split("#", 1)[0].strip()
                 if is_allowed(token, policy.allow_prefixes) or is_allowed(resolved, policy.allow_prefixes):
                     continue
-                if resolved.startswith("../") or not path_exists(repo_root, resolved):
+                if resolved.startswith("../") or not path_exists(
+                    repo_root, resolved, tracked
+                ):
                     record(
                         relpath,
                         token,

--- a/.agents/skills/ascend-memory-profiling/scripts/mem_analyze.py
+++ b/.agents/skills/ascend-memory-profiling/scripts/mem_analyze.py
@@ -12,12 +12,22 @@ Output: printed report + saved report.json / report.txt
 from __future__ import annotations
 
 import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 import csv
 import json
 import re
-import sys
 from dataclasses import dataclass, field, asdict
-from pathlib import Path
 from typing import Any
 
 

--- a/.agents/skills/ascend-memory-profiling/scripts/mem_collect.py
+++ b/.agents/skills/ascend-memory-profiling/scripts/mem_collect.py
@@ -37,6 +37,16 @@ import time
 import uuid
 from pathlib import Path
 
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 from _common import (
     ENV_PREAMBLE,
     MSPROF_WRAPPER_REMOTE_PATH,

--- a/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/classify.py
+++ b/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/classify.py
@@ -593,4 +593,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
+    import sys
+    from pathlib import Path
+    _repo_root = Path(__file__).resolve().parents[5]
+    _lib = _repo_root / ".agents" / "lib"
+    if str(_lib) not in sys.path:
+        sys.path.insert(0, str(_lib))
+    from vaws_venv import ensure_workspace_interpreter
+    ensure_workspace_interpreter(repo_root=_repo_root)
     raise SystemExit(main())

--- a/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/cross_rank.py
+++ b/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/cross_rank.py
@@ -309,4 +309,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
+    import sys
+    from pathlib import Path
+    _repo_root = Path(__file__).resolve().parents[5]
+    _lib = _repo_root / ".agents" / "lib"
+    if str(_lib) not in sys.path:
+        sys.path.insert(0, str(_lib))
+    from vaws_venv import ensure_workspace_interpreter
+    ensure_workspace_interpreter(repo_root=_repo_root)
     raise SystemExit(main())

--- a/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/html_report.py
+++ b/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/html_report.py
@@ -3165,4 +3165,12 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+    from pathlib import Path
+    _repo_root = Path(__file__).resolve().parents[5]
+    _lib = _repo_root / ".agents" / "lib"
+    if str(_lib) not in sys.path:
+        sys.path.insert(0, str(_lib))
+    from vaws_venv import ensure_workspace_interpreter
+    ensure_workspace_interpreter(repo_root=_repo_root)
+    raise SystemExit(main())

--- a/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/html_report_v2/__init__.py
+++ b/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/html_report_v2/__init__.py
@@ -234,5 +234,3 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-if __name__ == "__main__":
-    raise SystemExit(main())

--- a/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/html_report_v2/__main__.py
+++ b/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/html_report_v2/__main__.py
@@ -12,4 +12,12 @@ except ImportError:  # pragma: no cover - script-mode fallback
     from html_report_v2 import main  # type: ignore[no-redef]
 
 if __name__ == "__main__":
+    import sys
+    from pathlib import Path
+    _repo_root = Path(__file__).resolve().parents[6]
+    _lib = _repo_root / ".agents" / "lib"
+    if str(_lib) not in sys.path:
+        sys.path.insert(0, str(_lib))
+    from vaws_venv import ensure_workspace_interpreter
+    ensure_workspace_interpreter(repo_root=_repo_root)
     raise SystemExit(main())

--- a/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/normalize.py
+++ b/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/normalize.py
@@ -524,4 +524,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
+    import sys
+    from pathlib import Path
+    _repo_root = Path(__file__).resolve().parents[5]
+    _lib = _repo_root / ".agents" / "lib"
+    if str(_lib) not in sys.path:
+        sys.path.insert(0, str(_lib))
+    from vaws_venv import ensure_workspace_interpreter
+    ensure_workspace_interpreter(repo_root=_repo_root)
     raise SystemExit(main())

--- a/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/report.py
+++ b/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/report.py
@@ -1527,4 +1527,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
+    import sys
+    from pathlib import Path
+    _repo_root = Path(__file__).resolve().parents[5]
+    _lib = _repo_root / ".agents" / "lib"
+    if str(_lib) not in sys.path:
+        sys.path.insert(0, str(_lib))
+    from vaws_venv import ensure_workspace_interpreter
+    ensure_workspace_interpreter(repo_root=_repo_root)
     raise SystemExit(main())

--- a/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/segment.py
+++ b/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/segment.py
@@ -4036,4 +4036,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
+    import sys
+    from pathlib import Path
+    _repo_root = Path(__file__).resolve().parents[5]
+    _lib = _repo_root / ".agents" / "lib"
+    if str(_lib) not in sys.path:
+        sys.path.insert(0, str(_lib))
+    from vaws_venv import ensure_workspace_interpreter
+    ensure_workspace_interpreter(repo_root=_repo_root)
     raise SystemExit(main())

--- a/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/summarize.py
+++ b/.agents/skills/ascend-profiling-analysis/scripts/ascend_profile/summarize.py
@@ -1879,4 +1879,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
+    import sys
+    from pathlib import Path
+    _repo_root = Path(__file__).resolve().parents[5]
+    _lib = _repo_root / ".agents" / "lib"
+    if str(_lib) not in sys.path:
+        sys.path.insert(0, str(_lib))
+    from vaws_venv import ensure_workspace_interpreter
+    ensure_workspace_interpreter(repo_root=_repo_root)
     raise SystemExit(main())

--- a/.agents/skills/ascend-profiling-analysis/scripts/dev/golden_db_vs_csv.py
+++ b/.agents/skills/ascend-profiling-analysis/scripts/dev/golden_db_vs_csv.py
@@ -31,12 +31,22 @@ zero unexplained mismatches.
 from __future__ import annotations
 
 import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[5]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 import csv
 import json
-import sys
 import time
 from decimal import Decimal, InvalidOperation
-from pathlib import Path
 from typing import Any, Iterable, Iterator, Mapping
 
 csv.field_size_limit(1024 * 1024 * 1024)

--- a/.agents/skills/ascend-profiling-analysis/scripts/profile_sweep.py
+++ b/.agents/skills/ascend-profiling-analysis/scripts/profile_sweep.py
@@ -22,6 +22,16 @@ import time
 from pathlib import Path
 from typing import Any, Sequence
 
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 try:
     from . import _common as common  # type: ignore[import-not-found]
 except ImportError:  # pragma: no cover - direct script execution

--- a/.agents/skills/ascend-profiling-collection/scripts/profile_control.py
+++ b/.agents/skills/ascend-profiling-collection/scripts/profile_control.py
@@ -32,6 +32,15 @@ import sys
 from pathlib import Path
 from typing import Any
 
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 _SCRIPT_DIR = Path(__file__).resolve().parent
 if str(_SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPT_DIR))

--- a/.agents/skills/ascend-profiling-collection/scripts/run_remote_analyse.py
+++ b/.agents/skills/ascend-profiling-collection/scripts/run_remote_analyse.py
@@ -72,6 +72,16 @@ import time
 from pathlib import Path
 from typing import Any
 
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 _SCRIPT_DIR = Path(__file__).resolve().parent
 if str(_SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPT_DIR))

--- a/.agents/skills/ascend-tensor-dump/scripts/dump_compare.py
+++ b/.agents/skills/ascend-tensor-dump/scripts/dump_compare.py
@@ -26,6 +26,16 @@ import sys
 from pathlib import Path
 from typing import Any, Iterable
 
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 STAT_NAMES = ("nan_count", "inf_count", "max_abs", "min", "max", "mean")
 
 DEFAULT_MAX_ELEMENTS = 2_000_000

--- a/.agents/skills/ascend-triton-kernel-validation/scripts/validate_triton_impl.py
+++ b/.agents/skills/ascend-triton-kernel-validation/scripts/validate_triton_impl.py
@@ -3,11 +3,23 @@
 
 from __future__ import annotations
 
+import sys
+
 import argparse
 import ast
 import json
 from pathlib import Path
 from typing import Any
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 
 ALLOWED_TORCH_CALLS = {
     "torch.empty",

--- a/.agents/skills/machine-management/scripts/inventory.py
+++ b/.agents/skills/machine-management/scripts/inventory.py
@@ -20,6 +20,16 @@ import time
 from pathlib import Path
 from typing import Any
 
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))

--- a/.agents/skills/machine-management/scripts/machine_add.py
+++ b/.agents/skills/machine-management/scripts/machine_add.py
@@ -8,8 +8,21 @@ All outputs are JSON.
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import argparse
 from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 
 import manage_machine as machine_ops
 from _workflow_common import (  # noqa: E402

--- a/.agents/skills/machine-management/scripts/machine_remove.py
+++ b/.agents/skills/machine-management/scripts/machine_remove.py
@@ -8,8 +8,21 @@ normal removal work. All outputs are JSON.
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import argparse
 from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 
 from _workflow_common import (  # noqa: E402
     WorkflowError,

--- a/.agents/skills/machine-management/scripts/machine_repair.py
+++ b/.agents/skills/machine-management/scripts/machine_repair.py
@@ -8,8 +8,21 @@ All outputs are JSON.
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import argparse
 from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 
 import manage_machine as machine_ops
 from _workflow_common import (  # noqa: E402

--- a/.agents/skills/machine-management/scripts/machine_verify.py
+++ b/.agents/skills/machine-management/scripts/machine_verify.py
@@ -8,8 +8,21 @@ All outputs are JSON.
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import argparse
 from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 
 from _workflow_common import (  # noqa: E402
     WorkflowError,

--- a/.agents/skills/machine-management/scripts/manage_machine.py
+++ b/.agents/skills/machine-management/scripts/manage_machine.py
@@ -14,12 +14,22 @@ import argparse
 import json
 import os
 import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 import queue
 import re
 import shlex
 import shutil
 import subprocess
-import sys
 import tempfile
 import threading
 import time

--- a/.agents/skills/modelscope/scripts/modelscope_auto.py
+++ b/.agents/skills/modelscope/scripts/modelscope_auto.py
@@ -14,6 +14,16 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 import requests
 
 

--- a/.agents/skills/modelscope/scripts/modelscope_download_status.py
+++ b/.agents/skills/modelscope/scripts/modelscope_download_status.py
@@ -3,12 +3,24 @@
 
 from __future__ import annotations
 
+import sys
+
 import argparse
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 
 import requests
 

--- a/.agents/skills/npu-fleet-monitor/scripts/manage_monitor.py
+++ b/.agents/skills/npu-fleet-monitor/scripts/manage_monitor.py
@@ -31,6 +31,10 @@ LIB_DIR = REPO_ROOT / ".agents" / "lib"
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=REPO_ROOT)
+
 from vaws_local_state import STATE_DIRNAME, shared_inventory_path, shared_workspace_root  # noqa: E402
 
 VAWS_TOP_REPO = "vllm-ascend-workspace/vaws-top"

--- a/.agents/skills/remote-code-parity/scripts/gc_runtime_cache.py
+++ b/.agents/skills/remote-code-parity/scripts/gc_runtime_cache.py
@@ -1,10 +1,22 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import sys
+
 import argparse
 import json
 from pathlib import Path
 from typing import Any
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 
 from common import SshEndpoint, json_dump, quoted, ssh_exec
 from remote_code_parity import DEFAULT_CONTAINER_CACHE_ROOT, cache_workspace_root

--- a/.agents/skills/remote-code-parity/scripts/install_consent.py
+++ b/.agents/skills/remote-code-parity/scripts/install_consent.py
@@ -1,10 +1,22 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import sys
+
 import argparse
 import json
 from pathlib import Path
 from typing import Any
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 
 from common import json_dump, load_state, now_utc, repo_root_from, save_state, update_state
 

--- a/.agents/skills/remote-code-parity/scripts/parity_sync.py
+++ b/.agents/skills/remote-code-parity/scripts/parity_sync.py
@@ -19,6 +19,10 @@ LIB_DIR = ROOT / '.agents' / 'lib'
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 from vaws_session_state import load_session_lookup  # noqa: E402
 from vaws_local_state import shared_inventory_path, resolve_inventory_read_path  # noqa: E402
 

--- a/.agents/skills/remote-code-parity/scripts/parity_watch.py
+++ b/.agents/skills/remote-code-parity/scripts/parity_watch.py
@@ -2,6 +2,8 @@
 """Continuously publish content snapshots to staging; never change running code."""
 from __future__ import annotations
 
+import sys
+
 import argparse
 import contextlib
 import io
@@ -9,6 +11,16 @@ import json
 import signal
 import threading
 from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 
 import remote_code_parity as parity
 

--- a/.agents/skills/remote-code-parity/scripts/transport_benchmark.py
+++ b/.agents/skills/remote-code-parity/scripts/transport_benchmark.py
@@ -3,16 +3,28 @@
 
 from __future__ import annotations
 
+import sys
+
 import argparse
 import hashlib
 import json
 import os
 import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 import statistics
 import subprocess
 import tempfile
 import time
-from pathlib import Path
 
 
 def run(

--- a/.agents/skills/repo-init/scripts/install_gh_user.py
+++ b/.agents/skills/repo-init/scripts/install_gh_user.py
@@ -13,11 +13,21 @@ import io
 import json
 import os
 import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 import platform
 import re
 import shutil
 import stat
-import sys
 import tarfile
 import tempfile
 import urllib.request

--- a/.agents/skills/repo-init/scripts/repo_init_probe.py
+++ b/.agents/skills/repo-init/scripts/repo_init_probe.py
@@ -17,11 +17,21 @@ import argparse
 import json
 import os
 import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 import platform
 import re
 import shutil
 import subprocess
-import sys
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Tuple
 

--- a/.agents/skills/repo-init/scripts/repo_init_profile.py
+++ b/.agents/skills/repo-init/scripts/repo_init_profile.py
@@ -15,6 +15,16 @@ import pathlib
 import sys
 from typing import Any, Sequence
 
+ROOT = pathlib.Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 LIB_DIR = pathlib.Path(__file__).resolve().parents[3] / "lib"
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))

--- a/.agents/skills/repo-init/scripts/repo_topology.py
+++ b/.agents/skills/repo-init/scripts/repo_topology.py
@@ -15,6 +15,16 @@ import subprocess
 import sys
 from typing import Any, Sequence
 
+ROOT = pathlib.Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 
 class RepoTopologyError(RuntimeError):
     """Raised for deterministic, user-facing failures."""

--- a/.agents/skills/repo-init/scripts/resolve_vllm_ci_pin.py
+++ b/.agents/skills/repo-init/scripts/resolve_vllm_ci_pin.py
@@ -10,6 +10,16 @@ import sys
 from pathlib import Path
 from typing import Any
 
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 
 HEX_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
 SAFE_REF_RE = re.compile(r"^[A-Za-z0-9._/-]+$")

--- a/.agents/skills/session-management/scripts/npu_coordination.py
+++ b/.agents/skills/session-management/scripts/npu_coordination.py
@@ -23,6 +23,10 @@ LIB_DIR = ROOT / ".agents" / "lib"
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 from vaws_host_queue_module import host_queue_module_path, load_host_protocol  # noqa: E402
 
 _host = load_host_protocol()

--- a/.agents/skills/session-management/scripts/session_create.py
+++ b/.agents/skills/session-management/scripts/session_create.py
@@ -22,6 +22,10 @@ for _p in (str(LIB_DIR), str(MM_SCRIPTS), str(_SELF_DIR)):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 import inventory as inventory_store  # noqa: E402
 import manage_machine as machine_ops  # noqa: E402
 from _workflow_common import bootstrap_container, host_target, verify_machine  # noqa: E402

--- a/.agents/skills/session-management/scripts/session_diff.py
+++ b/.agents/skills/session-management/scripts/session_diff.py
@@ -29,6 +29,10 @@ LIB_DIR = ROOT / ".agents" / "lib"
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 from vaws_session_state import SessionStateError, load_session_lookup  # noqa: E402
 
 

--- a/.agents/skills/session-management/scripts/session_gc.py
+++ b/.agents/skills/session-management/scripts/session_gc.py
@@ -21,6 +21,10 @@ LIB_DIR = ROOT / ".agents" / "lib"
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 from vaws_remote_dev import ssh_exec  # noqa: E402
 from vaws_remote_target import SshEndpoint  # noqa: E402
 from vaws_session_state import load_index, load_leases, load_session_lookup, release_all_session_leases, session_live_leases  # noqa: E402

--- a/.agents/skills/session-management/scripts/session_list.py
+++ b/.agents/skills/session-management/scripts/session_list.py
@@ -14,6 +14,10 @@ LIB_DIR = ROOT / ".agents" / "lib"
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 from vaws_session_state import load_index, load_leases, load_session_lookup  # noqa: E402
 
 

--- a/.agents/skills/session-management/scripts/session_remove.py
+++ b/.agents/skills/session-management/scripts/session_remove.py
@@ -17,6 +17,10 @@ for _p in (str(LIB_DIR), str(MM_SCRIPTS)):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 from _workflow_common import remove_container  # noqa: E402
 from vaws_session_state import (  # noqa: E402
     load_session_lookup,

--- a/.agents/skills/session-management/scripts/session_status.py
+++ b/.agents/skills/session-management/scripts/session_status.py
@@ -16,6 +16,10 @@ LIB_DIR = ROOT / ".agents" / "lib"
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 from vaws_remote_dev import ssh_exec  # noqa: E402
 from vaws_remote_target import SshEndpoint  # noqa: E402
 from vaws_session_state import (  # noqa: E402

--- a/.agents/skills/vllm-ascend-benchmark/scripts/bench_compare.py
+++ b/.agents/skills/vllm-ascend-benchmark/scripts/bench_compare.py
@@ -48,9 +48,19 @@ from __future__ import annotations
 import argparse
 import shlex
 import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 import traceback
 from dataclasses import replace
-from pathlib import Path
 from typing import Any
 
 _SCRIPT_DIR = Path(__file__).resolve().parent

--- a/.agents/skills/vllm-ascend-benchmark/scripts/bench_run.py
+++ b/.agents/skills/vllm-ascend-benchmark/scripts/bench_run.py
@@ -39,8 +39,18 @@ from __future__ import annotations
 
 import argparse
 import sys
-import traceback
 from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+import traceback
 from typing import Any
 
 _SCRIPT_DIR = Path(__file__).resolve().parent

--- a/.agents/skills/vllm-ascend-correctness-validation/scripts/aisbench_adapter.py
+++ b/.agents/skills/vllm-ascend-correctness-validation/scripts/aisbench_adapter.py
@@ -4,14 +4,24 @@
 from __future__ import annotations
 
 import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 import csv
 import json
 import os
 import re
 import shlex
-import sys
 import tempfile
-from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 SCHEMA_VERSION = 1

--- a/.agents/skills/vllm-ascend-serving/scripts/serve_probe_npus.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/serve_probe_npus.py
@@ -20,6 +20,16 @@ import argparse
 import sys
 from pathlib import Path
 
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 _SCRIPT_DIR = Path(__file__).resolve().parent
 if str(_SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPT_DIR))

--- a/.agents/skills/vllm-ascend-serving/scripts/serve_start.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/serve_start.py
@@ -37,6 +37,16 @@ import time
 from pathlib import Path
 from typing import Any
 
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 _SCRIPT_DIR = Path(__file__).resolve().parent
 if str(_SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPT_DIR))

--- a/.agents/skills/vllm-ascend-serving/scripts/serve_status.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/serve_status.py
@@ -17,6 +17,16 @@ import sys
 from pathlib import Path
 from typing import Any
 
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 _SCRIPT_DIR = Path(__file__).resolve().parent
 if str(_SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPT_DIR))

--- a/.agents/skills/vllm-ascend-serving/scripts/serve_stop.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/serve_stop.py
@@ -18,6 +18,16 @@ import time
 from pathlib import Path
 from typing import Any
 
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 _SCRIPT_DIR = Path(__file__).resolve().parent
 if str(_SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPT_DIR))

--- a/.agents/tests/test_cli_surface_inventory.py
+++ b/.agents/tests/test_cli_surface_inventory.py
@@ -319,7 +319,7 @@ class RepositoryCoherenceTests(unittest.TestCase):
         )
         self.assertEqual(
             by_repository["vllm-ascend-workspace/vaws-knowledge"]["commit"],
-            "16befcade10ec2acca74731888339524574a326c",
+            "ae39db2c4ad9cf658b38f6624f6bc49e76274418",
         )
         for meta in owners.values():
             self.assertEqual(meta["source_availability"], "uninspected")

--- a/.agents/tests/test_dependency.py
+++ b/.agents/tests/test_dependency.py
@@ -23,7 +23,7 @@ class SpecLockTests(unittest.TestCase):
         versions = deps.required_versions()
         self.assertEqual(versions["vaws-remote-dev"], "0.2.0")
         self.assertEqual(versions["vaws-coordinator"], "0.2.0")
-        self.assertEqual(versions["vaws-knowledge"], "0.1.3")
+        self.assertEqual(versions["vaws-knowledge"], "0.1.4")
         self.assertNotIn(deps.VAWS_TOP_NAME, versions)
 
     def test_status_tracks_only_the_three_packages(self) -> None:
@@ -38,7 +38,7 @@ class SpecLockTests(unittest.TestCase):
         )
         self.assertEqual(
             locked["vaws-knowledge"]["commit"],
-            "16befcade10ec2acca74731888339524574a326c",
+            "ae39db2c4ad9cf658b38f6624f6bc49e76274418",
         )
         self.assertEqual(
             locked["vaws-remote-dev"]["commit"],

--- a/.agents/tests/test_interpreter_shim_guard.py
+++ b/.agents/tests/test_interpreter_shim_guard.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""P9: local entries hop onto ``.venv``; remote payloads stay lib-free.
+
+Test files are not entry points. A ``__main__`` file that is neither a test
+nor in the CLI-surface inventory is a classification gap, not a file to shim.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+INVENTORY_SCRIPT = ROOT / ".agents" / "scripts" / "cli_surface_inventory.py"
+LIB_DIR = ROOT / ".agents" / "lib"
+SHIM_NAME = "ensure_workspace_interpreter"
+
+
+def load_inventory_module():
+    name = "_cli_surface_inventory_shim_guard"
+    spec = importlib.util.spec_from_file_location(name, INVENTORY_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+inventory = load_inventory_module()
+LIB_MODULES = frozenset(path.stem for path in LIB_DIR.glob("*.py") if path.stem != "__init__")
+
+
+def _has_main(tree: ast.AST) -> bool:
+    return inventory.has_main_guard(tree)
+
+
+def _imported_names(tree: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level and not node.module:
+                continue
+            if node.module:
+                names.add(node.module.split(".", 1)[0])
+    return names
+
+
+class InterpreterShimGuardTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.payload = inventory.build_inventory(ROOT, quiet=True)
+        cls.entries = {item["path"]: item for item in cls.payload["entry_points"]}
+
+    def test_inventoried_non_payloads_contain_the_shim(self) -> None:
+        missing = []
+        for path, record in sorted(self.entries.items()):
+            role = (record.get("classification") or {}).get("support_role")
+            if role == "payload":
+                continue
+            text = (ROOT / path).read_text(encoding="utf-8")
+            if SHIM_NAME not in text:
+                missing.append(path)
+        self.assertEqual(missing, [])
+
+    def test_payloads_import_nothing_from_agents_lib(self) -> None:
+        leaked = []
+        for path, record in sorted(self.entries.items()):
+            role = (record.get("classification") or {}).get("support_role")
+            if role != "payload":
+                continue
+            tree = ast.parse((ROOT / path).read_text(encoding="utf-8"), filename=path)
+            imported = _imported_names(tree) & LIB_MODULES
+            if imported:
+                leaked.append(f"{path}: {sorted(imported)}")
+        self.assertEqual(leaked, [])
+
+    def test_main_files_that_are_neither_tests_nor_inventory_are_gaps(self) -> None:
+        gaps = []
+        for rel in inventory.tracked_files(ROOT):
+            if not rel.startswith(".agents/") or not rel.endswith(".py"):
+                continue
+            if inventory.is_test_path(rel):
+                continue
+            try:
+                tree = ast.parse((ROOT / rel).read_text(encoding="utf-8"), filename=rel)
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            if not _has_main(tree):
+                continue
+            if rel not in self.entries:
+                gaps.append(rel)
+        self.assertEqual(gaps, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_knowledge_query_cli.py
+++ b/.agents/tests/test_knowledge_query_cli.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""P19: the scaffold knowledge CLI accepts reader coordinates."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+QUERY = ROOT / ".agents" / "scripts" / "knowledge_query.py"
+A3_ONLY = "5329d20b-8e64-4de9-ac53-ba766cf096eb"
+A3_FINGERPRINT = "graph mode dump manifest far fewer records than eager"
+
+
+def load_query_module():
+    name = "_knowledge_query_p19"
+    spec = importlib.util.spec_from_file_location(name, QUERY)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+query_cli = load_query_module()
+
+
+def _run(*argv: str) -> tuple[int, dict, str]:
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        code = query_cli.main(
+            [
+                "--knowledge-dir",
+                str(ROOT / ".agents" / "knowledge"),
+                "--candidate-dir",
+                str(ROOT / ".vaws-local" / "knowledge" / "candidate"),
+                *argv,
+            ]
+        )
+    return code, json.loads(out.getvalue()), err.getvalue()
+
+
+class ReaderCoordinateCliTests(unittest.TestCase):
+    def test_soc_mismatch_withholds_the_a3_entry(self) -> None:
+        code, payload, _ = _run(
+            "--query",
+            A3_FINGERPRINT,
+            "--layer",
+            "project",
+            "--include-unverified",
+            "--soc",
+            "NotA3",
+        )
+        self.assertEqual(0, code)
+        uuids = [item["uuid"] for item in payload["results"]]
+        self.assertNotIn(A3_ONLY, uuids)
+        self.assertEqual("NotA3", payload["reader_coordinate"]["supplied"]["soc"])
+
+    def test_matching_soc_returns_the_entry_and_populates_the_coordinate(self) -> None:
+        code, payload, _ = _run(
+            "--query",
+            A3_FINGERPRINT,
+            "--layer",
+            "project",
+            "--include-unverified",
+            "--soc",
+            "A3",
+        )
+        self.assertEqual(0, code)
+        uuids = [item["uuid"] for item in payload["results"]]
+        self.assertIn(A3_ONLY, uuids)
+        supplied = payload["reader_coordinate"]["supplied"]
+        self.assertEqual("A3", supplied["soc"])
+        self.assertIn("cann", payload["reader_coordinate"]["unsupplied_expected_dimensions"])
+
+    def test_run_manifest_fills_derivable_dimensions(self) -> None:
+        from vaws_coordinator.run_manifest import new_manifest, write_manifest
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "run-manifest.json"
+            write_manifest(
+                path,
+                new_manifest(
+                    run_type="debug",
+                    run_id="debug-p19-reader",
+                    workspace_root=ROOT,
+                    environment={"soc": "A3", "cann": "8.2.RC1"},
+                    created_at="2026-09-09T00:00:00Z",
+                ),
+            )
+            code, payload, _ = _run(
+                "--query",
+                A3_FINGERPRINT,
+                "--layer",
+                "project",
+                "--include-unverified",
+                "--run-manifest",
+                str(path),
+            )
+        self.assertEqual(0, code)
+        supplied = payload["reader_coordinate"]["supplied"]
+        self.assertEqual("A3", supplied["soc"])
+        self.assertEqual("8.2.RC1", supplied["cann"])
+        self.assertNotIn("torch", supplied)
+        self.assertIn(A3_ONLY, [item["uuid"] for item in payload["results"]])
+
+
+class ReaderCoordinateGuardTests(unittest.TestCase):
+    def test_old_package_is_a_hard_failure(self) -> None:
+        with mock.patch.object(query_cli, "version", return_value="0.1.3"):
+            with self.assertRaises(SystemExit) as ctx:
+                query_cli.require_knowledge_reader_cli()
+        self.assertIn("too old", str(ctx.exception))
+        self.assertIn("0.1.4", str(ctx.exception))
+        self.assertIn("uv sync", str(ctx.exception))
+
+    def test_missing_package_is_a_hard_failure(self) -> None:
+        with mock.patch.object(
+            query_cli, "version", side_effect=query_cli.PackageNotFoundError("vaws-knowledge")
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                query_cli.require_knowledge_reader_cli()
+        self.assertIn("not installed", str(ctx.exception))
+        self.assertIn("uv sync", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_tracked_path_check.py
+++ b/.agents/tests/test_tracked_path_check.py
@@ -222,6 +222,45 @@ class DetectionTests(unittest.TestCase):
         self.assertEqual((code, payload["status"]), (0, "reported"))
         self.assertEqual(payload["counts"]["new"], 1)
 
+    def test_untracked_leftover_does_not_satisfy_existence(self) -> None:
+        write(self.repo.root / "docs" / "guide.md", "See `.agents/skills/missing/SKILL.md`.\n")
+        self.repo._git_add()
+        leftover = self.repo.root / ".agents" / "skills" / "missing" / "SKILL.md"
+        leftover.parent.mkdir(parents=True, exist_ok=True)
+        leftover.write_text("# leftover\n", encoding="utf-8")
+        self.assertTrue(leftover.exists())
+        self.assertFalse(guard.path_exists(self.repo.root, ".agents/skills/missing/SKILL.md"))
+        # Do not git-add the leftover; SyntheticRepo.run() would.
+        code, payload = invoke("--repo-root", str(self.repo.root), "--mode", "enforce")
+        self.assertEqual((code, payload["status"]), (1, "failed"))
+        self.assertEqual(payload["counts"]["new"], 1)
+        self.assertEqual(
+            payload["new_violations"][0]["resolved"],
+            ".agents/skills/missing/SKILL.md",
+        )
+
+    def test_untracked_leftover_does_not_stale_a_baseline_row(self) -> None:
+        write(self.repo.root / "docs" / "guide.md", "See `.agents/skills/missing/SKILL.md`.\n")
+        self.repo.accept(
+            {
+                "rule": "missing-path",
+                "path": "docs/guide.md",
+                "named_path": ".agents/skills/missing/SKILL.md",
+            }
+        )
+        leftover = self.repo.root / ".agents" / "skills" / "missing" / "SKILL.md"
+        leftover.parent.mkdir(parents=True, exist_ok=True)
+        leftover.write_text("# leftover\n", encoding="utf-8")
+        self.assertTrue(leftover.exists())
+        code, payload = invoke("--repo-root", str(self.repo.root), "--mode", "enforce")
+        self.assertEqual(
+            (code, payload["status"]),
+            (0, "passed"),
+            payload.get("new_violations") or payload.get("stale_baseline") or payload,
+        )
+        self.assertEqual(payload["counts"]["accepted"], 1)
+        self.assertEqual(payload["baseline"]["stale_count"], 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.trae/skills/modelscope/scripts/modelscope_auto.py
+++ b/.trae/skills/modelscope/scripts/modelscope_auto.py
@@ -14,6 +14,16 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+
 import requests
 
 

--- a/.trae/skills/modelscope/scripts/modelscope_download_status.py
+++ b/.trae/skills/modelscope/scripts/modelscope_download_status.py
@@ -3,12 +3,24 @@
 
 from __future__ import annotations
 
+import sys
+
 import argparse
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB = ROOT / ".agents" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+from vaws_venv import ensure_workspace_interpreter  # noqa: E402
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
 
 import requests
 

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -45,12 +45,12 @@ are **not** the original 132-entry snapshot and **not** the unimplemented
 | Measure | Value |
 |---|---|
 | Entry points (definition in §3) | **115** |
-| Supported agent-facing launchers | 67 |
+| Supported agent-facing launchers | 68 |
 | Compatibility wrappers | 17 |
 | Internal / diagnostic CLIs | 13 |
-| Generated projections | 4 |
+| Generated projections | 2 |
 | Hooks | 3 |
-| Remote payloads | 9 |
+| Remote payloads | 10 |
 | Test / maturation harnesses | 2 |
 | Responsibility | mechanics 99 · mixed 16 · judgment 0 |
 | Files importing `argparse` (non-test) | 105 |
@@ -112,12 +112,12 @@ launchers:
 
 | Role | Meaning | Current count |
 |---|---|---|
-| `supported` | agent-facing launcher or domain command that currently owns the mechanic | 67 |
+| `supported` | agent-facing launcher or domain command that currently owns the mechanic | 68 |
 | `compatibility` | still-present managed toolbox or legacy `--machine` wrapper whose semantics differ from the extracted provider | 17 |
 | `internal` | library or pipeline stage that grew a diagnostic `__main__` | 13 |
-| `generated` | Trae ModelScope projection produced from the canonical package | 4 |
+| `generated` | Trae ModelScope projection produced from the canonical package | 2 |
 | `hook` | client or git lifecycle adapter | 3 |
-| `payload` | executable spawned on the container or by another command | 9 |
+| `payload` | executable copied onto the NPU container and run without `.venv` / `.agents/lib` | 10 |
 | `harness` | maturation / golden / stress tooling | 2 |
 
 Responsibility (`mechanics` / `judgment` / `mixed`) is independent of support
@@ -402,11 +402,11 @@ option.
 | `.agents/hooks/knowledge_session_end.py` | bare | - | 0 | client-config:1, routing:1, test:1 | mechanics | hook | .agents/hooks/knowledge_session_end.py | - |
 | `.agents/hooks/tracked_leak_precommit.py` | argparse | - | 8 | docs:1, policy:1, test:1 | mechanics | hook | .agents/hooks/tracked_leak_precommit.py | - |
 | `.agents/hooks/vaws_session.py` | argparse | - | 4 | docs:1, other:1, policy:1, script:1, test:2 | mechanics | hook | .agents/hooks/vaws_session.py | - |
-| `.agents/scripts/cli_surface_inventory.py` | argparse | - | 3 | policy:1, test:2 | mechanics | supported | .agents/scripts/cli_surface_inventory.py | vaws lint |
+| `.agents/scripts/cli_surface_inventory.py` | argparse | - | 3 | policy:1, test:3 | mechanics | supported | .agents/scripts/cli_surface_inventory.py | vaws lint |
 | `.agents/scripts/envelope_lint.py` | argparse | scan, check, run | 5 | docs:2, test:2 | mechanics | supported | .agents/scripts/envelope_lint.py | vaws lint |
 | `.agents/scripts/knowledge_capture.py` | argparse | - | 9 | docs:1, hook:1, routing:2, skill-doc:5, test:4 | mixed | supported | .agents/scripts/knowledge_capture.py | vaws knowledge |
 | `.agents/scripts/knowledge_export.py` | argparse | - | 7 | docs:1, routing:2, script:1, skill-doc:3, test:1 | mechanics | supported | .agents/scripts/knowledge_export.py | vaws knowledge |
-| `.agents/scripts/knowledge_query.py` | argparse | - | 9 | docs:1, routing:2, skill-doc:1, test:2 | mechanics | supported | .agents/scripts/knowledge_query.py | vaws knowledge |
+| `.agents/scripts/knowledge_query.py` | argparse | - | 9 | docs:1, routing:2, skill-doc:1, test:3 | mechanics | supported | .agents/scripts/knowledge_query.py | vaws knowledge |
 | `.agents/scripts/knowledge_validate.py` | argparse | - | 1 | docs:1, other:1, routing:1, skill-doc:1, test:2 | mechanics | supported | .agents/scripts/knowledge_validate.py | vaws knowledge |
 | `.agents/scripts/remote_artifact_manifest.py` | argparse | - | 1 | policy:1, routing:1 | mechanics | compatibility | .agents/scripts/remote_artifact_manifest.py | vaws remote |
 | `.agents/scripts/remote_artifact_pull.py` | argparse | - | 2 | policy:1, routing:1, script:1, skill-doc:1 | mechanics | compatibility | .agents/scripts/remote_artifact_pull.py | vaws remote |
@@ -466,7 +466,7 @@ option.
 | `.agents/skills/ascend-triton-operator-development/scripts/triton_development.py` | argparse | plan, finalize | 6 | routing:1, skill-doc:2, test:1 | mixed | supported | .agents/skills/ascend-triton-operator-development/scripts/triton_development.py | guidance |
 | `.agents/skills/ascend-triton-workflow/scripts/triton_workflow.py` | argparse | plan, link, finalize | 4 | routing:1, skill-doc:2, test:1 | mixed | supported | .agents/skills/ascend-triton-workflow/scripts/triton_workflow.py | guidance |
 | `.agents/skills/curate-workspace-knowledge/scripts/knowledge_curate.py` | argparse | list, inspect, promote, merge, reject, deprecate, resolve, verify, list-unresolved | 21 | policy:1, routing:1, skill-doc:2, test:5 | mixed | supported | .agents/skills/curate-workspace-knowledge/scripts/knowledge_curate.py | vaws knowledge |
-| `.agents/skills/machine-management/scripts/inventory.py` | argparse | summary, get, put, upsert, remove | 15 | docs:1, policy:1, routing:1, script:4, skill-doc:4, test:2 | mechanics | internal | .agents/skills/machine-management/scripts/machine_add.py | vaws machine |
+| `.agents/skills/machine-management/scripts/inventory.py` | argparse | summary, get, put, upsert, remove | 15 | docs:1, policy:1, routing:1, script:4, skill-doc:4, test:3 | mechanics | internal | .agents/skills/machine-management/scripts/machine_add.py | vaws machine |
 | `.agents/skills/machine-management/scripts/machine_add.py` | argparse | - | 13 | routing:1, script:3, skill-doc:4 | mechanics | supported | .agents/skills/machine-management/scripts/machine_add.py | vaws machine |
 | `.agents/skills/machine-management/scripts/machine_remove.py` | argparse | - | 1 | routing:1, script:1, skill-doc:4 | mechanics | supported | .agents/skills/machine-management/scripts/machine_remove.py | vaws machine |
 | `.agents/skills/machine-management/scripts/machine_repair.py` | argparse | - | 8 | routing:1, script:1, skill-doc:4 | mechanics | supported | .agents/skills/machine-management/scripts/machine_repair.py | vaws machine |
@@ -481,7 +481,7 @@ option.
 | `.agents/skills/remote-code-parity/scripts/install_consent.py` | argparse | resolve, set, batch-set, resolve-sync-mode, set-sync-mode | 7 | routing:1, skill-doc:5 | mechanics | supported | .agents/skills/remote-code-parity/scripts/install_consent.py | vaws sync |
 | `.agents/skills/remote-code-parity/scripts/parity_sync.py` | argparse | - | 17 | docs:1, mirror:1, routing:2, script:4, skill-doc:10, test:2 | mechanics | supported | .agents/skills/remote-code-parity/scripts/parity_sync.py | vaws sync |
 | `.agents/skills/remote-code-parity/scripts/parity_watch.py` | argparse | - | 2 | script:1, skill-doc:3, test:1 | mechanics | supported | .agents/skills/remote-code-parity/scripts/parity_watch.py | vaws sync |
-| `.agents/skills/remote-code-parity/scripts/remote_code_parity.py` | bare | - | 0 | docs:2, routing:1, script:2, skill-doc:3 | mechanics | payload | .agents/skills/remote-code-parity/scripts/remote_code_parity.py | - |
+| `.agents/skills/remote-code-parity/scripts/remote_code_parity.py` | bare | - | 0 | docs:2, routing:1, script:2, skill-doc:3 | mechanics | supported | .agents/skills/remote-code-parity/scripts/remote_code_parity.py | vaws sync |
 | `.agents/skills/remote-code-parity/scripts/transport_benchmark.py` | argparse | - | 4 | skill-doc:2 | mechanics | harness | .agents/skills/remote-code-parity/scripts/transport_benchmark.py | - |
 | `.agents/skills/repo-init/scripts/install_gh_user.py` | bare | - | 0 | script:1 | mechanics | supported | .agents/skills/repo-init/scripts/install_gh_user.py | vaws workspace |
 | `.agents/skills/repo-init/scripts/repo_init_probe.py` | argparse | - | 1 | mirror:1, routing:1, skill-doc:4 | mechanics | supported | .agents/skills/repo-init/scripts/repo_init_probe.py | vaws workspace |
@@ -510,10 +510,10 @@ option.
 | `.agents/skills/vllm-ascend-serving/scripts/serve_start.py` | argparse | - | 16 | docs:1, mirror:1, routing:1, script:5, skill-doc:12, test:2 | mechanics | supported | .agents/skills/vllm-ascend-serving/scripts/serve_start.py | vaws serve |
 | `.agents/skills/vllm-ascend-serving/scripts/serve_status.py` | argparse | - | 2 | docs:1, mirror:1, routing:1, script:2, skill-doc:4 | mechanics | supported | .agents/skills/vllm-ascend-serving/scripts/serve_status.py | vaws serve |
 | `.agents/skills/vllm-ascend-serving/scripts/serve_stop.py` | argparse | - | 3 | docs:1, mirror:1, routing:1, script:5, skill-doc:13, test:1 | mechanics | supported | .agents/skills/vllm-ascend-serving/scripts/serve_stop.py | vaws serve |
-| `.trae/skills/modelscope/scripts/download_from_modelscope.py` | argparse | - | 12 | mirror:2, routing:1, script:2, skill-doc:1, test:1 | mechanics | generated | .agents/skills/modelscope/scripts/download_from_modelscope.py | - |
+| `.trae/skills/modelscope/scripts/download_from_modelscope.py` | argparse | - | 12 | mirror:2, routing:1, script:2, skill-doc:1, test:1 | mechanics | payload | .agents/skills/modelscope/scripts/download_from_modelscope.py | - |
 | `.trae/skills/modelscope/scripts/modelscope_auto.py` | argparse | ensure, status, verify, worker | 11 | mirror:1, routing:1, script:1, skill-doc:1, test:1 | mechanics | generated | .agents/skills/modelscope/scripts/modelscope_auto.py | - |
 | `.trae/skills/modelscope/scripts/modelscope_download_status.py` | argparse | - | 3 | mirror:1, routing:1, script:1, skill-doc:1, test:1 | mechanics | generated | .agents/skills/modelscope/scripts/modelscope_download_status.py | - |
-| `.trae/skills/modelscope/scripts/verify_modelscope_sha256.py` | argparse | - | 8 | mirror:2, routing:1, script:2, skill-doc:1, test:1 | mechanics | generated | .agents/skills/modelscope/scripts/verify_modelscope_sha256.py | - |
+| `.trae/skills/modelscope/scripts/verify_modelscope_sha256.py` | argparse | - | 8 | mirror:2, routing:1, script:2, skill-doc:1, test:1 | mechanics | payload | .agents/skills/modelscope/scripts/verify_modelscope_sha256.py | - |
 <!-- /current-cli-surface-table -->
 
 ## 11. Measurement limitations

--- a/docs/dependency-plane.md
+++ b/docs/dependency-plane.md
@@ -17,7 +17,7 @@ must name git+https tag sources because `vaws-coordinator` depends on
 |---|---|---|---|
 | `vaws-remote-dev` | `remote_dev` | `v0.2.0` | process-in import + MCP server |
 | `vaws-coordinator` | `vaws_coordinator` | `v0.2.0` | process-in import + stdio MCP |
-| `vaws-knowledge` | `vaws_knowledge` | `v0.1.3` (pinned to the commons PR branch commit until `v0.1.3` is tagged) | process-in import + MCP |
+| `vaws-knowledge` | `vaws_knowledge` | `v0.1.4` | process-in import + MCP |
 | `vaws-top` | — | uvx only | fleet dashboard; not imported |
 
 `uv sync` writes `.venv` and records the resolved git commits in `uv.lock`.

--- a/docs/target-state.md
+++ b/docs/target-state.md
@@ -208,30 +208,38 @@ than a `tests/` directory). `modelscope` is referenced by no other skill.
 ### 4.4 Entry points
 
 Tracked Python under `.agents/` divides into two populations, and they get
-opposite treatment. 202 files carry `if __name__ == "__main__"`; 34 carry the
-shim today.
+opposite treatment. The CLI-surface inventory is the authority for which
+files are entry points. Test files (`tests/` directories, `test_*.py`,
+`selftest_*.py`, `*_test.py`, `conftest.py`) are not entry points: pytest
+does not go through `__main__`, and they do not receive the shim. A
+`__main__` file that is neither a test nor in the inventory is a
+classification gap the guard flags, not a file to shim by default.
 
-**Local entry points** — anything an agent or a hook runs on the workstation
-— carry `ensure_workspace_interpreter`, so that `python3 path/to/script.py`
-works from a shell that never activated `.venv`. A guard test enforces this,
-and CI runs the entry-point smoke under the system interpreter as well as
-`uv run`, because the two disagreeing is exactly the failure CI was not
-catching.
+**Local entry points** — inventoried files the inventory does **not**
+classify as `payload` — carry `ensure_workspace_interpreter`, so that
+`python3 path/to/script.py` works from a shell that never activated
+`.venv`. A guard test enforces this, and CI runs the entry-point smoke
+under the system interpreter as well as `uv run`, because the two
+disagreeing is exactly the failure CI was not catching.
 
-**Remote payloads** must not carry it. These are files whose `__main__` runs
-on the NPU container, reached by copying the source over and invoking the
-container's interpreter: `weight_inspector.py` is read and written to
-`/tmp/_vaws_weight_inspector.py`, and the tensor-dump assets are imported
-inside the vLLM process. There is no `.venv` and no scaffold checkout at the
-far end, so the shim would add an import that cannot resolve. Their contract
-is the opposite one: stdlib-only, no scaffold imports, runnable by a bare
-`python3`.
+**Remote payloads** must not carry it. These are inventoried files whose
+`__main__` runs on the NPU container, reached by copying the source over
+and invoking the container's interpreter: `weight_inspector.py` is read
+and written to `/tmp/_vaws_weight_inspector.py`, and the tensor-dump
+assets are imported inside the vLLM process. There is no `.venv` and no
+`.agents/lib` at the far end, so the shim would add an import that cannot
+resolve. Their contract is the opposite one: they import nothing from
+`.agents/lib`. Generated Trae byte-copies of those payloads inherit the
+same `payload` classification so the shim stays out of both sides of a
+byte-identical pair.
 
-The line between the two populations is not a new list to maintain. The CLI
-surface inventory already classifies nine entry points as `payload`
-("executable spawned on the container or by another command"), and that
-classification is the input to the guard. A file that changes population has
-to change its inventory row in the same commit, which is the point.
+The line between the two populations is not a new list to maintain. The
+inventory's `payload` class is the input to the guard. A file that
+changes population has to change its inventory row in the same commit,
+which is the point. Overlay `payload` means "runs without the workspace
+interpreter", not merely "spawned by another command": a workstation
+helper that another script launches (for example `remote_code_parity.py`)
+is `supported`, not `payload`.
 
 ### 4.5 Local state
 
@@ -333,25 +341,21 @@ twelve scope dimensions. Commons implements the evaluation
 `ASSUMED_ANY`) and `query()` accepts a `reader_coordinate`.
 
 The MCP path is already wired: the tool schema in the locked
-`vaws-knowledge` v0.1.3 declares `reader_coordinate` on both query tools and
-forwards it to `query()`. An agent speaking MCP can ask "does this apply to
-my container" today. This corrects an earlier draft of this section, which
-said no entry point could pass a coordinate; that was true of `main` before
-the knowledge engine moved into the package and is no longer true.
+`vaws-knowledge` package declares `reader_coordinate` on both query tools
+and forwards it to `query()`. An agent speaking MCP can ask "does this
+apply to my container" today.
 
-Two gaps remain, and they are the whole of the work here:
-
-- Neither CLI exposes coordinate arguments, so every script and hook that
-  shells out gets unscoped answers with an empty `reader_coordinate` in the
-  response.
-- Nothing fills the coordinate automatically. The agent has to restate
-  twelve dimensions that the Run Manifest and the machine profile already
-  know. An axiom the caller must retype by hand is an axiom that gets
-  skipped.
-
-The target state exposes the arguments on both CLIs and has the scaffold
-populate what it can derive, leaving the agent to override rather than
-originate. Building a second MCP surface is not part of it.
+Both CLIs expose the same twelve scope dimensions (`--soc` … `--component`),
+a `--reader-coordinate` JSON object, and `--run-manifest`. A query that
+names a `soc` an entry's scope excludes does not return that entry. The
+response's `reader_coordinate` is populated. A caller inside a run does
+not retype what the Run Manifest v1 already recorded:
+`vaws_coordinator.run_manifest.load_manifest` fills the derivable
+dimensions; anything not derivable stays absent and is reported as
+`unknown` / unsupplied. Neither CLI invents a version to fill a hole. A
+missing or too-old `vaws-knowledge` (before the coordinate flags) fails
+with cause and `uv sync` as the remedy; there is no silent unscoped
+fallback. Building a second MCP surface is not part of it.
 
 ### 5.5 Redaction
 
@@ -411,7 +415,7 @@ package names the subset it makes true.
 | P6 | `import vaws_coordinator.run_manifest` succeeds; `.agents/lib/vaws_run_manifest.py` and the coordinator's `vendor/` are absent; a manifest written by `vaws_coordinator.ready_runtime` passes `vaws_coordinator.run_manifest.validate_manifest`. |
 | P7 | `rg 'VAWS_PARITY_SCRIPT\|VAWS_MACHINE_INVENTORY'` across the coordinator source is empty. |
 | P8 | `.agents/knowledge/` contains only `*.v2.yaml`; `vaws-knowledge validate .agents/knowledge` exits 0. |
-| P9 | Every tracked `.agents/**/*.py` with `if __name__ == "__main__"` that the inventory does **not** classify as `payload` contains `ensure_workspace_interpreter`; every `payload` one imports nothing from `.agents/lib`. One guard test asserts both halves against the inventory. |
+| P9 | Every inventoried CLI-surface entry that is **not** classified `payload` contains `ensure_workspace_interpreter`; every inventoried `payload` entry imports nothing from `.agents/lib`. Test files are not entry points and do not receive the shim. A `__main__` file that is neither a test nor in the inventory is a classification gap the guard flags. One guard test asserts those three facts against the inventory. |
 | P10 | `tracked_path_check.py --mode enforce` passes with an empty baseline. |
 | P11 | `rg -l 'Status: dated' docs` is empty. |
 | P11a | A pull request that touches only `docs/` runs the document guards. Until 2026-09-09 the job holding them was filtered to `.agents/**`, so a docs-only change merged without the anti-rot guard whose subject is tracked documents. |
@@ -473,4 +477,4 @@ package names the subset it makes true.
 | 2026-09-09 | Skills adopt Result Envelope v1 rather than the envelope being deleted | it currently has zero producers and eleven competing sentinels; a contract with no producers is not a contract, and the attribution/evidence structure is what agents need |
 | 2026-09-09 | Unmultiplexed SSH stays an endpoint option | long-stream `mux=False` is a recorded failure signature, not an accident |
 | 2026-09-09 | Reader coordinates become reachable from both CLIs and are auto-filled where derivable | the MCP tool in v0.1.3 already accepts them; the gap is CLI exposure plus population from the Run Manifest and machine profile. No second MCP surface |
-| 2026-09-09 | The interpreter shim applies to local entry points only, keyed off the inventory's `payload` class | remote payloads run on the container with no `.venv` and no scaffold checkout; 202 files carry `__main__` and nine are already classified as payloads |
+| 2026-09-09 | The interpreter shim applies to inventoried non-`payload` entry points only; tests are not entries; unclassified `__main__` files are classification gaps | remote payloads run on the container with no `.venv` and no `.agents/lib`; putting the shim in every tracked `__main__` would re-exec 80+ pytest files the spec did not intend |

--- a/docs/tracked-path-guard.md
+++ b/docs/tracked-path-guard.md
@@ -43,6 +43,11 @@ the first `*`. A `scripts/<name>.py` token also resolves as
 Markdown links such as `](../<file>.md)` are resolved against the referring
 file.
 
+A named path exists only when `git ls-files` lists that file or a file
+under that directory. An untracked leftover on disk does not satisfy the
+reference and does not turn a baseline row stale. The working tree is
+not consulted.
+
 `.vaws-local/` and `.vaws-runtime/` are allowed (untracked state).
 Placeholders such as `<session-id>` are allowed. The former in-tree
 remote-dev `state/` directory is **not** allowed: that path is drift.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.11"
 dependencies = [
   "vaws-remote-dev==0.2.0",
   "vaws-coordinator==0.2.0",
-  "vaws-knowledge==0.1.3",
+  "vaws-knowledge==0.1.4",
 ]
 
 [dependency-groups]
@@ -22,7 +22,7 @@ package = false
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", tag = "v0.2.0" }
 vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", tag = "v0.2.0" }
-vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", tag = "v0.1.3" }
+vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", tag = "v0.1.4" }
 
 [tool.pytest.ini_options]
 pythonpath = [".agents/lib"]

--- a/uv.lock
+++ b/uv.lock
@@ -838,8 +838,8 @@ dependencies = [
 
 [[package]]
 name = "vaws-knowledge"
-version = "0.1.3"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?tag=v0.1.3#16befcade10ec2acca74731888339524574a326c" }
+version = "0.1.4"
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?tag=v0.1.4#ae39db2c4ad9cf658b38f6624f6bc49e76274418" }
 dependencies = [
     { name = "jsonschema" },
     { name = "packaging" },
@@ -872,7 +872,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?tag=v0.2.0" },
-    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?tag=v0.1.3" },
+    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?tag=v0.1.4" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?tag=v0.2.0" },
 ]
 


### PR DESCRIPTION
## Summary
- **P9:** inventoried non-`payload` entries carry `ensure_workspace_interpreter`; inventoried payloads import nothing from `.agents/lib`. Tests are not entries. Unclassified `__main__` files are classification gaps.
- **P10:** `tracked_path_check` decides existence from `git ls-files`, not the working tree. The dated baseline is unchanged (24 attributed rows; P10's empty-baseline target is not this tree yet).
- **P19:** both knowledge CLIs accept the twelve scope dimensions, `--reader-coordinate`, and `--run-manifest` (via `vaws_coordinator.run_manifest`). A mismatched `soc` withholds that entry; `reader_coordinate` is populated; a run fills derivable dimensions.
- Pin `vaws-knowledge==0.1.4` (`ae39db2`). Please **merge as a merge commit**, not squash.

## Test plan
- [x] Full `skill-catalog.yml` validate job `run:` list (33 steps; the workflow currently has 33 `run:` steps, not 32)
- [x] Six guards (`skill_catalog`, `tracked_path_check --mode enforce`, `cli_surface_inventory`, `repo_boundary_check --mode enforce`, `tracked_leak_scan`, `sync_claude_skills --check`) all exit 0
- [x] P9 guard, P10 leftover tests, P19 CLI tests
- [ ] `gh pr checks` on this PR after CI starts


Made with [Cursor](https://cursor.com)