### PR TITLE
Narrow skill activation and validate managed serving lifecycle

### DIFF
--- a/.agents/lib/vaws_session_state.py
+++ b/.agents/lib/vaws_session_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import os
 import re
@@ -52,8 +53,11 @@ def task_dir(task_id: str, repo_root: Path = ROOT) -> Path:
     return task_state_root(repo_root) / require_task_id(task_id)
 
 
-def serving_state_path(task_id: str, repo_root: Path = ROOT) -> Path:
-    return task_dir(task_id, repo_root) / "serving.json"
+def serving_state_path(task_id: str, repo_root: Path = ROOT, *, service: str = "vllm") -> Path:
+    if not isinstance(service, str) or not service.strip():
+        raise SessionStateError("service must be a nonempty string")
+    digest = hashlib.sha256(service.encode("utf-8")).hexdigest()
+    return task_dir(task_id, repo_root) / "serving" / f"{digest}.json"
 
 
 def benchmark_dir(task_id: str, repo_root: Path = ROOT) -> Path:
@@ -81,13 +85,16 @@ def load_json_object(path: Path) -> dict[str, Any]:
     return data
 
 
-def load_serving_state(task_id: str, *, repo_root: Path = ROOT) -> dict[str, Any] | None:
+def load_serving_state(task_id: str, *, service: str = "vllm", repo_root: Path = ROOT) -> dict[str, Any] | None:
     """Human business launch config. Not an execution recovery receipt."""
-    path = serving_state_path(task_id, repo_root)
+    path = serving_state_path(task_id, repo_root, service=service)
     if not path.exists():
-        return None
+        path = task_dir(task_id, repo_root) / "serving.json"
+        if not path.exists():
+            return None
     try:
