### PR TITLE
Support explicit single-card sharing in managed serving

### DIFF
--- a/.agents/lib/vaws_task_target.py
+++ b/.agents/lib/vaws_task_target.py
@@ -81,6 +81,7 @@ def service_resources(
     npu_count: int | None = None,
     devices: list[int] | None = None,
     service_port: int | None = 0,
+    allow_external_busy: bool = False,
 ) -> dict[str, Any]:
     """Preserve explicit resource requests for TaskClient.run validation."""
     resources: dict[str, Any] = {}
@@ -92,6 +93,8 @@ def service_resources(
         resources["npu_count"] = 1
     if service_port is not None:
         resources["service_port"] = service_port
+    if allow_external_busy:
+        resources["allow_external_busy"] = True
     return resources
 
 

--- a/.agents/skills/vllm-ascend-pd-serving/references/inputs.md
+++ b/.agents/skills/vllm-ascend-pd-serving/references/inputs.md
@@ -4,6 +4,10 @@ This is an illustrative configuration shape. Select cases and values for the
 actual task. The tool generates report metadata internally; observed output
 files are produced by the relevant execution or measurement harness.
 
+Each role parses its vLLM arguments when its managed process starts. The
+topology does not run a separate parse-only import before launch. Coordinator
+still owns group preparation, resource admission and execution cleanup.
+
 ```json
 {
   "group_id": "pd-group",

--- a/.agents/skills/vllm-ascend-pd-serving/scripts/pd_serving.py
+++ b/.agents/skills/vllm-ascend-pd-serving/scripts/pd_serving.py
@@ -164,7 +164,7 @@ def role_env(service: Mapping[str, Any]) -> dict[str, str]:
     return reject_reserved_env({str(k): str(v) for k, v in dict(service.get("env") or {}).items()})
 
 
-def role_shell_command(service: Mapping[str, Any], *, preflight_only=False) -> str:
+def role_shell_command(service: Mapping[str, Any]) -> str:
     extra = [str(item) for item in service.get("args") or []]
     return build_serve_command(
         model=str(service["model"]),
@@ -172,7 +172,6 @@ def role_shell_command(service: Mapping[str, Any], *, preflight_only=False) -> s
         tp=service.get("tp"),
         dp=service.get("dp"),
         extra_args=extra,
-        preflight_only=preflight_only,
     )
 
 
@@ -185,7 +184,6 @@ def topology_from_config(config: Mapping[str, Any]) -> dict[str, Any]:
             "name": str(service["name"]),
             "npu_count": npu_count,
             "command": role_shell_command(service),
-            "preflight": role_shell_command(service, preflight_only=True),
             "service_port": int(service["port"]) if service.get("port") is not None else 0,
         }
         env = role_env(service)

--- a/.agents/skills/vllm-ascend-pd-serving/tests/test_pd_serving.py
+++ b/.agents/skills/vllm-ascend-pd-serving/tests/test_pd_serving.py
@@ -90,8 +90,10 @@ class PdServingTests(unittest.TestCase):
         self.assertEqual(names, ["decode", "prefill"])
         for role in topology["roles"]:
             self.assertIn('"$VAWS_PYTHON"', role["command"])
+            self.assertIn("exec \"$VAWS_PYTHON\" -m vllm.entrypoints.cli.main serve", role["command"])
             self.assertIn("--kv-transfer-config", role["command"])
             self.assertEqual(role["npu_count"], 1)
+            self.assertNotIn("preflight", role)
 
     def test_role_env_is_topology_data_not_shell_json(self) -> None:
         cfg = config()

--- a/.agents/skills/vllm-ascend-serving/SKILL.md
+++ b/.agents/skills/vllm-ascend-serving/SKILL.md
@@ -28,6 +28,12 @@ context explicitly.
 
 Use pd-serving for prefill/decode topology, benchmark for measurement, and profiling-collection for profiler-window control.
 
+Use `--host` before `--` to select a coordinator placement host. When the user
+authorizes sharing an occupied card, pass one explicit `--devices` card and
+`--allow-external-busy` with TP1/DP1. Coordinator still owns the execution and
+lease. Relaunch preserves these settings; `--no-allow-external-busy` restores
+exclusive admission.
+
 Read the relevant detail only when needed:
 
 - [behavior](references/behavior.md)

--- a/.agents/skills/vllm-ascend-serving/references/behavior.md
+++ b/.agents/skills/vllm-ascend-serving/references/behavior.md
@@ -12,6 +12,17 @@ Business launch settings are saved per service name after admission succeeds.
 Relaunching one named service cannot reuse another service's model or options;
 a rejected change leaves the previous settings available.
 
+`--host` before the `--` separator selects the coordinator placement host;
+vLLM listening arguments belong after the separator. Explicitly authorized
+sharing uses `--allow-external-busy`, one `--devices` card and TP1/DP1. The
+coordinator keeps lease, owned process, port and release checks. The default
+requires an idle card. Host and sharing settings survive named relaunch;
+`--no-allow-external-busy` explicitly restores exclusive admission.
+
+The managed service process parses vLLM arguments once during startup. There
+is no extra remote import solely to parse the same arguments before launch.
+An argument or import failure is reported through the owned execution log.
+
 Use serving.py status or serving.py stop with --execution-id or --service. A service reference is resolved by coordinator within the current task. Pending states retain their execution reference. Restart or release follows the requested lifecycle; no separate allocation, parity command or status ledger is needed.
 
 Reuse the native task context and actual business source bindings. Choose model, parallelism and serving options from the request. Resource state and HTTP/models/first-token readiness are separate observations.

--- a/.agents/skills/vllm-ascend-serving/references/behavior.md
+++ b/.agents/skills/vllm-ascend-serving/references/behavior.md
@@ -18,6 +18,8 @@ sharing uses `--allow-external-busy`, one `--devices` card and TP1/DP1. The
 coordinator keeps lease, owned process, port and release checks. The default
 requires an idle card. Host and sharing settings survive named relaunch;
 `--no-allow-external-busy` explicitly restores exclusive admission.
+Shared mode takes TP/DP through the wrapper; extra parallel-size options and
+vLLM `--config` files are rejected so they cannot override the single-card request.
 
 The managed service process parses vLLM arguments once during startup. There
 is no extra remote import solely to parse the same arguments before launch.

--- a/.agents/skills/vllm-ascend-serving/references/command-recipes.md
+++ b/.agents/skills/vllm-ascend-serving/references/command-recipes.md
@@ -6,6 +6,12 @@ From the repository root:
 uv run --no-project python .agents/skills/vllm-ascend-serving/scripts/serving.py start --model /models/example --tp 1
 ```
 
+With user authorization to share one occupied card:
+
+```text
+uv run --no-project python .agents/skills/vllm-ascend-serving/scripts/serving.py start --model /models/example --host worker-one --devices 0 --tp 1 --dp 1 --allow-external-busy -- --gpu-memory-utilization 0.1
+```
+
 Use serving.py status or serving.py stop with --execution-id or --service. A service reference is resolved by coordinator within the current task. Pending states retain their execution reference. Restart or release follows the requested lifecycle; no separate allocation, parity command or status ledger is needed.
 
 Use `--help` for argument details. Reports create their own identifiers and

--- a/.agents/skills/vllm-ascend-serving/scripts/_serving_start.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/_serving_start.py
@@ -129,7 +129,6 @@ def build_serve_command(
     wrap_script_content: str = "",
     runtime_dir: str = "",
     expected_vllm: str = "",
-    preflight_only: bool = False,
 ) -> str:
     argv = [
         '"$VAWS_PYTHON"',
@@ -167,18 +166,6 @@ def build_serve_command(
             f'if [ -n "$actual" ] && [ "$actual" != {shlex.quote(expected_vllm)} ]; then '
             f'echo "preset expects vllm {expected_vllm}, selected interpreter has $actual" >&2; exit 1; fi'
         )
-    if preflight_only:
-        parse_only = "\n".join([
-            "import sys",
-            "from vllm.entrypoints.cli.serve import cmd_init",
-            "from vllm.utils.argparse_utils import FlexibleArgumentParser",
-            "parser = FlexibleArgumentParser(prog='vllm')",
-            "subparsers = parser.add_subparsers(dest='subparser')",
-            "for command in cmd_init(): command.subparser_init(subparsers)",
-            "parser.parse_args(sys.argv[1:])",
-        ])
-        lines.append('"$VAWS_PYTHON" -c ' + shlex.quote(parse_only) + " " + " ".join(argv[3:]))
-        return "\n".join(lines)
     if wrap_script or wrap_script_content:
         if runtime_dir:
             lines.extend([f"runtime_dir={shlex.quote(runtime_dir)}", 'mkdir -m 700 -- "$runtime_dir"'])
@@ -340,9 +327,11 @@ def startup_failure_details(client, execution_id: str | None) -> dict[str, Any]:
 
 def merge_with_previous(previous: dict[str, Any], **overrides: Any) -> dict[str, Any]:
     merged = dict(previous)
-    for key in ("model", "served_model_name", "tp", "dp", "devices", "recipe", "python_abi", "cann"):
+    for key in ("model", "served_model_name", "tp", "dp", "devices", "host", "recipe", "python_abi", "cann"):
         if overrides.get(key) not in (None, ""):
             merged[key] = overrides[key]
+    if overrides.get("allow_external_busy") is not None:
+        merged["allow_external_busy"] = overrides["allow_external_busy"]
     env = dict(merged.get("env") or {})
     for key in overrides.get("unset_env") or []:
         env.pop(key, None)
@@ -407,6 +396,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--tp", "--tensor-parallel-size", dest="tp", type=int)
     parser.add_argument("--dp", "--data-parallel-size", dest="dp", type=int)
     parser.add_argument("--devices")
+    parser.add_argument("--host", help="coordinator placement host (before --)")
+    parser.add_argument("--allow-external-busy", action=argparse.BooleanOptionalAction, default=None,
+                        help="allow an explicitly selected single card to have external workers when authorized")
     parser.add_argument("--extra-env", action="append", default=[])
     parser.add_argument("--unset-env", action="append", default=[])
     parser.add_argument("--unset-args", action="append", default=[])
@@ -439,7 +431,7 @@ def _parse_extra_env(items: list[str]) -> dict[str, str]:
 
 def write_business_report(task_id: str, payload: dict[str, Any]) -> None:
     report = {key: payload.get(key) for key in (
-        "model", "served_model_name", "tp", "dp", "devices", "env", "extra_args",
+        "model", "served_model_name", "tp", "dp", "devices", "host", "allow_external_busy", "env", "extra_args",
         "wrap_script", "wrap_script_content", "runtime_dir", "execution_id", "service", "recipe", "python_abi", "cann",
     )}
     save_serving_state(task_id, report)
@@ -494,6 +486,8 @@ def main(argv: list[str] | None = None) -> int:
                 tp=args.tp,
                 dp=args.dp,
                 devices=args.devices,
+                host=args.host,
+                allow_external_busy=args.allow_external_busy,
                 recipe=args.recipe,
                 python_abi=args.python_abi,
                 cann=args.cann,
@@ -512,6 +506,8 @@ def main(argv: list[str] | None = None) -> int:
             args.recipe = merged.get("recipe") or args.recipe
             args.python_abi = merged.get("python_abi") or args.python_abi
             args.cann = merged.get("cann") or args.cann
+            args.host = merged.get("host") or args.host
+            args.allow_external_busy = merged.get("allow_external_busy", False)
         else:
             if not args.model:
                 print_json({"status": "needs_input", "error": "--model is required for a fresh start"})
@@ -535,6 +531,9 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         device_list = parse_devices_csv(devices) if devices else []
         npu_count = args.npu_count if args.npu_count is not None else (int(tp) * int(dp or 1) if tp is not None else 1)
+        if args.allow_external_busy and (len(device_list) != 1 or int(tp or 1) * int(dp or 1) != 1):
+            print_json({"status": "needs_input", "error": "--allow-external-busy requires one explicit --devices card and TP1/DP1"})
+            return 1
         command = build_serve_command(
             model=model,
             served_model_name=served_model_name,
@@ -552,6 +551,8 @@ def main(argv: list[str] | None = None) -> int:
             "tp": tp,
             "dp": dp,
             "devices": devices,
+            "host": args.host,
+            "allow_external_busy": bool(args.allow_external_busy),
             "env": launch_env,
             "extra_args": launch_extra_args,
             "wrap_script": wrap_script or None,
@@ -572,6 +573,7 @@ def main(argv: list[str] | None = None) -> int:
             npu_count=None if device_list else npu_count,
             devices=device_list or None,
             service_port=int(args.port) if args.port is not None else 0,
+            allow_external_busy=bool(args.allow_external_busy),
         )
         environment = named_environment(
             recipe=args.recipe,
@@ -586,16 +588,13 @@ def main(argv: list[str] | None = None) -> int:
         reply = run_command(
             client,
             command,
-            preflight=build_serve_command(
-                model=model, served_model_name=served_model_name, tp=tp, dp=dp,
-                extra_args=launch_extra_args, preflight_only=True,
-                expected_vllm=str((preset or {}).get("vllm_version") or "")),
             env=launch_env,
             environment=environment,
             resources=resources,
             timeout_seconds=None,
             service=args.service,
             restart=bool(args.relaunch),
+            **({"topology": {"host": args.host}} if args.host else {}),
         )
         business_report["execution_id"] = reply.get("execution_id")
         write_business_report(task_id, business_report)

--- a/.agents/skills/vllm-ascend-serving/scripts/_serving_start.py
+++ b/.agents/skills/vllm-ascend-serving/scripts/_serving_start.py
@@ -534,6 +534,17 @@ def main(argv: list[str] | None = None) -> int:
         if args.allow_external_busy and (len(device_list) != 1 or int(tp or 1) * int(dp or 1) != 1):
             print_json({"status": "needs_input", "error": "--allow-external-busy requires one explicit --devices card and TP1/DP1"})
             return 1
+        if args.allow_external_busy:
+            parallel_flags = {"--tensor-parallel-size", "-tp", "--data-parallel-size", "-dp",
+                              "--pipeline-parallel-size", "-pp", "--data-parallel-size-local", "-dpl",
+                              "--decode-context-parallel-size", "-dcp", "--prefill-context-parallel-size", "-pcp",
+                              "--nnodes", "--config"}
+            options = [arg.split("=", 1)[0].replace("_", "-") for arg in launch_extra_args if arg.startswith("-")]
+            # vLLM accepts abbreviated options and YAML configuration, which
+            # could otherwise replace the single-card topology after validation.
+            if any(flag.startswith(option) for option in options for flag in parallel_flags):
+                print_json({"status": "needs_input", "error": "shared single-card serving takes TP/DP through wrapper --tp/--dp; extra parallel-size overrides and --config are unsupported"})
+                return 1
         command = build_serve_command(
             model=model,
             served_model_name=served_model_name,

--- a/.agents/skills/vllm-ascend-serving/tests/test_serving_identity.py
+++ b/.agents/skills/vllm-ascend-serving/tests/test_serving_identity.py
@@ -42,6 +42,44 @@ class ServingPresetTests(unittest.TestCase):
 
 
 class ServeCommandTests(unittest.TestCase):
+    def test_shared_single_card_placement_and_relaunch_settings(self):
+        previous = None
+        for options, shared in ((["--model", "/data/m", "--host", "worker-one", "--devices", "6",
+                                  "--tp", "1", "--dp", "1", "--allow-external-busy"], True),
+                                (["--relaunch"], True),
+                                (["--relaunch", "--no-allow-external-busy"], False)):
+            with self.subTest(options=options):
+                client = SimpleNamespace(run=mock.Mock(return_value={"state": "queued", "execution_id": "exec-one"}))
+                with mock.patch.object(serve_start, "task_client", return_value=client), \
+                     mock.patch.object(serve_start, "task_id_of", return_value="task-one"), \
+                     mock.patch.object(serve_start, "load_serving_state", return_value=previous), \
+                     mock.patch.object(serve_start, "save_serving_state") as save, \
+                     mock.patch.object(serve_start, "print_json"):
+                    self.assertEqual(serve_start.main([*options, "--no-wait"]), 0)
+                request = client.run.call_args.kwargs
+                self.assertEqual(request["topology"], {"host": "worker-one"})
+                self.assertEqual(request["resources"]["devices"], [6])
+                self.assertNotIn("npu_count", request["resources"])
+                self.assertEqual(request["resources"].get("allow_external_busy", False), shared)
+                self.assertNotIn("preflight", request)
+                previous = save.call_args.args[1]
+                self.assertEqual(previous["host"], "worker-one")
+                self.assertEqual(previous["allow_external_busy"], shared)
+
+    def test_shared_service_requires_one_explicit_card_and_single_rank(self):
+        for options in ([], ["--npu-count", "1"], ["--devices", "0,1"],
+                        ["--devices", "0", "--tp", "2"], ["--devices", "0", "--dp", "2"]):
+            with self.subTest(options=options):
+                client = SimpleNamespace(run=mock.Mock())
+                with mock.patch.object(serve_start, "task_client", return_value=client), \
+                     mock.patch.object(serve_start, "task_id_of", return_value="task-one"), \
+                     mock.patch.object(serve_start, "load_serving_state", return_value=None), \
+                     mock.patch.object(serve_start, "save_serving_state") as save, \
+                     mock.patch.object(serve_start, "print_json"):
+                    self.assertEqual(serve_start.main(["--model", "/data/m", "--allow-external-busy", *options]), 1)
+                client.run.assert_not_called()
+                save.assert_not_called()
+
     def test_local_wrapper_and_execution_runtime_survive_the_business_receipt(self):
         client = SimpleNamespace(run=mock.Mock(return_value={"state": "queued", "execution_id": "exec-one"}))
         with tempfile.TemporaryDirectory() as tmp:

--- a/.agents/skills/vllm-ascend-serving/tests/test_serving_identity.py
+++ b/.agents/skills/vllm-ascend-serving/tests/test_serving_identity.py
@@ -68,7 +68,16 @@ class ServeCommandTests(unittest.TestCase):
 
     def test_shared_service_requires_one_explicit_card_and_single_rank(self):
         for options in ([], ["--npu-count", "1"], ["--devices", "0,1"],
-                        ["--devices", "0", "--tp", "2"], ["--devices", "0", "--dp", "2"]):
+                        ["--devices", "0", "--tp", "2"], ["--devices", "0", "--dp", "2"],
+                        ["--devices", "0", "--", "--tensor-parallel-size", "2"],
+                        ["--devices", "0", "--", "--data-parallel-size=2"],
+                        ["--devices", "0", "--", "-tp", "2"],
+                        ["--devices", "0", "--", "-dp=2"],
+                        ["--devices", "0", "--", "--tensor_parallel_size", "2"],
+                        ["--devices", "0", "--", "--pipeline-parallel-size", "2"],
+                        ["--devices", "0", "--", "--tensor_p=2"],
+                        ["--devices", "0", "--", "-t", "2"],
+                        ["--devices", "0", "--", "--config", "remote.yaml"]):
             with self.subTest(options=options):
                 client = SimpleNamespace(run=mock.Mock())
                 with mock.patch.object(serve_start, "task_client", return_value=client), \

--- a/docs/coordinator-consumption.md
+++ b/docs/coordinator-consumption.md
@@ -64,6 +64,13 @@ reserve NPUs or wait behind an NPU request. NPU workloads explicitly request
 `resources.npu_count` or devices. Source-free commands reuse an existing image
 interpreter; they do not install vLLM or create a task virtual environment.
 
+For user-authorized sharing, `resources={"devices": [id],
+"allow_external_busy": True}` permits external occupancy on one explicit card.
+Other managed leases and holds still block admission; device visibility, owned
+process completion and service-port release remain required. `topology.host`
+selects the host. The serving entry exposes these as `--host`, `--devices` and
+`--allow-external-busy` before the vLLM argument separator.
+
 A long-running service uses `timeout_seconds=None`, `resources.service_port=0`
 (or an explicit port), and a task-scoped business name (`service`). The same
 spec reconnects; a changed spec without `restart=True` is an error. `--relaunch`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ package = false
 
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "64a29a705e4969ed235dc67db453e7e15fa23446" }
-vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "74c7a9789e3ed14177cbce8eba40cda8e2b1d3ef" }
+vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "b67a57556e2dfbeb2931a4f8f1933666daa7d8d2" }
 vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "c95293836a3b595c13a80189197d44a2980c9fbd" }
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ package = false
 
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "64a29a705e4969ed235dc67db453e7e15fa23446" }
-vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "c502d39d8db1d272195470c6855060e03a6a2e31" }
+vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "a2f83f7efb320597729ec21023bac4c6184b8199" }
 vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "c95293836a3b595c13a80189197d44a2980c9fbd" }
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ package = false
 
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "64a29a705e4969ed235dc67db453e7e15fa23446" }
-vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "b67a57556e2dfbeb2931a4f8f1933666daa7d8d2" }
+vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "c502d39d8db1d272195470c6855060e03a6a2e31" }
 vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "c95293836a3b595c13a80189197d44a2980c9fbd" }
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -4240,7 +4240,7 @@ wheels = [
 [[package]]
 name = "vaws-coordinator"
 version = "0.4.0"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=c502d39d8db1d272195470c6855060e03a6a2e31#c502d39d8db1d272195470c6855060e03a6a2e31" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=a2f83f7efb320597729ec21023bac4c6184b8199#a2f83f7efb320597729ec21023bac4c6184b8199" }
 dependencies = [
     { name = "setuptools-scm" },
     { name = "vaws-remote-dev" },
@@ -4284,7 +4284,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pillow", specifier = ">=11" },
-    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=c502d39d8db1d272195470c6855060e03a6a2e31" },
+    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=a2f83f7efb320597729ec21023bac4c6184b8199" },
     { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=c95293836a3b595c13a80189197d44a2980c9fbd" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=64a29a705e4969ed235dc67db453e7e15fa23446" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -4240,7 +4240,7 @@ wheels = [
 [[package]]
 name = "vaws-coordinator"
 version = "0.4.0"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=b67a57556e2dfbeb2931a4f8f1933666daa7d8d2#b67a57556e2dfbeb2931a4f8f1933666daa7d8d2" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=c502d39d8db1d272195470c6855060e03a6a2e31#c502d39d8db1d272195470c6855060e03a6a2e31" }
 dependencies = [
     { name = "setuptools-scm" },
     { name = "vaws-remote-dev" },
@@ -4284,7 +4284,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pillow", specifier = ">=11" },
-    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=b67a57556e2dfbeb2931a4f8f1933666daa7d8d2" },
+    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=c502d39d8db1d272195470c6855060e03a6a2e31" },
     { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=c95293836a3b595c13a80189197d44a2980c9fbd" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=64a29a705e4969ed235dc67db453e7e15fa23446" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -4240,7 +4240,7 @@ wheels = [
 [[package]]
 name = "vaws-coordinator"
 version = "0.4.0"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=74c7a9789e3ed14177cbce8eba40cda8e2b1d3ef#74c7a9789e3ed14177cbce8eba40cda8e2b1d3ef" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=b67a57556e2dfbeb2931a4f8f1933666daa7d8d2#b67a57556e2dfbeb2931a4f8f1933666daa7d8d2" }
 dependencies = [
     { name = "setuptools-scm" },
     { name = "vaws-remote-dev" },
@@ -4284,7 +4284,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pillow", specifier = ">=11" },
-    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=74c7a9789e3ed14177cbce8eba40cda8e2b1d3ef" },
+    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=b67a57556e2dfbeb2931a4f8f1933666daa7d8d2" },
     { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=c95293836a3b595c13a80189197d44a2980c9fbd" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=64a29a705e4969ed235dc67db453e7e15fa23446" },
 ]


### PR DESCRIPTION
Serving can explicitly share one selected physical NPU with existing external workers through `--host`, `--devices` and `--allow-external-busy`. Named relaunch preserves these settings, while `--no-allow-external-busy` restores exclusive admission. Shared mode requires TP1/DP1 and rejects extra parallelism options, their abbreviations and vLLM configuration files that could override the single-card request.

Colocated serving and each prefill/decode role now parse vLLM arguments during managed startup without a second remote parse-only import. Startup failures remain available through the owned execution log. The coordinator dependency is pinned to `a2f83f7efb320597729ec21023bac4c6184b8199`, which supplies the explicit sharing lifecycle, reduces redundant prepared-view work and fixes concurrent Windows context publication. Documentation covers the resource flag and serving arguments.

Validation:

- Serving: Windows 20 passed, 1 skipped; Linux 21 passed; 20 subtests passed on each.
- Prefill/decode serving: 9 passed on each of Windows and Linux.
- Full coordinator preparation/lifecycle candidate: Windows 420 passed, 10 skipped; Linux 428 passed, 2 skipped; 51 subtests passed on each.
- A real single-device model completed HTTP inference, short benchmark, profiling database export and verified owned-resource release.
- Final context-publication regressions: owner 25 passed on Windows and Linux; consumer 17 passed and 7 subtests on each. The previous implementation failed the deterministic publication-race cases.
- Final commit a3bf9f8 passed Linux/macOS/Windows CI (run 34693146648); dependency lock and immutable installation were verified.


