### PR TITLE
feat(client): consume SSH timing and status freshness feedback

### DIFF
--- a/.agents/tests/test_local_tests.py
+++ b/.agents/tests/test_local_tests.py
@@ -26,9 +26,24 @@ def alive(pid):
         os.kill(pid, 0)
     except ProcessLookupError:
         return False
-    # An already-reaped command can leave a briefly visible zombie on Linux CI.
-    status = Path(f"/proc/{pid}/stat")
-    return not status.exists() or status.read_text().split(") ", 1)[1][0] != "Z"
+    # Linux may expose a zombie before reaping it, or remove its proc entry
+    # between kill(0) and read_text(). Neither state is a surviving child.
+    if sys.platform == "linux":
+        try:
+            status = Path(f"/proc/{pid}/stat").read_text()
+        except (FileNotFoundError, ProcessLookupError):
+            return False
+        return status.rsplit(") ", 1)[1][0] != "Z"
+    return True
+
+
+class ProcessObservationTests(unittest.TestCase):
+    @unittest.skipUnless(sys.platform == "linux", "Linux proc observation")
+    def test_reaped_between_signal_probe_and_proc_read_is_dead(self):
+        for error in (FileNotFoundError, ProcessLookupError):
+            with self.subTest(error=error.__name__):
+                with patch.object(os, "kill"), patch.object(Path, "read_text", side_effect=error):
+                    self.assertFalse(alive(12345))
 
 
 class LocalTestRunnerTests(unittest.TestCase):

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,5 +26,6 @@ is the archive for dated evidence.
 
 ## Dated validation evidence
 
+- [observation-feedback-2026-09-11.md](observation-feedback-2026-09-11.md) — SSH batching/timing evidence and status freshness behavior.
 - [cli-feedback-2026-09-11.md](cli-feedback-2026-09-11.md) — paired Windows CLI startup measurements and parser side-effect checks.
 - [windows-validation-2026-09-11.md](windows-validation-2026-09-11.md) — completed Windows non-NPU validation, repairs, limits and a proposed experience-optimization sequence.

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -444,7 +444,7 @@ option.
 | `.agents/scripts/sync_claude_skills.py` | argparse | - | 1 | mirror:2, other:1, policy:1, routing:1, skill-doc:1, test:2 | mechanics | supported | .agents/scripts/sync_claude_skills.py | vaws lint |
 | `.agents/scripts/tracked_leak_scan.py` | argparse | - | 10 | docs:1, hook:1, other:1, policy:1, script:1, test:3 | mechanics | supported | .agents/scripts/tracked_leak_scan.py | vaws lint |
 | `.agents/scripts/tracked_path_check.py` | argparse | - | 6 | docs:1, other:1, policy:1, test:2 | mechanics | supported | .agents/scripts/tracked_path_check.py | vaws lint |
-| `.agents/scripts/vaws.py` | argparse | status, env, hook, task-server | 1 | docs:1, other:1, policy:1, routing:1, test:4 | mechanics | supported | .agents/scripts/vaws.py | vaws task |
+| `.agents/scripts/vaws.py` | argparse | status, env, hook, task-server | 1 | docs:2, other:1, policy:1, routing:1, test:4 | mechanics | supported | .agents/scripts/vaws.py | vaws task |
 | `.agents/scripts/vaws_client_setup.py` | argparse | - | 5 | docs:4, policy:1, script:1, skill-doc:2, test:3 | mechanics | supported | .agents/scripts/vaws_client_setup.py | vaws workspace |
 | `.agents/scripts/vaws_deps.py` | argparse | status, doctor, sync | 1 | docs:3, other:1, policy:1, routing:3, script:1, skill-doc:4, test:2 | mechanics | supported | .agents/scripts/vaws_deps.py | vaws workspace |
 | `.agents/scripts/workspace_identity.py` | argparse | summary, ensure, validate-alias, set-alias, decline-alias | 1 | skill-doc:1 | mechanics | supported | .agents/scripts/workspace_identity.py | vaws workspace |

--- a/docs/coordinator-consumption.md
+++ b/docs/coordinator-consumption.md
@@ -26,6 +26,15 @@ history.
 | `vaws_execution` | Status, tail, stop, or read the ordinary endpoint of one owned execution |
 | `vaws_finish` | Close admission; stop owned executions; keep container, roots, evidence |
 
+Task MCP/CLI status may reuse a snapshot for two seconds. Use `refresh: true`
+or `vaws.py execution --refresh` for a new observation. Compact results retain
+`observation_freshness` (snapshot completion time, age, source and deferred
+refresh) plus per-role sampling times. Busy executions return immediately
+with the cached observation and mark refresh as deferred. Python
+`TaskClient.observe()` remains fresh by default; `refresh=False` permits caching.
+These observations do not grant resource access. Tail, target and stop keep
+their existing behavior.
+
 CLI: `python3 .agents/scripts/vaws.py session|run|execution|finish` execs
 `python -m vaws_coordinator.vaws`. MCP: `python -m vaws_coordinator task-server`.
 

