### PR TITLE
feat: adopt vaws-remote-dev 0.3.0 for forwards, interactive SSH, and analysis sync

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -70,7 +70,7 @@ compatibility backend for managed sessions, sync, service adapters, and cleanup.
 - `.agents/lib/vaws_session_id.py` and `.agents/lib/vaws_session_state.py` are the shared libraries for session identity, state, locks, and leases.
 - `.agents/lib/vaws_remote_dev.py` injects scaffold environment into the installed `vaws-remote-dev` package and is the only scaffold place that may call its SSH transport.
 - `.agents/lib/vaws_remote_target.py` maps machines and sessions to host/container endpoints. It is not SSH transport.
-- `.agents/lib/vaws_remote_adapters.py` keeps service, sync, and cleanup CLIs that remote-dev v0.2.0 cannot express.
+- `.agents/lib/vaws_remote_adapters.py` keeps service, sync, and cleanup CLIs that remote-dev v0.3.0 cannot express.
 - `.agents/lib/vaws_validate.py` is the shared validation library for agent-facing ids, environment names, path boundaries, and NPU device lists.
 - `.agents/lib/vaws_coordinator_launch.py` launches the installed vaws-coordinator package (task identity, `vaws_*` tools, runtime pool).
 - `AGENTS.md` carries repository-wide routing rules and mandatory decision gates.

--- a/.agents/lib/vaws_remote_adapters.py
+++ b/.agents/lib/vaws_remote_adapters.py
@@ -1,4 +1,4 @@
-"""Service, sync, and cleanup adapters that remote-dev v0.2.0 cannot express.
+"""Service, sync, and cleanup adapters that remote-dev v0.3.0 cannot express.
 
 These spawn existing serving/parity/session CLIs. SSH, when needed, goes
 through ``vaws_remote_dev``. This is not a second transport.

--- a/.agents/lib/vaws_remote_dev.py
+++ b/.agents/lib/vaws_remote_dev.py
@@ -12,7 +12,8 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Mapping, TextIO
+from collections.abc import Mapping, Sequence
+from typing import Any, TextIO
 
 ROOT = Path(__file__).resolve().parents[2]
 LIB = ROOT / ".agents" / "lib"
@@ -28,7 +29,7 @@ STATE_DIRNAME = "remote-dev-state"
 LOCAL_STATE_DIRNAME = ".vaws-local"
 ASCEND_RUNTIME_ENV_FILE = "/etc/profile.d/vaws-ascend-env.sh"
 SSH_MUX_DIR = "~/.ssh/vaws-mux"
