### PR TITLE
feat(tests): report local progress and validate failed-only retries

### DIFF
--- a/.agents/lib/vaws_local_tests.py
+++ b/.agents/lib/vaws_local_tests.py
@@ -1,0 +1,338 @@
+"""Local pytest subprocesses with progress, receipts and conservative pass reuse."""
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+import hashlib
+import importlib.metadata
+import json
+import math
+import os
+from pathlib import Path
+import platform
+import signal
+import subprocess
+import sys
+import time
+from urllib.parse import unquote, urlparse
+import uuid
+import xml.etree.ElementTree as ET
+
+SCHEMA = 1
+FINAL = {"passed", "failed", "timed_out", "interrupted", "error", "not_run"}
+
+
+def digest_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    if not path.is_file():
+        return "missing"
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def digest_json(value) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True).encode()).hexdigest()
+
+
+def source_digest(root: Path, on_progress=None) -> str:
+    """Hash actual tracked/untracked source bytes, recursively including gitlinks."""
+    names = subprocess.check_output(
+        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"], cwd=root,
+    ).decode("utf-8", errors="surrogateescape").split("\0")
+    # Uninitialized submodules still have meaningful pinned source identities.
+    index = subprocess.check_output(["git", "ls-files", "--stage", "-z"], cwd=root)
+    values = [("gitlink", row.decode("utf-8", errors="surrogateescape"))
+              for row in index.split(b"\0") if row.startswith(b"160000 ")]
+    for number, name in enumerate(sorted(set(names) - {""})):
+        if on_progress and number % 128 == 0:
+            on_progress(f"source files checked: {number}")
+        path = root / name
+        value = source_digest(path, on_progress) if path.is_dir() and (path / ".git").exists() else digest_file(path)
+        values.append((name, value, os.readlink(path) if path.is_symlink() else None))
+    return digest_json(values)
+
+
+def installed_file_signature(path: Path):
+    try:
+        stat = path.stat()
+        return [stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns, stat.st_ino]
+    except FileNotFoundError:
+        return "missing"
+
+
+def fingerprint(root: Path, cases: list[str], pytest_args: list[str], on_progress=None) -> dict:
+    """Hash sources; identify installed dependencies by RECORD and file metadata."""
+    packages = []
+    for dist in importlib.metadata.distributions():
+        files = []
+        for number, path in enumerate(sorted(dist.files or [], key=str)):
+            if str(path).endswith(".pyc"):
+                continue
+            if on_progress and number % 128 == 0:
+                on_progress(f"checking dependency {dist.metadata['Name']}: {number} files")
+            files.append((str(path), installed_file_signature(Path(dist.locate_file(path)))))
+        metadata = [dist.read_text(name) for name in ("METADATA", "RECORD", "direct_url.json")]
+        direct = json.loads(dist.read_text("direct_url.json") or "{}")
+        editable = None
+        if direct.get("dir_info", {}).get("editable"):
+            parsed = urlparse(direct["url"])
+            path = unquote(parsed.path)
+            if os.name == "nt" and len(path) > 2 and path[0] == "/" and path[2] == ":":
+                path = path[1:]
+            editable = source_digest(Path(path), on_progress)
+        packages.append((dist.metadata["Name"], dist.version, digest_json([files, metadata]), editable))
+    parts = {
+        "root": str(root), "sources": source_digest(root, on_progress),
+        "dependencies": digest_json(sorted(packages)),
+        "dependency_method": "installed RECORD, metadata and file stat; editable source bytes",
+        "python": [sys.executable, sys.version], "platform": platform.platform(),
+        "environment": digest_json(dict(os.environ)),
+        "cases": cases, "pytest_args": pytest_args,
+    }
+    return {"digest": digest_json(parts), "parts": parts}
+
+
+def write_receipt(path: Path, receipt: dict) -> None:
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def junit_counts(path: Path) -> dict:
+    root = ET.parse(path).getroot()
+    suites = list(root.iter("testsuite"))
+    if not suites:
+        raise ValueError("JUnit has no test suite")
+    counts = {key: sum(int(suite.attrib.get(key, 0)) for suite in suites)
+              for key in ("tests", "failures", "errors", "skipped")}
+    if counts["tests"] <= 0 or any(value < 0 for value in counts.values()):
+        raise ValueError("JUnit has no completed tests or invalid counts")
+    return counts
+
+
+@contextmanager
+def owned_process(command: list[str], **kwargs):
+    if os.name == "nt":
+        from vaws_windows import owned_process as windows_process
+        with windows_process(command, **kwargs) as process:
+            yield process
+        return
+    process = subprocess.Popen(command, start_new_session=True, **kwargs)
+    try:
+        yield process
+    finally:
+        # Always drain this group, including grandchildren left by a failed test.
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            process.wait(timeout=0.5)
+        except subprocess.TimeoutExpired:
+            pass
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait(timeout=5)
+
+
+def select_cases(root: Path, selections: list[str], split: str) -> list[str]:
+    selections = selections or [".agents/tests", *[
+        str(path.relative_to(root)) for path in sorted((root / ".agents/skills").glob("*/tests"))
+    ]]
+    found = set()
+    for selected in selections:
+        path = (root / selected).resolve()
+        if not path.is_relative_to(root) or not path.exists():
+            raise ValueError(f"test selection must exist inside the repository: {selected}")
+        if path.is_file():
+            found.add(path.relative_to(root).as_posix())
+        elif split == "file" or path == root / ".agents/tests":
+            found.update(item.relative_to(root).as_posix() for item in path.rglob("test_*.py"))
+        else:
+            found.add(path.relative_to(root).as_posix())
+    if not found:
+        raise ValueError("no test files selected")
+    return sorted(found)
+
+
+def reusable(row: dict) -> bool:
+    try:
+        return (row["status"] == "passed" and row["pytest_exit_code"] == 0
+                and all(digest_file(Path(row[key])) == row[key + "_sha256"]
+                        and row[key + "_sha256"] != "missing" for key in ("log", "junit"))
+                and junit_counts(Path(row["junit"])) == row["counts"])
+    except (KeyError, TypeError, OSError, ValueError, ET.ParseError):
+        return False
+
+
+def run(root: Path, cases: list[str], *, jobs: int = 1, timeout: float = 600,
+        heartbeat: float = 10, pytest_args: list[str] | None = None,
+        previous: dict | None = None, progress=sys.stderr) -> tuple[dict, int]:
+    pytest_args = pytest_args or []
+    started = time.monotonic()
+    output = root / ".vaws-local/test-runs" / (time.strftime("%Y%m%d-%H%M%S") + "-" + uuid.uuid4().hex[:8])
+    output.mkdir(parents=True)
+    receipt_path = output / "summary.json"
+    print(f"[prepare] fingerprinting sources and dependencies; summary={receipt_path}", file=progress, flush=True)
+    preparation = {"schema_version": SCHEMA, "summary": str(receipt_path),
+                   "status": "preparing", "cases": [], "elapsed_seconds": 0.0}
+    write_receipt(receipt_path, preparation)
+    last_progress = started
+
+    def preparing(message):
+        nonlocal last_progress
+        now = time.monotonic()
+        if now - last_progress >= heartbeat:
+            last_progress = now
+            preparation.update(elapsed_seconds=round(now - started, 3), preparation=message)
+            print(f"[prepare] {message}; {now - started:.1f}s", file=progress, flush=True)
+            write_receipt(receipt_path, preparation)
+
+    try:
+        identity = fingerprint(root, cases, pytest_args, on_progress=preparing)
+    except BaseException as exc:
+        preparation.update(status="error", error=str(exc), elapsed_seconds=round(time.monotonic() - started, 3))
+        write_receipt(receipt_path, preparation)
+        raise
+    same = bool(previous and previous.get("fingerprint") == identity)
+    old = {row["case"]: row for row in previous.get("cases", [])} if same else {}
+    receipt = {"schema_version": SCHEMA, "summary": str(receipt_path), "status": "running",
+               "preparation_seconds": round(time.monotonic() - started, 3),
+               "fingerprint": identity, "reuse_allowed": same,
+               "reuse_reason": "inputs match" if same else "new run or inputs changed",
+               "settings": {"jobs": jobs, "timeout_seconds": timeout, "heartbeat_seconds": heartbeat},
+               "cases": [], "elapsed_seconds": 0.0}
+    for index, case in enumerate(cases):
+        prior = old.get(case)
+        if prior and reusable(prior):
+            receipt["cases"].append(dict(prior, reused=True))
+            print(f"[reuse] {case}", file=progress, flush=True)
+        else:
+            receipt["cases"].append({"case": case, "status": "not_run", "reused": False,
+                "log": str(output / f"{index:04d}.log"), "junit": str(output / f"{index:04d}.xml"),
+                "pytest_exit_code": None, "elapsed_seconds": 0.0})
+    pending = [row for row in receipt["cases"] if not row["reused"]]
+    active = []
+    interrupted = []
+    handlers = {}
+
+    def stop(signum, frame):
+        interrupted.append(signum)
+
+    def save():
+        receipt["elapsed_seconds"] = round(time.monotonic() - started, 3)
+        write_receipt(receipt_path, receipt)
+
+    try:
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            handlers[signum] = signal.signal(signum, stop)
+        save()
+        while pending or active:
+            while pending and len(active) < jobs and not interrupted:
+                row = pending.pop(0)
+                row["status"] = "running"
+                command = [sys.executable, "-m", "pytest", row["case"], "-q", *pytest_args,
+                           "--junitxml=" + row["junit"]]
+                log = Path(row["log"]).open("wb")
+                context = owned_process(command, cwd=root, stdin=subprocess.DEVNULL,
+                                        stdout=log, stderr=subprocess.STDOUT)
+                try:
+                    process = context.__enter__()
+                except Exception as exc:
+                    log.close()
+                    row.update(status="error", error=str(exc), log_sha256=digest_file(Path(row["log"])))
+                else:
+                    active.append((row, process, context, log, time.monotonic(), time.monotonic()))
+                    print(f"[start] {row['case']} pid={process.pid} log={row['log']}", file=progress, flush=True)
+                save()
+            for entry in list(active):
+                row, process, context, log, began, notified = entry
+                now = time.monotonic()
+                elapsed = now - began
+                code = process.poll()
+                status = "interrupted" if interrupted else "timed_out" if elapsed >= timeout and code is None else None
+                if code is not None or status:
+                    context.__exit__(None, None, None)
+                    log.close()
+                    row.update(status=status or ("passed" if code == 0 else "failed"),
+                               pytest_exit_code=code if code is not None else process.returncode,
+                               elapsed_seconds=round(time.monotonic() - began, 3))
+                    try:
+                        row["counts"] = junit_counts(Path(row["junit"]))
+                        if row["status"] == "passed" and (row["counts"]["failures"] or row["counts"]["errors"]):
+                            raise ValueError("JUnit contradicts successful pytest exit")
+                    except (OSError, ValueError, ET.ParseError) as exc:
+                        if row["status"] == "passed":
+                            row.update(status="error", error=str(exc))
+                    for key in ("log", "junit"):
+                        row[key + "_sha256"] = digest_file(Path(row[key]))
+                    active.remove(entry)
+                    print(f"[{row['status']}] {row['case']} {row['elapsed_seconds']:.1f}s exit={row['pytest_exit_code']} log={row['log']}", file=progress, flush=True)
+                    save()
+                elif now - notified >= heartbeat:
+                    row["elapsed_seconds"] = round(elapsed, 3)
+                    print(f"[running] {row['case']} {elapsed:.1f}s log={row['log']}", file=progress, flush=True)
+                    active[active.index(entry)] = (*entry[:5], now)
+                    save()
+            if interrupted and not active:
+                break
+            if pending or active:
+                time.sleep(min(0.1, heartbeat))
+    finally:
+        for row, process, context, log, began, notified in active:
+            context.__exit__(None, None, None)
+            log.close()
+            row.update(status="interrupted", pytest_exit_code=process.returncode,
+                       elapsed_seconds=round(time.monotonic() - began, 3))
+        for signum, handler in handlers.items():
+            signal.signal(signum, handler)
+        receipt["status"] = "interrupted" if interrupted else (
+            "passed" if all(row["status"] == "passed" for row in receipt["cases"]) else "failed")
+        save()
+    return receipt, 128 + interrupted[0] if interrupted else (0 if receipt["status"] == "passed" else 1)
+
+
+def main(root: Path, argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="repository test files or directories")
+    parser.add_argument("--split", choices=("suite", "file"), default="suite")
+    parser.add_argument("--jobs", type=int, default=1)
+    parser.add_argument("--timeout", type=float, default=600, help="seconds per subprocess")
+    parser.add_argument("--heartbeat", type=float, default=10, help="seconds between progress lines")
+    parser.add_argument("--rerun-failed", type=Path, help="previous summary; changed inputs rerun all original cases")
+    parser.add_argument("--pytest-arg", action="append", default=[], help="repeatable pytest argument; use = for options")
+    args = parser.parse_args(argv)
+    if (not 1 <= args.jobs <= 32 or not math.isfinite(args.timeout) or args.timeout <= 0
+            or not math.isfinite(args.heartbeat) or args.heartbeat <= 0):
+        parser.error("jobs must be 1..32; timeout and heartbeat must be positive and finite")
+    try:
+        previous = None
+        if args.rerun_failed:
+            if args.paths:
+                parser.error("--rerun-failed uses the original selection; omit paths")
+            previous = json.loads(args.rerun_failed.read_text(encoding="utf-8"))
+            if not isinstance(previous, dict) or previous.get("schema_version") != SCHEMA:
+                raise ValueError("unsupported previous summary schema")
+            parts = previous["fingerprint"]["parts"]
+            if (not isinstance(parts["cases"], list) or not all(isinstance(value, str) for value in parts["cases"])
+                    or not isinstance(parts["pytest_args"], list)
+                    or not all(isinstance(value, str) for value in parts["pytest_args"])
+                    or not isinstance(previous["cases"], list)
+                    or not all(isinstance(row, dict) and isinstance(row.get("case"), str) for row in previous["cases"])):
+                raise ValueError("malformed previous summary")
+            cases = select_cases(root, parts["cases"], "suite")
+            extra = args.pytest_arg or parts["pytest_args"]
+        else:
+            cases = select_cases(root, args.paths, args.split)
+            extra = args.pytest_arg
+        result, code = run(root, cases, jobs=args.jobs, timeout=args.timeout,
+                           heartbeat=args.heartbeat, pytest_args=extra, previous=previous)
+    except (OSError, ValueError, KeyError, TypeError, subprocess.SubprocessError) as exc:
+        print(json.dumps({"schema_version": SCHEMA, "status": "error", "error": str(exc)}))
+        return 2
+    print(json.dumps(result))
+    return code

