### PR TITLE
perf(cli): skip task discovery for parser feedback

### DIFF
--- a/.agents/lib/vaws_coordinator_launch.py
+++ b/.agents/lib/vaws_coordinator_launch.py
@@ -21,10 +21,6 @@ from vaws_dependency import (  # noqa: E402
     USABLE_STATES,
     inspect,
 )
-from vaws_local_state import (  # noqa: E402
-    agent_sessions_root,
-    shared_workspace_root,
-)
 
 PACKAGE = "vaws-coordinator"
 LOCAL_STATE_DIRNAME = ".vaws-local"
@@ -43,8 +39,11 @@ def _absolute_path(value: str, repo_root: Path) -> str:
 
 def coordinator_environment(base: Mapping[str, str] | None = None, *, repo_root: Path = ROOT) -> dict[str, str]:
     """Environment for a coordinator process (task server, CLI, hook)."""
+    from vaws_local_state import agent_sessions_root, shared_workspace_root
+
     env = dict(os.environ if base is None else base)
-    env.setdefault("VAWS_AGENT_SESSIONS_DIR", str(agent_sessions_root(repo_root)))
+    if "VAWS_AGENT_SESSIONS_DIR" not in env:
+        env["VAWS_AGENT_SESSIONS_DIR"] = str(agent_sessions_root(repo_root))
     sessions = Path(env["VAWS_AGENT_SESSIONS_DIR"]).expanduser()
     if not sessions.is_absolute():
         sessions = shared_workspace_root(repo_root) / sessions
