### PR TITLE
docs: add measured Windows cache and offline installation workflow

### DIFF
--- a/.agents/skills/repo-init/SKILL.md
+++ b/.agents/skills/repo-init/SKILL.md
@@ -38,7 +38,9 @@ installed package commands can use `uv run python` on either platform.
 3. Configure missing or explicitly requested forks/remotes with
    `repo_topology.py`. Do not rewrite established fetch/push settings.
 4. Run `uv sync` for package-dependent work and inspect capabilities with
-   `python3 .agents/scripts/vaws_deps.py doctor`.
+   `python3 .agents/scripts/vaws_deps.py doctor`. For Windows cache placement
+   or offline transfer, follow the linked installation recipe in
+   [Command recipes](references/command-recipes.md).
 5. For authorized broad init, run `.agents/scripts/knowledge_setup.py` and the
    selected client's `.agents/scripts/vaws_client_setup.py --apply` entry.
    A read-only knowledge setup can use `--read-only`; it does not require NPU

--- a/.agents/skills/repo-init/references/command-recipes.md
+++ b/.agents/skills/repo-init/references/command-recipes.md
@@ -108,6 +108,20 @@ python3 .agents/scripts/vaws_deps.py sync
 is a separate service. See
 [docs/dependency-plane.md](../../../../docs/dependency-plane.md).
 
+Windows PowerShell, using a cache on the workspace filesystem:
+
+```powershell
+$cachePath = Join-Path (Get-Location).Path '.vaws-local\uv-cache'
+uv sync --locked --group dev --cache-dir $cachePath --link-mode hardlink
+if ($LASTEXITCODE -ne 0) { throw 'Dependency installation failed' }
+& .\.venv\Scripts\python.exe .agents/scripts/vaws_deps.py doctor
+```
+
+For offline preparation, exact tool/lock checks and restoring a transferred
+cache, use [Windows installation](../../../../docs/windows-installation.md).
+Keep the default knowledge package installed; cache placement does not require
+changing machine identity, forks or native client settings.
+
 ## Quiet main comparison
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ is the archive for dated evidence.
 
 ## Current contracts
 
+- [windows-installation.md](windows-installation.md) — PowerShell setup, same-filesystem uv cache and verified offline transfer.
 - [local-tests.md](local-tests.md) — local test progress, subprocess lifetime, retained evidence and validated retries.
 - [runtime-feedback-design.md](runtime-feedback-design.md) — real-machine progress, loaded runtime identity, state projection, compact output and connection diagnostics.
 - [README.md](README.md) — this index.
@@ -26,6 +27,7 @@ is the archive for dated evidence.
 
 ## Dated validation evidence
 
+- [installation-feedback-2026-09-11.md](installation-feedback-2026-09-11.md) — fresh/cached Windows installation timings, cache relocation and dependency extras decision.
 - [observation-feedback-2026-09-11.md](observation-feedback-2026-09-11.md) — SSH batching/timing evidence and status freshness behavior.
 - [cli-feedback-2026-09-11.md](cli-feedback-2026-09-11.md) — paired Windows CLI startup measurements and parser side-effect checks.
 - [windows-validation-2026-09-11.md](windows-validation-2026-09-11.md) — completed Windows non-NPU validation, repairs, limits and a proposed experience-optimization sequence.

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -446,7 +446,7 @@ option.
 | `.agents/scripts/tracked_path_check.py` | argparse | - | 6 | docs:1, other:1, policy:1, test:2 | mechanics | supported | .agents/scripts/tracked_path_check.py | vaws lint |
 | `.agents/scripts/vaws.py` | argparse | status, env, hook, task-server | 1 | docs:2, other:1, policy:1, routing:1, test:4 | mechanics | supported | .agents/scripts/vaws.py | vaws task |
 | `.agents/scripts/vaws_client_setup.py` | argparse | - | 5 | docs:4, policy:1, script:1, skill-doc:2, test:3 | mechanics | supported | .agents/scripts/vaws_client_setup.py | vaws workspace |