-        return load_json_object(path)
+        data = load_json_object(path)
+        return data if data.get("service", "vllm") == service else None
     except SessionStateError as exc:
         raise SessionStateError(
             f"serving report is unreadable: {path} ({exc}); inspect the running "
@@ -96,7 +103,7 @@ def load_serving_state(task_id: str, *, repo_root: Path = ROOT) -> dict[str, Any
 
 
 def save_serving_state(task_id: str, data: dict[str, Any], *, repo_root: Path = ROOT) -> Path:
-    path = serving_state_path(task_id, repo_root)
+    path = serving_state_path(task_id, repo_root, service=data.get("service", "vllm"))
     _atomic_write_json(path, data)
     return path
 

--- a/.agents/lib/vaws_task_target.py
+++ b/.agents/lib/vaws_task_target.py
@@ -5,8 +5,6 @@ This is not a request ledger, allocator, or recovery manager.
 from __future__ import annotations
 
 import argparse
-import os
-from pathlib import Path
 from typing import Any
 
 DONE = frozenset({"succeeded", "failed", "timeout", "cancelled", "inconclusive"})
@@ -31,13 +29,12 @@ class TaskTargetError(RuntimeError):
 
 
 def resolve_context_file(explicit: str | None = None) -> str:
-    filename = (explicit or os.environ.get("VAWS_CONTEXT_FILE") or "").strip()
-    if not filename:
-        raise TaskTargetError(
-            "VAWS context is required; pass --context-file or set VAWS_CONTEXT_FILE "
-            "from the native session hook. Do not guess the task from cwd or history."
-        )
-    return str(Path(filename).expanduser().resolve())
+    from vaws_coordinator.agent_session import load_context
+
+    try:
+        return load_context(explicit or "")["context_file"]
+    except ValueError as exc:
+        raise TaskTargetError(str(exc)) from exc
 
 
 def task_client(context_file: str | None = None, **kwargs: Any) -> Any:

--- a/.agents/skills/ascend-memory-profiling/SKILL.md
+++ b/.agents/skills/ascend-memory-profiling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ascend-memory-profiling
-description: Profile and attribute HBM memory usage on Ascend NPU for vLLM serving scenarios. Breaks down memory into fixed overhead, model weights, KV cache, HCCL buffers, activations, and runtime, with traceable evidence chains. Use for requests like "分析显存占用", "显存 profiling", "HBM 用了多少", "内存各部分拆分". Do not use for performance profiling (kernel timing, throughput), offline inference, or non-Ascend hardware.
+description: Attribute vLLM serving HBM usage on Ascend to weights, KV cache, HCCL, activations and runtime using measured evidence. Use for 显存归因, 显存 profiling, or 内存各部分拆分. A quick current memory-usage or idle-card lookup uses the fleet monitor; kernel latency analysis uses profiling-analysis.
 ---
 
 # ascend-memory-profiling

--- a/.agents/skills/ascend-memory-profiling/scripts/_common.py
+++ b/.agents/skills/ascend-memory-profiling/scripts/_common.py
@@ -103,11 +103,11 @@ def selected_python(target: dict[str, Any]) -> str:
 def load_serving_state(
     task_id: str,
     *,
+    service: str = "vllm",
     state_repo_root: Path = ROOT,
 ) -> dict[str, Any] | None:
     """Read the serving skill's persisted receipt for a task."""
-    del state_repo_root
-    return load_task_serving_state(task_id)
+    return load_task_serving_state(task_id, service=service, repo_root=state_repo_root)
 
 
 def get_machine_alias(machine: dict[str, Any]) -> str:

--- a/.agents/skills/ascend-memory-profiling/scripts/mem_collect.py
+++ b/.agents/skills/ascend-memory-profiling/scripts/mem_collect.py
@@ -385,7 +385,7 @@ def collect_weight_manifest(ep: SshEndpoint, python: str, model_path: str, local
 
 def _resolve_attach_state(args: argparse.Namespace, target: dict) -> dict:
     """Merge coordinator facts with optional local business launch config."""
-    report = load_serving_state(args.session_id) or {}
+    report = load_serving_state(args.session_id, service=args.service) or {}
     live = bool(target.get("live"))
     return {
         **report,

--- a/.agents/skills/ascend-profiling-analysis/SKILL.md
+++ b/.agents/skills/ascend-profiling-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ascend-profiling-analysis
-description: Analyze Ascend NPU torch profiler output (kernel_details.csv / trace_view.json / op_summary / communication.json) for one or many profiling roots and produce a traceable report (rank/step/layer/operator summary, cross-rank alignment, diagnosis findings, report.md / report.xlsx / report.html with single-step inspectors, bubble tracing axes, and zoomable Chrome-tracing-style timelines). Use for requests like "分析 profiling", "解析这份 kernel_details", "看 step/layer 切分", "跨 rank 对齐", "通信慢/EP 不均/快慢卡", "生成 profiling 报告". Do not use for HBM/显存归因 (use ascend-memory-profiling), service lifecycle (use vllm-ascend-serving), benchmarks (use vllm-ascend-benchmark), or采集 profiling 数据 (use ascend-profiling-collection).
+description: Analyze existing Ascend profiler databases, kernel_details.csv, traces or communication summaries for step, layer, operator and cross-rank timing. Use when profiler data is available and timing analysis or a profiling report is requested. New trace collection uses profiling-collection; a slow-service report without traces does not by itself select this analyzer.
 ---
 
 # ascend-profiling-analysis

--- a/.agents/skills/npu-fleet-monitor/scripts/manage_monitor.py
+++ b/.agents/skills/npu-fleet-monitor/scripts/manage_monitor.py
@@ -41,7 +41,7 @@ VAWS_TOP_REPO = "vllm-ascend-workspace/vaws-top"
 VAWS_TOP_SKILL_PATH = ".agents/skills/vaws-top/SKILL.md"
 # Single version constant: the release tag. The wheel filename below is derived
 # from it so the tag and the wheel version cannot drift apart.
-VAWS_TOP_REF = "v0.1.1"
+VAWS_TOP_REF = "v0.1.2"
 VAWS_TOP_VERSION = VAWS_TOP_REF.removeprefix("v")
 # The console script is named after the repository and the import package uses
 # underscores; derive both so the only literal naming the extracted project is
@@ -94,8 +94,14 @@ def consumer_env(
     inherited = dict(os.environ) if inherited is None else inherited
     shared_root = shared_workspace_root(repo_root)
     host_pool = shared_root / "hosts.txt"
+    from vaws_coordinator.machine_directory import MACHINES_FILENAME
+    from vaws_coordinator.state_paths import agent_sessions_root, coordinator_state_dir
+
+    coordinator_inventory = coordinator_state_dir(agent_sessions_root(repo_root)) / MACHINES_FILENAME
+    default_inventory = (coordinator_inventory if coordinator_inventory.is_file()
+                         else shared_inventory_path(repo_root))
     defaults = {
-        "NFM_INVENTORY_FILES": str(shared_inventory_path(repo_root)),
+        "NFM_INVENTORY_FILES": str(default_inventory),
         "NFM_HOST_POOL_FILES": str(host_pool) if host_pool.is_file() else "",
         "NFM_BOOTSTRAP_COMMAND": "",
     }

--- a/.agents/skills/npu-fleet-monitor/tests/test_manage_monitor.py
+++ b/.agents/skills/npu-fleet-monitor/tests/test_manage_monitor.py
@@ -125,6 +125,17 @@ class EnvironmentTests(unittest.TestCase):
         self.assertEqual(env["NFM_INVENTORY_FILES"], "/flag/a.json")
         self.assertEqual(env["NFM_BOOTSTRAP_COMMAND"], "env-cmd {host}")
 
+    def test_consumer_env_reuses_registered_coordinator_inventory(self) -> None:
+        from vaws_coordinator.machine_directory import MACHINES_FILENAME
+        from vaws_coordinator.state_paths import agent_sessions_root, coordinator_state_dir
+        with tempfile.TemporaryDirectory() as root:
+            repo = Path(root)
+            inventory = coordinator_state_dir(agent_sessions_root(repo)) / MACHINES_FILENAME
+            inventory.parent.mkdir(parents=True)
+            inventory.write_text('{"machines": []}', encoding="utf-8")
+            env = MODULE.consumer_env(namespace(), repo_root=repo, inherited={})
+            self.assertEqual(env["NFM_INVENTORY_FILES"], str(inventory))
+
     def test_consumer_env_normalizes_path_lists_and_rejects_newlines(self) -> None:
         with tempfile.TemporaryDirectory() as root:
             repo = Path(root)

--- a/.agents/skills/vllm-ascend-benchmark/SKILL.md
+++ b/.agents/skills/vllm-ascend-benchmark/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vllm-ascend-benchmark
-description: Run vLLM online-serving benchmarks on a workspace-managed remote container. Use for requests like "跑个 benchmark", "对比性能", "压测一下", "测下吞吐", or "看下有没有性能回退". Do not use for accuracy tests, nightly CI matrix runs, offline inference, or service-only lifecycle.
+description: Measure throughput and latency of a vLLM online service with a specified workload, including request-rate and concurrency sweeps. Use for 跑 benchmark, 压测, or 测吞吐. Code baseline-versus-candidate comparisons and performance regression decisions use vllm-ascend-performance-regression; accuracy and service lifecycle have separate workflows.
 ---
 
 # vllm-ascend-benchmark

--- a/.agents/skills/vllm-ascend-change-validation/SKILL.md
+++ b/.agents/skills/vllm-ascend-change-validation/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: vllm-ascend-change-validation
-description: Analyze vLLM and vllm-ascend diffs, map affected components to the minimum sufficient correctness, build, performance, graph, operator, distributed, and profiling evidence, link downstream Run Manifest results, and produce a PR-ready validation report. Use for PR validation, workspace-diff risk analysis, deciding what tests a change requires, or documenting untested combinations. Do not use as a replacement for the downstream execution skills or for a change with no accessible diff.
+description: Consolidate executed vLLM or vllm-ascend change validation into a report tied to an accessible diff and Run Manifest evidence. Use when asked to validate a change experimentally or produce a formal validation report. Ordinary PR reading, code review, diff explanation, and test suggestions use native code and Git tools.
 ---
 
 # vllm-ascend-change-validation
 
 Map an accessible diff to the minimum evidence needed for a reviewable validation conclusion.
+
+Use this workflow when the requested result needs experiment evidence or a
+formal validation report. A request to read or review a PR, explain a change,
+or suggest tests can be completed directly without this workflow. A report
+alone requires no runtime, task allocation or new experiment.
 
 Read the changed behavior and affected callers before choosing tests. Build, numerical, graph, distributed and performance evidence cover different failure modes. Existing evidence is reusable when its observed code states and scope match the diff.
 

--- a/.agents/skills/vllm-ascend-change-validation/agents/openai.yaml
+++ b/.agents/skills/vllm-ascend-change-validation/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
   display_name: vLLM Ascend Change Validation
-  short_description: Map code changes to evidence-backed validation plans
-  default_prompt: Use $vllm-ascend-change-validation to map an accessible diff to
-    the minimum evidence needed for a reviewable validation conclusion.
+  short_description: Consolidate experimental evidence for a code change
+  default_prompt: Use $vllm-ascend-change-validation to produce a validation
+    report from an accessible diff and relevant experiment evidence.

--- a/.agents/skills/vllm-ascend-correctness-validation/SKILL.md
+++ b/.agents/skills/vllm-ascend-correctness-validation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vllm-ascend-correctness-validation
-description: Plan, execute, normalize, and compare vLLM Ascend inference correctness across baseline and candidate code states, eager and graph modes, offline generate or chat, online chat completions, and AISBench task metrics. Use for accuracy validation, token-output comparison, graph-versus-eager checks, deterministic regression testing, or failure classification. Do not use to root-cause an already reproduced graph-only or isolated-operator failure, or for throughput benchmarking, HBM attribution, or profiling-only analysis.
+description: Run and compare vLLM Ascend inference outputs or accuracy metrics across code states, eager/graph modes, or serving configurations. Use for token comparison, numerical regression checks, and AISBench accuracy evaluation. An already reproduced graph, operator or distributed failure uses its debug workflow; ordinary unit tests and code review use native tools.
 ---
 
 # vllm-ascend-correctness-validation

--- a/.agents/skills/vllm-ascend-serving/SKILL.md
+++ b/.agents/skills/vllm-ascend-serving/SKILL.md
@@ -20,6 +20,13 @@ python .agents/skills/vllm-ascend-serving/scripts/serving.py start --model /mode
 
 Use serving.py status or serving.py stop with --execution-id or --service. A service reference is resolved by coordinator within the current task. Pending states retain their execution reference. Restart or release follows the requested lifecycle; no separate allocation, parity command or status ledger is needed.
 
+Start follows preparation and HTTP/models/first-token readiness within
+--health-timeout. Use --no-wait when an immediate execution receipt is wanted.
+After a bounded wait, continue with the same reference. Codex local commands
+can resolve their actual native thread identity through the coordinator when
+the hook has not exported VAWS_CONTEXT_FILE; other clients supply their native
+context explicitly.
+
 Use pd-serving for prefill/decode topology, benchmark for measurement, and profiling-collection for profiler-window control.
 
 Read the relevant detail only when needed:

--- a/.agents/skills/vllm-ascend-serving/references/behavior.md
+++ b/.agents/skills/vllm-ascend-serving/references/behavior.md
@@ -2,6 +2,16 @@
 
 Start, inspect or stop one managed single-node vLLM Ascend service.
 
+Start uses one bounded wait across preparation, launch and HTTP/models/first-token
+readiness. --health-timeout sets that budget; --no-wait returns the coordinator
+receipt immediately. A pending timeout retains the execution reference and is
+not a readiness result. Status and stop resolve that same task-owned reference.
+Preparation-step changes appear in progress. A terminal start reads its owned
+log tail once and includes the import or runtime exception in the result.
+Business launch settings are saved per service name after admission succeeds.
+Relaunching one named service cannot reuse another service's model or options;
+a rejected change leaves the previous settings available.
+
 Use serving.py status or serving.py stop with --execution-id or --service. A service reference is resolved by coordinator within the current task. Pending states retain their execution reference. Restart or release follows the requested lifecycle; no separate allocation, parity command or status ledger is needed.
 
 Reuse the native task context and actual business source bindings. Choose model, parallelism and serving options from the request. Resource state and HTTP/models/first-token readiness are separate observations.
@@ -12,3 +22,10 @@ Progress is written to stderr; stdout contains the structured result. Remote
 device execution uses coordinator ownership. Local report construction does not
 allocate devices or alter an execution. Reports describe the supplied evidence;
 missing evidence is not a passing result.
+
+If an import failure comes from a version-conditional plugin branch after a
+snapshot install, compare the bound source's release identity with the reported
+installed version. A verified release may require the plugin's `VLLM_VERSION`
+compatibility setting in `--extra-env`; record that choice in the execution.
+Do not infer a release from a model name or change package metadata to conceal
+a source/runtime mismatch.

--- a/.agents/skills/vllm-ascend-serving/scripts/_serving_start.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/_serving_start.py
@@ -300,7 +300,28 @@ def diagnose_env_failure(stderr_tail: str) -> dict[str, Any] | None:
     matched = [tag for pattern, tag in _ENV_ERROR_PATTERNS if pattern in stderr_tail or re.search(pattern, stderr_tail)]
     if not matched:
         return None
-    return {"error_tags": sorted(set(matched)), "cause": "remote Python package version mismatch"}
+    return {"error_tags": sorted(set(matched)), "cause": "remote Python import or runtime initialization failed"}
+
+
+def startup_failure_details(client, execution_id: str | None) -> dict[str, Any]:
+    if not execution_id:
+        return {}
+    try:
+        tail = client.observe(execution_id, "tail")
+    except Exception:
+        return {}
+    text = "\n".join(str(tail.get(key) or "") for key in ("stdout", "stderr"))
+    if not text.strip():
+        text = str(tail.get("tail") or "")
+    errors = re.findall(r"\b[A-Z]\w*(?:Error|Exception):[^\r\n]+", text)
+    imports = [line for line in errors if line.startswith(("ModuleNotFoundError:", "ImportError:"))]
+    details: dict[str, Any] = {}
+    if errors:
+        details["log_error"] = (imports or errors)[-1][-1000:]
+    diagnosis = diagnose_env_failure(text)
+    if diagnosis:
+        details["env_diagnosis"] = diagnosis
+    return details
 
 
 def merge_with_previous(previous: dict[str, Any], **overrides: Any) -> dict[str, Any]:
@@ -343,6 +364,25 @@ def classify_run_state(state: str) -> str:
     return "pending"
 
 
+def wait_for_launch(client, reply: dict[str, Any], deadline: float) -> dict[str, Any]:
+    """Follow the submitted execution through preparation using its owner."""
+    execution_id = reply.get("execution_id")
+    last_progress = None
+    while execution_id and classify_run_state(str(reply.get("state") or "")) == "pending":
+        state = reply.get("state")
+        step = (reply.get("progress") or {}).get("step")
+        current = (state, step)
+        if current != last_progress:
+            emit_progress("prepare", str(step or state), state=state, execution_id=execution_id)
+            last_progress = current
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return {**reply, "wait_timed_out": True}
+        reply = client.wait(execution_id, until="running",
+                            timeout_seconds=min(15, remaining), poll_interval=2)
+    return reply
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
     parser.add_argument("--context-file")
@@ -359,6 +399,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--relaunch", action="store_true", help="replace a live named service (TaskClient restart=True)")
     parser.add_argument("--port", type=int)
     parser.add_argument("--health-timeout", type=int, default=DEFAULT_HEALTH_TIMEOUT)
+    parser.add_argument("--no-wait", action="store_true",
+                        help="return the execution receipt without waiting for launch or HTTP readiness")
     parser.add_argument("--wrap-script", default="")
     parser.add_argument("--npu-count", type=int)
     parser.add_argument("--recipe", help="named coordinator environment recipe")
@@ -420,7 +462,7 @@ def main(argv: list[str] | None = None) -> int:
             })
         client = task_client(args.context_file)
         task_id = task_id_of(client)
-        previous = load_serving_state(task_id)
+        previous = load_serving_state(task_id, service=args.service)
         if args.relaunch:
             if previous is None:
                 print_json({"status": "needs_input", "error": "no previous business config to relaunch"})
@@ -480,7 +522,7 @@ def main(argv: list[str] | None = None) -> int:
             wrap_script=wrap_script,
             expected_vllm=str((preset or {}).get("vllm_version") or ""),
         )
-        write_business_report(task_id, {
+        business_report = {
             "model": model,
             "served_model_name": served_model_name,
             "tp": tp,
@@ -493,7 +535,7 @@ def main(argv: list[str] | None = None) -> int:
             "recipe": args.recipe,
             "python_abi": args.python_abi,
             "cann": args.cann,
-        })
+        }
         if device_list and args.npu_count is not None:
             print_json({
                 "status": "needs_input",
@@ -514,6 +556,7 @@ def main(argv: list[str] | None = None) -> int:
             preset=preset,
         )
         emit_progress("launch", "submitting managed vLLM execution")
+        deadline = time.monotonic() + args.health_timeout
         reply = run_command(
             client,
             command,
@@ -528,6 +571,9 @@ def main(argv: list[str] | None = None) -> int:
             service=args.service,
             restart=bool(args.relaunch),
         )
+        write_business_report(task_id, business_report)
+        if not args.no_wait:
+            reply = wait_for_launch(client, reply, deadline)
         state = str(reply.get("state") or "")
         kind = classify_run_state(state)
         execution_id = reply.get("execution_id")
@@ -543,15 +589,19 @@ def main(argv: list[str] | None = None) -> int:
             "devices": devices,
             **execution_summary(reply),
         }
-        if kind == "pending":
+        if kind == "pending" or (args.no_wait and kind == "running"):
             output["status"] = state
-            output["running"] = False
+            output["running"] = kind == "running"
             output["ready"] = False
+            if reply.get("wait_timed_out"):
+                output["wait_timed_out"] = True
+                output["error"] = "startup wait timed out; use status with the same service or execution reference"
             print_json(output)
             return 0
         if kind == "terminal":
             output["status"] = "failed"
-            output["error"] = reply.get("reason") or reply.get("error") or f"execution ended in {state}"
+            output.update(startup_failure_details(client, execution_id))
+            output["error"] = reply.get("reason") or reply.get("error") or output.get("log_error") or f"execution ended in {state}"
             print_json(output)
             return 1
         port = service_port_of(reply)
@@ -578,7 +628,7 @@ def main(argv: list[str] | None = None) -> int:
 
         emit_progress("probe", f"waiting for ready (timeout={args.health_timeout}s)")
         readiness = wait_for_ready(
-            endpoint, port, args.health_timeout, served_model_name,
+            endpoint, port, max(0, deadline - time.monotonic()), served_model_name,
             still_running=still_running, log_text=log_text,
         )
         output["port"] = port

--- a/.agents/skills/vllm-ascend-serving/tests/test_serving_identity.py
+++ b/.agents/skills/vllm-ascend-serving/tests/test_serving_identity.py
@@ -72,6 +72,50 @@ class ServeCommandTests(unittest.TestCase):
 
 
 class QueuedStatusTests(unittest.TestCase):
+    def test_rejected_start_keeps_previous_business_settings(self):
+        client = SimpleNamespace(run=mock.Mock(side_effect=ValueError("service has different options")))
+        with mock.patch.object(serve_start, "task_client", return_value=client), mock.patch.object(serve_start, "task_id_of", return_value="task-1"), mock.patch.object(serve_start, "load_serving_state", return_value=None), mock.patch.object(serve_start, "save_serving_state") as save, mock.patch.object(serve_start, "load_workspace_identity", return_value=None), mock.patch.object(serve_start, "effective_workspace_alias", return_value=None), mock.patch.object(serve_start, "print_json"):
+            rc = serve_start.main(["--model", "/data/m", "--service", "one"])
+        self.assertEqual(rc, 2)
+        save.assert_not_called()
+
+    def test_terminal_start_reports_the_import_cause_without_http_probe(self):
+        client = SimpleNamespace(
+            run=mock.Mock(return_value={"state": "failed", "execution_id": "one", "resources_released": True}),
+            observe=mock.Mock(return_value={"stdout": "ModuleNotFoundError: No module named 'vllm.example'",
+                                           "stderr": "RuntimeError: Engine core initialization failed"}),
+        )
+        with mock.patch.object(serve_start, "task_client", return_value=client), mock.patch.object(serve_start, "task_id_of", return_value="task-1"), mock.patch.object(serve_start, "load_serving_state", return_value=None), mock.patch.object(serve_start, "save_serving_state"), mock.patch.object(serve_start, "load_workspace_identity", return_value=None), mock.patch.object(serve_start, "effective_workspace_alias", return_value=None), mock.patch.object(serve_start, "wait_for_ready") as probe, mock.patch.object(serve_start, "print_json") as printed:
+            rc = serve_start.main(["--model", "/data/m"])
+        self.assertEqual(rc, 1)
+        self.assertIn("No module named 'vllm.example'", printed.call_args.args[0]["error"])
+        self.assertTrue(printed.call_args.args[0]["resources_released"])
+        client.observe.assert_called_once_with("one", "tail")
+        probe.assert_not_called()
+
+    def test_launch_wait_follows_the_same_execution_until_running(self):
+        client = SimpleNamespace(wait=mock.Mock(side_effect=[
+            {"state": "preparing", "execution_id": "one", "wait_timed_out": True},
+            {"state": "running", "execution_id": "one", "service_port": 8001},
+        ]))
+        with mock.patch.object(serve_start.time, "monotonic", return_value=10):
+            result = serve_start.wait_for_launch(client, {"state": "queued", "execution_id": "one"}, 30)
+        self.assertEqual(result["state"], "running")
+        self.assertEqual(client.wait.call_count, 2)
+        self.assertTrue(all(call.args == ("one",) for call in client.wait.call_args_list))
+
+    def test_launch_wait_returns_terminal_failure_or_bounded_pending(self):
+        client = SimpleNamespace(wait=mock.Mock(return_value={"state": "failed", "execution_id": "one"}))
+        with mock.patch.object(serve_start.time, "monotonic", return_value=10):
+            failed = serve_start.wait_for_launch(client, {"state": "preparing", "execution_id": "one"}, 30)
+        self.assertEqual(failed["state"], "failed")
+        client.wait.reset_mock()
+        with mock.patch.object(serve_start.time, "monotonic", return_value=30):
+            pending = serve_start.wait_for_launch(client, {"state": "queued", "execution_id": "one"}, 30)
+        self.assertTrue(pending["wait_timed_out"])
+        self.assertEqual(pending["execution_id"], "one")
+        client.wait.assert_not_called()
+
     def test_start_preserves_pending_phase_without_port_probe(self):
         captured: dict = {}
 
@@ -85,7 +129,7 @@ class QueuedStatusTests(unittest.TestCase):
             observe=mock.Mock(side_effect=AssertionError("must not probe queued work")),
         )
         with tempfile.TemporaryDirectory() as tmp, mock.patch.object(serve_start, "task_client", return_value=client), mock.patch.object(serve_start, "task_id_of", return_value="task-1"), mock.patch.object(serve_start, "load_serving_state", return_value=None), mock.patch.object(serve_start, "save_serving_state"), mock.patch.object(serve_start, "load_workspace_identity", return_value=None), mock.patch.object(serve_start, "effective_workspace_alias", return_value=None), mock.patch.object(serve_start, "print_json") as printed:
-            rc = serve_start.main(["--model", "/data/m"])
+            rc = serve_start.main(["--model", "/data/m", "--no-wait"])
         self.assertEqual(rc, 0)
         payload = printed.call_args[0][0]
         self.assertEqual(payload["status"], "waiting_for_runtime")
@@ -119,7 +163,7 @@ class QueuedStatusTests(unittest.TestCase):
             "extra_args": [],
         }
         with mock.patch.object(serve_start, "task_client", return_value=client), mock.patch.object(serve_start, "task_id_of", return_value="task-1"), mock.patch.object(serve_start, "load_serving_state", return_value=previous), mock.patch.object(serve_start, "save_serving_state"), mock.patch.object(serve_start, "load_workspace_identity", return_value=None), mock.patch.object(serve_start, "effective_workspace_alias", return_value=None), mock.patch.object(serve_start, "print_json"):