--- a/.agents/lib/vaws_windows.py
+++ b/.agents/lib/vaws_windows.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import ctypes
 from ctypes import wintypes
+from contextlib import contextmanager
 import subprocess
 import sys
 
@@ -27,12 +28,14 @@ def pid_alive(pid: int) -> bool:
         kernel.CloseHandle(handle)
 
 
-def run_owned(command: list[str], *, env: dict[str, str]) -> int:
-    """Wait for a child; abrupt launcher termination closes its whole job tree.
+@contextmanager
+def owned_process(command: list[str], *, release_on_exit: bool = False, **kwargs):
+    """Own a child tree, including children of the Windows venv redirector.
 
     Start suspended so even the Windows venv redirector cannot launch children
     outside the job. All Win32 declarations preserve 64-bit process handles.
-    Only used before the installed workspace packages can be imported.
+    Closing the context kills descendants unless a caller explicitly releases
+    them after a normal exit. The job also closes on abrupt parent termination.
     """
     size_t = ctypes.c_size_t
 
@@ -84,7 +87,7 @@ def run_owned(command: list[str], *, env: dict[str, str]) -> int:
         limits = ExtendedLimits()
         limits.basic.flags = 0x2000  # JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
         check(set_limits(job, 9, ctypes.byref(limits), ctypes.sizeof(limits)))
-        process = subprocess.Popen(command, env=env, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr,
+        process = subprocess.Popen(command, **kwargs,
                                    creationflags=subprocess.CREATE_NO_WINDOW | 0x00000004)  # CREATE_SUSPENDED
         handle = check(open_process(0x0101, False, process.pid))  # SET_QUOTA | TERMINATE
         try:
@@ -110,16 +113,23 @@ def run_owned(command: list[str], *, env: dict[str, str]) -> int:
                 close(thread)
         finally:
             close(threads)
-        result = process.wait()
+        yield process
         # A normal CLI exit must preserve package-owned detached services
         # (coordinator, knowledge, monitor). Abrupt parent termination skips
         # this step and the kernel closes every still-owned descendant.
-        limits.basic.flags = 0
-        check(set_limits(job, 9, ctypes.byref(limits), ctypes.sizeof(limits)))
-        return result
+        if release_on_exit and process.poll() is not None:
+            limits.basic.flags = 0
+            check(set_limits(job, 9, ctypes.byref(limits), ctypes.sizeof(limits)))
     finally:
         close(job)
         if process is not None:
             if process.poll() is None:
                 process.kill()  # Also covers assignment failure before resume.
             process.wait(timeout=5)
+
+
+def run_owned(command: list[str], *, env: dict[str, str]) -> int:
+    """Bootstrap a package CLI, preserving services on a normal CLI exit."""
+    with owned_process(command, env=env, stdin=sys.stdin, stdout=sys.stdout,
+                       stderr=sys.stderr, release_on_exit=True) as process:
+        return process.wait()

--- a/.agents/policy/cli-surface-inventory.json
+++ b/.agents/policy/cli-surface-inventory.json
@@ -21,6 +21,12 @@
     }
   ],
   "classification": {
+    ".agents/scripts/local_tests.py": {
+      "responsibility": "mechanics",
+      "support_role": "harness",
+      "target_kind": "self",
+      "note": "local pytest file/suite subprocesses with progress, bounded lifetime and validated failed-only reruns"
+    },
     ".agents/hooks/knowledge_session_end.py": {
       "responsibility": "mechanics",
       "support_role": "hook",

--- a/.agents/scripts/local_tests.py
+++ b/.agents/scripts/local_tests.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Run local tests with per-file/suite progress, retained logs and safe retries."""
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / ".agents/lib"))
+from vaws_venv import ensure_workspace_interpreter
+
+ensure_workspace_interpreter(repo_root=ROOT)
+
+from vaws_local_tests import main
+
+if __name__ == "__main__":
+    raise SystemExit(main(ROOT))