-| `.agents/scripts/vaws_deps.py` | argparse | status, doctor, sync | 1 | docs:3, other:1, policy:1, routing:3, script:1, skill-doc:4, test:2 | mechanics | supported | .agents/scripts/vaws_deps.py | vaws workspace |
+| `.agents/scripts/vaws_deps.py` | argparse | status, doctor, sync | 1 | docs:4, other:1, policy:1, routing:3, script:1, skill-doc:4, test:2 | mechanics | supported | .agents/scripts/vaws_deps.py | vaws workspace |
 | `.agents/scripts/workspace_identity.py` | argparse | summary, ensure, validate-alias, set-alias, decline-alias | 1 | skill-doc:1 | mechanics | supported | .agents/scripts/workspace_identity.py | vaws workspace |
 | `.agents/scripts/workspace_profile.py` | argparse | summary, validate, ensure | 4 | routing:1, script:1, skill-doc:4 | mechanics | supported | .agents/scripts/workspace_profile.py | vaws workspace |
 | `.agents/skills/ascend-memory-profiling/scripts/mem_analyze.py` | argparse | - | 1 | skill-doc:1 | mixed | supported | .agents/skills/ascend-memory-profiling/scripts/mem_analyze.py | vaws profile |

--- a/docs/dependency-plane.md
+++ b/docs/dependency-plane.md
@@ -10,21 +10,23 @@ import.
 ## Packages
 
 `pyproject.toml` declares the three in-process packages. `[tool.uv.sources]`
-must name git+https tag sources because `vaws-coordinator` depends on
+names public git+https sources because `vaws-coordinator` depends on
 `vaws-remote-dev`, which is not on PyPI.
 
-| Package | Module | Source tag | Role |
+| Package | Module | Required version | Role |
 |---|---|---|---|
-| `vaws-remote-dev` | `remote_dev` | `0.5.1` at `c24a64a` | process-in import + MCP server |
-| `vaws-coordinator` | `vaws_coordinator` | `0.3.2` at `8e67391` | process-in import + stdio MCP |
-| `vaws-knowledge` | `vaws_knowledge` | `0.3.2` at `41363d3` | process-in import + MCP |
+| `vaws-remote-dev` | `remote_dev` | from `pyproject.toml` | process-in import + MCP server |
+| `vaws-coordinator` | `vaws_coordinator` | from `pyproject.toml` | process-in import + stdio MCP |
+| `vaws-knowledge` | `vaws_knowledge` | from `pyproject.toml` | process-in import + MCP |
 | `vaws-top` | — | uvx only | fleet dashboard; not imported |
 
 `uv sync` writes `.venv` and records the resolved git commits in `uv.lock`.
 CI runs `uv lock --check`. Do not copy those SHAs into workflows.
 
-The workspace consumes these release tags through the lockfile. Acceptance
-uses the installed packages, including their public APIs and packaged data.
+Sources may select release tags or validated commit revisions; `uv.lock`
+records their resolved commits. Read exact installed/locked identities through
+`vaws_deps.py status` instead of maintaining a second SHA table. Acceptance
+uses installed packages, including their public APIs and packaged data.
 
 ## Loader
 