-            rc = serve_start.main(["--relaunch"])
+            rc = serve_start.main(["--relaunch", "--no-wait"])
         self.assertEqual(rc, 0)
         self.assertTrue(captured["restart"])
         self.assertEqual(captured["resources"]["npu_count"], 2)
@@ -150,7 +194,7 @@ class QueuedStatusTests(unittest.TestCase):
             observe=mock.Mock(side_effect=AssertionError("must not probe preparing work")),
         )
         with tempfile.TemporaryDirectory() as tmp, mock.patch.object(serve_start, "task_client", return_value=client), mock.patch.object(serve_start, "task_id_of", return_value="task-1"), mock.patch.object(serve_start, "load_serving_state", return_value=None), mock.patch.object(serve_start, "save_serving_state"), mock.patch.object(serve_start, "load_workspace_identity", return_value=None), mock.patch.object(serve_start, "effective_workspace_alias", return_value=None), mock.patch.object(serve_start, "print_json") as printed:
-            rc = serve_start.main(["--model", "/data/m"])
+            rc = serve_start.main(["--model", "/data/m", "--no-wait"])
         self.assertEqual(rc, 0)
         payload = printed.call_args[0][0]
         self.assertEqual(payload["status"], "preparing")

--- a/.agents/tests/test_serving_business_state.py
+++ b/.agents/tests/test_serving_business_state.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import sys
+
+LIB = Path(__file__).resolve().parents[1] / "lib"
+sys.path.insert(0, str(LIB))
+
+from vaws_session_state import load_serving_state, save_serving_state
+
+
+def test_service_settings_do_not_cross_names_or_escape_task_root(tmp_path):
+    task = "vaws-business-test"
+    first = {"service": "a/b", "model": "model-one", "tp": 1}
+    second = {"service": "a-b", "model": "model-two", "tp": 2}
+    paths = [save_serving_state(task, row, repo_root=tmp_path) for row in (first, second)]
+    assert paths[0] != paths[1]
+    assert all(path.is_relative_to(tmp_path / ".vaws-local" / "tasks" / task) for path in paths)
+    assert load_serving_state(task, service="a/b", repo_root=tmp_path) == first
+    assert load_serving_state(task, service="a-b", repo_root=tmp_path) == second
+    assert load_serving_state(task, service="missing", repo_root=tmp_path) is None