--- a/.agents/tests/test_local_tests.py
+++ b/.agents/tests/test_local_tests.py
@@ -1,0 +1,176 @@
+"""Real pytest children exercise receipts, failures, retries and process ownership."""
+from __future__ import annotations
+
+import io
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+LIB = Path(__file__).resolve().parents[1] / "lib"
+sys.path.insert(0, str(LIB))
+import vaws_local_tests as runner
+
+
+def alive(pid):
+    if os.name == "nt":
+        from vaws_windows import pid_alive
+        return pid_alive(pid)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    # An already-reaped command can leave a briefly visible zombie on Linux CI.
+    status = Path(f"/proc/{pid}/stat")
+    return not status.exists() or status.read_text().split(") ", 1)[1][0] != "Z"
+
+
+class LocalTestRunnerTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        subprocess.run(["git", "init", "-q", str(self.root)], check=True)
+        (self.root / ".gitignore").write_text(".vaws-local/\n__pycache__/\n.pytest_cache/\n")
+        (self.root / ".vaws-local").mkdir()
+
+    def write(self, name, body):
+        (self.root / name).write_text(body, encoding="utf-8")
+
+    def execute(self, cases, **kwargs):
+        # Process behavior is real; avoid repeatedly hashing the test host's
+        # entire dependency installation in this bounded integration fixture.
+        progress = io.StringIO()
+        with patch.object(runner, "fingerprint", return_value={"digest": runner.source_digest(self.root)}):
+            receipt, code = runner.run(self.root, cases, progress=progress, heartbeat=0.2, **kwargs)
+        return receipt, code, progress.getvalue()
+
+    def assert_dead(self, pid):
+        deadline = time.monotonic() + 5
+        while alive(pid) and time.monotonic() < deadline:
+            time.sleep(0.05)
+        self.assertFalse(alive(pid), f"owned process {pid} survived")
+
+    def test_failure_does_not_stop_other_files_and_unchanged_pass_is_reused(self):
+        self.write("test_pass.py", "def test_pass():\n    assert True\n")
+        self.write("test_flaky.py", "from pathlib import Path\ndef test_flaky():\n    assert Path('.vaws-local/fixed').exists()\n")
+        cases = ["test_flaky.py", "test_pass.py"]
+        first, code, progress = self.execute(cases, jobs=2)
+        self.assertEqual(code, 1)
+        self.assertEqual([row["pytest_exit_code"] for row in first["cases"]], [1, 0])
+        self.assertEqual([row["status"] for row in first["cases"]], ["failed", "passed"])
+        self.assertIn("[start] test_pass.py", progress)
+        self.assertEqual(json.loads(Path(first["summary"]).read_text()), first)
+        (self.root / ".vaws-local/fixed").touch()
+        second, code, _ = self.execute(cases, previous=first)
+        self.assertEqual(code, 0)
+        self.assertEqual([row["reused"] for row in second["cases"]], [False, True])
+        Path(second["cases"][1]["log"]).write_text("corrupt")
+        third, code, _ = self.execute(cases, previous=second)
+        self.assertEqual(code, 0)
+        self.assertFalse(third["cases"][1]["reused"])
+        self.write("helper.py", "value = 2\n")
+        fourth, code, _ = self.execute(cases, previous=third)
+        self.assertEqual(code, 0)
+        self.assertFalse(any(row["reused"] for row in fourth["cases"]))
+
+    def test_crashed_pytest_child_drains_grandchild_and_preserves_exit(self):
+        self.write("test_crash.py", """import os, subprocess, sys
+from pathlib import Path
+def test_crash():
+    child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(120)'])
+    Path('.vaws-local/pid').write_text(str(child.pid))
+    print('before crash', flush=True)
+    os._exit(73)
+""")
+        receipt, code, _ = self.execute(["test_crash.py"])
+        row = receipt["cases"][0]
+        self.assertEqual((code, row["status"], row["pytest_exit_code"]), (1, "failed", 73))
+        self.assertTrue(Path(row["log"]).exists())
+        self.assert_dead(int((self.root / ".vaws-local/pid").read_text()))
+
+    def test_timeout_retains_log_emits_heartbeat_and_runs_next_file(self):
+        self.write("test_hang.py", """import subprocess, sys, time
+from pathlib import Path
+def test_hang():
+    child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(120)'])
+    Path('.vaws-local/pid').write_text(str(child.pid))
+    print('still working', flush=True)
+    time.sleep(120)
+""")
+        self.write("test_pass.py", "def test_pass():\n    assert True\n")
+        receipt, code, progress = self.execute(["test_hang.py", "test_pass.py"], timeout=4, pytest_args=["-s"])
+        self.assertEqual([row["status"] for row in receipt["cases"]], ["timed_out", "passed"])
+        self.assertEqual(code, 1)
+        self.assertIn("[running] test_hang.py", progress)
+        self.assertIn("still working", Path(receipt["cases"][0]["log"]).read_text())
+        self.assert_dead(int((self.root / ".vaws-local/pid").read_text()))
+
+    def test_success_exit_without_junit_is_an_error(self):
+        self.write("test_false_success.py", "import os\ndef test_exit():\n    os._exit(0)\n")
+        receipt, code, _ = self.execute(["test_false_success.py"])
+        self.assertEqual((code, receipt["cases"][0]["status"]), (1, "error"))
+        self.assertEqual(receipt["cases"][0]["pytest_exit_code"], 0)
+
+    def test_interrupt_retains_partial_receipt_and_drains_children(self):
+        self.write("test_interrupt.py", """import subprocess, sys, time
+from pathlib import Path
+def test_interrupt():
+    child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(120)'])
+    Path('.vaws-local/pid').write_text(str(child.pid))
+    time.sleep(120)
+""")
+        # Inject SIGINT through Python's real handler in the owning runner.
+        # Windows console signals cannot target CREATE_NO_WINDOW children.
+        code = f"""import sys, signal, threading, time
+from pathlib import Path
+sys.path.insert(0, {str(LIB)!r})
+import vaws_local_tests as runner
+runner.fingerprint = lambda *args, **kwargs: {{'digest': 'fixture'}}
+root = Path({str(self.root)!r})
+def interrupt():
+    deadline = time.monotonic() + 15
+    while not (root / '.vaws-local/pid').exists() and time.monotonic() < deadline:
+        time.sleep(.05)
+    signal.raise_signal(signal.SIGINT)
+threading.Thread(target=interrupt, daemon=True).start()
+result, status = runner.run(root, ['test_interrupt.py'], heartbeat=.2)
+print(result['summary'], flush=True)
+raise SystemExit(status)
+"""
+        completed = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=25)
+        self.assertEqual(completed.returncode, 130, completed.stderr)
+        receipt = json.loads(Path(completed.stdout.strip()).read_text())
+        self.assertEqual(receipt["status"], "interrupted")
+        self.assertEqual(receipt["cases"][0]["status"], "interrupted")
+        self.assertTrue(Path(receipt["cases"][0]["log"]).exists())
+        self.assert_dead(int((self.root / ".vaws-local/pid").read_text()))
+
+    def test_fingerprint_tracks_dependency_files_arguments_environment_and_source(self):
+        self.write("dependency.py", "x = 1\n")
+        class Distribution:
+            metadata = {"Name": "fixture"}
+            version = "1"
+            files = ["dependency.py"]
+            def locate_file(_, path):
+                return self.root / path
+            def read_text(_, path):
+                return None
+        with patch.object(runner.importlib.metadata, "distributions", return_value=[Distribution()]):
+            first = runner.fingerprint(self.root, ["test_a.py"], [])
+            self.write("dependency.py", "x = 2\n")
+            second = runner.fingerprint(self.root, ["test_a.py"], [])
+            self.assertNotEqual(first["parts"]["dependencies"], second["parts"]["dependencies"])
+            self.assertNotEqual(second, runner.fingerprint(self.root, ["test_a.py"], ["-x"]))
+            with patch.dict(os.environ, {"TEST_RUNNER_INPUT": "changed"}):
+                self.assertNotEqual(second, runner.fingerprint(self.root, ["test_a.py"], []))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/skill-catalog.yml
+++ b/.github/workflows/skill-catalog.yml
@@ -135,17 +135,8 @@ jobs:
           uv run python .agents/scripts/vaws_deps.py doctor
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           uv lock --check
-      - name: Native client, hooks, bootstrap and knowledge contracts
-        run: uv run python -B -m pytest .agents/tests -q --junitxml=windows-workspace.xml
-      - name: Every skill's local tests
-        run: |
-          foreach ($suite in Get-ChildItem .agents/skills -Directory) {
-            $tests = Join-Path $suite.FullName 'tests'
-            if (Test-Path -LiteralPath $tests) {
-              uv run python -B -m pytest $tests -q
-              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-            }
-          }
+      - name: All local workspace and skill tests with progress
+        run: uv run python -B .agents/scripts/local_tests.py --jobs 2 --timeout 600 > windows-workspace.json
       - name: Generated projections and repository guards
         run: |
           uv run python .agents/scripts/sync_claude_skills.py --check