@@ -75,8 +77,19 @@ Equivalent form that creates the environment first:
 uv run python3 .agents/scripts/vaws_deps.py doctor
 ```
 
+On Windows PowerShell, use `uv run python` or the environment directly:
+
+```powershell
+& .\.venv\Scripts\python.exe .agents/scripts/vaws_deps.py doctor
+```
+
+The [Windows installation guide](windows-installation.md) includes a
+same-filesystem cache and a verified offline transfer recipe. It preserves
+the full default package set.
+
 System `python3` cannot see `.venv`. Entry scripts re-exec
-`.venv/bin/python` when a sentinel package is missing and the venv exists.
+`.venv/bin/python` (POSIX) or `.venv/Scripts/python.exe` (Windows) when a
+sentinel package is missing and the venv exists.
 `VAWS_SKIP_VENV_REEXEC=1` disables the hop. A missing `.venv` is an error
 whose remedy is `uv sync`.
 

--- a/docs/installation-feedback-2026-09-11.md
+++ b/docs/installation-feedback-2026-09-11.md
@@ -1,0 +1,97 @@
+Status: 2026-09-11 validation evidence
+
+# Windows installation feedback
+
+The measured bottleneck after downloading was installing many small files.
+Using a cache on the environment's filesystem reduced fresh cached installs
+from 25.56–26.11 seconds in copy mode to 8.20–8.92 seconds with hardlinks.
+The [PowerShell installation guide](windows-installation.md) makes that
+configuration and an offline transfer workflow explicit without changing
+global cache policy or removing default knowledge capabilities.
+
+## Conditions and measurements
+
+One Windows x64 machine, PowerShell, Python 3.13.12 and uv 0.10.7. Every run
+created a fresh environment with `uv sync --locked --group dev`; warm runs
+added `--offline --no-python-downloads`. The dependency inputs were workspace
+commit `5bac5d8612cc7bb15fdf3e50c31ec9ff88dfd073`, copied into an isolated
+source directory. Each environment installed 176 packages.
+
+| Cache state | Link mode | Network policy | Wall time |
+|---|---|---|---:|
+| Empty dedicated cache | copy | online | 38.37 s |
+| Populated cache, first pair | copy | offline | 26.11 s |
+| Populated cache, first pair | hardlink | offline | 8.92 s |
+| Populated cache, reverse pair | hardlink | offline | 8.20 s |
+| Populated cache, reverse pair | copy | offline | 25.56 s |
+
+The cache and environments were on the same local filesystem. Explicit
+`--link-mode copy` measured the copy algorithm; this was **not** a direct
+cross-drive benchmark. Copy/hardlink order was reversed once to expose a
+simple order effect. Two warm samples per mode support the observed range,
+not a population percentile or a universal performance promise. The cold
+sample includes network/build time and is not a fully cold OS-cache trial.
+
+The dedicated cache contained 56,521 files and 704,731,332 logical bytes
+(672.1 MiB). A fresh environment contained 55,645 files and approximately
+665.8 MiB of logical data. Hardlinks share file data; adding these logical
+sizes does not measure physical disk usage.
+
+## Offline transfer and final dependency verification
+
+The whole dedicated cache was copied to a different directory with native
+PowerShell. No symlinks or junctions were found in the original. After its uv
+operations completed, `uv cache clean` removed that task's original cache.
+The relocated cache then created another fresh environment offline in
+8.88 seconds, with no original-cache fallback. The cache copy itself took
+33.01 seconds; transfer cost must be counted when preparing a bundle.
+
+After the observation improvements, the final dependency inputs from workspace
+commit `c7c7e24f029d05ad91bcc7c75daec55717eab83d` were verified separately:
+the two changed owner commits were added to the relocated cache online, then
+a fresh offline environment installed all 176 packages in **8.54 seconds**.
+This confirms the final lock, rather than only the earlier measurement lock.
+
+Both offline environments passed five checks: imports of remote-dev,
+coordinator, knowledge and OpenViking; each of the three package CLI help
+commands; and workspace doctor with `outcome: success`. The import check
+denied Python socket connect/DNS events and observed none. The child HOME
+and runtime-state directories were isolated, and workspace venv re-execution
+was disabled so the checks could not silently use the original environment.
+
+This validates cache relocation and environment reconstruction on the same
+Windows machine. A second physical machine, Python installation on an empty
+OS, different platform, vaws-top deployment, knowledge Release downloads and
+NPU service execution were not part of this experiment. Raw measurements,
+logs and dependency footprints are retained locally under untracked
+`.vaws-local/experience-optimization/`; no endpoint or user identity is needed
+in this public report.
+
+## Dependency extras decision
+
+The largest installed distributions, from their recorded files, were:
+
+| Distribution | Files | Logical MiB |
+|---|---:|---:|
+| volcengine-python-sdk | 26,385 | 190.7 |
+| openviking | 1,375 | 81.2 |
+| litellm | 2,999 | 53.8 |
+| numpy | 949 | 40.1 |
+| onnxruntime | 326 | 40.0 |
+| babel | 1,122 | 29.5 |
+| lark-oapi | 10,734 | 20.3 |
+
+The locked inverted dependency tree places the Volcengine SDK under
+`vaws-knowledge -> openviking[ark]`, and lark-oapi under OpenViking. These are
+package-owner dependency choices. Moving the entire knowledge package behind
+a workspace extra would remove a default capability; it would not selectively
+trim those integrations. Keep the complete default dependency set for this
+change. Any future minimal package profile belongs with the knowledge owner
+and needs separate capability and offline acceptance evidence. The measured
+hardlink workflow already improves cached installation without that behavior
+change.
+
+The cache/filesystem and offline-option behavior is documented by
+[uv cache concepts](https://docs.astral.sh/uv/concepts/cache/) and
+[uv CLI options](https://docs.astral.sh/uv/reference/cli/). Measurements above
+come from this workspace's local experiment.

--- a/docs/windows-installation.md
+++ b/docs/windows-installation.md
@@ -1,0 +1,106 @@
+Status: current
+
+# Windows installation and offline transfer
+
+Run these PowerShell commands from the workspace root. Install Windows x64
+Python, uv and Git first. The validated combination is Python 3.13.12 and uv
+0.10.7; the project supports other Python versions, but a prepared cache must
+be validated again for another platform, interpreter or uv version. See the
+[installation measurements](installation-feedback-2026-09-11.md).
+
+## Online installation with a cache on the workspace drive
+
+```powershell
+$workspaceRoot = (Get-Location).Path
+$cachePath = Join-Path $workspaceRoot '.vaws-local\uv-cache'
+uv sync --locked --group dev --python 3.13 --no-python-downloads --cache-dir $cachePath --link-mode hardlink
+if ($LASTEXITCODE -ne 0) { throw 'Dependency installation failed' }
+& .\.venv\Scripts\python.exe .agents/scripts/vaws_deps.py doctor
+if ($LASTEXITCODE -ne 0) { throw 'Dependency inspection failed' }
+```
+
+`--cache-dir` applies to this command. Keep using the same cache path on later
+syncs. A local cache on the same filesystem as `.venv` permits hardlinks;
+cross-filesystem installations fall back to copying. This matters when the
+workspace is on a different drive from the default user cache. A junction or
+mounted directory can still cross filesystems despite sharing a drive letter.
+Use `--link-mode copy` when the destination filesystem cannot hardlink.
+No global uv settings need to change. See
+[uv cache location](https://docs.astral.sh/uv/concepts/cache/#cache-directory)
+and [uv sync options](https://docs.astral.sh/uv/reference/cli/#uv-sync).
+
+`--group dev` includes the local test dependencies. Omitting it does not remove
+the three required runtime packages or the default knowledge capability.
+`--no-python-downloads` makes a missing interpreter visible immediately; install
+Python before continuing.
+
+## Prepare an offline bundle while online
+
+First complete the online sync above for the exact checkout and target Python.
+Wait for all uv operations using this cache to finish before copying it.
+Create a new bundle directory; copy the entire cache without changing its
+internal files. The manifest records the lock and tool combination.
+
+```powershell
+$bundlePath = Join-Path $workspaceRoot ('.vaws-local\offline-bundle-' + (Get-Date -Format 'yyyyMMdd-HHmmss'))
+if (Test-Path -LiteralPath $bundlePath) { throw 'Choose a new bundle directory' }
+New-Item -ItemType Directory -Path $bundlePath -ErrorAction Stop | Out-Null
+Copy-Item -LiteralPath $cachePath -Destination (Join-Path $bundlePath 'uv-cache') -Recurse -Force -ErrorAction Stop
+$pythonIdentity = & .\.venv\Scripts\python.exe -c 'import platform, sysconfig; print(platform.python_version(), sysconfig.get_platform())'
+if ($LASTEXITCODE -ne 0) { throw 'Cannot read Python identity' }
+$manifest = [ordered]@{
+    uv = (uv --version)
+    python = $pythonIdentity
+    pyproject_sha256 = (Get-FileHash -LiteralPath 'pyproject.toml' -Algorithm SHA256).Hash
+    lock_sha256 = (Get-FileHash -LiteralPath 'uv.lock' -Algorithm SHA256).Hash
+}
+$manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $bundlePath 'manifest.json') -Encoding utf8 -ErrorAction Stop
+$bundlePath
+```
+
+Transfer that bundle and the matching workspace checkout separately. Prepare
+the Python/uv/Git installers while online if the destination lacks them. Do not
+copy `.venv` as the installation: recreate it from the lock and cache. The
+bundle does not include model weights, remote containers, shared knowledge
+Release downloads or the separate vaws-top service. Those have their own
+preparation and storage requirements. Native client configuration belongs to
+the destination machine; see [repo-init](../.agents/skills/repo-init/SKILL.md).
+
+## Recreate the environment offline
+
+Open PowerShell at the matching destination checkout and set the bundle path
+to the directory you transferred. The following checks prevent accidentally
+using a bundle prepared for a different lock or interpreter. Use a new local
+cache directory instead of merging files into an active uv cache.
+
+```powershell
+$workspaceRoot = (Get-Location).Path
+$bundlePath = Read-Host 'Path to the transferred offline bundle'
+$manifest = Get-Content -LiteralPath (Join-Path $bundlePath 'manifest.json') -Raw -ErrorAction Stop | ConvertFrom-Json
+if ((uv --version) -ne $manifest.uv) { throw 'Install the uv version recorded in manifest.json' }
+$pythonIdentity = py -3.13 -c 'import platform, sysconfig; print(platform.python_version(), sysconfig.get_platform())'
+if ($LASTEXITCODE -ne 0) { throw 'Install the prepared Python interpreter first' }
+if ($pythonIdentity -ne $manifest.python) { throw 'Python version or platform differs from the prepared cache' }
+if ((Get-FileHash -LiteralPath 'pyproject.toml' -Algorithm SHA256).Hash -ne $manifest.pyproject_sha256) { throw 'pyproject.toml differs from the bundle' }
+if ((Get-FileHash -LiteralPath 'uv.lock' -Algorithm SHA256).Hash -ne $manifest.lock_sha256) { throw 'uv.lock differs from the bundle' }
+$cachePath = Join-Path $workspaceRoot ('.vaws-local\offline-cache-' + (Get-Date -Format 'yyyyMMdd-HHmmss'))
+if (Test-Path -LiteralPath $cachePath) { throw 'Choose a new cache directory' }
+New-Item -ItemType Directory -Path (Split-Path -Parent $cachePath) -Force -ErrorAction Stop | Out-Null
+Copy-Item -LiteralPath (Join-Path $bundlePath 'uv-cache') -Destination $cachePath -Recurse -Force -ErrorAction Stop
+uv sync --locked --group dev --python 3.13 --offline --no-python-downloads --cache-dir $cachePath --link-mode hardlink
+if ($LASTEXITCODE -ne 0) { throw 'Offline sync failed; retain the output and prepare the missing cache entries online' }
+& .\.venv\Scripts\python.exe .agents/scripts/vaws_deps.py doctor
+if ($LASTEXITCODE -ne 0) { throw 'Dependency inspection failed' }
+```
+
+The `py` command assumes the Windows Python launcher is installed; an explicit
+path to the same interpreter can replace it. `--offline` limits uv to local and
+cached data. A failure means the bundle, interpreter or selected dependencies
+are incomplete; prepare those on a connected machine with the same lock and
+retry. A changed lock needs a new prepared cache. Preserve the failed output.
+
+Inspect the doctor's JSON `outcome` and individual capabilities. Successful
+package installation does not prove remote access or NPU execution. A missing
+optional fleet monitor may appear separately from the installed packages.
+Use `uv cache clean --cache-dir $cachePath` only when intentionally discarding
+that cache; do not manually alter uv's internal cache layout.


### PR DESCRIPTION
Document a PowerShell installation workflow that keeps the uv cache on the environment's filesystem and reconstructs an offline environment from a transferred cache. The recipe checks Python/uv identity and dependency-file hashes, preserves the full default knowledge capability, and states what the bundle does not prepare.

Fresh Windows cached installs took 25.56–26.11 seconds in copy mode and 8.20–8.92 seconds with hardlinks. A relocated cache worked after the original task cache was cleaned. The final workspace lock installed 176 packages offline in 8.54 seconds and passed package imports, three package CLI help checks and doctor. The report records sample limits, transfer cost and the dependency extras decision. No second-machine or NPU execution is claimed.

Update the dependency contract's stale source-tag table, repo-init references, documentation index and generated CLI reference counts together. Default dependencies and global uv configuration are unchanged.

Validation: 67 affected tests and 28 subtests passed; all three PowerShell blocks parse; skill projections, catalog, tracked-path and leak guards passed with no new findings. The complete offline reconstruction and package checks are recorded in the dated report.

Completes the installation phase of https://github.com/vllm-ascend-workspace/.github/issues/6.
