### PR TITLE
Use coordinator with fewer serial startup operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ package = false
 
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" }
-vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "a0dfa5c07cdfdf909b46f743514d6a787fa8d128" }
+vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "6caa71ef6664d6d6b9cbb0e859893efec182d7f4" }
 vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "c95293836a3b595c13a80189197d44a2980c9fbd" }
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ package = false
 
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" }
-vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "78fb8df6bfadf33577cd5cd18f79dcbbf3250f71" }
+vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "53ca3e0eaed702cd51f37bb6529152c9bafc729b" }
 vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "c95293836a3b595c13a80189197d44a2980c9fbd" }
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ package = false
 
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" }
-vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "53ca3e0eaed702cd51f37bb6529152c9bafc729b" }
+vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "a0dfa5c07cdfdf909b46f743514d6a787fa8d128" }
 vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "c95293836a3b595c13a80189197d44a2980c9fbd" }
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -4240,7 +4240,7 @@ wheels = [
 [[package]]
 name = "vaws-coordinator"
 version = "0.4.0"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=53ca3e0eaed702cd51f37bb6529152c9bafc729b#53ca3e0eaed702cd51f37bb6529152c9bafc729b" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=a0dfa5c07cdfdf909b46f743514d6a787fa8d128#a0dfa5c07cdfdf909b46f743514d6a787fa8d128" }
 dependencies = [
     { name = "setuptools-scm" },
     { name = "vaws-remote-dev" },
@@ -4284,7 +4284,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pillow", specifier = ">=11" },
-    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=53ca3e0eaed702cd51f37bb6529152c9bafc729b" },
+    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=a0dfa5c07cdfdf909b46f743514d6a787fa8d128" },
     { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=c95293836a3b595c13a80189197d44a2980c9fbd" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -4240,7 +4240,7 @@ wheels = [
 [[package]]
 name = "vaws-coordinator"
 version = "0.4.0"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=78fb8df6bfadf33577cd5cd18f79dcbbf3250f71#78fb8df6bfadf33577cd5cd18f79dcbbf3250f71" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=53ca3e0eaed702cd51f37bb6529152c9bafc729b#53ca3e0eaed702cd51f37bb6529152c9bafc729b" }
 dependencies = [
     { name = "setuptools-scm" },
     { name = "vaws-remote-dev" },
@@ -4284,7 +4284,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pillow", specifier = ">=11" },
-    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=78fb8df6bfadf33577cd5cd18f79dcbbf3250f71" },
+    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=53ca3e0eaed702cd51f37bb6529152c9bafc729b" },
     { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=c95293836a3b595c13a80189197d44a2980c9fbd" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -4240,7 +4240,7 @@ wheels = [
 [[package]]
 name = "vaws-coordinator"
 version = "0.4.0"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=a0dfa5c07cdfdf909b46f743514d6a787fa8d128#a0dfa5c07cdfdf909b46f743514d6a787fa8d128" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=6caa71ef6664d6d6b9cbb0e859893efec182d7f4#6caa71ef6664d6d6b9cbb0e859893efec182d7f4" }
 dependencies = [
     { name = "setuptools-scm" },
     { name = "vaws-remote-dev" },
@@ -4284,7 +4284,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pillow", specifier = ">=11" },
-    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=a0dfa5c07cdfdf909b46f743514d6a787fa8d128" },
+    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=6caa71ef6664d6d6b9cbb0e859893efec182d7f4" },
     { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=c95293836a3b595c13a80189197d44a2980c9fbd" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" },
 ]


### PR DESCRIPTION
Update the coordinator pin to reduce serial startup work using existing transport and ownership protocols. The owner combines submit/acquire and supervisor-identity/activation exchanges, overlaps independent preflight reads, skips only the impossible fresh supervisor lookup, and reuses the preparation connection with bounded exit waits. No new caller fields or prewarming workflow are introduced.

A fresh same-host single-device baseline took 45.5 seconds through confirmed release. The candidate took 40.1 seconds after daemon restart and 34.3 seconds on a warm repeat, with the business import/tensor workload still about 8 seconds. A further dirty one-line edit completed in 42.2 seconds and verified the new marker. Source materialization fell from 6.5 seconds to 2.7 seconds, and the warm launch stage from 15.2 seconds to about 8.6 seconds. These are small sequential development-loop samples, not a model inference benchmark or latency guarantee.

The affected consumer checks passed 49 tests and 44 subtests; lock and immutable environment receipt match the installed commits. Only the coordinator pin changes. Owner implementation: https://github.com/vllm-ascend-workspace/vaws-coordinator/pull/23. The pin also includes https://github.com/vllm-ascend-workspace/vaws-coordinator/pull/24, which preserves the granted timing event in the existing transaction, including recovery from initial connection failure, without changing resource behavior or adding remote calls.