@@ -161,4 +152,7 @@ jobs:
         if: always()
         with:
           name: windows-workspace-results
-          path: windows-workspace.xml
+          path: |
+            windows-workspace.json
+            .vaws-local/test-runs/
+          include-hidden-files: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ is the archive for dated evidence.
 
 ## Current contracts
 
+- [local-tests.md](local-tests.md) — local test progress, subprocess lifetime, retained evidence and validated retries.
 - [runtime-feedback-design.md](runtime-feedback-design.md) — real-machine progress, loaded runtime identity, state projection, compact output and connection diagnostics.
 - [README.md](README.md) — this index.
 - [agent-first-openviking-spec.md](agent-first-openviking-spec.md) — target behavior and implementation status for permissive Agent workflows, local knowledge, public contributions and prebuilt distribution; Grok review is deferred.

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -38,7 +38,7 @@ entry points.
 | Measurement | AST `__main__` / `__main__.py` discovery of tracked (and untracked-unignored) Python outside `vllm/` and `vllm-ascend/`; overlay and owner selectors from `.agents/policy/cli-surface-inventory.json`; `pyproject.toml` / `uv.lock`; no import, fetch, `--help`, NPU or SSH |
 
 The census is the AST of the inspected files plus those committed package owners. The
-96-entry overlay and four owner-selector records live in
+97-entry overlay and four owner-selector records live in
 `.agents/policy/cli-surface-inventory.json` (metadata only; not executable).
 Re-run the generator after this overlay changes. Do not paste a future commit
 SHA into this file as if it were an input.