-REQUIRED_TRANSPORT_VERSION = "0.2.0"
+REQUIRED_TRANSPORT_VERSION = "0.3.0"
 
 DEFAULT_ENV = {
     "REMOTE_DEV_RUNTIME_ENV_FILE": ASCEND_RUNTIME_ENV_FILE,
@@ -117,10 +118,10 @@ def require_package(repo_root: Path = ROOT) -> dict[str, Any]:
 
 
 def require_transport(repo_root: Path = ROOT):
-    """Import v0.2.0 stream APIs or fail with the cause and remedy.
+    """Import v0.3.0 stream, forward, and interactive APIs or fail.
 
     Does not catch ``ImportError`` and continue. A missing package or a
-    pre-v0.2.0 install cannot silently fall back to raw ``ssh``.
+    pre-v0.3.0 install cannot silently fall back to raw ``ssh``.
     """
     require_package(repo_root=repo_root)
     apply_consumer_environment(repo_root=repo_root)
@@ -128,7 +129,11 @@ def require_transport(repo_root: Path = ROOT):
         from remote_dev.core.endpoint import Endpoint
         from remote_dev.core.errors import RemoteExecutionError
         from remote_dev.core.ssh_transport import (
+            interactive_ssh_command,
+            local_forward_ssh_command,
+            open_local_forward,
             run_bytes,
+            run_interactive,
             run_script,
             run_stream,
             ssh_base_cmd,
@@ -148,7 +153,11 @@ def require_transport(repo_root: Path = ROOT):
     return {
         "Endpoint": Endpoint,
         "RemoteExecutionError": RemoteExecutionError,
+        "interactive_ssh_command": interactive_ssh_command,
+        "local_forward_ssh_command": local_forward_ssh_command,
+        "open_local_forward": open_local_forward,
         "run_bytes": run_bytes,
+        "run_interactive": run_interactive,
         "run_script": run_script,
         "run_stream": run_stream,
         "ssh_base_cmd": ssh_base_cmd,
@@ -331,6 +340,77 @@ def ssh_run_bytes(
     ep = endpoint_from(endpoint, connect_timeout_s=connect_timeout)
     timeout_ms = None if timeout is None else int(timeout * 1000)
     return api["run_bytes"](ep, remote_command, stdin=stdin, timeout_ms=timeout_ms)
+
+
+def local_forward_ssh_command(
+    endpoint: Any,
+    *,
+    local_host: str,
+    local_port: int,
+    remote_host: str,
+    remote_port: int,
+    connect_timeout_s: int | None = None,
+) -> list[str]:
+    """Argv for ``ssh -N -L``. Refuses a multiplexed endpoint."""
+    api = require_transport()
+    ep = endpoint_from(endpoint, long_stream=True, connect_timeout_s=connect_timeout_s)
+    return list(
+        api["local_forward_ssh_command"](
+            ep,
+            local_host=local_host,
+            local_port=local_port,
+            remote_host=remote_host,
+            remote_port=remote_port,
+        )
+    )
+
+
+def open_local_forward(
+    endpoint: Any,
+    remote_port: int,
+    *,
+    remote_host: str = "127.0.0.1",
+    local_host: str = "127.0.0.1",
+    local_port: int | None = None,
+    ready_timeout_s: float | None = 15.0,
+    connect_timeout_s: int | None = None,
+):
+    """Open a local→remote forward via the package. Skills do not Popen ``ssh``."""
+    api = require_transport()
+    ep = endpoint_from(endpoint, long_stream=True, connect_timeout_s=connect_timeout_s)
+    return api["open_local_forward"](
+        ep,
+        remote_port,
+        remote_host=remote_host,
+        local_host=local_host,
+        local_port=local_port,
+        ready_timeout_s=ready_timeout_s,
+    )
+
+
+def interactive_ssh_command(
+    endpoint: Any,
+    remote_command: Sequence[str] = (),
+    *,
+    connect_timeout_s: int = 10,
+) -> list[str]:
+    """Argv for one-off password bootstrap. Refuses a multiplexed endpoint."""
+    api = require_transport()
+    ep = endpoint_from(endpoint, ssh_mux=False, connect_timeout_s=connect_timeout_s)
+    return list(api["interactive_ssh_command"](ep, remote_command))
+
+
+def run_interactive(
+    endpoint: Any,
+    remote_command: Sequence[str] | str = (),
+    *,
+    env: Mapping[str, str] | None = None,
+    connect_timeout_s: int = 10,
+) -> int:
+    """One-off interactive SSH inheriting the local TTY. Returns ssh's rc."""
+    api = require_transport()
+    ep = endpoint_from(endpoint, ssh_mux=False, connect_timeout_s=connect_timeout_s)
+    return int(api["run_interactive"](ep, remote_command, env=env))
 
 
 def run_cli_tool(tool: str, argv: list[str] | None = None) -> int:

--- a/.agents/skills/ascend-memory-profiling/scripts/_common.py
+++ b/.agents/skills/ascend-memory-profiling/scripts/_common.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import json
 import os
 import shlex
-import subprocess
 import sys
 import uuid
 from pathlib import Path
@@ -21,7 +20,7 @@ for _p in (str(LIB_DIR), str(MM_SCRIPTS)):
         sys.path.insert(0, _p)
 
 from vaws_local_state import allocate_run_dir  # noqa: E402
-from vaws_remote_dev import ssh_argv, ssh_exec, ssh_run_bytes  # noqa: E402
+from vaws_remote_dev import ssh_exec, ssh_run_bytes  # noqa: E402
 from vaws_result_envelope import progress as envelope_progress  # noqa: E402
 from vaws_remote_target import (  # noqa: E402
     SshEndpoint,
@@ -44,10 +43,6 @@ ENV_PREAMBLE = (
 )
 
 
-def _ssh_base_cmd(endpoint: SshEndpoint) -> list[str]:
-    return ssh_argv(endpoint)
-
-
 def ssh_upload(endpoint: SshEndpoint, local_path: Path, remote_path: str) -> None:
     """Upload a file to the remote machine via stdin redirect."""
     with open(local_path, "rb") as f:
@@ -61,14 +56,6 @@ def ssh_write_text(endpoint: SshEndpoint, content: str, remote_path: str) -> Non
     result = ssh_run_bytes(endpoint, f"cat > {shlex.quote(remote_path)}", stdin=content.encode())
     if result.returncode != 0:
         raise RuntimeError(f"ssh_write_text failed (rc={result.returncode}): {result.stderr!r}")
-
-
-def ssh_bg_exec(
-    endpoint: SshEndpoint,
-    script: str,
-) -> subprocess.Popen:
-    cmd = [*_ssh_base_cmd(endpoint), "bash", "-c", shlex.quote(script)]
-    return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 
 
 def progress(msg: str, **extra: Any) -> None:

--- a/.agents/skills/ascend-profiling-analysis/scripts/_common.py
+++ b/.agents/skills/ascend-profiling-analysis/scripts/_common.py
@@ -18,10 +18,13 @@ remotely.
 
 from __future__ import annotations
 
+import fnmatch
+import io
 import json
 import shlex
 import subprocess
 import sys
+import tarfile
 import time
 from pathlib import Path
 from typing import Any, Iterable
@@ -33,7 +36,7 @@ if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
 from vaws_local_state import allocate_run_dir  # noqa: E402
-from vaws_remote_dev import ssh_argv, ssh_exec, ssh_stream as remote_ssh_stream  # noqa: E402
+from vaws_remote_dev import ssh_argv, ssh_exec, ssh_run_bytes, ssh_stream as remote_ssh_stream  # noqa: E402
 from vaws_result_envelope import PROGRESS_SENTINEL, progress as envelope_progress  # noqa: E402
 from vaws_remote_target import (  # noqa: E402
     SshEndpoint,
@@ -291,12 +294,47 @@ def ssh_stream(
 
 
 # ---------------------------------------------------------------------------
-# tar-over-ssh sync helpers (rsync is not always installed in Ascend containers)
+# Directory sync helpers (rsync is not always installed in Ascend containers).
+# Local packing/unpacking uses stdlib tarfile so this module never spawns
+# ``tar`` or ``ssh``. Remote unpack/pack still uses the remote ``tar`` binary
+# through ``ssh_run_bytes``.
 # ---------------------------------------------------------------------------
 
-def _ssh_pipe_cmd(endpoint: SshEndpoint, remote_cmd: str) -> list[str]:
-    """SSH command that runs a remote shell snippet, suitable for tar piping."""
-    return [*ssh_argv(endpoint), remote_cmd]
+def _tar_name_excluded(name: str, patterns: tuple[str, ...]) -> bool:
+    normalized = name.replace("\\", "/").lstrip("./")
+    if not normalized or normalized == ".":
+        return False
+    candidates = (normalized, Path(normalized).name, *Path(normalized).parts)
+    return any(
+        fnmatch.fnmatch(candidate, pattern)
+        for candidate in candidates
+        for pattern in patterns
+    )
+
+
+def _tar_bytes_from_directory(local_path: Path, extra_excludes: Iterable[str]) -> bytes:
+    patterns = tuple(extra_excludes)
+    buf = io.BytesIO()
+
+    def _filter(info: tarfile.TarInfo) -> tarfile.TarInfo | None:
+        if _tar_name_excluded(info.name, patterns):
+            return None
+        return info
+
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        tf.add(str(local_path), arcname=".", filter=_filter)
+    return buf.getvalue()
+
+
+def _extract_tar_bytes(data: bytes, local_path: Path) -> None:
+    local_path.mkdir(parents=True, exist_ok=True)
+    if not data:
+        return
+    kwargs: dict[str, Any] = {}
+    if hasattr(tarfile, "data_filter"):
+        kwargs["filter"] = "data"
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tf:
+        tf.extractall(local_path, **kwargs)
 
 
 def sync_to_remote(
@@ -306,7 +344,7 @@ def sync_to_remote(
     *,
     extra_excludes: Iterable[str] = ("__pycache__", "*.pyc"),
 ) -> None:
-    """Mirror ``local_path/`` into ``remote_path/`` using ``tar | ssh tar -x``.
+    """Mirror ``local_path/`` into ``remote_path/`` via in-memory tar + ``run_bytes``.
 
     Implements --delete by clearing ``remote_path`` first, then unpacking the
     tarball. Lightweight on purpose: callers pick the smallest subtree they
@@ -327,34 +365,17 @@ def sync_to_remote(
         timeout=120,
     )
 
-    tar_args = ["tar", "-cz"]
-    for pattern in extra_excludes:
-        tar_args.extend(["--exclude", pattern])
-    tar_args.extend(["-C", str(local_path), "."])
-    remote_unpack = f"tar -xz -C {shlex.quote(remote_path)}"
-
-    tar_proc = subprocess.Popen(tar_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    ssh_proc = subprocess.Popen(
-        _ssh_pipe_cmd(endpoint, remote_unpack),
-        stdin=tar_proc.stdout,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+    archive = _tar_bytes_from_directory(local_path, extra_excludes)
+    result = ssh_run_bytes(
+        endpoint,
+        f"tar -xz -C {shlex.quote(remote_path)}",
+        stdin=archive,
     )
-    if tar_proc.stdout is not None:
-        tar_proc.stdout.close()  # let ssh_proc receive EOF when tar exits
-    ssh_out, ssh_err = ssh_proc.communicate()
-    tar_err = tar_proc.stderr.read() if tar_proc.stderr else b""
-    tar_proc.wait()
-    if tar_proc.returncode != 0:
-        raise RuntimeError(
-            "local tar failed (rc={rc}): {err}".format(
-                rc=tar_proc.returncode, err=tar_err.decode("utf-8", "replace")[:1000]
-            )
-        )
-    if ssh_proc.returncode != 0:
+    if result.returncode != 0:
+        err = (result.stderr or b"").decode("utf-8", "replace")
         raise RuntimeError(
             "remote tar -x failed (rc={rc}): {err}".format(
-                rc=ssh_proc.returncode, err=ssh_err.decode("utf-8", "replace")[:1000]
+                rc=result.returncode, err=err[:1000]
             )
         )
 
@@ -366,7 +387,7 @@ def sync_from_remote(
     *,
     include_paths: Iterable[str] | None = None,
 ) -> None:
-    """Mirror ``remote_path/`` into ``local_path/`` using ``ssh tar -c | tar -x``.
+    """Mirror ``remote_path/`` into ``local_path/`` via ``run_bytes`` + tarfile.
 
     When ``include_paths`` is provided, only those relative paths are tarred
     on the remote side. Missing paths are silently skipped (some sweep roots
@@ -394,36 +415,18 @@ def sync_from_remote(
             f"tar -cz \"${{present[@]}}\""
         )
 
-    ssh_proc = subprocess.Popen(
-        _ssh_pipe_cmd(endpoint, remote_pack),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    tar_proc = subprocess.Popen(
-        ["tar", "-xz", "-C", str(local_path)],
-        stdin=ssh_proc.stdout,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    if ssh_proc.stdout is not None:
-        ssh_proc.stdout.close()
-    tar_out, tar_err = tar_proc.communicate()
-    ssh_err = ssh_proc.stderr.read() if ssh_proc.stderr else b""
-    ssh_proc.wait()
-    if ssh_proc.returncode != 0:
+    result = ssh_run_bytes(endpoint, remote_pack)
+    if result.returncode != 0:
+        err = (result.stderr or b"").decode("utf-8", "replace")
         raise RuntimeError(
             "remote tar -c failed (rc={rc}): {err}".format(
-                rc=ssh_proc.returncode, err=ssh_err.decode("utf-8", "replace")[:1000]
+                rc=result.returncode, err=err[:1000]
             )
         )
-    # tar -x can exit 0 with empty stdin (no requested paths existed); only
-    # bail out on a real non-zero local tar exit.
-    if tar_proc.returncode not in (0,):
-        raise RuntimeError(
-            "local tar -x failed (rc={rc}): {err}".format(
-                rc=tar_proc.returncode, err=tar_err.decode("utf-8", "replace")[:1000]
-            )
-        )
+    try:
+        _extract_tar_bytes(result.stdout or b"", local_path)
+    except tarfile.TarError as exc:
+        raise RuntimeError(f"local tarfile extract failed: {exc}") from exc
 
 
 # ---------------------------------------------------------------------------

--- a/.agents/skills/ascend-profiling-analysis/tests/conftest.py
+++ b/.agents/skills/ascend-profiling-analysis/tests/conftest.py
@@ -4,9 +4,56 @@ the package.
 """
 from __future__ import annotations
 
+import importlib.util
 import sys
 from pathlib import Path
 
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
-if str(SCRIPTS_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPTS_DIR))
+_COMMON_FILE = SCRIPTS_DIR / "_common.py"
+
+
+def _claim_skill_imports() -> None:
+    """Make this skill's ``_common`` win in a shared pytest process.
+
+    Collection (and other skill) suites also expose a top-level ``_common``.
+    Pytest may load this conftest before those suites finish importing, so a
+    one-shot ``sys.path`` tweak at module import is not enough.
+    """
+    scripts = str(SCRIPTS_DIR)
+    while scripts in sys.path:
+        sys.path.remove(scripts)
+    sys.path.insert(0, scripts)
+
+    cached = sys.modules.get("_common")
+    cached_file = Path(getattr(cached, "__file__", "") or "").resolve()
+    if cached is not None and cached_file == _COMMON_FILE.resolve():
+        return
+
+    sys.modules.pop("_common", None)
+    spec = importlib.util.spec_from_file_location("_common", _COMMON_FILE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_common"] = module
+    spec.loader.exec_module(module)
+
+    for name in ("profile_analyze", "profile_sweep"):
+        loaded = sys.modules.get(name)
+        common = getattr(loaded, "common", None) if loaded is not None else None
+        if loaded is not None and (
+            common is None or not hasattr(common, "REQUIRED_SINGLE_ARTIFACTS")
+        ):
+            sys.modules.pop(name, None)
+
+
+_claim_skill_imports()
+
+
+def pytest_configure(config) -> None:
+    del config
+    _claim_skill_imports()
+
+
+def pytest_collect_file(file_path, parent):
+    del file_path, parent
+    _claim_skill_imports()
+    return None

--- a/.agents/skills/ascend-profiling-analysis/tests/test_skill_contract.py
+++ b/.agents/skills/ascend-profiling-analysis/tests/test_skill_contract.py
@@ -7,7 +7,11 @@ full pipeline.
 """
 from __future__ import annotations
 
+import io
 import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
@@ -169,6 +173,77 @@ def test_ssh_base_cmd_sets_default_connect_timeout() -> None:
     assert f"ConnectTimeout={common.SSH_CONNECT_TIMEOUT_SECONDS}" in cmd
 
 
+def test_sync_to_remote_uses_run_bytes_and_excludes_bytecode() -> None:
+    """If this helper goes back to spawning local ``tar``/``ssh``, Popen is called."""
+    with tempfile.TemporaryDirectory() as tmp:
+        src = Path(tmp) / "src"
+        src.mkdir()
+        (src / "ok.py").write_text("x = 1\n", encoding="utf-8")
+        (src / "__pycache__").mkdir()
+        (src / "__pycache__" / "ok.cpython-311.pyc").write_bytes(b"nope")
+        (src / "skip.pyc").write_bytes(b"nope")
+        seen: dict[str, object] = {}
+
+        def fake_exec(_endpoint, script, **_kwargs):
+            seen["wipe"] = script
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        def fake_bytes(_endpoint, remote_command, *, stdin=None, **_kwargs):
+            seen["remote"] = remote_command
+            seen["stdin"] = stdin
+            return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+        with (
+            mock.patch.object(common, "ssh_exec", side_effect=fake_exec),
+            mock.patch.object(common, "ssh_run_bytes", side_effect=fake_bytes),
+            mock.patch.object(common.subprocess, "Popen") as popen,
+        ):
+            common.sync_to_remote(object(), src, "/tmp/dst")
+            popen.assert_not_called()
+
+        assert "rm -rf" in str(seen["wipe"])
+        assert "tar -xz" in str(seen["remote"])
+        with tarfile.open(fileobj=io.BytesIO(seen["stdin"]), mode="r:gz") as tf:
+            names = [name.replace("\\", "/").lstrip("./") for name in tf.getnames()]
+        assert any(name == "ok.py" or name.endswith("/ok.py") for name in names)
+        assert not any("__pycache__" in name or name.endswith(".pyc") for name in names)
+
+
+def test_sync_from_remote_extracts_via_tarfile() -> None:
+    buf = io.BytesIO()
+    payload = b"hi\n"
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        info = tarfile.TarInfo(name="hello.txt")
+        info.size = len(payload)
+        tf.addfile(info, io.BytesIO(payload))
+    with tempfile.TemporaryDirectory() as tmp:
+        dest = Path(tmp) / "out"
+        with (
+            mock.patch.object(
+                common,
+                "ssh_run_bytes",
+                return_value=SimpleNamespace(returncode=0, stdout=buf.getvalue(), stderr=b""),
+            ),
+            mock.patch.object(common.subprocess, "Popen") as popen,
+        ):
+            common.sync_from_remote(object(), "/remote", dest)
+            popen.assert_not_called()
+        assert (dest / "hello.txt").read_bytes() == payload
+
+
+def test_sync_from_remote_empty_stdout_is_ok() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        dest = Path(tmp) / "out"
+        dest.mkdir()
+        with mock.patch.object(
+            common,
+            "ssh_run_bytes",
+            return_value=SimpleNamespace(returncode=0, stdout=b"", stderr=b""),
+        ):
+            common.sync_from_remote(object(), "/remote", dest)
+        assert list(dest.iterdir()) == []
+
+
 def test_all_stage_parsers_disable_abbrev() -> None:
     """acceptance.md: every argparse parser must set allow_abbrev=False."""
     from ascend_profile import (
@@ -211,5 +286,8 @@ if __name__ == "__main__":
     test_remote_python_probe_timeout_required_fails_closed()
     test_remote_python_probe_timeout_optional_falls_back_to_python3()
     test_ssh_base_cmd_sets_default_connect_timeout()
+    test_sync_to_remote_uses_run_bytes_and_excludes_bytecode()
+    test_sync_from_remote_extracts_via_tarfile()
+    test_sync_from_remote_empty_stdout_is_ok()
     test_all_stage_parsers_disable_abbrev()
     print("ok")

--- a/.agents/skills/ascend-profiling-collection/scripts/_common.py
+++ b/.agents/skills/ascend-profiling-collection/scripts/_common.py
@@ -14,11 +14,9 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 import json
-import socket
 import subprocess
 import sys
 import threading
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -61,7 +59,7 @@ def _load_serving_common():
 SERVING = _load_serving_common()
 # Loading serving common put LIB_DIR on sys.path.
 from vaws_local_state import allocate_run_dir, safe_run_token  # noqa: E402
-from vaws_remote_dev import ssh_argv  # noqa: E402
+from vaws_remote_dev import open_local_forward, require_transport  # noqa: E402
 from vaws_remote_target import ascend_env_preamble  # noqa: E402
 
 SshEndpoint = SERVING.SshEndpoint
@@ -125,69 +123,24 @@ ASCEND_ENV_PREAMBLE = ascend_env_preamble()
 # Local SSH tunnel for sending workload requests from the local machine
 # ---------------------------------------------------------------------------
 
-def _find_free_local_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        sock.listen(1)
-        return int(sock.getsockname()[1])
-
-
 @contextlib.contextmanager
 def open_local_tunnel(ep, remote_port: int):
     """Open an ephemeral ``ssh -L`` tunnel to ``127.0.0.1:<remote_port>``.
 
     Yields a dict with ``local_port`` and ``base_url``. Used by the workload
     sender so multimodal payloads (image data URLs) can be assembled locally
-    and POSTed without round-tripping through SSH heredocs.
+    and POSTed without round-tripping through SSH heredocs. Transport lives
+    in ``vaws-remote-dev`` ``open_local_forward``.
     """
-    local_port = _find_free_local_port()
-    base = list(ssh_argv(ep, long_stream=True))
-    sep = base.index("--")
-    cmd = [
-        *base[:sep],
-        "-o", "ExitOnForwardFailure=yes",
-        "-N",
-        "-L", f"127.0.0.1:{local_port}:127.0.0.1:{remote_port}",
-        *base[sep:],
-    ]
-    proc = subprocess.Popen(
-        cmd,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    api = require_transport()
     try:
-        deadline = time.time() + 15
-        last_error = ""
-        while time.time() < deadline:
-            if proc.poll() is not None:
-                stderr = proc.stderr.read() if proc.stderr is not None else ""
-                raise RuntimeError(
-                    f"ssh tunnel exited early (rc={proc.returncode}): {stderr[:2000]}"
-                )
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-                sock.settimeout(0.5)
-                try:
-                    sock.connect(("127.0.0.1", local_port))
-                    yield {
-                        "local_port": local_port,
-                        "base_url": f"http://127.0.0.1:{local_port}",
-                    }
-                    return
-                except OSError as exc:
-                    last_error = str(exc)
-                    time.sleep(0.2)
-        raise RuntimeError(
-            f"timed out waiting for ssh tunnel to localhost:{local_port} ({last_error})"
-        )
-    finally:
-        if proc.poll() is None:
-            proc.terminate()
-            try:
-                proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait(timeout=5)
+        with open_local_forward(ep, remote_port) as fwd:
+            yield {
+                "local_port": int(fwd.local_port),
+                "base_url": f"http://{fwd.local_host}:{fwd.local_port}",
+            }
+    except api["RemoteExecutionError"] as exc:
+        raise RuntimeError(str(exc)) from exc
 
 
 # ---------------------------------------------------------------------------

--- a/.agents/skills/ascend-profiling-collection/tests/test_collection.py
+++ b/.agents/skills/ascend-profiling-collection/tests/test_collection.py
@@ -14,7 +14,6 @@ import io
 import json
 import os
 import shutil
-import socket
 import subprocess
 import sys
 import tempfile
@@ -48,12 +47,21 @@ def _load(name: str, filename: str):
     return module
 
 
-# Collection ``_common`` must win over any other skill's module of the same name.
+# Collection ``_common`` must win over any other skill's module of the same name
+# while siblings load. Drop the generic alias afterwards so a later skill
+# suite in the same pytest process can import its own ``_common``.
 sys.modules.pop("_common", None)
 common = _load("vaws_profcoll_common_under_test", "_common.py")
 sys.modules["_common"] = common
 profile_control = _load("vaws_profcoll_profile_control_under_test", "profile_control.py")
 collect = _load("vaws_profcoll_collect_under_test", "collect_torch_profile_case.py")
+if sys.modules.get("_common") is common:
+    del sys.modules["_common"]
+# collect / profile_control insert this skill's scripts/ onto sys.path.
+# Leave it there and later suites import the wrong ``_common``.
+_scripts = str(SCRIPTS)
+while _scripts in sys.path:
+    sys.path.remove(_scripts)
 
 
 class FakeProcess:
@@ -62,6 +70,7 @@ class FakeProcess:
         self.stderr = io.StringIO(stderr)
         self.terminated = False
         self.killed = False
+        self.pid = 1_000_001
 
     def poll(self) -> int | None:
         return self.returncode
@@ -117,16 +126,6 @@ def collect_argv(tmp: str, **overrides: object) -> list[str]:
     return argv
 
 
-class FreePortTests(unittest.TestCase):
-    def test_find_free_local_port_binds_loopback_ephemeral(self) -> None:
-        port = common._find_free_local_port()
-        self.assertIsInstance(port, int)
-        self.assertGreater(port, 0)
-        self.assertLess(port, 65536)
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            sock.bind(("127.0.0.1", port))
-
-
 def _parse_ssh_g(text: str) -> dict[str, list[str]]:
     parsed: dict[str, list[str]] = {}
     for line in text.splitlines():
@@ -161,7 +160,19 @@ def _effective_ssh_config(cmd: list[str], home: str) -> tuple[dict[str, list[str
 
 
 class TunnelArgvTests(unittest.TestCase):
+    """Assert the ``open_local_forward`` path, not a skill-built argv.
+
+    If collection goes back to ``subprocess.Popen`` + ``ssh_argv``,
+    ``test_open_local_tunnel_uses_unmuxed_keepalive_forward`` fails because
+    the package Popen is never called. If that package argv loses
+    ``ExitOnForwardFailure`` or puts ``-N``/``-L`` after ``--``, the real
+    ``ssh -G`` parse fails the same way the pre-migration hand-rolled
+    command did.
+    """
+
     def test_open_local_tunnel_uses_unmuxed_keepalive_forward(self) -> None:
+        import remote_dev.core.ssh_transport as ssh_transport
+
         captured: dict[str, list[str]] = {}
 
         def fake_popen(cmd, **_kwargs):
@@ -173,14 +184,17 @@ class TunnelArgvTests(unittest.TestCase):
         connect_sock.connect.return_value = None
 
         with (
-            mock.patch.object(common.subprocess, "Popen", side_effect=fake_popen),
-            mock.patch.object(common.socket, "socket", return_value=connect_sock),
-            mock.patch.object(common, "_find_free_local_port", return_value=34567),
+            mock.patch.object(common.subprocess, "Popen") as skill_popen,
+            mock.patch.object(ssh_transport.subprocess, "Popen", side_effect=fake_popen),
+            mock.patch.object(ssh_transport.socket, "socket", return_value=connect_sock),
+            mock.patch.object(ssh_transport, "_find_free_local_port", return_value=34567),
+            mock.patch.object(ssh_transport.os, "killpg", side_effect=ProcessLookupError),
         ):
             with common.open_local_tunnel(fake_endpoint(), 8000) as tunnel:
                 self.assertEqual(tunnel["local_port"], 34567)
                 self.assertEqual(tunnel["base_url"], "http://127.0.0.1:34567")
 
+        skill_popen.assert_not_called()
         cmd = captured["cmd"]
         self.assertEqual(cmd[0], "ssh")
         sep = cmd.index("--")
@@ -202,11 +216,13 @@ class TunnelArgvTests(unittest.TestCase):
         self.assertEqual(cfg.get("serveralivecountmax"), ["10"])
 
     def test_open_local_tunnel_raises_when_ssh_exits_before_listen(self) -> None:
+        import remote_dev.core.ssh_transport as ssh_transport
+
         def fake_popen(cmd, **_kwargs):
             return FakeProcess(returncode=255, stderr="bind: Address already in use")
 
-        with mock.patch.object(common.subprocess, "Popen", side_effect=fake_popen):
-            with self.assertRaisesRegex(RuntimeError, r"ssh tunnel exited early \(rc=255\)"):
+        with mock.patch.object(ssh_transport.subprocess, "Popen", side_effect=fake_popen):
+            with self.assertRaisesRegex(RuntimeError, r"exited early"):
                 with common.open_local_tunnel(fake_endpoint(), 8000):
                     self.fail("context must not yield after the tunnel dies")
 
@@ -373,6 +389,17 @@ class WorkloadGateTests(unittest.TestCase):
         self.assertEqual(
             collect._evaluate_workload(mixed, _ok_request(2), 0.8)["status"],
             "benchmark_below_threshold",
+        )
+
+
+class CommonImportIsolationTests(unittest.TestCase):
+    def test_generic_common_alias_is_not_left_in_sys_modules(self) -> None:
+        cached = sys.modules.get("_common")
+        self.assertIsNot(
+            cached,
+            common,
+            "collection tests must not leave their helper as sys.modules['_common']; "
+            "that poisons later skill suites in the same pytest process",
         )
 
 

--- a/.agents/skills/ascend-profiling-collection/tests/test_collection.py
+++ b/.agents/skills/ascend-profiling-collection/tests/test_collection.py
@@ -162,21 +162,24 @@ def _effective_ssh_config(cmd: list[str], home: str) -> tuple[dict[str, list[str
 class TunnelArgvTests(unittest.TestCase):
     """Assert the ``open_local_forward`` path, not a skill-built argv.
 
-    If collection goes back to ``subprocess.Popen`` + ``ssh_argv``,
-    ``test_open_local_tunnel_uses_unmuxed_keepalive_forward`` fails because
-    the package Popen is never called. If that package argv loses
-    ``ExitOnForwardFailure`` or puts ``-N``/``-L`` after ``--``, the real
-    ``ssh -G`` parse fails the same way the pre-migration hand-rolled
-    command did.
+    ``common.subprocess`` and ``ssh_transport.subprocess`` are the same
+    stdlib module, so two nested ``patch.object(..., "Popen")`` mocks
+    cannot be distinguished — the inner patch shadows the outer. One
+    Popen mock records every spawn. The skill must spawn ssh exactly
+    once, and that argv must be the package forward. A second skill-side
+    ``subprocess.Popen(["ssh", ...])`` makes ``len(calls) == 1`` fail.
+    If the package argv loses ``ExitOnForwardFailure`` or puts
+    ``-N``/``-L`` after ``--``, the real ``ssh -G`` parse fails the same
+    way the pre-migration hand-rolled command did.
     """
 
     def test_open_local_tunnel_uses_unmuxed_keepalive_forward(self) -> None:
         import remote_dev.core.ssh_transport as ssh_transport
 
-        captured: dict[str, list[str]] = {}
+        calls: list[list[str]] = []
 
         def fake_popen(cmd, **_kwargs):
-            captured["cmd"] = list(cmd)
+            calls.append(list(cmd))
             return FakeProcess()
 
         connect_sock = mock.MagicMock()
@@ -184,7 +187,6 @@ class TunnelArgvTests(unittest.TestCase):
         connect_sock.connect.return_value = None
 
         with (
-            mock.patch.object(common.subprocess, "Popen") as skill_popen,
             mock.patch.object(ssh_transport.subprocess, "Popen", side_effect=fake_popen),
             mock.patch.object(ssh_transport.socket, "socket", return_value=connect_sock),
             mock.patch.object(ssh_transport, "_find_free_local_port", return_value=34567),
@@ -194,8 +196,8 @@ class TunnelArgvTests(unittest.TestCase):
                 self.assertEqual(tunnel["local_port"], 34567)
                 self.assertEqual(tunnel["base_url"], "http://127.0.0.1:34567")
 
-        skill_popen.assert_not_called()
-        cmd = captured["cmd"]
+        self.assertEqual(len(calls), 1, calls)
+        cmd = calls[0]
         self.assertEqual(cmd[0], "ssh")
         sep = cmd.index("--")
         self.assertEqual(cmd[sep + 1 :], ["192.0.2.10"])

--- a/.agents/skills/machine-management/scripts/manage_machine.py
+++ b/.agents/skills/machine-management/scripts/manage_machine.py
@@ -43,7 +43,7 @@ _LIB_DIR = pathlib.Path(__file__).resolve().parents[4] / ".agents" / "lib"
 if str(_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_LIB_DIR))
 
-from vaws_remote_dev import ssh_argv  # noqa: E402
+from vaws_remote_dev import interactive_ssh_command, run_interactive, ssh_argv  # noqa: E402
 from vaws_result_envelope import PROGRESS_SENTINEL  # noqa: E402
 
 
@@ -771,26 +771,9 @@ def ssh_command(
     identity_file: pathlib.Path | None = None,
 ) -> list[str]:
     if not batch_mode:
-        # remote-dev always uses BatchMode=yes. Interactive password bootstrap
-        # has no package equivalent; keep a local interactive argv and do not
-        # attach it to a ControlMaster.
-        command = [
-            "ssh",
-            "-o",
-            "BatchMode=no",
-            "-o",
-            "StrictHostKeyChecking=accept-new",
-            "-o",
-            "LogLevel=ERROR",
-            "-o",
-            "ConnectTimeout=10",
-        ]
-        if identity_file is not None:
-            command.extend(["-i", str(identity_file), "-o", "IdentitiesOnly=yes"])
-        for option in extra_options:
-            command.extend(["-o", option])
-        command.extend(["-p", str(target.port), f"{target.user}@{target.host}"])
-        return command
+        raise MachineManagementError(
+            "interactive SSH is interactive_ssh_command / run_interactive, not ssh_command"
+        )
     command = ssh_argv(
         target,
         connect_timeout_s=10,
@@ -2895,15 +2878,11 @@ def build_bootstrap_host_key_command(
 ) -> tuple[str, list[str]]:
     del key_path
     remote_cmd = build_authorized_keys_remote_command(public_key)
-    command = ssh_command(
+    command = interactive_ssh_command(
         target,
-        batch_mode=False,
-        extra_options=(
-            "PreferredAuthentications=password,keyboard-interactive",
-            "PubkeyAuthentication=no",
-            "NumberOfPasswordPrompts=1",
-        ),
-    ) + ["sh", "-c", remote_cmd]
+        ["sh", "-c", remote_cmd],
+        connect_timeout_s=10,
+    )
     return "ssh", command
 
 
@@ -2973,7 +2952,16 @@ def cmd_bootstrap_host_key(args: argparse.Namespace) -> int:
         print_json(payload)
         return 0
 
-    returncode = run_local_interactive(command)
+    try:
+        returncode = run_interactive(
+            target,
+            ["sh", "-c", build_authorized_keys_remote_command(public_key)],
+            connect_timeout_s=10,
+        )
+    except Exception as exc:
+        if "not found" in str(exc).lower():
+            raise MachineManagementError("required local command not found: ssh") from exc
+        raise
     after = check_direct_ssh(target, identity_file=private_key)
     payload.update(
         {

--- a/.agents/skills/machine-management/tests/test_bootstrap_interactive.py
+++ b/.agents/skills/machine-management/tests/test_bootstrap_interactive.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[4]
+LIB_DIR = ROOT / ".agents" / "lib"
+SCRIPTS = ROOT / ".agents" / "skills" / "machine-management" / "scripts"
+for value in (str(LIB_DIR), str(SCRIPTS)):
+    if value not in sys.path:
+        sys.path.insert(0, value)
+
+import manage_machine as machine_ops  # noqa: E402
+import vaws_remote_dev as remote_dev  # noqa: E402
+
+
+def _effective_ssh_config(cmd: list[str], home: str) -> dict[str, list[str]]:
+    ssh = shutil.which("ssh")
+    if ssh is None:
+        raise AssertionError(
+            "ssh binary is required to parse interactive argv; a skipped "
+            "parser test is how BatchMode=yes bootstrap survives"
+        )
+    result = subprocess.run(
+        [ssh, "-G", "-F", "/dev/null", *cmd[1:]],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env={"HOME": home, "PATH": os.environ.get("PATH", "")},
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"ssh -G failed (rc={result.returncode}): {(result.stderr or '')[:2000]}"
+        )
+    parsed: dict[str, list[str]] = {}
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        key, _, value = line.partition(" ")
+        parsed.setdefault(key.lower(), []).append(value)
+    return parsed
+
+
+class InteractiveBootstrapTests(unittest.TestCase):
+    def test_bootstrap_argv_matches_package_interactive_command(self) -> None:
+        target = machine_ops.SshTarget(host="192.0.2.10", user="ubuntu", port=22)
+        _tool, command = machine_ops.build_bootstrap_host_key_command(
+            target,
+            key_path=Path("/tmp/id.pub"),
+            public_key="ssh-ed25519 AAAA test",
+        )
+        expected = remote_dev.interactive_ssh_command(
+            target,
+            command[command.index("--") + 2 :],
+            connect_timeout_s=10,
+        )
+        self.assertEqual(command, expected)
+        self.assertIn("BatchMode=no", command)
+        self.assertNotIn("BatchMode=yes", command)
+        with tempfile.TemporaryDirectory() as home:
+            cfg = _effective_ssh_config(command, home)
+        self.assertEqual(cfg.get("batchmode"), ["no"])
+        self.assertIn((cfg.get("controlmaster") or [""])[0].lower(), {"false", "no"})
+        self.assertIn(
+            (cfg.get("pubkeyauthentication") or [""])[0].lower(), {"false", "no"}
+        )
+        self.assertEqual(cfg.get("numberofpasswordprompts"), ["1"])
+
+    def test_tty_path_calls_run_interactive_not_local_runner(self) -> None:
+        args = SimpleNamespace(
+            host="192.0.2.10",
+            user="ubuntu",
+            host_port=22,
+            public_key_file=None,
+            print_command=False,
+        )
+        with (
+            mock.patch.object(machine_ops, "find_public_key", return_value=Path("/tmp/id.pub")),
+            mock.patch.object(
+                machine_ops, "private_key_for_public_key", return_value=Path("/tmp/id")
+            ),
+            mock.patch.object(machine_ops, "load_public_key", return_value="ssh-ed25519 AAAA"),
+            mock.patch.object(
+                machine_ops,
+                "read_password_value",
+                return_value=(None, None, machine_ops.DEFAULT_PASSWORD_ENV),
+            ),
+            mock.patch.object(
+                machine_ops,
+                "check_direct_ssh",
+                side_effect=[
+                    {"ok": False, "returncode": 255, "stdout": "", "stderr": "denied"},
+                    {"ok": True, "returncode": 0, "stdout": "ok", "stderr": ""},
+                ],
+            ),
+            mock.patch.object(machine_ops, "run_interactive", return_value=0) as interactive,
+            mock.patch.object(machine_ops, "run_local_interactive") as local_runner,
+            mock.patch.object(machine_ops, "run_with_askpass") as askpass,
+            mock.patch.object(machine_ops, "print_json"),
+        ):
+            rc = machine_ops.cmd_bootstrap_host_key(args)
+        self.assertEqual(rc, 0)
+        interactive.assert_called_once()
+        local_runner.assert_not_called()
+        askpass.assert_not_called()
+
+    def test_password_path_stays_on_askpass(self) -> None:
+        args = SimpleNamespace(
+            host="192.0.2.10",
+            user="ubuntu",
+            host_port=22,
+            public_key_file=None,
+            print_command=False,
+        )
+        with (
+            mock.patch.object(machine_ops, "find_public_key", return_value=Path("/tmp/id.pub")),
+            mock.patch.object(
+                machine_ops, "private_key_for_public_key", return_value=Path("/tmp/id")
+            ),
+            mock.patch.object(machine_ops, "load_public_key", return_value="ssh-ed25519 AAAA"),
+            mock.patch.object(
+                machine_ops,
+                "read_password_value",
+                return_value=("secret", "literal", machine_ops.DEFAULT_PASSWORD_ENV),
+            ),
+            mock.patch.object(
+                machine_ops,
+                "check_direct_ssh",
+                side_effect=[
+                    {"ok": False, "returncode": 255, "stdout": "", "stderr": "denied"},
+                    {"ok": True, "returncode": 0, "stdout": "ok", "stderr": ""},
+                ],
+            ),
+            mock.patch.object(
+                machine_ops,
+                "run_with_askpass",
+                return_value=SimpleNamespace(returncode=0, stdout="", stderr=""),
+            ) as askpass,
+            mock.patch.object(machine_ops, "run_interactive") as interactive,
+            mock.patch.object(machine_ops, "print_json"),
+        ):
+            rc = machine_ops.cmd_bootstrap_host_key(args)
+        self.assertEqual(rc, 0)
+        askpass.assert_called_once()
+        interactive.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_cli_surface_inventory.py
+++ b/.agents/tests/test_cli_surface_inventory.py
@@ -306,7 +306,7 @@ class RepositoryCoherenceTests(unittest.TestCase):
         by_repository = {meta["repository"]: meta for meta in owners.values()}
         self.assertEqual(
             by_repository["vllm-ascend-workspace/remote-dev"]["commit"],
-            "8ecc09d5865a564d3b7cab822a1d474d12b2dcb9",
+            "8f3cebfd1c42839fef41b06aaf8da4052cc23954",
         )
         self.assertEqual(
             by_repository["vllm-ascend-workspace/vaws-coordinator"]["commit"],

--- a/.agents/tests/test_dependency.py
+++ b/.agents/tests/test_dependency.py
@@ -21,7 +21,7 @@ import vaws_dependency as deps  # noqa: E402
 class SpecLockTests(unittest.TestCase):
     def test_pyproject_requires_the_three_packages(self) -> None:
         versions = deps.required_versions()
-        self.assertEqual(versions["vaws-remote-dev"], "0.2.0")
+        self.assertEqual(versions["vaws-remote-dev"], "0.3.0")
         self.assertEqual(versions["vaws-coordinator"], "0.2.0")
         self.assertEqual(versions["vaws-knowledge"], "0.1.4")
         self.assertNotIn(deps.VAWS_TOP_NAME, versions)
@@ -42,7 +42,7 @@ class SpecLockTests(unittest.TestCase):
         )
         self.assertEqual(
             locked["vaws-remote-dev"]["commit"],
-            "8ecc09d5865a564d3b7cab822a1d474d12b2dcb9",
+            "8f3cebfd1c42839fef41b06aaf8da4052cc23954",
         )
         expected_versions = deps.required_versions()
         for name in deps.PACKAGE_NAMES:

--- a/.agents/tests/test_remote_dev_transport.py
+++ b/.agents/tests/test_remote_dev_transport.py
@@ -1,7 +1,11 @@
 """Composed SSH argv and mux-stream refusal for the remote-dev consumer."""
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -16,6 +20,40 @@ import vaws_remote_dev as remote_dev  # noqa: E402
 HOST = "192.0.2.10"
 PORT = 46001
 USER = "root"
+
+
+def _require_openssh() -> str:
+    path = shutil.which("ssh")
+    if path is None:
+        raise AssertionError(
+            "OpenSSH ssh is required to parse composed argv with ssh -G; "
+            "a skipped parser test is how options-after-destination shipped"
+        )
+    return path
+
+
+def _effective_ssh_config(argv: list[str], home: str) -> dict[str, str]:
+    ssh = _require_openssh()
+    proc = subprocess.run(
+        [ssh, "-G", "-F", "/dev/null", *argv[1:]],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env={"HOME": home, "PATH": os.environ.get("PATH", "")},
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"ssh -G failed (rc={proc.returncode}): {(proc.stderr or '')[:2000]}"
+        )
+    parsed: dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
+        key, _, value = line.partition(" ")
+        parsed[key.lower()] = value.strip()
+    return parsed
 
 
 class TransportArgvTests(unittest.TestCase):
@@ -64,6 +102,66 @@ class MuxedStreamRefusalTests(unittest.TestCase):
             "mux" in message or "controlmaster" in message or "stream" in message,
             ctx.exception,
         )
+
+    def test_local_forward_refuses_a_muxed_endpoint(self) -> None:
+        api = remote_dev.require_transport()
+        endpoint = remote_dev.as_endpoint(HOST, PORT, USER, ssh_mux=True)
+        with self.assertRaises(api["RemoteExecutionError"]):
+            api["local_forward_ssh_command"](
+                endpoint,
+                local_host="127.0.0.1",
+                local_port=47001,
+                remote_host="127.0.0.1",
+                remote_port=8000,
+            )
+
+    def test_interactive_refuses_a_muxed_endpoint(self) -> None:
+        api = remote_dev.require_transport()
+        endpoint = remote_dev.as_endpoint(HOST, PORT, USER, ssh_mux=True)
+        with self.assertRaises(api["RemoteExecutionError"]):
+            api["interactive_ssh_command"](endpoint, ["true"])
+
+
+class V03ConsumerArgvTests(unittest.TestCase):
+    def setUp(self) -> None:
+        remote_dev.require_transport()
+        self.endpoint = SimpleNamespace(host=HOST, port=PORT, user=USER)
+
+    def test_local_forward_argv_is_independent_with_exit_on_forward_failure(self) -> None:
+        argv = remote_dev.local_forward_ssh_command(
+            self.endpoint,
+            local_host="127.0.0.1",
+            local_port=34567,
+            remote_host="127.0.0.1",
+            remote_port=8000,
+        )
+        sep = argv.index("--")
+        self.assertLess(argv.index("ExitOnForwardFailure=yes"), sep)
+        self.assertLess(argv.index("-N"), sep)
+        self.assertLess(argv.index("-L"), sep)
+        self.assertEqual(argv[sep + 1 :], [HOST])
+        with tempfile.TemporaryDirectory() as home:
+            cfg = _effective_ssh_config(argv, home)
+        self.assertEqual(cfg.get("exitonforwardfailure", "").lower(), "yes")
+        self.assertIn(cfg.get("controlmaster", "").lower(), {"false", "no"})
+        self.assertEqual(cfg.get("sessiontype", "").lower(), "none")
+        self.assertEqual(cfg.get("serveraliveinterval"), "30")
+
+    def test_interactive_argv_is_password_bootstrap_off_the_mux(self) -> None:
+        argv = remote_dev.interactive_ssh_command(
+            self.endpoint, ["sh", "-c", "true"], connect_timeout_s=10
+        )
+        joined = " ".join(argv)
+        self.assertIn("BatchMode=no", joined)
+        self.assertNotIn("BatchMode=yes", joined)
+        self.assertIn("PubkeyAuthentication=no", joined)
+        self.assertEqual(argv[argv.index("--") + 1 :], [HOST, "sh", "-c", "true"])
+        with tempfile.TemporaryDirectory() as home:
+            cfg = _effective_ssh_config(argv, home)
+        self.assertEqual(cfg.get("batchmode", "").lower(), "no")
+        self.assertIn(cfg.get("controlmaster", "").lower(), {"false", "no"})
+        self.assertIn(cfg.get("pubkeyauthentication", "").lower(), {"false", "no"})
+        self.assertEqual(cfg.get("numberofpasswordprompts"), "1")
 
 
 if __name__ == "__main__":

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -197,7 +197,7 @@ MCP `remote_*` names are unchanged. The `remote_exec.py` / probe / job /
 artifact wrappers are thin CLIs over `vaws-remote-dev` and remain
 compatibility because their stdout is `remote-dev.result.v1`, not the old
 toolbox envelope. Service, sync, cleanup, and target-resolve wrappers stay
-because remote-dev v0.2.0 has no equivalent API.
+because remote-dev v0.3.0 has no equivalent API.
 
 The six-file Trae ModelScope package is generated from
 `.agents/skills/modelscope` by `.agents/scripts/sync_claude_skills.py`

--- a/docs/dependency-plane.md
+++ b/docs/dependency-plane.md
@@ -15,7 +15,7 @@ must name git+https tag sources because `vaws-coordinator` depends on
 
 | Package | Module | Source tag | Role |
 |---|---|---|---|
-| `vaws-remote-dev` | `remote_dev` | `v0.2.0` | process-in import + MCP server |
+| `vaws-remote-dev` | `remote_dev` | `v0.3.0` | process-in import + MCP server |
 | `vaws-coordinator` | `vaws_coordinator` | `v0.2.0` | process-in import + stdio MCP |
 | `vaws-knowledge` | `vaws_knowledge` | `v0.1.4` | process-in import + MCP |
 | `vaws-top` | — | uvx only | fleet dashboard; not imported |

--- a/docs/remote-dev-consumption.md
+++ b/docs/remote-dev-consumption.md
@@ -5,7 +5,7 @@ Status: current
 The remote development substrate used to live in this repository at
 `.remote-dev/`. It is now the public package
 [`vaws-remote-dev`](https://github.com/vllm-ascend-workspace/remote-dev)
-(`v0.2.0`, locked by `uv.lock`). This document is the consumer-side
+(`v0.3.0`, locked by `uv.lock`). This document is the consumer-side
 contract.
 
 Phase 1 of the sequenced plan recorded in [target-state.md](target-state.md).
@@ -76,9 +76,13 @@ Skills do not construct SSH options. They call `.agents/lib/vaws_remote_dev.py`:
 |---|---|---|
 | Short command | `ssh_exec` → `run_script` | Default multiplexed connection |
 | Long-lived stream | `ssh_stream` → `Endpoint.for_long_stream()` + `run_stream` | Independent connection (`ControlMaster=no`) plus keepalives |
-| Composed argv only | `ssh_argv(..., long_stream=True)` | Same independent options; used when a skill must append `-N -L` |
+| Local port forward | `open_local_forward` → `ssh -N -L` | `for_long_stream` plus `ExitOnForwardFailure=yes`; refuses mux |
+| Interactive bootstrap | `run_interactive` / `interactive_ssh_command` | `BatchMode=no`, password/keyboard-interactive only; refuses mux |
+| Binary stdin/stdout | `ssh_run_bytes` → `run_bytes` | Default multiplexed connection |
+| Composed argv only | `ssh_argv(...)` | Package-built options; skills do not append `-N` / `-L` / extra `-o` |
 
-`run_stream` refuses a multiplexed endpoint (`RemoteExecutionError`). Do not
-pass `ssh_mux=True` for a stream. If the package is missing or older than
-v0.2.0, `require_transport()` fails and names `uv sync` as the remedy. There
-is no fallback to raw `ssh`.
+`run_stream`, `open_local_forward`, and `run_interactive` refuse a
+multiplexed endpoint (`RemoteExecutionError`). Do not pass `ssh_mux=True`
+for those calls. If the package is missing or older than v0.3.0,
+`require_transport()` fails and names `uv sync` as the remedy. There is no
+fallback to raw `ssh`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "vaws-workspace"
 version = "0"
 requires-python = ">=3.11"
 dependencies = [
-  "vaws-remote-dev==0.2.0",
+  "vaws-remote-dev==0.3.0",
   "vaws-coordinator==0.2.0",
   "vaws-knowledge==0.1.4",
 ]
@@ -20,7 +20,7 @@ dev = [
 package = false
 
 [tool.uv.sources]
-vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", tag = "v0.2.0" }
+vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", tag = "v0.3.0" }
 vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", tag = "v0.2.0" }
 vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", tag = "v0.1.4" }
 

--- a/uv.lock
+++ b/uv.lock
@@ -848,8 +848,8 @@ dependencies = [
 
 [[package]]
 name = "vaws-remote-dev"
-version = "0.2.0"
-source = { git = "https://github.com/vllm-ascend-workspace/remote-dev?tag=v0.2.0#8ecc09d5865a564d3b7cab822a1d474d12b2dcb9" }
+version = "0.3.0"
+source = { git = "https://github.com/vllm-ascend-workspace/remote-dev?tag=v0.3.0#8f3cebfd1c42839fef41b06aaf8da4052cc23954" }
 
 [[package]]
 name = "vaws-workspace"
@@ -873,7 +873,7 @@ dev = [
 requires-dist = [
     { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?tag=v0.2.0" },
     { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?tag=v0.1.4" },
-    { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?tag=v0.2.0" },
+    { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?tag=v0.3.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- Pin `vaws-remote-dev` to **v0.3.0** (`8f3cebfd`) and expose `open_local_forward` / `run_interactive` through `.agents/lib/vaws_remote_dev.py`.
- Replace skill-private SSH/tar process spawns: collection tunnels use `open_local_forward`; machine-management TTY bootstrap uses `run_interactive`; analysis sync packs with stdlib `tarfile` + `run_bytes` (one tar-over-ssh site, so no package-level artifact API).
- Delete unused memprof `ssh_bg_exec`. Analysis `scripts/ascend_profile/` is unchanged.

## Test plan
- [x] CI `validate` job `run:` steps (empty temporary `HOME`)
- [x] Combined pytest process: `.agents/tests` + collection + machine-management + analysis + memprof
- [x] Six guards (`skill_catalog`, `tracked_path_check --mode enforce`, `cli_surface_inventory`, `repo_boundary_check --mode enforce`, `tracked_leak_scan`, `sync_claude_skills --check`)
- [ ] `gh pr checks` after CI starts