@@ -57,11 +56,15 @@ def coordinator_environment(base: Mapping[str, str] | None = None, *, repo_root:
 
 def historical_manager_state_dir(repo_root: Path = ROOT) -> Path:
     """Path the pre-extraction manager used as its default ``--state-dir``."""
+    from vaws_local_state import shared_workspace_root
+
     return shared_workspace_root(repo_root) / LOCAL_STATE_DIRNAME / "coordinator"
 
 
 def package_status(repo_root: Path = ROOT) -> dict[str, Any]:
     """Describe the installed coordinator package."""
+    from vaws_local_state import agent_sessions_root
+
     info = inspect(PACKAGE, repo_root=repo_root)
     return {
         "name": PACKAGE,
@@ -88,14 +91,16 @@ def require_package(repo_root: Path = ROOT) -> dict[str, Any]:
     return info
 
 
-def exec_module(module: str, args: list[str], *, repo_root: Path = ROOT) -> int:
+def exec_module(module: str, args: list[str], *, repo_root: Path = ROOT, prepare_environment: bool = True) -> int:
     """Replace this process with ``python -m <module> ...`` under scaffold env.
 
     Regular launch must not write the coordinator-owned machine store. Host
     import uses ``python -m vaws_coordinator provision``.
+    Explicit parser help can skip workspace environment discovery because it
+    exits before reading task state or launching a service.
     """
     require_package(repo_root)
-    env = coordinator_environment(repo_root=repo_root)
+    env = coordinator_environment(repo_root=repo_root) if prepare_environment else dict(os.environ)
     command = [sys.executable, "-m", module, *args]
     if os.name == "nt":
         # Windows execve spawns a replacement which outlives the MCP parent's

--- a/.agents/scripts/vaws.py
+++ b/.agents/scripts/vaws.py
@@ -126,31 +126,28 @@ def cmd_env(args: argparse.Namespace) -> int:
 
 def cmd_hook(args: argparse.Namespace) -> int:
     try:
-        require_package()
+        return exec_module("vaws_coordinator.hooks.vaws_session", list(args.args))
     except CoordinatorUnavailable as exc:
         sys.stdin.read()
         progress(f"vaws-coordinator hook skipped: {exc}")
         print("")
         return 0
-    return exec_module("vaws_coordinator.hooks.vaws_session", list(args.args))
 
 
 def cmd_task_server(_args: argparse.Namespace) -> int:
     try:
-        require_package()
+        return exec_module("vaws_coordinator", ["task-server"])
     except CoordinatorUnavailable as exc:
         progress(f"vaws-task MCP server cannot start: {exc}")
         return 2
-    return exec_module("vaws_coordinator", ["task-server"])
 
 
 def exec_task_cli(argv: list[str]) -> int:
     operation = argv[0] if argv else "session"
     try:
-        require_package()
+        return exec_module("vaws_coordinator.vaws", argv)
     except CoordinatorUnavailable:
         return unavailable(operation)
-    return exec_module("vaws_coordinator.vaws", argv)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -178,7 +175,7 @@ def main(argv: list[str] | None = None) -> int:
     if argv and argv[0] in TASK_OPS:
         if any(item in {"-h", "--help"} for item in argv):
             try:
-                require_package()
+                return exec_module("vaws_coordinator.vaws", argv, prepare_environment=False)
             except CoordinatorUnavailable:
                 print(
                     f"usage: vaws.py {argv[0]} ...\n"

--- a/.agents/tests/test_cli_feedback.py
+++ b/.agents/tests/test_cli_feedback.py
@@ -1,0 +1,58 @@
+"""Parser feedback must not depend on task state or execution backends."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / ".agents/scripts/vaws.py"
+
+
+class CliFeedbackTests(unittest.TestCase):
+    def test_help_and_root_argument_errors_need_no_state_or_subprocess(self):
+        # sitecustomize is inherited by POSIX execve as well as Windows runpy.
+        guard = '''
+import importlib.abc, sys
+class NoExecutionImports(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname in {"vaws_local_state", "vaws_coordinator.service", "vaws_coordinator.backend", "vaws_coordinator.task_client", "remote_dev.core.ssh_transport"}:
+            raise AssertionError("parser imported execution state: " + fullname)
+sys.meta_path.insert(0, NoExecutionImports())
+def audit(event, args):
+    if event in {"socket.connect", "subprocess.Popen", "os.system"}:
+        raise AssertionError("parser attempted side effect: " + event)
+sys.addaudithook(audit)
+'''
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "sitecustomize.py").write_text(guard, encoding="utf-8")
+            home = root / "home"
+            home.mkdir()
+            env = os.environ.copy()
+            env.update(PYTHONPATH=str(root), HOME=str(home), USERPROFILE=str(home))
+            cases = [
+                (["--help"], 0),
+                (["status", "--help"], 0),
+                (["env", "--help"], 0),
+                (["session", "--help"], 0),
+                (["run", "--help"], 0),
+                (["--unknown-option"], 2),
+            ]
+            for argv, expected in cases:
+                with self.subTest(argv=argv):
+                    result = subprocess.run(
+                        [sys.executable, str(SCRIPT), *argv], cwd=ROOT, env=env,
+                        capture_output=True, encoding="utf-8", timeout=15,
+                    )
+                    self.assertEqual(result.returncode, expected, result.stderr)
+                    self.assertIn("usage:", result.stdout + result.stderr)
+                    self.assertNotIn("AssertionError", result.stdout + result.stderr)
+            self.assertEqual(list(home.iterdir()), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,4 +25,5 @@ is the archive for dated evidence.
 
 ## Dated validation evidence
 
+- [cli-feedback-2026-09-11.md](cli-feedback-2026-09-11.md) — paired Windows CLI startup measurements and parser side-effect checks.
 - [windows-validation-2026-09-11.md](windows-validation-2026-09-11.md) — completed Windows non-NPU validation, repairs, limits and a proposed experience-optimization sequence.

--- a/docs/cli-feedback-2026-09-11.md
+++ b/docs/cli-feedback-2026-09-11.md
@@ -1,0 +1,50 @@
+# CLI feedback measurements
+
+Status: dated 2026-09-11
+
+The workspace launcher now defers task-state discovery until an operation needs
+it and performs one package check per launch. Explicit coordinator help bypasses
+workspace environment discovery. remote-dev imports execution modules only after
+parsing and basic argument validation.
+
+## Windows paired comparison
+
+Python 3.13.12 on Windows; 20 fresh processes per revision and case, alternating
+baseline/candidate order. Both revisions ran from source worktrees with the same
+installed dependencies. Baselines: workspace `ecd45ba`, remote-dev `34a460d`.
+Times include interpreter startup and output capture. These are local feedback
+measurements, not remote execution or NPU performance measurements.
+
+| Command | Median before / after (ms) | p95 before / after (ms) | Median reduction |
+| --- | ---: | ---: | ---: |
+| Workspace help | 190 / 132 | 205 / 140 | 30% |
+| Workspace session help | 424 / 234 | 432 / 238 | 45% |
+| Workspace invalid option | 190 / 131 | 205 / 137 | 31% |
+| remote-dev help | 189 / 161 | 203 / 173 | 15% |
+| remote-dev read help | 178 / 152 | 182 / 162 | 15% |
+| remote-dev invalid option | 191 / 163 | 194 / 173 | 15% |
+| remote-dev missing endpoint | 177 / 151 | 185 / 158 | 15% |
+
+One additional process per revision used an empty Python bytecode cache. The
+workspace session-help sample changed from 743 to 552 ms; other candidate samples
+were 373-472 ms. This is not an OS-cold benchmark: the OS file cache was not reset.
+Single first-run samples do not establish a latency distribution.
+
+Exit codes and help/error output matched. For structured missing-endpoint errors,
+semantic fields matched after excluding generated timestamps and result IDs.
+Initial measurements of coordinator and knowledge help were already below one
+second; those packages received no speculative startup rewrite.
+
+## Validation
+
+- Workspace parser, coordinator consumer and scaffold safety tests: 47 passed,
+  including 33 subtests.
+- remote-dev parser and client parity tests: 46 passed, 13 platform skips,
+  including 41 subtests.
+- Fresh-process guards reject execution-module imports, socket connections,
+  subprocess creation and shell execution during help. An isolated home remains
+  empty. remote-dev covers every tool's help; workspace covers root, status,
+  environment, session and run help plus a root argument error.
+
+Raw samples and JUnit receipts are retained in untracked local test output.
+Hosted CI remains the authority for Linux/macOS behavior on the submitted code.

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -443,7 +443,7 @@ option.
 | `.agents/scripts/sync_claude_skills.py` | argparse | - | 1 | mirror:2, other:1, policy:1, routing:1, skill-doc:1, test:2 | mechanics | supported | .agents/scripts/sync_claude_skills.py | vaws lint |
 | `.agents/scripts/tracked_leak_scan.py` | argparse | - | 10 | docs:1, hook:1, other:1, policy:1, script:1, test:3 | mechanics | supported | .agents/scripts/tracked_leak_scan.py | vaws lint |
 | `.agents/scripts/tracked_path_check.py` | argparse | - | 6 | docs:1, other:1, policy:1, test:2 | mechanics | supported | .agents/scripts/tracked_path_check.py | vaws lint |
-| `.agents/scripts/vaws.py` | argparse | status, env, hook, task-server | 1 | docs:1, other:1, policy:1, routing:1, test:3 | mechanics | supported | .agents/scripts/vaws.py | vaws task |
+| `.agents/scripts/vaws.py` | argparse | status, env, hook, task-server | 1 | docs:1, other:1, policy:1, routing:1, test:4 | mechanics | supported | .agents/scripts/vaws.py | vaws task |
 | `.agents/scripts/vaws_client_setup.py` | argparse | - | 5 | docs:4, policy:1, script:1, skill-doc:2, test:3 | mechanics | supported | .agents/scripts/vaws_client_setup.py | vaws workspace |
 | `.agents/scripts/vaws_deps.py` | argparse | status, doctor, sync | 1 | docs:3, other:1, policy:1, routing:3, script:1, skill-doc:4, test:2 | mechanics | supported | .agents/scripts/vaws_deps.py | vaws workspace |
 | `.agents/scripts/workspace_identity.py` | argparse | summary, ensure, validate-alias, set-alias, decline-alias | 1 | skill-doc:1 | mechanics | supported | .agents/scripts/workspace_identity.py | vaws workspace |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
 package = false
 
 [tool.uv.sources]
-vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "9120004fd30967c38b35965af7d2b0cbae9a6809" }
+vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "56d33ee6ef3f864235c1a6900223c02afec19b5f" }
 vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "a962d080382d0b6617c945ea038af6c6fe361f20" }
 vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "89c273b6f3bf184614ec2463d40f91e8f048d45b" }
 

--- a/uv.lock
+++ b/uv.lock
@@ -4238,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "vaws-remote-dev"
 version = "0.5.1"
-source = { git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=9120004fd30967c38b35965af7d2b0cbae9a6809#9120004fd30967c38b35965af7d2b0cbae9a6809" }
+source = { git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=56d33ee6ef3f864235c1a6900223c02afec19b5f#56d33ee6ef3f864235c1a6900223c02afec19b5f" }
 
 [[package]]
 name = "vaws-workspace"
@@ -4262,7 +4262,7 @@ dev = [
 requires-dist = [
     { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=a962d080382d0b6617c945ea038af6c6fe361f20" },
     { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=89c273b6f3bf184614ec2463d40f91e8f048d45b" },
-    { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=9120004fd30967c38b35965af7d2b0cbae9a6809" },
+    { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=56d33ee6ef3f864235c1a6900223c02afec19b5f" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Workspace help and local argument errors unnecessarily discovered task state and launched Git probes; delegated help also repeated the package check. Defer state discovery, skip it for explicit help, and perform one package check per launch.

Twenty alternating Windows source-worktree samples reduced root-help median from 190 to 132 ms and session-help from 424 to 234 ms. Output and exit codes matched. The dated report records medians, p95, first-bytecode-run samples and limitations.

Pin the merged remote-dev CLI improvement from https://github.com/vllm-ascend-workspace/remote-dev/pull/8. Validation with installed locked packages: 47 parser/consumer/safety tests passed, including 33 subtests. Fresh-process guards reject task-state imports, network access and subprocess creation during help; CLI inventory and tracked-path checks pass.

Part of https://github.com/vllm-ascend-workspace/.github/issues/6.