--- a/docs/observation-feedback-2026-09-11.md
+++ b/docs/observation-feedback-2026-09-11.md
@@ -1,0 +1,64 @@
+# SSH and status observation feedback
+
+Status: dated 2026-09-11
+
+## SSH measurements
+
+On native Windows, ten alternating pairs compared three separate related
+read-only OS/cwd/Python queries with one SSH request returning the same facts.
+Both arms used independent connections to one Linux endpoint. Facts matched
+in every pair; no model/device library was imported and no NPU was allocated.
+
+| Method | Median | Sample p95 |
+| --- | ---: | ---: |
+| Three independent SSH requests | 13.768 s | 14.167 s |
+| One request with three facts | 4.601 s | 4.740 s |
+
+The measured reduction was 67%. Ten samples make p95 the sample maximum;
+this is endpoint-specific exploratory evidence, not a network SLA. The
+remote-dev connection diagnostic now gathers these facts in one fixed request.
+It never replays arbitrary business commands. Existing full context probes
+already batch their work in one SSH request.
+
+Three real probes of the new diagnostic succeeded. SSH duration ranged
+4.587-4.818 s, received TCP milestone 0.300-0.584 s, and authentication milestone
+2.891-3.170 s. The small remote facts query took about 0.012 ms and final
+stream drain/exit 5.7-7.1 ms. Connection timing includes client startup and
+authentication; TCP is a subset. Pure transfer time and unobserved milestones
+remain unknown. The remainder includes channel/Python startup and transport.
+
+These phases come from actual local receive events and a remote monotonic
+timer. They are not packet-level timings. Ordinary bash results expose total
+transport/decoding costs without turning on verbose SSH. Raw endpoint identities
+and receipts are kept only in untracked local output.
+
+## Status freshness
+
+The coordinator task MCP/CLI can reuse a status snapshot for up to two seconds.
+Responses expose snapshot completion time, age, source, freshness, per-role
+sampling times and whether a busy execution deferred refresh. Use:
+
+```powershell
+uv run python .agents/scripts/vaws.py execution --execution-id <id> --context-file <context> --refresh
+```
+
+TaskClient's library default continues to request fresh status; `refresh=False`
+opts into caching. Tail, target, stop, allocation and background progression
+retain their existing behavior. A cached observation grants no resource access.
+
+Tests verify that a second cached read makes zero managed-control calls, expiry
+or explicit refresh makes a new call, and busy observations return without
+waiting for the execution lock. Ownership, state/error/release fields, compact
+output and CLI/IPC argument forwarding remain covered. This removes repeated
+status probes but is not a live NPU-service latency benchmark.
+
+## Validation
+
+- remote-dev diagnostics/transport/client parity: 88 passed, 22 platform skips,
+  18 subtests, including real local pipe milestones and timeout output.
+- Coordinator task-client/ownership/freshness: 38 passed, 6 subtests.
+- Coordinator task-server contracts: 18 passed, 8 subtests.
+
+Owner PRs are remote-dev #9 and coordinator #14. Consumer pins select those
+changes after owner CI and merge; hosted CI supplies the supported-platform
+validation for the submitted revisions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ dev = [
 package = false
 
 [tool.uv.sources]
-vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "56d33ee6ef3f864235c1a6900223c02afec19b5f" }
-vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "a962d080382d0b6617c945ea038af6c6fe361f20" }
+vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "7b86d9183fe0fcc5dd2737a916803a7bfa434174" }
+vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "81d5e715c23c171cc0a19f04e6118c56ef63fb48" }
 vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "89c273b6f3bf184614ec2463d40f91e8f048d45b" }
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -4217,7 +4217,7 @@ wheels = [
 [[package]]
 name = "vaws-coordinator"
 version = "0.3.2"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=a962d080382d0b6617c945ea038af6c6fe361f20#a962d080382d0b6617c945ea038af6c6fe361f20" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=81d5e715c23c171cc0a19f04e6118c56ef63fb48#81d5e715c23c171cc0a19f04e6118c56ef63fb48" }
 dependencies = [
     { name = "vaws-remote-dev" },
 ]
@@ -4238,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "vaws-remote-dev"
 version = "0.5.1"
-source = { git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=56d33ee6ef3f864235c1a6900223c02afec19b5f#56d33ee6ef3f864235c1a6900223c02afec19b5f" }
+source = { git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=7b86d9183fe0fcc5dd2737a916803a7bfa434174#7b86d9183fe0fcc5dd2737a916803a7bfa434174" }
 
 [[package]]
 name = "vaws-workspace"
@@ -4260,9 +4260,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=a962d080382d0b6617c945ea038af6c6fe361f20" },
+    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=81d5e715c23c171cc0a19f04e6118c56ef63fb48" },
     { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=89c273b6f3bf184614ec2463d40f91e8f048d45b" },
-    { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=56d33ee6ef3f864235c1a6900223c02afec19b5f" },
+    { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=7b86d9183fe0fcc5dd2737a916803a7bfa434174" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Consume the merged remote-dev and coordinator observation improvements. Task MCP/CLI status now has a two-second cache with visible age and explicit refresh; library status remains fresh by default. SSH diagnostics report observed connection/remote execution phases and gather related OS/cwd/Python facts in one fixed read-only request.

The dated report records ten alternating Windows SSH pairs: three separate requests at median 13.768 seconds versus 4.601 seconds batched (67% lower), with matching facts. Three live diagnostic probes passed. Unobservable transfer time remains unknown. Cache tests verify zero managed-control calls on a hit, expiry, explicit refresh, busy nonblocking replies and ownership checks.

Owner PRs, including supported-platform CI, are merged: https://github.com/vllm-ascend-workspace/remote-dev/pull/9 and https://github.com/vllm-ascend-workspace/vaws-coordinator/pull/14. The workspace pins those tested production commits and documents consumption. No NPU execution is claimed.

Part of https://github.com/vllm-ascend-workspace/.github/issues/6.

Validation: 62 affected workspace tests and 17 subtests passed. The first hosted Linux run exposed a race in the local-test helper when a child disappeared between the signal probe and /proc read; the helper now handles both missing-process errors, with a Linux regression case. Six real child-process tests pass on Windows; hosted CI is rerunning on the repaired head.