--- a/.agents/tests/test_skill_envelope_adoption.py
+++ b/.agents/tests/test_skill_envelope_adoption.py
@@ -36,7 +36,8 @@ def _validate_tracked_schema(envelope: dict) -> None:
 
 
 def _run(script: Path, *args: str) -> subprocess.CompletedProcess[str]:
-    env = {key: value for key, value in os.environ.items() if key != "VAWS_CONTEXT_FILE"}
+    env = {key: value for key, value in os.environ.items()
+           if key not in {"VAWS_CONTEXT_FILE", "CODEX_THREAD_ID", "CODEX_SESSION_ID"}}
     return subprocess.run(
         [sys.executable, str(script), "status", *args],
         capture_output=True,

--- a/.claude/skills/ascend-memory-profiling/SKILL.md
+++ b/.claude/skills/ascend-memory-profiling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "ascend-memory-profiling"
-description: "Profile and attribute HBM memory usage on Ascend NPU for vLLM serving scenarios. Breaks down memory into fixed overhead, model weights, KV cache, HCCL buffers, activations, and runtime, with traceable evidence chains. Use for requests like \"分析显存占用\", \"显存 profiling\", \"HBM 用了多少\", \"内存各部分拆分\". Do not use for performance profiling (kernel timing, throughput), offline inference, or non-Ascend hardware."
+description: "Attribute vLLM serving HBM usage on Ascend to weights, KV cache, HCCL, activations and runtime using measured evidence. Use for 显存归因, 显存 profiling, or 内存各部分拆分. A quick current memory-usage or idle-card lookup uses the fleet monitor; kernel latency analysis uses profiling-analysis."
 ---
 
 <!-- Generated from .agents/skills/ascend-memory-profiling/SKILL.md. Do not edit. -->

--- a/.claude/skills/ascend-profiling-analysis/SKILL.md
+++ b/.claude/skills/ascend-profiling-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "ascend-profiling-analysis"
-description: "Analyze Ascend NPU torch profiler output (kernel_details.csv / trace_view.json / op_summary / communication.json) for one or many profiling roots and produce a traceable report (rank/step/layer/operator summary, cross-rank alignment, diagnosis findings, report.md / report.xlsx / report.html with single-step inspectors, bubble tracing axes, and zoomable Chrome-tracing-style timelines). Use for requests like \"分析 profiling\", \"解析这份 kernel_details\", \"看 step/layer 切分\", \"跨 rank 对齐\", \"通信慢/EP 不均/快慢卡\", \"生成 profiling 报告\". Do not use for HBM/显存归因 (use ascend-memory-profiling), service lifecycle (use vllm-ascend-serving), benchmarks (use vllm-ascend-benchmark), or采集 profiling 数据 (use ascend-profiling-collection)."
+description: "Analyze existing Ascend profiler databases, kernel_details.csv, traces or communication summaries for step, layer, operator and cross-rank timing. Use when profiler data is available and timing analysis or a profiling report is requested. New trace collection uses profiling-collection; a slow-service report without traces does not by itself select this analyzer."
 ---
 
 <!-- Generated from .agents/skills/ascend-profiling-analysis/SKILL.md. Do not edit. -->

--- a/.claude/skills/vllm-ascend-benchmark/SKILL.md
+++ b/.claude/skills/vllm-ascend-benchmark/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "vllm-ascend-benchmark"
-description: "Run vLLM online-serving benchmarks on a workspace-managed remote container. Use for requests like \"跑个 benchmark\", \"对比性能\", \"压测一下\", \"测下吞吐\", or \"看下有没有性能回退\". Do not use for accuracy tests, nightly CI matrix runs, offline inference, or service-only lifecycle."
+description: "Measure throughput and latency of a vLLM online service with a specified workload, including request-rate and concurrency sweeps. Use for 跑 benchmark, 压测, or 测吞吐. Code baseline-versus-candidate comparisons and performance regression decisions use vllm-ascend-performance-regression; accuracy and service lifecycle have separate workflows."
 ---
 
 <!-- Generated from .agents/skills/vllm-ascend-benchmark/SKILL.md. Do not edit. -->

--- a/.claude/skills/vllm-ascend-change-validation/SKILL.md
+++ b/.claude/skills/vllm-ascend-change-validation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "vllm-ascend-change-validation"
-description: "Analyze vLLM and vllm-ascend diffs, map affected components to the minimum sufficient correctness, build, performance, graph, operator, distributed, and profiling evidence, link downstream Run Manifest results, and produce a PR-ready validation report. Use for PR validation, workspace-diff risk analysis, deciding what tests a change requires, or documenting untested combinations. Do not use as a replacement for the downstream execution skills or for a change with no accessible diff."
+description: "Consolidate executed vLLM or vllm-ascend change validation into a report tied to an accessible diff and Run Manifest evidence. Use when asked to validate a change experimentally or produce a formal validation report. Ordinary PR reading, code review, diff explanation, and test suggestions use native code and Git tools."
 ---
 
 <!-- Generated from .agents/skills/vllm-ascend-change-validation/SKILL.md. Do not edit. -->

--- a/.claude/skills/vllm-ascend-correctness-validation/SKILL.md
+++ b/.claude/skills/vllm-ascend-correctness-validation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "vllm-ascend-correctness-validation"
-description: "Plan, execute, normalize, and compare vLLM Ascend inference correctness across baseline and candidate code states, eager and graph modes, offline generate or chat, online chat completions, and AISBench task metrics. Use for accuracy validation, token-output comparison, graph-versus-eager checks, deterministic regression testing, or failure classification. Do not use to root-cause an already reproduced graph-only or isolated-operator failure, or for throughput benchmarking, HBM attribution, or profiling-only analysis."
+description: "Run and compare vLLM Ascend inference outputs or accuracy metrics across code states, eager/graph modes, or serving configurations. Use for token comparison, numerical regression checks, and AISBench accuracy evaluation. An already reproduced graph, operator or distributed failure uses its debug workflow; ordinary unit tests and code review use native tools."
 ---
 
 <!-- Generated from .agents/skills/vllm-ascend-correctness-validation/SKILL.md. Do not edit. -->

--- a/README.en.md
+++ b/README.en.md
@@ -41,13 +41,13 @@ The workspace owns project materials, client wiring and business skills. `remote
 | **npu-fleet-monitor**  | Build, start, inspect, or stop the local NPU dashboard from the standalone vaws-top repository | When continuously monitoring fleet resources and history  |
 | **modelscope**       | Download, resume, status-check, and SHA256-verify ModelScope model weights                  | When model weights need to be downloaded into an explicit local directory |
 | **vllm-ascend-serving** | Launch a vLLM Ascend inference service on a remote container, through coordinator-owned execution | When you need an inference service on a remote machine |
-| **vllm-ascend-benchmark** | Run `vllm bench serve` performance benchmarks on a remote container, with multi-run warmup and statistical aggregation | When you need throughput/latency benchmarks or performance regression checks |
+| **vllm-ascend-benchmark** | Run `vllm bench serve` performance benchmarks on a remote container, with multi-run warmup and statistical aggregation | When measuring throughput/latency; use performance-regression for code comparisons |
 | **ascend-memory-profiling** | Profile and attribute HBM memory usage on Ascend NPU, with per-component breakdown and evidence chains | When you need to analyze memory consumption of a vLLM serving workload |
 | **ascend-profiling-collection** | Collect Ascend torch-profiler data: start service, bracket profile window, run workload, remote analyse, and write a manifest | When you need kernel_details/trace_view captures |
 | **ascend-profiling-analysis** | Analyze collected profiler roots/manifests and generate step/layer/operator/cross-rank reports | When you need to analyze profiling output |
 | **vllm-ascend-graph-debug** | Diagnose graph compile, capture, replay, and graph/eager correctness divergence | When graph mode fails or diverges from eager mode |
 | **vllm-ascend-correctness-validation** | Compare baseline/candidate, eager/graph, offline/online, and AISBench correctness | When validating accuracy or normalized outputs |
-| **vllm-ascend-change-validation** | Derive validation plans from code diffs and aggregate PR evidence | When validating a workspace change or PR |
+| **vllm-ascend-change-validation** | Consolidate experimental validation evidence against a code diff | For experimental validation or formal reports; ordinary PR reading/review uses native tools |
 | **vllm-ascend-performance-regression** | Run alternating A/B experiments and assess variance and regression thresholds | When deciding whether throughput or latency regressed |
 | **vllm-ascend-distributed-debug** | Diagnose topology, endpoint, collective, and per-rank distributed failures | When a failure depends on ranks, nodes, or parallel topology |
 | **ascend-tensor-dump** | Capture bounded intermediate tensor dumps and locate the first divergent stage, in eager or graph mode | When output is wrong or two configurations disagree and the divergence must be localized |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Agent 按任务选择工具或技能；执行引用、状态推进和报告由�
 | **ascend-profiling-analysis** | 分析已采集的 profiler root/manifest，生成 step/layer/operator/cross-rank 诊断报告 | 需要分析 profiling 结果或生成报告时 |
 | **vllm-ascend-graph-debug** | 定位图编译、捕获、重放及 graph/eager 正确性分歧 | 图模式失败或与 eager 结果不一致时 |
 | **vllm-ascend-correctness-validation** | 对比 baseline/candidate、eager/graph、离线/在线和 AISBench 正确性 | 需要精度验证或输出对拍时 |
-| **vllm-ascend-change-validation** | 根据代码 diff 生成验证计划并汇总证据和 PR 报告 | 验证工作区变更或 PR 时 |
+| **vllm-ascend-change-validation** | 对照代码 diff 汇总已执行的验证证据和报告 | 需要实验验证或正式验证报告时；普通 PR 阅读和 review 直接使用原生工具 |
 | **vllm-ascend-performance-regression** | 运行交替 A/B 实验并分析波动和回退阈值 | 判断吞吐或延迟是否回退时 |
 | **vllm-ascend-distributed-debug** | 从拓扑、端点、collective 和逐 rank 事件诊断分布式故障 | 故障依赖多卡、多机或 rank 时 |
 | **ascend-tensor-dump** | 有界采集中间张量并定位首个数值分叉的 stage，覆盖 eager 与图模式 | 输出错误或两个配置结果不一致，需要定位到层、stage 或单算子时 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ is the archive for dated evidence.
 
 ## Dated validation evidence
 
+- [workflow-usability-validation-2026-09-11.md](workflow-usability-validation-2026-09-11.md) — skill boundary audit, bounded service startup, source reuse and real four-host fleet lifecycle observations.
 - [agent-only-validation-2026-09-11.md](agent-only-validation-2026-09-11.md) — Agent-only entry consolidation and Windows PowerShell/WSL acceptance, including corrections and hardware limits.
 - [installation-feedback-2026-09-11.md](installation-feedback-2026-09-11.md) — fresh/cached Windows installation timings, cache relocation and dependency extras decision.
 - [observation-feedback-2026-09-11.md](observation-feedback-2026-09-11.md) — SSH batching/timing evidence and status freshness behavior.

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -40,7 +40,7 @@ by tests rather than repeated as instructions in every task.
 | `.agents/scripts/sync_claude_skills.py` | argparse | - | 1 | mirror:2, other:1, policy:1, routing:1, skill-doc:1, test:2 | mechanics | supported | .agents/scripts/sync_claude_skills.py | vaws lint |
 | `.agents/scripts/tracked_leak_scan.py` | argparse | - | 10 | docs:1, hook:1, other:1, policy:1, script:1, test:3 | mechanics | supported | .agents/scripts/tracked_leak_scan.py | vaws lint |
 | `.agents/scripts/tracked_path_check.py` | argparse | - | 6 | docs:1, other:1, policy:1, test:2 | mechanics | supported | .agents/scripts/tracked_path_check.py | vaws lint |
-| `.agents/scripts/vaws.py` | argparse | status, env, hook, task-server | 1 | docs:2, other:1, policy:1, routing:1, test:4 | mechanics | supported | .agents/scripts/vaws.py | vaws task |
+| `.agents/scripts/vaws.py` | argparse | status, env, hook, task-server | 1 | docs:1, other:1, policy:1, routing:1, test:4 | mechanics | supported | .agents/scripts/vaws.py | vaws task |
 | `.agents/scripts/vaws_client_setup.py` | argparse | - | 5 | docs:4, policy:1, script:1, skill-doc:2, test:3 | mechanics | supported | .agents/scripts/vaws_client_setup.py | vaws workspace |
 | `.agents/scripts/vaws_deps.py` | argparse | status, doctor, sync | 1 | client-config:1, docs:8, other:1, policy:1, routing:1, script:4, skill-doc:4, test:7 | mechanics | supported | .agents/scripts/vaws_deps.py | vaws workspace |
 | `.agents/scripts/workspace_identity.py` | argparse | summary, ensure, validate-alias, set-alias, decline-alias | 1 | skill-doc:1 | mechanics | supported | .agents/scripts/workspace_identity.py | vaws workspace |

--- a/docs/coordinator-consumption.md
+++ b/docs/coordinator-consumption.md
@@ -10,14 +10,13 @@ own request association, and does not tick the pool.
 
 See [target-state.md](target-state.md) and [dependency-plane.md](dependency-plane.md).
 
-The closeout candidate is checked with a local editable package. The
-published tag and lock update are parent-owned.
-
 ## 1. Public actions
 
 Configure clients with `python3 .agents/scripts/vaws_client_setup.py`.
 The native hook supplies `context_file`; never guess the task from cwd or
-history.
+history. For local Codex commands, the package can also resolve the actual
+`CODEX_THREAD_ID` when the hook did not export `VAWS_CONTEXT_FILE`. Conflicting
+native IDs fail explicitly. MCP callers still supply their attachment context.
 
 | Tool | Meaning |
 |---|---|
@@ -27,7 +26,7 @@ history.
 | `vaws_finish` | Close admission; stop owned executions; keep container, roots, evidence |
 
 Task MCP/CLI status may reuse a snapshot for two seconds. Use `refresh: true`
-or `vaws.py execution --refresh` for a new observation. Compact results retain
+or `python -m vaws_coordinator.vaws execution --refresh` for a new observation. Compact results retain
 `observation_freshness` (snapshot completion time, age, source and deferred
 refresh) plus per-role sampling times. Busy executions return immediately
 with the cached observation and mark refresh as deferred. Python
@@ -35,8 +34,8 @@ with the cached observation and mark refresh as deferred. Python
 These observations do not grant resource access. Tail, target and stop keep
 their existing behavior.
 
-CLI: `python3 .agents/scripts/vaws.py session|run|execution|finish` execs
-`python -m vaws_coordinator.vaws`. MCP: `python -m vaws_coordinator task-server`.
+Package CLI: `python -m vaws_coordinator.vaws session|run|execution|finish`.
+MCP: `python -m vaws_coordinator task-server`.
 
 A long-running service uses `timeout_seconds=None`, `resources.service_port=0`
 (or an explicit port), and a task-scoped business name (`service`). The same
@@ -44,6 +43,8 @@ spec reconnects; a changed spec without `restart=True` is an error. `--relaunch`
 is `restart=True`. Status reads package facts. Health/first-token are skill
 business checks against the returned endpoint and port once the execution is
 actually running.
+The serving entry follows preparation and readiness within one
+`--health-timeout`; `--no-wait` returns the execution receipt immediately.
 
 Container hostname `/etc/hosts` repair is coordinator environment preparation,
 not a per-model launch snippet.
@@ -106,7 +107,7 @@ A multi-role PD launch uses `topology={"roles": [{"name", "command",
 is literal data. The package reserves the full group before any role starts
 and returns per-role `target` / `tail` on `observe(..., role=...)` and on
 `roles[]`. Unmatched environment constraints stay `waiting_for_runtime`. CLI:
-`python3 .agents/scripts/vaws.py session|run|execution|finish`. MCP:
+`python -m vaws_coordinator.vaws session|run|execution|finish`. MCP:
 `python -m vaws_coordinator task-server`.
 
 ## 5. Source publication to an explicit endpoint

--- a/docs/npu-fleet-monitor.md
+++ b/docs/npu-fleet-monitor.md
@@ -9,12 +9,12 @@ Status: current
 所有调用都固定为 GitHub Release wheel：
 
 ```bash
-uvx --from "https://github.com/vllm-ascend-workspace/vaws-top/releases/download/v0.1.1/vaws_top-0.1.1-py3-none-any.whl" vaws-top <子命令>
+uvx --from "https://github.com/vllm-ascend-workspace/vaws-top/releases/download/v0.1.2/vaws_top-0.1.2-py3-none-any.whl" vaws-top <子命令>
 ```
 
 版本只有一个常量：`.agents/skills/npu-fleet-monitor/scripts/manage_monitor.py` 里的 `VAWS_TOP_REF`（tag），wheel 文件名和下载 URL 都从它派生，不会出现 tag 与 wheel 版本各写各的。升级监控就是改这一个常量。不再有依赖 pin 文件、本地 checkout、`npm` 构建或用户级服务单元。
 
-**为什么是 wheel 而不是 `git+https://…@v0.1.1`**：vaws-top 带 JS 前端，构建产物只存在于 Release wheel 里（`vaws_top/static` 不入库）。从 git 安装会在本机跑 hatch 构建 hook，需要 Node.js 22.13+；机器上没有 Node 时它会**静默**构建出一个没有前端的 wheel，直到 `serve` 才报错。这一条只针对 vaws-top；其余纯 Python 的外部包继续用 `git+tag`。
+**为什么是 wheel 而不是 `git+https://…@v0.1.2`**：vaws-top 带 JS 前端，构建产物只存在于 Release wheel 里（`vaws_top/static` 不入库）。从 git 安装会在本机跑 hatch 构建 hook，需要 Node.js 22.13+；机器上没有 Node 时它会**静默**构建出一个没有前端的 wheel，直到 `serve` 才报错。这一条只针对 vaws-top；其余纯 Python 的外部包继续用 `git+tag`。
 
 **运维契约**：vaws-top 发布新版本时必须把 wheel 上传为 Release 资产，否则本入口装不上监控。改 `VAWS_TOP_REF` 之前先确认对应 tag 的 Release 里有 `vaws_top-<版本>-py3-none-any.whl`。
 
@@ -34,7 +34,7 @@ python3 .agents/skills/npu-fleet-monitor/scripts/manage_monitor.py start    # �
 `start` 会：
 
 1. 以 `uvx --from <wheel> vaws-top serve --bind 127.0.0.1 --port 8788` 启动一个独立进程组，stdout/stderr 追加到 `serve.log`，pid、端口和 spec 写入 `serve.json`。
-2. 通过环境变量传入 `NFM_BIND=127.0.0.1`、`NFM_PORT`、`NFM_STATE_DIR`，以及消费者拥有的 `NFM_INVENTORY_FILES`、可选 `NFM_HOST_POOL_FILES`、`NFM_BOOTSTRAP_COMMAND`。优先级：显式 CLI 覆盖（`--inventory-files`、`--host-pool-files`、`--bootstrap-command`）> 调用者环境 > 脚手架默认（主 worktree 的 `.vaws-local/machine-inventory.json`、存在时的 `hosts.txt`）。容器准备属于 `python -m vaws_coordinator provision`，不是监控入口。
+2. 通过环境变量传入 `NFM_BIND=127.0.0.1`、`NFM_PORT`、`NFM_STATE_DIR`，以及消费者拥有的 `NFM_INVENTORY_FILES`、可选 `NFM_HOST_POOL_FILES`、`NFM_BOOTSTRAP_COMMAND`。优先级：显式 CLI 覆盖（`--inventory-files`、`--host-pool-files`、`--bootstrap-command`）> 调用者环境 > 默认（优先复用 coordinator 已登记的机器目录；未登记时读取主 worktree 的 `.vaws-local/machine-inventory.json`，以及存在时的 `hosts.txt`）。容器准备属于 `python -m vaws_coordinator provision`，不是监控入口。
 3. 绕过系统 HTTP 代理轮询 `http://127.0.0.1:8788/api/health`（`--wait-seconds`，默认 90 秒；进程提前退出时立即返回并附日志尾部），最终只在标准输出打印一条 JSON。
 
 若 `serve.json` 里的 pid 仍存活，`start` 直接报告现有实例（含它当时的 spec）而不重复启动。
@@ -65,7 +65,7 @@ python3 .agents/skills/npu-fleet-monitor/scripts/manage_monitor.py stop
 
 ## Agent 查询入口
 
-JSON 结果里的 `cli_prefix` 即上面的 `uvx` 命令前缀，`mcp_command` 是对应的 stdio MCP 命令（`… vaws-top mcp`，通过 `VAWS_TOP_URL` 指向 `http://127.0.0.1:8788`）。完整的 CLI/MCP 参数、`observation` 信封和高级选机指引见独立仓库 pinned tag 下的 [Agent CLI 与 MCP 文档](https://github.com/vllm-ascend-workspace/vaws-top/blob/v0.1.1/docs/agent-access.md) 与 [vaws-top Agent Skill](https://github.com/vllm-ascend-workspace/vaws-top/blob/v0.1.1/.agents/skills/vaws-top/SKILL.md)。
+JSON 结果里的 `cli_prefix` 即上面的 `uvx` 命令前缀，`mcp_command` 是对应的 stdio MCP 命令（`… vaws-top mcp`，通过 `VAWS_TOP_URL` 指向 `http://127.0.0.1:8788`）。完整的 CLI/MCP 参数、`observation` 信封和高级选机指引见独立仓库 pinned tag 下的 [Agent CLI 与 MCP 文档](https://github.com/vllm-ascend-workspace/vaws-top/blob/v0.1.2/docs/agent-access.md) 与 [vaws-top Agent Skill](https://github.com/vllm-ascend-workspace/vaws-top/blob/v0.1.2/.agents/skills/vaws-top/SKILL.md)。
 
 需要新增或准备远程用户容器时使用 `python -m vaws_coordinator provision`；项目用户名由 repo-init / workspace_profile 配置。监控服务本身不创建远程容器、不启动任务，也不占用 NPU lease。
 

--- a/docs/workflow-usability-validation-2026-09-11.md
+++ b/docs/workflow-usability-validation-2026-09-11.md
@@ -1,0 +1,144 @@
+# Workflow usability validation
+
+Status: dated evidence, 2026-09-11 to 2026-09-12
+
+This pass audited all 20 business skills and exercised managed execution on
+two available hosts in a four-host Ascend fleet. Two other hosts had observed
+workloads and were left available to their existing users. This is lifecycle
+and usability evidence, not a four-node inference or performance result.
+
+## Changes and ownership
+
+- Five overlapping descriptions were narrowed: change validation, correctness
+  validation, benchmark, profiling analysis and HBM attribution. Ordinary PR
+  reading, review and test suggestions can use native tools directly.
+- Serving start follows preparation, launch and HTTP/model/first-token checks
+  within one wait budget. It reports preparation-step changes; `--no-wait`
+  returns an execution reference immediately. Timeout retains that reference.
+- Business launch settings are isolated by service name and written only after
+  admission succeeds. Rejected changes retain the previous configuration.
+- Terminal startup results extract a bounded import/runtime exception from the
+  owned log tail. An import failure is not automatically called a version mismatch.
+- Coordinator resolves an actual Codex native identity when the local hook has
+  not exported its context. Ambiguous identities are rejected and MCP callers
+  still supply explicit context. No task identity comes from cwd or chat history.
+- Coordinator handles completed preparation failures as terminal failures,
+  checks build compatibility before installation and preserves POSIX remote
+  paths on Windows. Git long paths are enabled per operation without changing
+  user Git configuration.
+- Build attestation can use the latest completed installer log when successful
+  editable installation removed build caches. Missing or conflicting build
+  evidence remains an error. Default remote operation logs stay in local state.
+- Managed source materialization skips transport/reset only after checking the
+  exact remote snapshots and absence of tracked and nonignored untracked changes
+  under its existing lock. Runtime and allocation checks still run.
+- Fleet monitoring uses the coordinator inventory by default. The monitor
+  package fixes Windows SSH newline handling and closes SQLite reads reliably.
+
+Package changes: [monitor PR 5](https://github.com/vllm-ascend-workspace/vaws-top/pull/5),
+[coordinator PR 16](https://github.com/vllm-ascend-workspace/vaws-coordinator/pull/16),
+[coordinator PR 17](https://github.com/vllm-ascend-workspace/vaws-coordinator/pull/17),
+[coordinator PR 18](https://github.com/vllm-ascend-workspace/vaws-coordinator/pull/18).
+
+## Skill boundary review
+
+The following is a manual semantic review of positive and adjacent requests.
+It is not a measured model-routing accuracy result. Automatic skill invocation
+remains enabled; no additional mandatory router or confirmation step was added.
+The skill catalog and client projections are checked separately for consistency.
+
+| Skill | Example that selects it | Adjacent request and expected path |
+|---|---|---|
+| repo-init | 初始化工作区和客户端依赖 | 普通 Git pull uses native Git |
+| npu-fleet-monitor | 看四机空卡、启动监控 | Service allocation belongs to coordinator |
+| modelscope | 下载并校验模型权重 | Starting an installed model uses serving |
+| vllm-ascend-serving | 拉一个 TP=2 服务并检查首 token | PD topology uses pd-serving |
+| vllm-ascend-pd-serving | 拉起 prefill/decode 分离部署 | One colocated service uses serving |
+| vllm-ascend-benchmark | 测服务吞吐、扫并发 | Code A/B regression uses performance-regression |
+| vllm-ascend-performance-regression | 比较修改前后 TTFT 是否回退 | A single-state load test uses benchmark |
+| vllm-ascend-correctness-validation | 对比 eager/graph 输出 token | Ordinary unit tests use native tools |
+| vllm-ascend-change-validation | 汇总这个改动的实验验证报告 | Read/review a PR or suggest tests directly |
+| ascend-profiling-collection | 采一份 torch profiler 数据 | Existing traces use profiling-analysis |
+| ascend-profiling-analysis | 分析已有 DB 的跨 rank 时间线 | A slow-service complaint alone supplies no trace |
+| ascend-memory-profiling | 拆分权重、KV 和 HCCL 显存 | Current usage/idle-card lookup uses fleet observation |
+| vllm-ascend-graph-debug | eager 通过但 graph replay 卡死 | Initial correctness comparison uses correctness-validation |
+| vllm-ascend-distributed-debug | 多 rank HCCL 初始化挂住 | An isolated operator error uses operator-debug |
+| ascend-operator-debug | 一个 ACLNN 算子在特定 dtype 崩溃 | Whole-model graph localization uses graph-debug |
+| ascend-tensor-dump | 固定输入复现后定位首个中间张量差异 | Establish deterministic reproduction first |
+| ascend-triton-operator-development | 从 PyTorch 写第一个正确 kernel | An already correct kernel uses optimization |
+| ascend-triton-kernel-validation | 验证候选 kernel 的 shape/dtype 矩阵 | Implementing a missing kernel uses development |
+| ascend-triton-kernel-optimization | 优化已通过正确性的 kernel | Failed correctness returns to development/validation |
+| ascend-triton-workflow | 完整交付迁移、验证和优化 | A single scoped stage uses its owning skill |
+
+## Real managed scenarios
+
+Host aliases below omit private infrastructure identifiers. All device commands
+used coordinator ownership and existing user containers; fleet observations
+were never treated as device reservations.
+
+| Scenario | Observed result |
+|---|---|
+| Four-host discovery and monitor | All four endpoints observable after the Windows transport fix; hosts A and D had capacity, B and C had workloads |
+| Native context without exported context file | Local managed entry resolved this actual native task |
+| Host A, single NPU | `arange(8).sum()` returned 28; succeeded, quiet and released |
+| Host D, two NPUs | Both device results were 28; succeeded, quiet and released |
+| Host A, Qwen3-0.6B, TP=1 eager | Health, model discovery and first token succeeded through one start call |
+| Reconnect to the same named eager service | Same execution reference; no second service allocation |
+| Change live eager service to TP=2 without restart | Rejected; saved TP=1 configuration retained |
+| Unavailable requested machine type, two-second wait | Returned waiting state and same reference; no provisioning started; cancellation released it |
+| Initial version-conditional import failure | Original missing-module evidence retained; execution resources released |
+| Host A, Qwen3-0.6B, TP=2 graph | Health, model discovery and first token succeeded; owned logs explicitly recorded ACL graph replay |
+| Source reuse followed by explicit process failure | Exact clean-source shortcut observed; NPU sum returned 28, process exited with code 7, failed state and resource release confirmed |
+
+All 13 executions created during diagnosis and validation ended in terminal
+states with resource release confirmed. Both smoke services were stopped.
+
+The eager and TP=2 graph readiness loops took 132.4 and 118.6 seconds in these
+runs. Those are readiness-loop durations, not full cold-start times or
+comparable throughput/latency measurements. Graph capture sizes were 1, 2 and 4;
+the smoke service used max model length 512 and max sequences 4.
+
+The source checkout was verified as the v0.27.1 release while its installed
+snapshot SCM version caused the plugin to select an older import branch.
+Successful service runs recorded the plugin's `VLLM_VERSION=0.27.1` setting.
+This is a conditional compatibility setting for that verified source, not a
+new universal default or fabricated package version.
+
+Host D also exposed a completed native build whose profile lacked SoC metadata.
+The fix recovered the actual selection from completed build evidence. Recovery
+used the package's profile writer and registry after the failed execution was
+stopped; it did not manufacture a ready profile. A later managed dual-device
+execution then succeeded. This recovery is not evidence of a fresh unattended
+cold install after the fix.
+
+## Verification and limits
+
+Windows local tests covered all 58 discovered suites/files (1,587 JUnit cases,
+including subtests). Two failures were a stale generated CLI table and a
+missing-context fixture inheriting the newly supported native identity. Both
+were corrected and their affected tests rerun. Coordinator changes also had
+Windows and Linux package CI and focused source/build-evidence tests. The clean
+source probe was tested against real Git/Bash repositories on Windows and Linux,
+including tracked modifications and nonignored untracked files.
+The affected consumer checks on WSL/Linux passed 127 tests and 39 subtests, with
+one platform-specific skip. The Windows rerun covering both corrected fixtures
+and per-service settings passed 24 tests; repository guard tests passed 107 tests
+and 133 subtests.
+
+A concurrent remote-dev delivery advanced the final dependency combination to
+remote-dev 0.6.0 (`9ef9902`) and coordinator 0.3.3 (`b2ee686`), including the
+synchronous coordinator adapter. Both platform environments were synchronized.
+Affected consumer tests against those installed packages passed 145 tests and
+74 subtests on Windows, and 102 tests and 44 subtests on Linux (one skip each).
+Doctor passed and the restarted idle daemon reported the same loaded and
+installed commits. Earlier model lifecycle evidence above predates this last
+dependency update; it is not presented as a fresh model run on the final pins.
+A further managed single-NPU run on the final installed combination returned
+28, succeeded and released its resources; its source materialization also used
+the verified clean-snapshot shortcut.
+
+Raw receipts, logs and native execution references remain under untracked local
+state. Public reports contain no private endpoint, container or credential data.
+The observed model runs are smoke checks; no accuracy benchmark, sustained load
+test, HBM attribution, or multi-host collective test is claimed. User containers
+and unrelated workloads were preserved throughout.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ package = false
 
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "9ef9902f74475b4c7964ceb00ed7fb95a5cb922f" }
-vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "445ed2e1e431260420641492aadc9d86d38a56b3" }
+vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "b2ee6862e4d1aed17e91b9077a08adbece7fafaf" }
 vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "89c273b6f3bf184614ec2463d40f91e8f048d45b" }
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -4217,7 +4217,7 @@ wheels = [
 [[package]]
 name = "vaws-coordinator"
 version = "0.3.3"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=445ed2e1e431260420641492aadc9d86d38a56b3#445ed2e1e431260420641492aadc9d86d38a56b3" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=b2ee6862e4d1aed17e91b9077a08adbece7fafaf#b2ee6862e4d1aed17e91b9077a08adbece7fafaf" }
 dependencies = [
     { name = "vaws-remote-dev" },
 ]
@@ -4262,7 +4262,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pillow", specifier = ">=11" },
-    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=445ed2e1e431260420641492aadc9d86d38a56b3" },
+    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=b2ee6862e4d1aed17e91b9077a08adbece7fafaf" },
     { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=89c273b6f3bf184614ec2463d40f91e8f048d45b" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=9ef9902f74475b4c7964ceb00ed7fb95a5cb922f" },
 ]


### PR DESCRIPTION
Ordinary PR review and quick fleet observations could select experimental workflows, while serving start returned before preparation completed. This change narrows five overlapping skill descriptions and makes one serving start follow preparation and health/model/first-token readiness within its wait budget. Pending calls retain their execution reference; `--no-wait` returns immediately.

Named services keep separate business settings, rejected changes preserve the previous settings, and startup failures report a bounded exception from the owned log tail. Native task context and default monitor inventory are resolved through the owning packages. Consumer pins include the Windows monitor fixes, preparation/build-evidence fixes and verified clean-source reuse.

Validation covered all 20 skill boundaries by manual semantic review and real lifecycle scenarios on two available hosts in a four-host Ascend fleet: single- and dual-device computation, TP=1 eager and TP=2 ACL graph serving, reconnect, rejected configuration changes, unavailable-resource waiting, startup failure, explicit process failure and cleanup. All 13 executions are terminal with resources released, including a final single-device run after synchronizing the concurrent remote-dev 0.6 delivery. Private raw evidence stays untracked; the dated report records the scope and limitations.

Windows full local execution covered 58 suites/files and 1,587 JUnit cases. Two fixture/document failures were corrected and affected checks passed. WSL/Linux affected checks passed 127 tests and 39 subtests (one skip); Windows reruns passed 24 tests, with repository guard tests passing 107 tests and 133 subtests. Catalog/projection, boundary, path and leak checks passed. The boundary review does not claim a measured LLM misrouting rate.

After the final dependency update, installed-package consumer tests passed 145 tests and 74 subtests on Windows, and 102 tests and 44 subtests on Linux (one skip each). Doctor passed and loaded daemon commits match installed pins.

Runtime changes: vllm-ascend-workspace/vaws-top#5 and vllm-ascend-workspace/vaws-coordinator#16, vllm-ascend-workspace/vaws-coordinator#17, vllm-ascend-workspace/vaws-coordinator#18. Tracks vllm-ascend-workspace/.github#8.
