### PR TITLE
Reduce managed Python edit turnaround and status latency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ dev = [
 package = false
 
 [tool.uv.sources]
-vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "64a29a705e4969ed235dc67db453e7e15fa23446" }
-vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "a2f83f7efb320597729ec21023bac4c6184b8199" }
+vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" }
+vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "78fb8df6bfadf33577cd5cd18f79dcbbf3250f71" }
 vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "c95293836a3b595c13a80189197d44a2980c9fbd" }
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -4240,7 +4240,7 @@ wheels = [
 [[package]]
 name = "vaws-coordinator"
 version = "0.4.0"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=a2f83f7efb320597729ec21023bac4c6184b8199#a2f83f7efb320597729ec21023bac4c6184b8199" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=78fb8df6bfadf33577cd5cd18f79dcbbf3250f71#78fb8df6bfadf33577cd5cd18f79dcbbf3250f71" }
 dependencies = [
     { name = "setuptools-scm" },
     { name = "vaws-remote-dev" },
@@ -4260,7 +4260,7 @@ dependencies = [
 [[package]]
 name = "vaws-remote-dev"
 version = "0.7.0"
-source = { git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=64a29a705e4969ed235dc67db453e7e15fa23446#64a29a705e4969ed235dc67db453e7e15fa23446" }
+source = { git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa#2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" }
 
 [[package]]
 name = "vaws-workspace"
@@ -4284,9 +4284,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pillow", specifier = ">=11" },
-    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=a2f83f7efb320597729ec21023bac4c6184b8199" },
+    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=78fb8df6bfadf33577cd5cd18f79dcbbf3250f71" },
     { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=c95293836a3b595c13a80189197d44a2980c9fbd" },
-    { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=64a29a705e4969ed235dc67db453e7e15fa23446" },
+    { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Managed Python edits spent most of their turnaround in repeated source preparation, full native registration and remote lifecycle calls. Update the remote-dev and coordinator pins to reuse admitted snapshots and validated native outputs, materialize fixed sources in one owned operation, cache host RPC code, and return cached status without blocking on remote work.

In same-host single-device measurements using a short import-and-tensor workload, repeated-source submission through confirmed release fell from 127.0–127.6 seconds to 42.5–43.9 seconds. Submission including client startup was about 0.76 seconds and cached status had a 30–38 ms maximum. A new source directory and new dirty edit completed in 59.4 seconds; a further one-line edit in that directory completed in 48.6 seconds, with 1.06-second admission. First capture and missing Git objects still cost more than a warm submission. All 1,103 reused native files matched the original build exactly.

Validation: 49 affected consumer tests and 44 subtests passed; the lock check, installed package commits and immutable environment receipt agree. Owner changes and their passing cross-platform CI are in https://github.com/vllm-ascend-workspace/vaws-coordinator/pull/22 and https://github.com/vllm-ascend-workspace/remote-dev/pull/12. No business skill, submodule or knowledge pin changes.