@@ -51,23 +51,23 @@ are **not** the original 132-entry snapshot and **not** the unimplemented
 
 | Measure | Value |
 |---|---|
-| Entry points (definition in §3) | **96** |
+| Entry points (definition in §3) | **97** |
 | Supported agent-facing launchers | 51 |
 | Compatibility wrappers | 17 |
 | Internal / diagnostic CLIs | 11 |
 | Generated projections | 2 |
 | Hooks | 4 |
 | Remote payloads | 10 |
-| Test / maturation harnesses | 1 |
-| Responsibility | mechanics 81 · mixed 15 · judgment 0 |
-| Files importing `argparse` (non-test) | 88 |
+| Test / maturation harnesses | 2 |
+| Responsibility | mechanics 82 · mixed 15 · judgment 0 |
+| Files importing `argparse` (non-test) | 90 |
 | Skills that ship at least one entry point | 20 |
-| Parser styles | argparse 85 · delegated 7 · bare 3 · bare-argv 1 |
+| Parser styles | argparse 86 · delegated 8 · bare 2 · bare-argv 1 |
 | Historical snapshot (original #85) | 132 entries; mechanics 81 · judgment 8 · mixed 8 · redundant 35 |
 | Historical proposed surface | **13 nouns**, 75 verbs (unimplemented) |
 
-The 96 roles are non-overlapping: every discovered entry has exactly one
-support role, and the seven role counts sum to 96. Support role is not
+The 97 roles are non-overlapping: every discovered entry has exactly one
+support role, and the seven role counts sum to 97. Support role is not
 inferred from a future `vaws <noun>` label, from a `__main__` guard alone, or
 from the absence of a basename mention.
 
@@ -419,6 +419,7 @@ option.
 | `.agents/scripts/knowledge_query.py` | argparse | - | 9 | routing:1, test:3 | mechanics | supported | .agents/scripts/knowledge_query.py | vaws knowledge |
 | `.agents/scripts/knowledge_setup.py` | argparse | - | 2 | docs:1, routing:2, skill-doc:3 | mechanics | supported | .agents/scripts/knowledge_setup.py | - |
 | `.agents/scripts/knowledge_validate.py` | argparse | - | 1 | other:1 | mechanics | supported | .agents/scripts/knowledge_validate.py | vaws knowledge |
+| `.agents/scripts/local_tests.py` | delegated | - | 6 | docs:1, other:1 | mechanics | harness | .agents/scripts/local_tests.py | - |
 | `.agents/scripts/remote_artifact_manifest.py` | argparse | - | 1 | policy:1 | mechanics | compatibility | .agents/scripts/remote_artifact_manifest.py | vaws remote |
 | `.agents/scripts/remote_artifact_pull.py` | argparse | - | 2 | policy:1, script:1, skill-doc:1 | mechanics | compatibility | .agents/scripts/remote_artifact_pull.py | vaws remote |
 | `.agents/scripts/remote_artifact_push.py` | argparse | - | 2 | policy:1 | mechanics | compatibility | .agents/scripts/remote_artifact_push.py | vaws remote |

--- a/docs/local-tests.md
+++ b/docs/local-tests.md
@@ -1,0 +1,58 @@
+# Local test progress and retries
+
+Status: current
+
+Run the workspace's local Python tests with visible progress and retained evidence:
+
+```powershell
+uv sync --locked --group dev
+uv run python .agents/scripts/local_tests.py --jobs 2 --timeout 600
+```
+
+The default selection runs each workspace test file separately and each skill's
+test directory as one suite. Use `--split file` to isolate every file, or provide
+repository-relative files/directories to narrow the selection. These commands
+run local control-plane tests; device execution remains in managed remote runs.
+
+```powershell
+uv run python .agents/scripts/local_tests.py .agents/tests/test_local_tests.py --heartbeat 5
+uv run python .agents/scripts/local_tests.py .agents/tests --pytest-arg=-x
+uv run python .agents/scripts/local_tests.py --rerun-failed .vaws-local/test-runs/<run>/summary.json
+```
+
+The runner prints start, periodic running and completion lines to stderr with the
+current file/suite, elapsed time and log path. Each subprocess has its own log and
+JUnit file. One JSON summary goes to stdout and is atomically updated under
+untracked `.vaws-local/test-runs/` while the run progresses. Redirect stdout to
+a file if a console should show only progress. Default concurrency is one and
+the default per-subprocess timeout is 600 seconds; neither failure nor timeout
+prevents unrelated pending cases from running.
+
+Each row retains the original pytest exit code, JUnit counts and one of `passed`,
+`failed`, `timed_out`, `interrupted`, `error`, or `not_run`; active rows temporarily
+show `running`. A zero exit without a valid, nonempty JUnit report is an error.
+The runner exits 0 only when every case passed, 1 on test failure, 2 on an input
+or setup error, and 128 plus the signal number on a handled interruption.
+
+`--rerun-failed` reuses successful rows only when the original selection, pytest
+arguments, repository source bytes, submodule state, installed dependency records
+and file metadata,
+editable source trees, interpreter/platform and environment hash still match.
+Missing or changed logs/JUnit rerun the affected case. Changed inputs rerun the
+entire original selection. Ignored runtime files and external services are not
+part of the source fingerprint; request a fresh run when those test inputs change.
+Environment values are hashed, not copied into receipts.
+
+Installed packages use their METADATA, RECORD, source metadata, and each installed
+file's size, timestamps and identity. They are not rehashed byte by byte; manual
+changes that deliberately preserve all those fields require a fresh run. Source
+worktrees, including editable dependencies, are hashed by content. Preparation
+has its own progress and elapsed time so large installations are visible.
+
+Windows child trees belong to a job object created before the interpreter is
+resumed. POSIX children use a dedicated process group. Completion, failure,
+timeout and handled interruption drain owned descendants, including processes
+left by a crashed pytest child. Windows also drains on abrupt runner termination.
+POSIX hard-kill of the runner itself and deliberately escaped sessions are outside
+this local runner's cleanup guarantee. Logs and partial summaries remain for
+inspection. This runner does not create resource leases or execution ledgers.


### PR DESCRIPTION
Long local test runs previously offered little progress and stopped the Windows skill loop at the first failure. Add a local pytest runner that isolates workspace files and skill suites, reports elapsed time and log paths, retains atomic partial summaries and JUnit files, and continues unrelated tests after failure or timeout. Windows CI now uses it and uploads the receipts.

Failed-only retries reuse passes only after checking source content, submodule state, dependency installation records/file metadata, editable sources, interpreter/platform, environment and pytest arguments. Changed or missing evidence reruns the affected tests. The Windows bootstrap job-object implementation is shared with the runner; POSIX test children use owned process groups.

Validation: the complete native Windows run passed all 64 subprocess groups in 108.7 seconds, including 6.5 seconds of preparation. JUnit reports 1,696 cases, 32 skips, zero failures and zero errors. Focused tests cover a pytest crash with a grandchild, timeout, interruption, log retention, heartbeat output, original exit codes, invalid success without JUnit, pass reuse and invalidation; existing bootstrap lifetime tests also pass. Inventory, path and leak guards pass.

Dependency preparation uses installation records and file metadata instead of rehashing every installed package byte; source worktrees still use content hashes. Ignored runtime inputs and deliberately metadata-preserving installed-file edits require a fresh run, as documented.

Part of https://github.com/vllm-ascend-workspace/.github/issues/6.
