### PR TITLE
Unify new-session startup and selected runtimes across agent clients

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -7,13 +7,17 @@ skills. Runtime behavior belongs to the four installed components; see
 - `skills/repo-init/` initializes or repairs workspace configuration and clients.
 - `scripts/workspace_forks.py` configures verified personal GitHub forks without
   a Skill or installed runtime.
-- `scripts/vaws_client_setup.py` wires native lifecycle callbacks. Codex local
-  environment setup and Cursor worktree setup call `scripts/vaws_worktree_setup.py`
-  in the new directory created by the client, before the Agent starts. It checks
-  upstream once and fixes eligible source, dependencies and wiring; SessionStart
-  attaches the native task automatically. Resume keeps its code and environment.
-  Contract tests cover the wiring; real GUI acceptance remains pending. See
-  [native client boundaries](../docs/native-workspace-isolation.md).
+- `scripts/vaws_client_setup.py` configures installed clients and shared project
+  guidance once. Official Codex, Cursor, Claude, Grok and Kimi use
+  `scripts/vaws_start.py` for one new-task preparation; existing native worktree
+  callbacks can supply an already selected workspace and environment.
+  Startup binds sources and returns the editing root. Resume retains the task,
+  directory and environment. See [client boundaries](../docs/native-workspace-isolation.md)
+  and [current acceptance progress](../docs/unified-session-validation-2026-09-13.md).
+- `scripts/vaws_native_mcp.py` routes the three VAWS providers by exact task
+  context to the selected component environment. It does not pick a task from
+  cwd or recent activity. The original client connection can serve new tasks
+  while earlier tasks retain their component selection.
 - `scripts/vaws_client.py` is an optional convenience for launching installed
   CLIs; ordinary native sessions do not require the Agent to call it.
   `scripts/workspace_update.py` provides explicit maintenance using the same
@@ -23,14 +27,15 @@ skills. Runtime behavior belongs to the four installed components; see
   measurements, profiling and debugging. Their `SKILL.md` files are the source
   of truth; the client skill catalog provides discovery.
 - `scripts/vaws.py` optionally forwards session/run/execution/finish to coordinator.
-  Native hooks bind the actual cwd; explicit source overrides remain available.
+  Startup binds the selected editing root; explicit source overrides remain available.
   Use native Git for source inspection.
 - Provisioning and native task identity remain in coordinator.
 - Direct remote I/O and optional source publication use their installed owner
   APIs. Managed runs prepare their bound sources internally.
 - Knowledge lookup and capture use the package tools. `scripts/knowledge_setup.py`
   retries package preparation or changes the requested sharing configuration.
-  Dependency sync prepares the model and index; MCP maintains them while alive.
+  Dependency sync prepares knowledge; MCP maintains it while alive. Linked
+  worktrees share configuration, content and reusable model/index state.
   New setup keeps public contribution disabled, and preserves existing choices.
 
 Knowledge is optional reference, using ordinary Markdown with a title and body.

--- a/.agents/hooks/knowledge_summary.py
+++ b/.agents/hooks/knowledge_summary.py
@@ -25,7 +25,12 @@ def in_project(payload: dict, *, client: str, project: Path) -> bool:
             from vaws_local_owner import managed_path
             value = managed_path(value, windows=True)
         path = Path(value).expanduser()
-        return path.is_absolute() and path.resolve().is_relative_to(project.resolve())
+        if not path.is_absolute():
+            return False
+        if path.resolve().is_relative_to(project.resolve()):
+            return True
+        from vaws_local_state import shared_workspace_root
+        return shared_workspace_root(path) == shared_workspace_root(project)
 
     if "cwd" in payload:
         return contains(payload["cwd"])
@@ -55,6 +60,7 @@ def main() -> int:
     except Exception:
         print("{}")
         return 0
+    scoped = False
     try:
         from vaws_knowledge.summary_hook import capture_summary
         from vaws_knowledge_service import service_config
@@ -63,9 +69,27 @@ def main() -> int:
         if len(raw) <= 1_048_576:
             payload = json.loads(raw)
             if isinstance(payload, dict) and in_project(payload, client=args.client, project=args.project):
-                capture_summary(payload, config=service_config(ROOT), client=args.client)
-    except Exception:
-        pass
+                scoped = True
+                native = {}
+                if args.client == "kimi":
+                    from vaws_kimi_summary import summary_result
+                    payload, native = summary_result(payload)
+                elif args.client == "cursor":
+                    from vaws_cursor_summary import summary_result
+                    payload, native = summary_result(payload)
+                result = capture_summary(payload, config=service_config(args.project), client=args.client)
+                facts = {"event": "knowledge_summary", "client": args.client,
+                         "status": result.get("status", "unknown") if isinstance(result, dict) else "unknown"}
+                if native:
+                    facts["native"] = native
+                from vaws_workspace_update import redact
+                print(redact(json.dumps(facts, ensure_ascii=False)), file=sys.stderr)
+    except Exception as exc:
+        if scoped:
+            from vaws_workspace_update import redact
+            print(json.dumps({"event": "knowledge_summary", "client": args.client, "status": "failed",
+                              "error_type": type(exc).__name__, "error": redact(str(exc))[:300]},
+                             ensure_ascii=False), file=sys.stderr)
     print("{}")
     return 0
 

--- a/.agents/hooks/vaws_session.py
+++ b/.agents/hooks/vaws_session.py
@@ -11,6 +11,9 @@ does not need the setup shell's environment.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
+import json
 import os
 import sys
 from pathlib import Path
@@ -30,7 +33,7 @@ if _pin.environment_receipt:
 # Updates belong before creation of a new editing copy, never in task hooks.
 ensure_workspace_interpreter(repo_root=ROOT)
 
-from vaws_coordinator_launch import CoordinatorUnavailable, exec_module  # noqa: E402
+from vaws_coordinator_launch import CoordinatorUnavailable, coordinator_environment, require_package  # noqa: E402
 from vaws_dependency import REMEDY  # noqa: E402
 
 
@@ -53,7 +56,32 @@ def main() -> int:
     if args.project is not None:
         forwarded += ["--project", str(args.project)]
     try:
-        return exec_module("vaws_coordinator.hooks.vaws_session", forwarded)
+        require_package()
+        os.environ.update(coordinator_environment(repo_root=ROOT))
+        from vaws_coordinator.hooks import vaws_session as native_hook
+        from vaws_start_context import hint_event, project_output
+
+        raw = sys.stdin.read()
+        try:
+            payload = json.loads(raw)
+        except ValueError:
+            payload = None
+        # Run the package entry itself so its scope, attachment and error
+        # behavior stay authoritative. Only startup hints need projection;
+        # PreToolUse keeps normal stdout and starts no additional interpreter.
+        previous_argv, previous_stdin = sys.argv, sys.stdin
+        output = io.StringIO() if hint_event(payload) else None
+        try:
+            sys.argv = [native_hook.__name__, *forwarded]
+            sys.stdin = io.StringIO(raw)
+            with contextlib.redirect_stdout(output) if output is not None else contextlib.nullcontext():
+                result = native_hook.main()
+        finally:
+            sys.argv, sys.stdin = previous_argv, previous_stdin
+        if output is not None:
+            print(project_output(args.client, payload, output.getvalue(),
+                                 root=args.project or ROOT), end="")
+        return result
     except CoordinatorUnavailable as exc:
         sys.stdin.read()
         print(

--- a/.agents/lib/vaws_claude_config.py
+++ b/.agents/lib/vaws_claude_config.py
@@ -35,6 +35,19 @@ def owned_entry(path: str, root: Path, name: str) -> bool:
     return same_repository(candidate.parents[2], root)
 
 
+def provider_kind(arguments, root: Path) -> str | None:
+    if not isinstance(arguments, list) or not all(isinstance(value, str) for value in arguments):
+        return None
+    kind = KINDS.get(tuple(arguments))
+    if kind is not None:
+        return kind
+    if len(arguments) == 2 and arguments[1] in KINDS.values() and any(
+        owned_entry(arguments[0], root, name) for name in ("vaws_native_mcp.py", "vaws_claude_entry.py")
+    ):
+        return arguments[1]
+    return None
+
+
 def add_claude_setup(files: dict, notes: list, project: Path, root: Path, *,
                      shell_command, parse_command, owned_server) -> None:
     """Adapt the already-merged plan, including old generated configurations."""
@@ -49,7 +62,7 @@ def add_claude_setup(files: dict, notes: list, project: Path, root: Path, *,
     python = None
     for name, server in servers.get("mcpServers", {}).items():
         arguments = server.get("args", [])
-        kind = KINDS.get(tuple(arguments))
+        kind = provider_kind(arguments, root)
         already_wrapped = len(arguments) == 2 and owned_entry(arguments[0], root, "vaws_claude_entry.py")
         if already_wrapped and arguments[1] in KINDS.values():
             kind = arguments[1]

--- a/.agents/lib/vaws_claude_config.py
+++ b/.agents/lib/vaws_claude_config.py
@@ -48,6 +48,16 @@ def provider_kind(arguments, root: Path) -> str | None:
     return None
 
 
+def wrapped_hook_kind(argv: list[str], root: Path) -> str | None:
+    """Recognize only the command forms emitted by Claude setup."""
+    if (len(argv) not in {3, 5} or not owned_entry(argv[1], root, "vaws_claude_entry.py")
+            or argv[2] not in {"session", "summary"}):
+        return None
+    if len(argv) == 5 and (argv[3] != "--agent-sessions-dir" or not argv[4]):
+        return None
+    return argv[2]
+
+
 def add_claude_setup(files: dict, notes: list, project: Path, root: Path, *,
                      shell_command, parse_command, owned_server) -> None:
     """Adapt the already-merged plan, including old generated configurations."""

--- a/.agents/lib/vaws_cursor_mcp_config.py
+++ b/.agents/lib/vaws_cursor_mcp_config.py
@@ -10,6 +10,7 @@ import json
 from pathlib import Path
 
 from vaws_environment import PIN_ENV, MANAGED_PIN_ENV
+from vaws_claude_config import provider_kind
 from vaws_workspace_update import common_dir
 
 KINDS = {
@@ -76,7 +77,7 @@ def add_cursor_global_mcp(files: dict, notes: list, project: Path, root: Path, *
         if name not in NAMES or not isinstance(server, dict):
             continue
         args = server.get("args", [])
-        kind = KINDS.get(tuple(args)) if isinstance(args, list) and all(isinstance(v, str) for v in args) else None
+        kind = provider_kind(args, root)
         if kind is None or not owned_server(server, project):
             continue
         existing = global_servers.get(name)

--- a/.agents/lib/vaws_cursor_summary.py
+++ b/.agents/lib/vaws_cursor_summary.py
@@ -1,0 +1,64 @@
+"""Read Cursor CLI's final response from its native sessionEnd transcript.
+
+The 2026.09.08 CLI --print path emits sessionEnd, not afterAgentResponse.
+Only the explicit native transcript's bounded tail is read; no transcript is
+searched for and no tool output, earlier turn or reasoning is summarized.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+MAX_TAIL_BYTES = 1_048_576
+
+
+def summary_result(payload: dict) -> tuple[dict, dict]:
+    facts = {"status": "no_summary", "reason": "native-final-text-unavailable"}
+    if isinstance(payload.get("transcript_path"), str):
+        facts["transcript_path"] = payload["transcript_path"]
+    if payload.get("hook_event_name") == "afterAgentResponse" and payload.get("text"):
+        return payload, {**facts, "status": "ready", "reason": "native-response-event"}
+    if ("hookEventName" in payload or payload.get("hook_event_name") != "sessionEnd"
+            or payload.get("final_status") != "completed"
+            or not isinstance(payload.get("conversation_id"), str) or not payload["conversation_id"]
+            or not isinstance(payload.get("transcript_path"), str) or not payload["transcript_path"]):
+        return payload, facts
+    try:
+        with Path(payload["transcript_path"]).open("rb") as stream:
+            offset = max(0, stream.seek(0, 2) - MAX_TAIL_BYTES)
+            stream.seek(offset)
+            lines = stream.read(MAX_TAIL_BYTES).splitlines()
+        if offset:
+            lines = lines[1:]  # The first row may begin before the bounded tail.
+        rows = iter(line for line in reversed(lines) if line.strip())
+        last = next(rows, None)
+        if last is None:
+            return payload, facts
+        row = json.loads(last)
+        # Headless writes this terminal marker after its final assistant row,
+        # before awaiting sessionEnd. Do not walk past another turn boundary.
+        if row.get("type") == "turn_ended":
+            if row.get("status") != "success":
+                return payload, facts
+            previous = next(rows, None)
+            if previous is None:
+                return payload, facts
+            row = json.loads(previous)
+        if row.get("role") != "assistant":
+            return payload, facts
+        content = row.get("message", {}).get("content", [])
+        if not isinstance(content, list) or any(item.get("type") == "tool_use" for item in content):
+            return payload, facts
+        text = "\n".join(item["text"] for item in content
+                         if item.get("type") == "text" and isinstance(item.get("text"), str)).strip()
+        if text:
+            return ({**payload, "hook_event_name": "afterAgentResponse", "text": text},
+                    {**facts, "status": "ready", "reason": "native-final-text"})
+    except (OSError, ValueError, TypeError, AttributeError) as exc:
+        # Optional capture never interrupts exit or falls back to an older turn.
+        facts["error"] = f"{type(exc).__name__}: {exc}"
+    return payload, facts
+
+
+def summary_payload(payload: dict) -> dict:
+    return summary_result(payload)[0]

--- a/.agents/lib/vaws_github.py
+++ b/.agents/lib/vaws_github.py
@@ -29,31 +29,54 @@ class ForkPolicyError(RuntimeError):
 
 
 class GitHubAPIError(ForkPolicyError):
-    def __init__(self, message: str, status: int | None = None):
+    def __init__(self, message: str, status: int | None = None, *, evidence: dict | None = None):
         super().__init__(message)
         self.status = status
+        self.evidence = evidence
 
 
 class GitHubClient:
     def api(self, endpoint: str, method: str = "GET", fields: dict | None = None) -> dict:
+        from vaws_workspace_update import redact
+
         command = ["gh", "api", "--hostname", "github.com", endpoint, "--method", method]
         if fields is not None:
             command += ["--input", "-"]
+        # Native terminals can force gh to colorize even captured JSON. Select
+        # machine output for this subprocess without changing the user's shell.
+        environment = os.environ.copy()
+        environment.update(CLICOLOR_FORCE="0", FORCE_COLOR="0", NO_COLOR="1")
+        environment.pop("GH_FORCE_TTY", None)
+
+        def evidence(result=None, **extra):
+            def output(value):
+                text = value.decode("utf-8", "replace") if isinstance(value, bytes) else value or ""
+                text = redact(text)
+                return re.sub(r"(?im)^([ \t]*[<>*]?[ \t]*(?:authorization|proxy-authorization):)[^\r\n]*",
+                              r"\1 [redacted]", text)
+            return {"command": [redact(item) for item in command], "endpoint": redact(endpoint),
+                    "method": method, "returncode": getattr(result, "returncode", None),
+                    "stdout": output(getattr(result, "stdout", None)),
+                    "stderr": output(getattr(result, "stderr", None)), **extra}
+
         try:
             result = subprocess.run(command, input=json.dumps(fields) if fields is not None else None,
-                                    capture_output=True, text=True, encoding="utf-8", timeout=60)
+                                    capture_output=True, text=True, encoding="utf-8", timeout=60,
+                                    env=environment)
         except (OSError, subprocess.TimeoutExpired) as exc:
-            raise GitHubAPIError(f"GitHub request could not complete: {exc}") from exc
+            raise GitHubAPIError(f"GitHub request could not complete: {redact(str(exc))}",
+                                 evidence=evidence(exc, error_type=type(exc).__name__)) from exc
         if result.returncode:
             status = re.search(r"HTTP (\d{3})", result.stderr)
-            raise GitHubAPIError(result.stderr.strip() or "GitHub request failed",
-                                 int(status[1]) if status else None)
+            facts = evidence(result)
+            raise GitHubAPIError(facts["stderr"].strip() or "GitHub request failed",
+                                 int(status[1]) if status else None, evidence=facts)
         try:
             value = json.loads(result.stdout)
         except json.JSONDecodeError as exc:
-            raise GitHubAPIError("GitHub returned invalid JSON") from exc
+            raise GitHubAPIError("GitHub returned invalid JSON", evidence=evidence(result)) from exc
         if not isinstance(value, dict):
-            raise GitHubAPIError("GitHub returned an unexpected response")
+            raise GitHubAPIError("GitHub returned an unexpected response", evidence=evidence(result))
         return value
 
 

--- a/.agents/lib/vaws_kimi_config.py
+++ b/.agents/lib/vaws_kimi_config.py
@@ -7,7 +7,7 @@ import re
 import tomllib
 from pathlib import Path
 
-from vaws_claude_config import KINDS, owned_entry, same_repository
+from vaws_claude_config import KINDS, owned_entry, provider_kind, same_repository
 from vaws_environment import PIN_ENV
 from vaws_local_owner import managed_path, managed_receipt, windows_mounted_workspace
 
@@ -50,48 +50,34 @@ def _hook_kind(hook, project, root, parse_command):
     return None
 
 
-def kimi_session_setup_enabled(text: str, project: Path, root: Path, *, parse_command) -> bool:
-    return any(hook.get("event") == "SessionSetup" and _hook_kind(hook, project, root, parse_command) == "adapter"
-               for hook in tomllib.loads(text).get("hooks", []))
+def remove_owned_kimi_hooks(text: str, project: Path, root: Path, *, parse_command) -> str:
+    """Remove this family's generated callbacks, retaining custom hooks verbatim.
 
-
-def migrate_kimi_hooks(text: str, project: Path, root: Path, *, parse_command) -> str:
-    """Replace obsolete generated callbacks covered by this family adapter."""
-    current = hashlib.sha256(str(project).encode()).hexdigest()[:16]
-    marker = re.compile(r"^# BEGIN VAWS session-([0-9a-f]{16})\n(.*?)^# END VAWS session-\1(?:\n|$)", re.M | re.S)
-
-    def owned(hook):
-        return _hook_kind(hook, project, root, parse_command) is not None
-
-    def obsolete(match):
-        if match[1] == current:
-            return match[0]
-        try:
-            parsed = tomllib.loads(match[2])
-        except tomllib.TOMLDecodeError:
-            return match[0]
-        hooks = parsed.get("hooks", [])
-        return "" if set(parsed) == {"hooks"} and hooks and all(owned(hook) for hook in hooks) else match[0]
-
-    text = marker.sub(obsolete, text)
+    The replacement uses official events unless initialization explicitly asks
+    for an extension. Old generated markers confer no ownership on user entries
+    that were subsequently added inside them.
+    """
     table = re.compile(r"^\[\[hooks\]\][ \t]*\n.*?(?=^[ \t]*\[|^# BEGIN VAWS|^# END VAWS|\Z)", re.M | re.S)
 
-    def old_unmarked(match):
+    def strip_owned(match):
         try:
             parsed = tomllib.loads(match[0])
         except tomllib.TOMLDecodeError:
             return match[0]
-        hooks = parsed.get("hooks", [])
-        return "" if set(parsed) == {"hooks"} and len(hooks) == 1 and owned(hooks[0]) else match[0]
+        entries = parsed.get("hooks", [])
+        if (set(parsed) == {"hooks"} and len(entries) == 1
+                and _hook_kind(entries[0], project, root, parse_command)):
+            return ""
+        return match[0]
 
-    # Native configuration writers can remove generated comments. Only exact
-    # generated hook entries outside remaining managed blocks are eligible.
-    result, end = [], 0
-    for match in marker.finditer(text):
-        result.extend((table.sub(old_unmarked, text[end:match.start()]), match[0]))
-        end = match.end()
-    result.append(table.sub(old_unmarked, text[end:]))
-    return "".join(result)
+    current = hashlib.sha256(str(project).encode()).hexdigest()[:16]
+    marker = re.compile(r"^# BEGIN VAWS session-([0-9a-f]{16})\n(.*?)^# END VAWS session-\1(?:\n|$)", re.M | re.S)
+
+    def unmark_replaced(match):
+        cleaned = table.sub(strip_owned, match[2])
+        return cleaned if cleaned != match[2] or match[1] == current else match[0]
+
+    return table.sub(strip_owned, marker.sub(unmark_replaced, text))
 
 
 def add_kimi_user_mcp(files: dict, notes: list, project: Path, root: Path, home: Path, *, owned_server) -> None:
@@ -105,7 +91,7 @@ def add_kimi_user_mcp(files: dict, notes: list, project: Path, root: Path, home:
     entry = managed_path(root / ".agents/scripts/vaws_native_mcp.py", windows=windows_mounted_workspace(root))
     bootstrap = managed_receipt(root)["python"]
     for name, server in list(local.get("mcpServers", {}).items()):
-        kind = KINDS.get(tuple(server.get("args", [])))
+        kind = provider_kind(server.get("args", []), root)
         if kind is None or not owned_server(server, project):
             continue
         prior = user_servers.get(name)

--- a/.agents/lib/vaws_kimi_config.py
+++ b/.agents/lib/vaws_kimi_config.py
@@ -15,9 +15,11 @@ DERIVED_ENV = {PIN_ENV, "REMOTE_DEV_STATE_DIR", "VAWS_KNOWLEDGE_CONFIG",
                "VAWS_KNOWLEDGE_PROJECT_ROOTS", "VAWS_KNOWLEDGE_CANDIDATE_ROOT", "VAWS_KNOWLEDGE_STATE"}
 
 
-def _hook_kind(hook, project, root, parse_command):
+def _hook_kind(hook, project, root, parse_command, include_summary=False):
     events = {"SessionSetup", "SessionStart", "SessionEnd", "SubagentStart", "SubagentStop",
               "PreToolUse", "UserPromptSubmit"}
+    if include_summary:
+        events.add("Stop")
     if not isinstance(hook, dict) or set(hook) - {"event", "command", "timeout"} or hook.get("event") not in events:
         return None
     try:
@@ -29,7 +31,10 @@ def _hook_kind(hook, project, root, parse_command):
         if len(argv) < 6:
             return None
         entry = Path(argv[1])
-        if not (entry.name == "vaws_session.py" and entry.parent.name == "hooks"
+        names = {"vaws_session.py"}
+        if include_summary and hook.get("event") == "Stop":
+            names.add("knowledge_summary.py")
+        if not (entry.name in names and entry.parent.name == "hooks"
                 and entry.parent.parent.name == ".agents" and same_repository(entry.parents[2], root)):
             return None
         options = argv[2:]
@@ -50,7 +55,8 @@ def _hook_kind(hook, project, root, parse_command):
     return None
 
 
-def remove_owned_kimi_hooks(text: str, project: Path, root: Path, *, parse_command) -> str:
+def remove_owned_kimi_hooks(text: str, project: Path, root: Path, *, parse_command,
+                            include_summary=False) -> str:
     """Remove this family's generated callbacks, retaining custom hooks verbatim.
 
     The replacement uses official events unless initialization explicitly asks
@@ -66,7 +72,7 @@ def remove_owned_kimi_hooks(text: str, project: Path, root: Path, *, parse_comma
             return match[0]
         entries = parsed.get("hooks", [])
         if (set(parsed) == {"hooks"} and len(entries) == 1
-                and _hook_kind(entries[0], project, root, parse_command)):
+                and _hook_kind(entries[0], project, root, parse_command, include_summary)):
             return ""
         return match[0]
 

--- a/.agents/lib/vaws_kimi_summary.py
+++ b/.agents/lib/vaws_kimi_summary.py
@@ -1,0 +1,106 @@
+"""Read one official Kimi 0.42 main-agent final step, never a session export.
+
+Kimi's Stop payload has cwd/session_id but no response text. Its wire 1.5
+schema records step.end before invoking Stop and flushes queued records in a
+microtask. Read only this session's bounded tail; unknown schemas are a miss.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+from pathlib import Path
+
+TAIL_BYTES = 1_048_576
+
+
+class FinalUnavailable(ValueError):
+    pass
+
+
+def journal_path(payload: dict, *, home: Path | None = None) -> Path | None:
+    session = payload.get("session_id")
+    cwd = payload.get("cwd")
+    if (payload.get("hook_event_name") != "Stop" or payload.get("agent_id", "main") != "main"
+            or not isinstance(session, str) or not re.fullmatch(r"[\w-]+", session)
+            or not isinstance(cwd, str) or not Path(cwd).is_absolute()):
+        return None
+    # Official encodeWorkDirKey; do not search other workspaces or sessions.
+    normalized = cwd.replace("\\", "/").rstrip("/")
+    slug = re.sub(r"[^a-z0-9._-]+", "-", normalized.rsplit("/", 1)[-1].lower()).strip("-")[:40].strip("-")
+    if slug in {"", ".", ".."}:
+        slug = "workspace"
+    key = "wd_" + slug + "_" + hashlib.sha256(normalized.encode()).hexdigest()[:12]
+    home = home or Path(os.environ.get("KIMI_CODE_HOME", str(Path.home() / ".kimi-code"))).expanduser()
+    return home / "sessions" / key / session / "agents/main/wire.jsonl"
+
+
+def _final_step(path: Path) -> tuple[str, str] | None:
+    with path.open("rb") as stream:
+        header = json.loads(stream.readline(4096))
+        if header.get("type") != "metadata" or header.get("protocol_version") != "1.5":
+            raise FinalUnavailable("unsupported-wire-version")
+        size = stream.seek(0, 2)
+        offset = max(0, size - TAIL_BYTES)
+        stream.seek(offset)
+        data = stream.read(TAIL_BYTES)
+    if not data.endswith(b"\n"):
+        return None  # the writer has not finished its current record
+    lines = data.splitlines()
+    if offset:
+        lines = lines[1:]  # the leading line may be truncated
+    step = None
+    texts = []
+    turn = ""
+    for raw in reversed(lines):
+        record = json.loads(raw)
+        if record.get("type") == "context.append_message" and step is None:
+            raise FinalUnavailable("new-prompt-after-final")
+        if record.get("type") != "context.append_loop_event":
+            continue
+        event = record.get("event", {})
+        kind = event.get("type")
+        if step is None:
+            if kind != "step.end" or event.get("finishReason") != "end_turn":
+                return None
+            step, turn = event.get("uuid"), event.get("turnId", "")
+            if not isinstance(step, str):
+                raise FinalUnavailable("unsupported-step-shape")
+        elif kind == "step.begin":
+            if event.get("uuid") != step:
+                raise FinalUnavailable("final-step-boundary-mismatch")
+            return "".join(reversed(texts)), str(turn)
+        elif kind == "content.part" and event.get("stepUuid") == step:
+            part = event.get("part", {})
+            if part.get("type") == "text" and isinstance(part.get("text"), str):
+                texts.append(part["text"])
+        else:
+            raise FinalUnavailable("non-final-step-content")
+    raise FinalUnavailable("final-step-exceeds-tail-limit")
+
+
+def summary_payload(payload: dict, *, home: Path | None = None) -> dict:
+    return summary_result(payload, home=home)[0]
+
+
+def summary_result(payload: dict, *, home: Path | None = None) -> tuple[dict, dict]:
+    path = journal_path(payload, home=home)
+    if path is None:
+        return payload, {"status": "no_summary", "reason": "missing-native-main-session-facts"}
+    for attempt in range(3):
+        try:
+            final = _final_step(path)
+        except FinalUnavailable as exc:
+            return payload, {"status": "no_summary", "reason": str(exc)}
+        except (OSError, ValueError, AttributeError, TypeError) as exc:
+            return payload, {"status": "no_summary", "reason": "native-journal-unavailable",
+                             "error_type": type(exc).__name__}
+        if final is not None:
+            text, turn = final
+            return ({**payload, "last_assistant_message": text, "turn_id": turn},
+                    {"status": "read", "turn_id": turn, "text_length": len(text)})
+        if attempt < 2:
+            time.sleep(0.025)  # allow only the already-queued native flush
+    return payload, {"status": "no_summary", "reason": "native-final-step-not-complete"}

--- a/.agents/lib/vaws_knowledge_service.py
+++ b/.agents/lib/vaws_knowledge_service.py
@@ -4,18 +4,60 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Sequence
 
-from vaws_local_owner import managed_path, managed_python, managed_receipt, windows_interop_env, windows_mounted_workspace
+from vaws_local_owner import accessible_windows_path, managed_path, managed_python, managed_receipt, windows_interop_env, windows_mounted_workspace
+from vaws_local_state import shared_workspace_root
+from vaws_session_state import write_json
 
 if TYPE_CHECKING:
     from vaws_knowledge.server.layers import ServiceConfig
 
 PROJECT_ROOT_RELATIVE = ".agents/knowledge"
 CANDIDATE_ROOT_RELATIVE = ".vaws-local/knowledge/candidate"
+LOCATION_ENV = ("VAWS_KNOWLEDGE_CONFIG", "VAWS_KNOWLEDGE_PROJECT_ROOTS",
+                "VAWS_KNOWLEDGE_CANDIDATE_ROOT", "VAWS_KNOWLEDGE_STATE")
+
+
+def knowledge_config_path(repo_root: Path) -> Path:
+    return shared_workspace_root(repo_root) / ".vaws-local/knowledge/service.json"
+
+
+def shared_project_config(repo_root: Path) -> Path:
+    """Update only the owned Markdown snapshot; retain user-selected mounts."""
+    primary = shared_workspace_root(repo_root)
+    path = primary / ".vaws-local/knowledge/service.json"
+    payload = json.loads(path.read_text(encoding="utf-8")) if path.is_file() else {}
+    if not isinstance(payload, dict):
+        raise ValueError("existing knowledge configuration must be a JSON object")
+    snapshot = path.parent / "project"
+    source = repo_root / PROJECT_ROOT_RELATIVE
+    files = {file.relative_to(source): file for file in source.rglob("*") if file.is_file()}
+    snapshot.mkdir(parents=True, exist_ok=True)
+    for relative, file in files.items():
+        target = snapshot / relative
+        if not target.is_file() or file.read_bytes() != target.read_bytes():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(file, target)
+    for file in snapshot.rglob("*"):
+        if file.is_file() and file.relative_to(snapshot) not in files:
+            file.unlink()
+    payload.setdefault("state_root", knowledge_owner_path(repo_root, path.parent / "instance"))
+    layers = payload.setdefault("layers", {})
+    project = layers.get("project")
+    defaults = [str(primary / PROJECT_ROOT_RELATIVE), knowledge_owner_path(repo_root, primary / PROJECT_ROOT_RELATIVE)]
+    if project is None or (isinstance(project, dict) and project.get("roots") in [[value] for value in defaults]):
+        layers["project"] = {**(project or {}), "roots": [knowledge_owner_path(repo_root, snapshot)]}
+    layers.setdefault("candidate", {"roots": [knowledge_owner_path(repo_root, path.parent / "candidate")]})
+    payload.setdefault("shared_sync", {"enabled": True})
+    payload.setdefault("publishing", {"enabled": False})
+    if not path.is_file() or json.loads(path.read_text(encoding="utf-8")) != payload:
+        write_json(path, payload)
+    return path
 
 
 def origin_repo_from_url(url: str) -> str:
@@ -53,7 +95,7 @@ def knowledge_identity(repo_root: Path) -> dict[str, str]:
 def knowledge_server_env(repo_root: Path) -> dict[str, str]:
     """Use the same roots from any client cwd or service-config directory."""
 
-    repo_root = repo_root.resolve()
+    repo_root = shared_workspace_root(repo_root)
     identity = knowledge_identity(repo_root)
     result = {"VAWS_KNOWLEDGE_ORIGIN_REPO": identity["origin_repo"]}
     config_path = repo_root / ".vaws-local/knowledge/service.json"
@@ -89,33 +131,55 @@ def knowledge_owner_env(repo_root: Path) -> dict[str, str]:
     return environment
 
 
-def run_knowledge_cli(repo_root: Path, arguments: Sequence[str]) -> tuple[int, dict[str, Any]]:
-    """Run the installed owner without importing its runtime into the caller."""
+def _run_knowledge(repo_root: Path, arguments: Sequence[str], *, receipt: dict | None = None,
+                   prepare: bool = False) -> tuple[int, dict[str, Any]]:
     try:
-        executable = knowledge_owner_python(repo_root)
+        executable = accessible_windows_path(receipt["python"]) if receipt else knowledge_owner_python(repo_root)
     except (OSError, ValueError, RuntimeError) as exc:
         return 1, {"status": "pending", "ready": False, "reason": str(exc)}
     if not Path(executable).is_file():
         return 1, {"status": "pending", "ready": False,
                    "reason": "knowledge owner interpreter is not installed", "interpreter": executable}
-    command = [executable, "-m", "vaws_knowledge", *arguments]
     try:
+        if prepare:
+            shared_project_config(repo_root)
+        environment = {key: value for key, value in os.environ.items() if key not in LOCATION_ENV}
+        environment.update(knowledge_owner_env(repo_root))
+        if receipt:
+            environment["VAWS_ENV_RECEIPT"] = receipt["receipt"]
+        command = [executable, *arguments]
         completed = subprocess.run(
-            command, cwd=str(repo_root), env={**os.environ, **knowledge_owner_env(repo_root)},
+            command, cwd=str(repo_root), env=environment,
             stdout=subprocess.PIPE, stderr=sys.stderr, text=True, encoding="utf-8", check=False,
         )
         payload = json.loads(completed.stdout)
         if not isinstance(payload, dict):
             raise ValueError("knowledge command returned no JSON object")
-    except (OSError, ValueError, TypeError) as exc:
+    except (OSError, ValueError, TypeError, RuntimeError) as exc:
         return 1, {"status": "pending", "ready": False, "reason": str(exc)}
     return completed.returncode, payload
 
 
-def prepare_knowledge(repo_root: Path) -> dict[str, Any]:
-    code, payload = run_knowledge_cli(
-        repo_root, ["prepare", "--project", knowledge_owner_path(repo_root, repo_root)],
-    )
+def run_knowledge_cli(repo_root: Path, arguments: Sequence[str]) -> tuple[int, dict[str, Any]]:
+    """Run the installed owner without importing its runtime into the caller."""
+    return _run_knowledge(repo_root, ["-m", "vaws_knowledge", *arguments])
+
+
+PREPARE_CODE = """import json
+from vaws_knowledge.server.layers import load_config
+from vaws_knowledge.publishing import run_once
+from vaws_knowledge.maintenance import maintain
+config = load_config()
+shared = run_once(config, force=True, verify=False)
+result = maintain(config, force=True, verify=False)
+result['config'] = str(config.config_path)
+result['shared'] = shared
+print(json.dumps(result, ensure_ascii=False))
+"""
+
+
+def prepare_knowledge(repo_root: Path, *, receipt: dict | None = None) -> dict[str, Any]:
+    code, payload = _run_knowledge(repo_root, ["-c", PREPARE_CODE], receipt=receipt, prepare=True)
     if code != 0 or payload.get("ready") is not True:
         return {**payload, "status": "pending", "ready": False}
     return payload
@@ -129,7 +193,7 @@ def service_config(
 ) -> ServiceConfig:
     from vaws_knowledge.server.layers import load_config
 
-    repo_root = repo_root.resolve()
+    repo_root = shared_workspace_root(repo_root)
     config_path = repo_root / ".vaws-local/knowledge/service.json"
     mapping: dict[str, Any] = {}
     if not config_path.is_file():
@@ -151,7 +215,7 @@ def service_config(
         mapping,
         env={},
         path=config_path if config_path.is_file() else None,
-        base_dir=repo_root,
+        base_dir=config_path.parent if config_path.is_file() else repo_root,
     )
 
 
@@ -160,7 +224,8 @@ def query_knowledge(*, knowledge_dir: Path, query: str, limit: int = 3) -> dict[
     repo = knowledge_dir.parent.parent if knowledge_dir.parent.name == ".agents" else knowledge_dir.parent
     try:
         from vaws_knowledge.server.query import query as package_query
-        result = package_query(service_config(repo, project_root=knowledge_dir), text=query, limit=limit)
+        override = None if knowledge_dir == repo / PROJECT_ROOT_RELATIVE else knowledge_dir
+        result = package_query(service_config(repo, project_root=override), text=query, limit=limit)
         return result.to_dict()
     except Exception as exc:
         return {"results": [], "unavailable": True, "degraded": True, "index_detail": str(exc)}

--- a/.agents/lib/vaws_mcp_runtime.py
+++ b/.agents/lib/vaws_mcp_runtime.py
@@ -230,6 +230,12 @@ class Provider:
             schema = copy.deepcopy(item.inputSchema)
             schema.setdefault("properties", {}).setdefault("context_file", {
                 "type": "string", "description": "Existing VAWS context; native hooks normally supply it."})
+            if self.environment.get("VAWS_MCP_CLIENT") == "kimi":
+                schema["properties"]["context_file"] = {
+                    "type": "string", "description": "Copy context_file supplied by this session's native hook or vaws_start result."}
+                required = schema.setdefault("required", [])
+                if "context_file" not in required:
+                    required.append("context_file")
             item.inputSchema = schema
             tools.append(item)
         return tools

--- a/.agents/lib/vaws_mcp_runtime.py
+++ b/.agents/lib/vaws_mcp_runtime.py
@@ -1,0 +1,278 @@
+"""Route a provider call to the immutable environment selected by its task.
+
+This adapter owns stdio connections, not task execution or knowledge behavior.
+Native identity selects a prepared receipt; existing task receipts never follow
+the latest catalog. Backend stderr and selected inputs remain inspectable.
+"""
+from __future__ import annotations
+
+import asyncio
+import copy
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import timedelta
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+
+from vaws_environment import read_receipt, saved_ready, PIN_ENV
+from vaws_local_state import shared_workspace_root
+from vaws_session_state import task_dir
+
+
+@dataclass(frozen=True)
+class Selection:
+    workspace: Path
+    receipt: str
+    python: str
+    key: str
+    context_file: str = ""
+
+
+def caller_context(arguments: dict, metadata: dict | None, *, state_dir: str = "") -> dict | None:
+    from vaws_coordinator.agent_session import AgentSessions, load_context
+
+    supplied = arguments.get("context_file")
+    context = None
+    store = AgentSessions(Path(state_dir) if state_dir else None)
+    metadata = metadata or {}
+    if "x-codex-turn-metadata" in metadata:
+        turn = metadata["x-codex-turn-metadata"]
+        native = turn.get("thread_id") if isinstance(turn, dict) else None
+        if not isinstance(native, str) or not native:
+            raise ValueError("native Codex request has no thread_id")
+        context = store.native_context("codex", native)
+    elif "kimi_code/session_id" in metadata:
+        native = metadata["kimi_code/session_id"]
+        agent = metadata.get("kimi_code/agent_id", "")
+        if not isinstance(native, str) or not native or not isinstance(agent, str):
+            raise ValueError("native Kimi request has no session identity")
+        context = store.native_context("kimi", native, "" if agent == "main" else agent)
+    if context is not None:
+        if supplied and str(supplied) != context["context_file"]:
+            raise ValueError("context_file differs from the native caller")
+        return context
+    return load_context(supplied, allow_native_context=False) if supplied else None
+
+
+def selection(root: Path, context: dict | None = None, *, catalog: bool = False) -> Selection:
+    shared = shared_workspace_root(root)
+    path = (task_dir(context["session"]["id"], shared) / "start.json" if context else
+            shared / ".vaws-local/latest-runtime.json")
+    if (context or catalog) and path.is_file():
+        result = json.loads(path.read_text(encoding="utf-8"))
+        target = Path(result["workspace"]).resolve(strict=True)
+        receipt = read_receipt(result["environment"]["receipt"])
+    else:
+        # No prepared task record is needed for native worktrees. Its actual
+        # attachment already names the directory prepared before the Agent.
+        target = Path(context["attachment"]["cwd"]) if context else root
+        target = target.resolve(strict=True)
+        if context:
+            from vaws_workspace_update import common_dir, git
+            shared_git = common_dir(root)
+            target = Path(git(target, "rev-parse", "--show-toplevel")).resolve()
+            actual_git = Path(git(target, "rev-parse", "--absolute-git-dir")).resolve()
+            selected_file = target / ".vaws-local/environment-selection" / f"{sys.platform}.json"
+            if common_dir(target) != shared_git or actual_git == shared_git or not selected_file.is_file():
+                raise ValueError("This new task has no prepared workspace. Run the project vaws_start.py entry once, then reuse its context.")
+        receipt = saved_ready(target)
+    return Selection(target, receipt["receipt"], receipt["python"], receipt["key"],
+                     context["context_file"] if context else "")
+
+
+def provider_command(kind: str, selected: Selection, environment: dict) -> tuple[list[str], dict]:
+    from vaws_coordinator_launch import coordinator_environment
+    from vaws_knowledge_service import knowledge_server_env
+
+    modules = {"task": ["-m", "vaws_coordinator", "task-server"],
+               "remote": ["-m", "remote_dev.mcp.server"],
+               "knowledge": ["-m", "vaws_knowledge.server.mcp_server"]}
+    env = dict(environment)
+    for key in ("PYTHONHOME", "PYTHONPATH", "VIRTUAL_ENV", "VAWS_MANAGED_ENV_RECEIPT",
+                "VAWS_CONTEXT_FILE", "VAWS_PARENT_CONTEXT", "VAWS_ATTACH_CONTEXT"):
+        env.pop(key, None)
+    env[PIN_ENV] = selected.receipt
+    env["VIRTUAL_ENV"] = str(Path(selected.python).parent.parent)
+    env["PATH"] = str(Path(selected.python).parent) + os.pathsep + env.get("PATH", "")
+    if kind == "task":
+        env = coordinator_environment(env, repo_root=selected.workspace)
+    elif kind == "remote":
+        env.setdefault("REMOTE_DEV_DEFAULT_USER", "root")
+        env["REMOTE_DEV_STATE_DIR"] = str(selected.workspace / ".vaws-local/remote-dev-state")
+    elif kind == "knowledge":
+        # A user MCP entry may have inherited its mother checkout's config.
+        # Target settings must win; model credentials/explicit backend settings
+        # are unrelated and remain in the environment.
+        for key in ("VAWS_KNOWLEDGE_CONFIG", "VAWS_KNOWLEDGE_PROJECT_ROOTS",
+                    "VAWS_KNOWLEDGE_CANDIDATE_ROOT", "VAWS_KNOWLEDGE_STATE"):
+            env.pop(key, None)
+        env.update(knowledge_server_env(selected.workspace))
+    else:
+        raise ValueError(f"unknown provider: {kind}")
+    return [selected.python, *modules[kind]], env
+
+
+class Backend:
+    """One task environment connection, owned and closed by one async worker."""
+
+    def __init__(self, kind: str, selected: Selection, root: Path, environment: dict):
+        self.kind, self.selected = kind, selected
+        self.command, self.environment = provider_command(kind, selected, environment)
+        digest = hashlib.sha256(str(selected.workspace).encode()).hexdigest()[:12]
+        self.stderr = shared_workspace_root(root) / ".vaws-local/mcp/providers" / f"{kind}-{selected.key[:12]}-{digest}.log"
+        self.closed = asyncio.Event()
+        self.requests = set()
+        self.ready = asyncio.get_running_loop().create_future()
+        self.worker = asyncio.create_task(self.run())
+
+    async def run(self):
+        from mcp import ClientSession, StdioServerParameters
+        from mcp.client.stdio import stdio_client
+        from mcp import types
+        import anyio
+
+        class CancellableSession(ClientSession):
+            async def send_request(self, request, result_type, *args, **kwargs):
+                # MCP SDK 1.30 assigns this ID before its first await, but does
+                # not send notifications/cancelled when its caller cancels.
+                request_id = self._request_id
+                try:
+                    return await super().send_request(request, result_type, *args, **kwargs)
+                except asyncio.CancelledError:
+                    with anyio.move_on_after(1, shield=True):
+                        with suppress(Exception):
+                            await self.send_notification(types.ClientNotification(types.CancelledNotification(
+                                method="notifications/cancelled", params=types.CancelledNotificationParams(
+                                    requestId=request_id, reason="native caller cancelled"))))
+                    raise
+
+        try:
+            self.stderr.parent.mkdir(parents=True, exist_ok=True)
+            with self.stderr.open("a", encoding="utf-8") as log:
+                facts = {"provider": self.kind, "workspace": str(self.selected.workspace),
+                         "environment": self.selected.key, "python": self.selected.python,
+                         "receipt": self.selected.receipt, "stderr": str(self.stderr)}
+                log.write(json.dumps({"vaws_provider_start": facts}) + "\n")
+                log.flush()
+                print(json.dumps({"vaws_provider_start": facts}), file=sys.stderr, flush=True)
+                parameters = StdioServerParameters(command=self.command[0], args=self.command[1:],
+                                                   cwd=self.selected.workspace, env=self.environment)
+                async with stdio_client(parameters, errlog=log) as (reader, writer):
+                    async with CancellableSession(reader, writer, read_timeout_seconds=timedelta(seconds=1800)) as session:
+                        await session.initialize()
+                        self.ready.set_result(session)
+                        await self.closed.wait()
+        except BaseException as exc:
+            if not self.ready.done():
+                if isinstance(exc, asyncio.CancelledError):
+                    self.ready.cancel()
+                else:
+                    self.ready.set_exception(exc)
+            if not isinstance(exc, asyncio.CancelledError):
+                failure = json.dumps({"vaws_provider_failed": type(exc).__name__, "error": str(exc),
+                                      "evidence": str(self.stderr)})
+                with suppress(OSError):
+                    with self.stderr.open("a", encoding="utf-8") as log:
+                        log.write(failure + "\n")
+                print(failure, file=sys.stderr, flush=True)
+            for request in self.requests:
+                request.cancel()
+            if isinstance(exc, asyncio.CancelledError):
+                raise
+
+    async def request(self, method: str, **arguments):
+        try:
+            session = await asyncio.shield(self.ready)
+        except Exception as exc:
+            raise RuntimeError(f"{self.kind} provider could not start in {self.selected.key}; evidence: {self.stderr}: {exc}") from exc
+        if self.worker.done():
+            raise RuntimeError(f"provider stopped; evidence: {self.stderr}")
+        request = asyncio.create_task(getattr(session, method)(**arguments))
+        self.requests.add(request)
+        try:
+            return await request
+        except Exception as exc:
+            raise RuntimeError(f"{self.kind} provider {method} failed in {self.selected.key}; evidence: {self.stderr}: {exc}") from exc
+        finally:
+            self.requests.discard(request)
+
+    async def close(self):
+        pending = list(self.requests)
+        for request in pending:
+            request.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        if not self.worker.done():
+            self.worker.cancel()
+        with suppress(asyncio.CancelledError):
+            await self.worker
+
+
+class Provider:
+    def __init__(self, kind: str, root: Path, environment: dict | None = None):
+        self.kind, self.root = kind, root
+        self.environment = dict(os.environ if environment is None else environment)
+        self.backends = {}
+
+    def backend(self, selected: Selection) -> Backend:
+        key = (str(selected.workspace), selected.receipt)
+        if key not in self.backends:
+            self.backends[key] = Backend(self.kind, selected, self.root, self.environment)
+        return self.backends[key]
+
+    async def list_tools(self):
+        result = await self.backend(selection(self.root, catalog=True)).request("list_tools")
+        tools = []
+        for tool in result.tools:
+            item = tool.model_copy(deep=True)
+            schema = copy.deepcopy(item.inputSchema)
+            schema.setdefault("properties", {}).setdefault("context_file", {
+                "type": "string", "description": "Existing VAWS context; native hooks normally supply it."})
+            item.inputSchema = schema
+            tools.append(item)
+        return tools
+
+    async def call_tool(self, name: str, arguments: dict, metadata: dict | None = None):
+        context = caller_context(arguments, metadata, state_dir=self.environment.get("VAWS_AGENT_SESSIONS_DIR", ""))
+        if context is None:
+            raise ValueError("No native task context was supplied. Pass the context_file from session startup; no workspace or runtime was guessed.")
+        selected = selection(self.root, context)
+        values = dict(arguments)
+        if self.kind == "task" and context:
+            values["context_file"] = context["context_file"]
+        elif self.kind != "task":
+            values.pop("context_file", None)
+        backend = self.backend(selected)
+        result = await backend.request("call_tool", name=name, arguments=values, meta=metadata)
+        result.meta = {**(result.meta or {}), "vaws_provider": {
+            "environment": selected.key, "workspace": str(selected.workspace),
+            "python": selected.python, "stderr": str(backend.stderr)}}
+        return result
+
+    async def close(self):
+        await asyncio.gather(*(backend.close() for backend in self.backends.values()), return_exceptions=True)
+
+
+async def serve(kind: str, root: Path):
+    from mcp.server.lowlevel import Server
+    from mcp.server.stdio import stdio_server
+
+    provider = Provider(kind, root)
+    server = Server("vaws-" + kind + "-environment", version="1")
+
+    @server.list_tools()
+    async def list_tools():
+        return await provider.list_tools()
+
+    @server.call_tool(validate_input=False)
+    async def call_tool(name, arguments):
+        meta = server.request_context.meta
+        return await provider.call_tool(name, arguments, meta.model_dump(exclude_none=True) if meta else None)
+
+    try:
+        async with stdio_server() as (reader, writer):
+            await server.run(reader, writer, server.create_initialization_options())
+    finally:
+        await provider.close()

--- a/.agents/lib/vaws_native_mode_config.py
+++ b/.agents/lib/vaws_native_mode_config.py
@@ -1,49 +1,17 @@
 """Plan supported native worktree preferences during one-time client setup.
 
 These functions never write user configuration or launch an Agent session.
-Grok only reads these preferences at user scope. Claude's WorktreeCreate hook
-is not a default-mode switch. Kimi's optional SessionSetup schema is probed
-with its own read-only config doctor, rather than inferred from a version.
+Project guidance supports stock clients independently of native preferences;
+these optional settings only improve native worktree creation when available.
 """
 from __future__ import annotations
 
 import copy
-import hashlib
 import json
 import os
 from pathlib import Path
 import re
-import subprocess
-import tempfile
 import tomllib
-
-
-def grok_native_defaults(executable: str | Path | None, project: Path) -> dict:
-    """Reuse acceptance of one installed binary during explicit initialization.
-
-    The personal build may share an upstream version number. Its installation
-    receipt identifies the actual bytes tested for bare startup and resume;
-    another executable or an update requires fresh evidence, not a version guess.
-    """
-    from vaws_local_state import shared_workspace_root
-    receipt_path = shared_workspace_root(project) / ".vaws-local/client-installations/grok-native.json"
-    unavailable = {"supported": False, "reason": "native-default-build-unverified"}
-    if not executable or not receipt_path.is_file():
-        return unavailable
-    try:
-        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
-        binary = Path(executable).resolve()
-        if (Path(receipt["binary"]).resolve() != binary
-                or receipt.get("capabilities", {}).get("bare_worktree_default") is not True):
-            return unavailable
-        with binary.open("rb") as stream:
-            actual = hashlib.file_digest(stream, "sha256").hexdigest()
-        if actual != receipt["sha256"]:
-            return {**unavailable, "reason": "native-default-build-changed"}
-        return {"supported": True, "reason": "accepted-native-default-build",
-                "receipt": str(receipt_path), "sha256": actual}
-    except (OSError, ValueError, KeyError, TypeError, AttributeError):
-        return unavailable
 
 
 def _set_scalar(text: str, table: str, key: str, value: str | bool) -> str:
@@ -73,48 +41,30 @@ def _set_scalar(text: str, table: str, key: str, value: str | bool) -> str:
 
 
 def add_native_mode(files: dict[Path, str], notes: list, client: str,
-                    project: Path, *, user_home: Path | None = None,
-                    capability: dict | None = None, kimi_tui_config: Path | None = None) -> None:
+                    project: Path, *, user_home: Path | None = None) -> None:
     """Append planned files/notes; the existing setup owner applies and backs up.
 
     Call only for explicitly requested one-time initialization, never from a
-    per-worktree callback. Kimi SessionSetup wiring remains with its existing
-    client builder; use kimi_session_setup_capability before enabling it.
+    per-worktree callback. Client upgrades remain under their native settings.
     """
     if client == "claude":
         notes.append({"client": client, "action": "unsupported", "scope": "native-cli",
                       "reason": "no-native-default-worktree-setting",
-                      "detail": "Claude Code 2.1.269 exposes --worktree and background isolation, "
-                                "not a default worktree setting for ordinary CLI sessions. "
-                                "WorktreeCreate only handles creation already requested by the client.",
+                      "detail": "WorktreeCreate prepares directories created by the native client; "
+                                "ordinary sessions use the shared project startup instructions.",
                       "reference": "https://code.claude.com/docs/en/worktrees"})
         return
-    accepted = bool(capability and capability.get("supported") is True)
-    if client == "kimi":
-        if not accepted or kimi_tui_config is None:
-            return
-        path = kimi_tui_config
-        values = {"upgrade": {"auto_install": False}}
-        reason = "preserve-native-session-extension"
-        detail = ("Native automatic installation is disabled for the verified SessionSetup extension "
-                  "so an official update cannot remove its supported hook event.")
-    elif client == "grok":
+    if client == "grok":
         home = (Path(user_home).expanduser() / ".grok" if user_home is not None
                 else Path(os.environ.get("GROK_HOME", str(Path.home() / ".grok"))).expanduser())
         path = home / "config.toml"
         values = {"cli": {"worktree_type": "git"},
                   "hints": {"new_session_worktree_mode": "always", "fork_worktree_mode": "always"}}
-        if accepted:
-            values["cli"]["auto_update"] = False
         reason = "native-worktree-preferences"
         detail = ("Grok loads these preferences only from user configuration. "
                   "They affect /new and /fork in the inspected stock client. "
-                  "Automatic bare startup also requires the native startup-default patch; "
-                  "only an installed binary receipt with matching hash and startup/resume "
-                  "acceptance can establish that capability.")
-        if accepted:
-            detail += (" Native automatic updates are disabled for this accepted personal build "
-                       "so an official release cannot overwrite its worktree patch.")
+                  "Unprepared new sessions use the shared project startup instructions. "
+                  "These preferences do not establish isolation or require a personal binary.")
     else:
         return
     try:
@@ -168,7 +118,8 @@ def add_grok_import_dedup(files: dict, notes: list, project: Path, root: Path, *
     Grok merges imported providers by their exact names. Its native underscore
     providers supersede our Cursor-only launchers; other imported servers remain.
     """
-    from vaws_cursor_mcp_config import KINDS, document, owned_entry
+    from vaws_cursor_mcp_config import document, owned_entry
+    from vaws_claude_config import provider_kind
 
     user_dir = Path.home()
     path = Path(os.environ.get("GROK_HOME", str(user_dir / ".grok"))).expanduser() / "config.toml"
@@ -197,7 +148,7 @@ def add_grok_import_dedup(files: dict, notes: list, project: Path, root: Path, *
                     or not isinstance(imported.get("env"), dict)
                     or imported["env"].get("VAWS_MCP_WORKSPACE") != "${workspaceFolder}"
                     or not isinstance(replacement, dict) or replacement.get("enabled") is False
-                    or replacement.get("args") != next(list(args) for args, value in KINDS.items() if value == kind)
+                    or provider_kind(replacement.get("args"), root) != kind
                     or not owned_server(replacement, project)):
                 continue
             duplicates.append(name)
@@ -219,37 +170,3 @@ def add_grok_import_dedup(files: dict, notes: list, project: Path, root: Path, *
     except (OSError, UnicodeError, ValueError, TypeError) as exc:
         notes.append({"client": "grok", "path": str(path), "action": "preserved",
                       "reason": "grok-compat-mcp-needs-integration", "detail": str(exc)})
-
-
-def kimi_session_setup_capability(executable: str | Path) -> dict:
-    """Ask the actual installed parser whether the SessionSetup extension exists.
-
-    A second unknown event must be rejected, so a CLI that ignores arbitrary
-    configuration cannot appear supported. Doctor parses fixture files only;
-    neither hook commands nor model requests run, and user config is untouched.
-    """
-    checks = []
-    try:
-        with tempfile.TemporaryDirectory(prefix="vaws-kimi-capability-") as folder:
-            directory = Path(folder)
-            environment = {**os.environ, "KIMI_CODE_HOME": str(directory)}
-            for event in ("SessionSetup", "VAWSUnsupportedEvent"):
-                path = directory / (event + ".toml")
-                path.write_text('[[hooks]]\nevent = ' + json.dumps(event)
-                                + '\ncommand = "exit 0"\n', encoding="utf-8")
-                result = subprocess.run([str(executable), "doctor", "config", str(path)],
-                                        cwd=directory, env=environment, capture_output=True,
-                                        text=True, encoding="utf-8", errors="replace", timeout=10)
-                checks.append({"event": event, "returncode": result.returncode,
-                               "output": (result.stdout + result.stderr)[-2048:]})
-        # The negative fixture's error must explicitly identify its hook field;
-        # an unrelated failure or an unsupported doctor command is not evidence.
-        supported = (checks[0]["returncode"] == 0 and checks[1]["returncode"] != 0
-                     and "hooks[0].event" in checks[1]["output"]
-                     and '"SessionSetup"' in checks[1]["output"])
-        return {"supported": supported,
-                "reason": "native-session-setup-supported" if supported else "native-session-setup-unavailable",
-                "checks": checks}
-    except (OSError, subprocess.SubprocessError) as exc:
-        return {"supported": False, "reason": "native-session-setup-probe-failed",
-                "error": str(exc), "checks": checks}

--- a/.agents/lib/vaws_start_context.py
+++ b/.agents/lib/vaws_start_context.py
@@ -1,0 +1,111 @@
+"""Project existing task preparation facts into native startup hints.
+
+The coordinator still owns attachment and hook scope. This read-only adapter
+uses the same selection as MCP dispatch; it never prepares or changes a task.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+
+from vaws_mcp_runtime import selection
+
+
+def hint_event(payload: object) -> bool:
+    return isinstance(payload, dict) and (
+        payload.get("hook_event_name") or payload.get("hookEventName")
+    ) in {"SessionStart", "UserPromptSubmit"}
+
+
+def existing_context(client: str, payload: dict) -> dict:
+    from vaws_coordinator.agent_session import AgentSessions
+
+    # These are native hook identities, never a directory or an inherited
+    # shell context. Cursor's documented SessionStart also supplies session_id.
+    field = "sessionId" if client == "grok" else "session_id"
+    native = payload.get("conversation_id") if client == "cursor" else None
+    native = native or payload.get(field)
+    if not isinstance(native, str) or not native:
+        raise ValueError("hook has no native session identity; no task was guessed")
+    event = payload.get("hook_event_name") or payload.get("hookEventName")
+    agent = payload.get("agent_id") or "" if event != "SessionStart" else ""
+    if client == "kimi" and agent == "main":
+        agent = ""
+    if not isinstance(agent, str):
+        raise ValueError("hook agent identity is not a string")
+    state = os.environ.get("VAWS_AGENT_SESSIONS_DIR")
+    return AgentSessions(Path(state) if state else None).native_context(client, native, agent)
+
+
+def preparation_hint(root: Path, client: str, context: dict) -> str:
+    if not context["session"].get("github_identity"):
+        return ("VAWS first-use setup is incomplete: no confirmed GitHub identity is bound. "
+                "Follow AGENTS.md first-use setup: ask once for the personal GitHub username "
+                "unless it was already supplied, then reuse that answer. "
+                "No prepared editing workspace or component runtime is confirmed.")
+    try:
+        selected = selection(root, context)
+    except ValueError as exc:
+        # This is selection's sole explicit unprepared result. All errors in
+        # an existing task record or native selection remain failures below.
+        if str(exc) != ("This new task has no prepared workspace. Run the project "
+                        "vaws_start.py entry once, then reuse its context."):
+            raise
+        command = ["uv", "run", "--no-project", "python", str(root.resolve() / ".agents/scripts/vaws_start.py"),
+                   "--client", client, "--context-file", context["context_file"]]
+        rendered = subprocess.list2cmdline(command) if os.name == "nt" else shlex.join(command)
+        return ("VAWS task is attached but its editing workspace and component runtime are NOT prepared. "
+                "First repository action, before file reads, edits or VAWS tool calls:\n"
+                f"{rendered}\n"
+                "Then use the returned workspace W for file tools and `cd W` for shell commands. "
+                "Native cwd/source defaults alone do not mean preparation is complete.")
+    return (f"VAWS task workspace is prepared: W={selected.workspace}\n"
+            f"Selected environment: {selected.key}\nSelected Python: {selected.python}\n"
+            "Use W for file tools and `cd W` for shell commands. Reuse this task's existing "
+            "workspace and environment; startup preparation need not be repeated.")
+
+
+def project_output(client: str, payload: dict, raw: str, *, root: Path) -> str:
+    """Preserve package noops/errors and each client's native output envelope."""
+    if not hint_event(payload) or not raw.strip():
+        return raw
+    event = payload.get("hook_event_name") or payload.get("hookEventName")
+    text_only = client == "kimi" and event == "UserPromptSubmit"
+    if text_only:
+        hint, output = raw.rstrip("\n"), None
+    else:
+        try:
+            output = json.loads(raw)
+        except ValueError:
+            return raw
+        if not isinstance(output, dict) or not output:
+            return raw
+        specific = output.get("hookSpecificOutput", {})
+        hint = output.get("additional_context") if client == "cursor" else specific.get("additionalContext")
+        # Some Cursor package events use the generic envelope. The client
+        # contract still consumes additional_context at the root.
+        if client == "cursor" and hint is None:
+            hint = specific.get("additionalContext")
+        if not isinstance(hint, str) or not hint:
+            return raw
+    try:
+        facts = preparation_hint(root, client, existing_context(client, payload))
+    except Exception as exc:
+        facts = (f"VAWS workspace selection could not be read: {type(exc).__name__}: {exc}. "
+                 "The existing task selection was left unchanged; inspect its context and "
+                 "recorded environment before continuing. No new workspace was inferred.")
+    hint = facts + "\n\n" + hint.replace("Client startup owns workspace and component preparation. ", "")
+    if text_only:
+        return hint + "\n"
+    if client == "cursor":
+        output["additional_context"] = hint
+        if "additionalContext" in specific:
+            specific.pop("additionalContext")
+            if set(specific) <= {"hookEventName"}:
+                output.pop("hookSpecificOutput")
+    else:
+        specific["additionalContext"] = hint
+    return json.dumps(output, ensure_ascii=False) + "\n"

--- a/.agents/lib/vaws_start_guidance.py
+++ b/.agents/lib/vaws_start_guidance.py
@@ -17,13 +17,13 @@ def guidance(client: str | None = None) -> str:
     selection = (" Replace CLIENT with your native client: codex, cursor, claude, grok or kimi."
                  if client is None else "")
     return (
-        "On first use, complete AGENTS.md's First use, forks and updates setup before "
-        "this new-session step.\n\n"
-        "For a new native session, use an independent native worktree when startup supplied "
-        "its selected environment. Otherwise make the first repository action "
+        "For a new native session, make the first repository action "
         f"`uv run --no-project python .agents/scripts/vaws_start.py --client {name}`."
         + selection + " Add `--context-file PATH` when the native hook supplied that context "
-        "and the command cannot obtain it from the client environment (official Kimi needs it).\n\n"
+        "and the command cannot obtain it from the client environment (official Kimi needs it). "
+        "The command checks saved initialization itself and reports missing first-use setup; "
+        "no configuration inspection is needed beforehand. If the native hook explicitly "
+        "reports a prepared workspace W and selected environment, use them directly.\n\n"
         "Use the returned `workspace` as W: shell tools use W as cwd (or `cd W && ...`), "
         "and file, search and patch tools use absolute paths under W. Sources and the selected "
         "environment are already bound; do not repeat session setup. Official Kimi calls to "

--- a/.agents/lib/vaws_start_guidance.py
+++ b/.agents/lib/vaws_start_guidance.py
@@ -17,6 +17,8 @@ def guidance(client: str | None = None) -> str:
     selection = (" Replace CLIENT with your native client: codex, cursor, claude, grok or kimi."
                  if client is None else "")
     return (
+        "On first use, complete AGENTS.md's First use, forks and updates setup before "
+        "this new-session step.\n\n"
         "For a new native session, use an independent native worktree when startup supplied "
         "its selected environment. Otherwise make the first repository action "
         f"`uv run --no-project python .agents/scripts/vaws_start.py --client {name}`."

--- a/.agents/lib/vaws_start_guidance.py
+++ b/.agents/lib/vaws_start_guidance.py
@@ -1,0 +1,76 @@
+"""Project instructions for one native session's selected editing directory.
+
+The native clients read these files themselves. Planning does not start a
+session, invoke a Skill, or infer identity from the current directory.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+BEGIN = "<!-- BEGIN VAWS session-start -->"
+END = "<!-- END VAWS session-start -->"
+
+
+def guidance(client: str | None = None) -> str:
+    name = client or "CLIENT"
+    selection = (" Replace CLIENT with your native client: codex, cursor, claude, grok or kimi."
+                 if client is None else "")
+    return (
+        "For a new native session, use an independent native worktree when startup supplied "
+        "its selected environment. Otherwise make the first repository action "
+        f"`uv run --no-project python .agents/scripts/vaws_start.py --client {name}`."
+        + selection + " Add `--context-file PATH` when the native hook supplied that context "
+        "and the command cannot obtain it from the client environment (official Kimi needs it).\n\n"
+        "Use the returned `workspace` as W: shell tools use W as cwd (or `cd W && ...`), "
+        "and file, search and patch tools use absolute paths under W. Sources and the selected "
+        "environment are already bound; do not repeat session setup. Official Kimi calls to "
+        "the task, remote-dev and knowledge MCP providers also carry the returned `context_file`. "
+        "Other clients receive context through hooks; if a tool reports missing context, pass "
+        "the existing `context_file`. Use configured knowledge tools when useful.\n\n"
+        "Resume keeps the earlier W, task and environment; do not prepare, update or create "
+        "another directory. Client UI/default cwd can remain at the original project.\n"
+    )
+
+
+def managed_block(original: str, body: str) -> str:
+    block = BEGIN + "\n" + body.rstrip() + "\n" + END
+    if BEGIN in original or END in original:
+        if original.count(BEGIN) != 1 or original.count(END) != 1:
+            raise ValueError("VAWS session-start instruction markers are incomplete or duplicated")
+        start, end = original.index(BEGIN), original.index(END)
+        if end < start:
+            raise ValueError("VAWS session-start instruction markers are reversed")
+        return original[:start] + block + original[end + len(END):]
+    return block + "\n\n" + original
+
+
+def add_start_guidance(files: dict[Path, str], notes: list, client: str, project: Path) -> None:
+    """Plan only generated blocks; keep all other project instructions intact."""
+    path = project / "AGENTS.md"
+    original = files.get(path)
+    if original is None:
+        original = path.read_text(encoding="utf-8") if path.exists() else ""
+    files[path] = managed_block(original, guidance())
+    if client == "claude":
+        projection = project / "CLAUDE.md"
+        original = files.get(projection)
+        if original is None:
+            original = projection.read_text(encoding="utf-8") if projection.exists() else ""
+        if BEGIN in original or END in original or "@AGENTS.md" not in original.splitlines():
+            files[projection] = managed_block(original, "@AGENTS.md")
+    elif client == "cursor":
+        projection = project / ".cursor/rules/vaws-session-start.mdc"
+        original = files.get(projection)
+        if original is None:
+            original = projection.read_text(encoding="utf-8") if projection.exists() else ""
+        if original and BEGIN not in original and END not in original:
+            notes.append({"path": str(projection), "action": "preserved", "reason": "custom-session-start-rule"})
+        elif original:
+            files[projection] = managed_block(original, guidance("cursor"))
+        else:
+            body = managed_block("", guidance("cursor"))
+            files[projection] = "---\ndescription: Select this native session's editing workspace\nalwaysApply: true\n---\n\n" + body
+    notes.append({"client": client, "path": str(path), "action": "configured",
+                  "reason": "new-session-project-guidance", "skill_required": False,
+                  "resume": "reuse-existing-workspace"})

--- a/.agents/lib/vaws_workspace_update.py
+++ b/.agents/lib/vaws_workspace_update.py
@@ -87,12 +87,13 @@ def common_dir(root: Path) -> Path:
 
 
 @contextmanager
-def update_lock(root: Path):
-    """Serialize updates for a Git repository, including linked worktrees."""
+def update_lock(root: Path, *, wait_seconds: float = 0):
+    """Serialize updates; new sessions can wait briefly for shared preparation."""
     from vaws_local_owner import windows_mounted_workspace
     if windows_mounted_workspace(root):
         raise Deferred("windows_owner_required", "run workspace_update.py with the native Windows owner")
-    with (common_dir(root) / "vaws-update.lock").open("a+b") as handle:
+    path = common_dir(root) / "vaws-update.lock"
+    with path.open("a+b") as handle:
         acquired = False
         try:
             if os.name == "nt":
@@ -102,18 +103,31 @@ def update_lock(root: Path):
                 if os.fstat(handle.fileno()).st_size == 0:
                     handle.write(b"0")
                     handle.flush()
-                handle.seek(0)
+            started = time.monotonic()
+            announced = False
+            while not acquired:
                 try:
-                    msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                    if os.name == "nt":
+                        handle.seek(0)
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                    else:
+                        import fcntl
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                 except OSError as exc:
-                    raise Deferred("updater_running") from exc
-            else:
-                import fcntl
-                try:
-                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-                except BlockingIOError as exc:
-                    raise Deferred("updater_running") from exc
-            acquired = True
+                    if os.name != "nt" and not isinstance(exc, BlockingIOError):
+                        raise
+                    elapsed = time.monotonic() - started
+                    if elapsed >= wait_seconds:
+                        detail = (f"workspace preparation is still running after {elapsed:.1f}s; "
+                                  f"lock: {path}") if wait_seconds else ""
+                        raise Deferred("updater_running", detail,
+                                       evidence={"lock": str(path), "waited_seconds": round(elapsed, 3)}) from exc
+                    if not announced:
+                        print("VAWS: waiting for another session's workspace preparation", file=sys.stderr, flush=True)
+                        announced = True
+                    time.sleep(min(0.2, wait_seconds - elapsed))
+                else:
+                    acquired = True
             yield
         finally:
             if acquired:

--- a/.agents/scripts/vaws_claude_entry.py
+++ b/.agents/scripts/vaws_claude_entry.py
@@ -70,6 +70,8 @@ def main(argv=None) -> int:
     try:
         target = workspace(Path.cwd(), os.environ.get("CLAUDE_PROJECT_DIR"))
         if args.kind in PROVIDERS:
+            from vaws_venv import ensure_workspace_interpreter
+            ensure_workspace_interpreter(repo_root=ROOT)
             import asyncio
             from vaws_mcp_runtime import serve
             asyncio.run(serve(args.kind, target))

--- a/.agents/scripts/vaws_claude_entry.py
+++ b/.agents/scripts/vaws_claude_entry.py
@@ -69,6 +69,11 @@ def main(argv=None) -> int:
     args, options = parser.parse_known_args(argv)
     try:
         target = workspace(Path.cwd(), os.environ.get("CLAUDE_PROJECT_DIR"))
+        if args.kind in PROVIDERS:
+            import asyncio
+            from vaws_mcp_runtime import serve
+            asyncio.run(serve(args.kind, target))
+            return 0
         command, environment = launch_plan(args.kind, target, options, os.environ)
         # Claude exposes this file only to SessionStart. Use the native
         # channel for subsequent shell tools, alongside the coordinator's

--- a/.agents/scripts/vaws_client_setup.py
+++ b/.agents/scripts/vaws_client_setup.py
@@ -6,7 +6,8 @@ policies, authenticate clients, run hooks, or contact a remote machine. It
 never writes a bearer token and must not be applied to the operator's live
 client configuration from tests.
 
-Three logical providers are written when needed:
+Three logical providers use the stable native MCP entry, which dispatches to
+the component environment selected by the native task:
 
 * `vaws-task` -> `python -m vaws_coordinator task-server`, which serves
   `vaws_session` / `vaws_run` / `vaws_execution` / `vaws_finish` and optional
@@ -54,6 +55,7 @@ from vaws_local_owner import managed_path as _managed_path, managed_python as _m
 from vaws_environment import PIN_ENV, native_ready, windows_ready, read_receipt
 from vaws_local_state import agent_sessions_root
 from vaws_native_task_env import user_task_env
+from vaws_claude_config import provider_kind
 from vaws_remote_dev import state_dir
 
 CLIENTS = {"claude", "grok", "kimi", "codex", "cursor"}
@@ -63,7 +65,10 @@ TASK_SERVER_NAME = "vaws-task"
 REMOTE_DEV_SERVER_NAME = "remote-dev"
 KNOWLEDGE_SERVER_NAME = "vaws-knowledge"
 HOOK_TIMEOUT_SECONDS = 12
-TASK_TOOL_MATCHER = r"(?:^|:|__)vaws_(session|run|execution|finish|message)$"
+TASK_TOOL_MATCHER = r"(?:^|:|__)vaws_(?:session|run|execution|finish|message)$"
+COMPANION_TOOL_MATCHER = r"^(?:MCP:)?(?:mcp__)?(?:vaws[-_]knowledge__knowledge_(?:query|explain|capture)|remote[-_]dev__remote_[a-z_]+)$"
+CONTEXT_TOOL_MATCHER = "(?:" + TASK_TOOL_MATCHER + "|" + COMPANION_TOOL_MATCHER + ")"
+CURSOR_CONTEXT_TOOL_MATCHER = "(?:" + CONTEXT_TOOL_MATCHER + r"|^MCP:(?:knowledge_(?:query|explain|capture)|remote_[a-z_]+)$)"
 
 
 def remote_dev_server_args():
@@ -164,14 +169,14 @@ def desired_mcp_servers(*, task_only=False):
     if not task_only:
         servers[REMOTE_DEV_SERVER_NAME] = {
             "command": native_ready(ROOT)["python"],
-            "args": remote_dev_server_args(),
+            "args": [str(ROOT / ".agents/scripts/vaws_native_mcp.py"), "remote"],
             "type": "stdio",
             "timeout": 600000,
             "env": remote_dev_env(),
         }
     servers[TASK_SERVER_NAME] = {
         "command": managed_python(),
-        "args": task_server_args(),
+        "args": [managed_path(ROOT / ".agents/scripts/vaws_native_mcp.py"), "task"],
         "type": "stdio",
         "timeout": 600000,
         "env": task_server_env(),
@@ -179,7 +184,7 @@ def desired_mcp_servers(*, task_only=False):
     if not task_only:
         servers[KNOWLEDGE_SERVER_NAME] = {
             "command": knowledge_owner_python(ROOT),
-            "args": knowledge_server_args(),
+            "args": [knowledge_owner_path(ROOT, ROOT / ".agents/scripts/vaws_native_mcp.py"), "knowledge"],
             "type": "stdio",
             "timeout": 600000,
             "env": knowledge_owner_env(ROOT),
@@ -285,14 +290,14 @@ def hook_groups(client, project, env=None):
             for event in EVENTS if event not in {"PreToolUse", "UserPromptSubmit"}
         }
         groups["preToolUse"] = [{"command": command, "timeout": HOOK_TIMEOUT_SECONDS,
-                                 "matcher": TASK_TOOL_MATCHER}]
+                                 "matcher": CURSOR_CONTEXT_TOOL_MATCHER}]
         return groups
     groups = {
         event: [{"hooks": [{"type": "command", "command": command, "timeout": HOOK_TIMEOUT_SECONDS}]}]
         for event in EVENTS if not (client == "kimi" and event == "PreToolUse")
     }
     if "PreToolUse" in groups:
-        groups["PreToolUse"][0]["matcher"] = TASK_TOOL_MATCHER
+        groups["PreToolUse"][0]["matcher"] = CONTEXT_TOOL_MATCHER
     return groups
 
 
@@ -492,7 +497,7 @@ def owned_workspace_interpreter(command, checkout):
 
 
 def owned_environment_server(existing, checkout):
-    if existing.get("args") not in (task_server_args(), knowledge_server_args(), remote_dev_server_args()):
+    if provider_kind(existing.get("args"), ROOT) is None:
         return False
     if owned_workspace_interpreter(existing.get("command", ""), checkout):
         return True
@@ -525,15 +530,16 @@ def legacy_generated_toml_server(text, name, key, existing, checkout):
 
 
 def managed_environment_change(existing, desired, *, checkout):
-    return (existing.get("args") == desired.get("args") and owned_environment_server(existing, checkout)
-            and (existing.get("command") != desired.get("command")
+    return (provider_kind(existing.get("args"), ROOT) == provider_kind(desired.get("args"), ROOT)
+            and owned_environment_server(existing, checkout)
+            and (existing.get("args") != desired.get("args") or existing.get("command") != desired.get("command")
                  or existing.get("env", {}).get(PIN_ENV) != desired.get("env", {}).get(PIN_ENV)))
 
 
 def knowledge_owner_defaults(existing, desired, checkout, *, legacy=False):
     """Normalize generated knowledge paths without replacing custom locations."""
     environment = dict(existing.get("env") or {})
-    if (existing.get("args") == desired.get("args") == knowledge_server_args()
+    if (provider_kind(existing.get("args"), ROOT) == provider_kind(desired.get("args"), ROOT) == "knowledge"
             and (legacy or owned_environment_server(existing, checkout))):
         if desired.get("env", {}).get("VAWS_KNOWLEDGE_CONFIG"):
             defaults = {"VAWS_KNOWLEDGE_PROJECT_ROOTS": ".agents/knowledge",
@@ -570,10 +576,28 @@ def update_toml_server_command(text, key, command):
     return text
 
 
+def update_toml_server_args(text, key, arguments):
+    headers = {f"[mcp_servers.{key}]", f"[mcp_servers.{json.dumps(key)}]"}
+    lines = text.splitlines(keepends=True)
+    inside = False
+    for index, line in enumerate(lines):
+        if line.strip().startswith("["):
+            inside = line.strip() in headers
+        elif inside and re.match(r"^args\s*=", line.strip()):
+            # Generated launch arrays occupy one line; custom multiline arrays
+            # remain unchanged and the complete TOML parse below rejects drift.
+            lines[index] = "args = " + json.dumps(arguments) + "\n"
+            candidate = "".join(lines)
+            tomllib.loads(candidate)
+            return candidate
+    return text
+
+
 def merge_server_entry(existing, desired, *, checkout=None):
     """Update generated environment entries; preserve user-managed entries."""
     checkout = ROOT if checkout is None else checkout
-    if existing.get("args") != desired.get("args") or not owned_environment_server(existing, checkout):
+    if (provider_kind(existing.get("args"), ROOT) != provider_kind(desired.get("args"), ROOT)
+            or not owned_environment_server(existing, checkout)):
         return dict(existing), "preserved"
     existing = {**existing, "env": knowledge_owner_defaults(existing, desired, checkout)} if "env" in existing else existing
     if managed_environment_change(existing, desired, checkout=checkout):
@@ -585,7 +609,7 @@ def merge_server_entry(existing, desired, *, checkout=None):
                 environment[key] = value
         if "WSLENV" in desired.get("env", {}):
             environment = windows_interop_env(environment)
-        return {**desired, **existing, "command": desired["command"], "env": environment}, "updated-managed"
+        return {**desired, **existing, "command": desired["command"], "args": desired["args"], "env": environment}, "updated-managed"
     merged = {**desired, **existing}
     desired_env = dict(desired.get("env") or {})
     existing_env = dict(existing.get("env") or {})
@@ -780,11 +804,12 @@ def build_plan(client, project, *, kimi_config=None, task_only=False, kimi_sessi
                 for alias in matching:
                     before = text
                     legacy = legacy_generated_toml_server(text, name, alias, existing[alias], project)
-                    if (existing[alias].get("args") == entry.get("args")
+                    if (provider_kind(existing[alias].get("args"), ROOT) == provider_kind(entry.get("args"), ROOT)
                             and (legacy or owned_environment_server(existing[alias], project))
                             and editable_toml_server_env(text, alias, existing[alias])):
                         try:
                             candidate = update_toml_server_command(text, alias, entry["command"])
+                            candidate = update_toml_server_args(candidate, alias, entry["args"])
                             candidate = fill_toml_server_env(candidate, alias, existing[alias], entry,
                                                              checkout=project, legacy=legacy)
                             rendered = tomllib.loads(candidate)["mcp_servers"][alias]
@@ -792,7 +817,7 @@ def build_plan(client, project, *, kimi_config=None, task_only=False, kimi_sessi
                             candidate = before
                             rendered = existing[alias]
                         desired_pin = entry.get("env", {}).get(PIN_ENV)
-                        if (rendered.get("command") == entry["command"]
+                        if (rendered.get("command") == entry["command"] and rendered.get("args") == entry["args"]
                                 and (desired_pin is None or rendered.get("env", {}).get(PIN_ENV) == desired_pin)):
                             text = candidate
                     updated = text != before
@@ -808,13 +833,13 @@ def build_plan(client, project, *, kimi_config=None, task_only=False, kimi_sessi
         if changed:
             files[path] = text
     if client == "kimi":
-        from vaws_kimi_config import add_kimi_user_mcp, kimi_session_setup_enabled, migrate_kimi_hooks
+        from vaws_kimi_config import add_kimi_user_mcp, remove_owned_kimi_hooks
         path = kimi_config or kimi_home() / "config.toml"
         original = path.read_text(encoding="utf-8") if path.exists() else ""
         project_key = hashlib.sha256(str(project).encode()).hexdigest()[:16]
-        # Official Kimi 0.42 does not understand SessionSetup. Preserve an
-        # explicit extension choice on repair, and never enable it implicitly.
-        extended = kimi_session_setup or kimi_session_setup_enabled(original, project, ROOT, parse_command=hook_argv)
+        # Official events are the default. A previous personal binary must not
+        # make SessionSetup a permanent requirement for later initialization.
+        extended = kimi_session_setup
         command = local_hook_command(["uv", "run", "--no-project", "python",
                                       str(ROOT / ".agents/scripts/vaws_kimi_session_setup.py"),
                                       "--project", str(project)]) if extended else groups["SessionStart"][0]["hooks"][0]["command"]
@@ -824,11 +849,10 @@ def build_plan(client, project, *, kimi_config=None, task_only=False, kimi_sessi
             + "\ntimeout = " + str(600 if event == "SessionSetup" else HOOK_TIMEOUT_SECONDS) + "\n"
             for event in events
         )
+        original = remove_owned_kimi_hooks(original, project, ROOT, parse_command=hook_argv)
         files[path] = managed_toml_text(original, "session-" + project_key, body)
-        if extended:
-            files[path] = migrate_kimi_hooks(files[path], project, ROOT, parse_command=hook_argv)
-            add_kimi_user_mcp(files, notes, project, ROOT, path.parent,
-                              owned_server=owned_environment_server)
+        add_kimi_user_mcp(files, notes, project, ROOT, path.parent,
+                          owned_server=owned_environment_server)
     from vaws_native_setup_config import add_native_setup
     add_native_setup(files, notes, client, project, ROOT)
     if client == "codex":
@@ -847,6 +871,8 @@ def build_plan(client, project, *, kimi_config=None, task_only=False, kimi_sessi
     if client == "grok":
         from vaws_grok_setup_config import plan_grok_setup
         executable_files = plan_grok_setup(files, notes, project, ROOT)
+    from vaws_start_guidance import add_start_guidance
+    add_start_guidance(files, notes, client, project)
     return {
         "files": files,
         "executable_files": executable_files,
@@ -902,7 +928,7 @@ def apply_plan(plan):
 def setup_installed_clients(args):
     """One-time initialization; each installed client keeps its existing builder."""
     from vaws_client_inventory import installed_clients
-    from vaws_native_mode_config import add_grok_import_dedup, add_native_mode, grok_native_defaults, kimi_session_setup_capability
+    from vaws_native_mode_config import add_grok_import_dedup, add_native_mode
 
     clients = {}
     for client, installation in installed_clients().items():
@@ -914,30 +940,11 @@ def setup_installed_clients(args):
             continue
         phase, current_path = "plan", None
         try:
-            capability = None
-            if client == "kimi":
-                executable = installation.get("executable")
-                capability = (kimi_session_setup_capability(executable) if executable else
-                              {"supported": False, "reason": "kimi_executable_unavailable"})
-                row["capability"] = capability
-                if not capability["supported"]:
-                    path = args.kimi_config or kimi_home() / "config.toml"
-                    if path.is_file() and any(hook.get("event") == "SessionSetup"
-                            for hook in tomllib.loads(path.read_text(encoding="utf-8")).get("hooks", [])
-                            if isinstance(hook, dict)):
-                        row.update(state="blocked", reason="unsupported_existing_session_setup")
-                        row["native_worktree"] = {"status": "unavailable",
-                            "missing_action": "Install a Kimi client supporting SessionSetup; existing configuration was preserved."}
-                        continue
-            elif client == "grok":
-                capability = grok_native_defaults(installation.get("executable"), args.project)
-                row["capability"] = capability
             plan = build_plan(client, args.project, kimi_config=args.kimi_config, task_only=args.task_only,
-                              kimi_session_setup=bool(client == "kimi" and capability and capability["supported"]),
+                              kimi_session_setup=bool(client == "kimi" and args.kimi_session_setup),
                               codex_global_hooks=client == "codex", cursor_global_mcp=client == "cursor")
             row["notes"] = plan["notes"]
-            add_native_mode(plan["files"], plan["notes"], client, args.project,
-                            capability=capability, kimi_tui_config=kimi_home() / "tui.toml")
+            add_native_mode(plan["files"], plan["notes"], client, args.project)
             if client == "grok":
                 add_grok_import_dedup(plan["files"], plan["notes"], args.project, ROOT,
                                       owned_server=owned_environment_server)
@@ -951,32 +958,18 @@ def setup_installed_clients(args):
                 elif not path.exists() or path.read_bytes() != content.encode("utf-8"):
                     row["files"].append({"path": str(path), "sha256": hashlib.sha256(content.encode()).hexdigest()})
             row["state"] = "configured" if args.apply else "preview"
-            native = {"status": "wiring_configured" if args.apply else "wiring_planned", "missing_action": None}
+            row["workspace_start"] = {"status": "configured" if args.apply else "planned",
+                                      "entry": ".agents/scripts/vaws_start.py", "trigger": "new-session-project-guidance",
+                                      "native_patch_required": False, "resume": "reuse-existing-workspace"}
+            native = {"status": "optional_native_wiring", "missing_action": None}
             if client in {"codex", "cursor"}:
-                native["default_mode"] = "not_verified"
-                native["missing_action"] = (
-                    "During initialization, use a supported native tool once to select Worktree mode and the VAWS local environment; "
-                    "use Computer Use only if no public setter exists and UI access is permitted. Skip if already selected; this is not a recurring session check."
-                    if client == "codex" else
-                    "During initialization, use a supported native tool once to select New Worktree as the default; "
-                    "use Computer Use only if no public setter exists and UI access is permitted. Skip if already selected; this is not a recurring session check.")
-                row["notes"].append({"client": client, "reason": "native-default-mode-requires-one-time-setting",
-                                     "detail": native["missing_action"]})
+                native["default_mode"] = "client_choice"
             elif client == "grok":
-                preference = next((note for note in reversed(plan["notes"])
-                                   if note.get("reason") == "native-worktree-preferences"), None)
-                native.update(scope="/new and /fork", initial_cli_start="not_verified")
-                if preference is None:
-                    native.update(status="preferences_preserved", missing_action="Integrate the existing Grok user preference table once; see notes.")
-                elif capability["supported"]:
-                    native.update(scope="new native sessions and /fork", initial_cli_start=(
-                        "native_default_enabled" if args.apply else "native_default_planned"))
-                else:
-                    native["missing_action"] = "Bare startup needs the native default-worktree patch and one startup/resume acceptance of the installed binary; the configured preference alone does not prove this."
+                native.update(scope="native --worktree, /new and /fork preferences", initial_cli_start="project-guidance")
             elif client == "claude":
-                native.update(default_mode="unsupported", missing_action="Claude has no supported ordinary CLI default-worktree setting; WorktreeCreate handles native worktree creation.")
-            elif not capability["supported"]:
-                native.update(status="session_setup_unavailable", missing_action="Install a Kimi client with the native SessionSetup extension, then rerun initialization.")
+                native.update(default_mode="project-guidance")
+            else:
+                native.update(default_mode="explicit_extension" if args.kimi_session_setup else "project-guidance")
             row["native_worktree"] = native
         except Exception as exc:
             row.update(state="failed", error={"phase": phase, "path": current_path,
@@ -992,7 +985,7 @@ def setup_installed_clients(args):
         path = shared_workspace_root(args.project) / ".vaws-local/client-initialization.json"
         record = {"state": result["state"], "attempted_at": utc_now_iso(), "project": str(args.project.resolve()),
                   "clients": {name: {key: value for key, value in row.items()
-                                     if key in {"state", "reason", "files", "native_worktree", "error"}}
+                                     if key in {"state", "reason", "files", "native_worktree", "workspace_start", "error"}}
                               for name, row in clients.items()}}
         try:
             write_json(path, record)

--- a/.agents/scripts/vaws_client_setup.py
+++ b/.agents/scripts/vaws_client_setup.py
@@ -55,7 +55,7 @@ from vaws_local_owner import managed_path as _managed_path, managed_python as _m
 from vaws_environment import PIN_ENV, native_ready, windows_ready, read_receipt
 from vaws_local_state import agent_sessions_root
 from vaws_native_task_env import user_task_env
-from vaws_claude_config import provider_kind
+from vaws_claude_config import provider_kind, wrapped_hook_kind
 from vaws_remote_dev import state_dir
 
 CLIENTS = {"claude", "grok", "kimi", "codex", "cursor"}
@@ -66,6 +66,7 @@ REMOTE_DEV_SERVER_NAME = "remote-dev"
 KNOWLEDGE_SERVER_NAME = "vaws-knowledge"
 HOOK_TIMEOUT_SECONDS = 12
 TASK_TOOL_MATCHER = r"(?:^|:|__)vaws_(?:session|run|execution|finish|message)$"
+LEGACY_CONTEXT_MATCHERS = frozenset({TASK_TOOL_MATCHER, r"(?:^|:|__)vaws_(session|run|execution|finish|message)$"})
 COMPANION_TOOL_MATCHER = r"^(?:MCP:)?(?:mcp__)?(?:vaws[-_]knowledge__knowledge_(?:query|explain|capture)|remote[-_]dev__remote_[a-z_]+)$"
 CONTEXT_TOOL_MATCHER = "(?:" + TASK_TOOL_MATCHER + "|" + COMPANION_TOOL_MATCHER + ")"
 CURSOR_CONTEXT_TOOL_MATCHER = "(?:" + CONTEXT_TOOL_MATCHER + r"|^MCP:(?:knowledge_(?:query|explain|capture)|remote_[a-z_]+)$)"
@@ -384,6 +385,11 @@ def owned_hook_command(command, client, project, expected=None):
     except ValueError:
         return False
     script = executed_hook_script(argv)
+    if client == "claude" and len(argv) >= 2 and script == argv[1] and _is_python_interpreter(argv[0]):
+        kind = wrapped_hook_kind(argv, ROOT)
+        if kind is not None:
+            direct = ROOT / ".agents/hooks" / ("vaws_session.py" if kind == "session" else "knowledge_summary.py")
+            return owned_hook_script(direct, expected=expected)
     if not script or not owned_hook_script(script, expected=expected):
         return False
     parsed_client = None
@@ -453,13 +459,20 @@ def merge_hook_event(existing, desired, client, project):
             if entries:
                 updated_group = dict(group)
                 updated_group["hooks"] = entries
-                # Older generated groups ran for every tool. Narrow only an
-                # entirely owned group; user matchers and mixed groups retain
-                # their existing scope.
-                if ("matcher" not in group and desired[0].get("matcher")
-                        and all(owned_hook_command(entry.get("command", ""), client, project, expected=expected)
-                                for entry in entries)):
-                    updated_group["matcher"] = desired[0]["matcher"]
+                matcher = desired[0].get("matcher")
+                owned = [entry for entry in entries if owned_hook_command(
+                    entry.get("command", ""), client, project, expected=expected)]
+                if matcher and owned and group.get("matcher") in LEGACY_CONTEXT_MATCHERS:
+                    custom = [entry for entry in entries if entry not in owned]
+                    if custom:
+                        # Expanding a VAWS matcher must not expand a sibling's
+                        # user-selected scope. Keep that group and move ours.
+                        result.append({**updated_group, "hooks": custom})
+                        result.append({"matcher": matcher, "hooks": owned})
+                        continue
+                    updated_group["matcher"] = matcher
+                elif "matcher" not in group and matcher and len(owned) == len(entries):
+                    updated_group["matcher"] = matcher
                 result.append(updated_group)
             continue
         command = group.get("command", "")
@@ -469,7 +482,8 @@ def merge_hook_event(existing, desired, client, project):
             updated = dict(group)
             updated["command"] = desired_command
             if desired[0].get("matcher"):
-                updated.setdefault("matcher", desired[0]["matcher"])
+                if "matcher" not in updated or updated["matcher"] in LEGACY_CONTEXT_MATCHERS:
+                    updated["matcher"] = desired[0]["matcher"]
             result.append(updated)
             replaced = True
         else:
@@ -754,9 +768,8 @@ def build_plan(client, project, *, kimi_config=None, task_only=False, kimi_sessi
     project = project.expanduser().resolve(strict=True)
     env = launch_env(client, project, kimi_config=kimi_config)
     groups = hook_groups(client, project, env)
-    # Kimi Code's Stop event supplies no final text; it keeps MCP access and
-    # session hooks without installing a summary hook that cannot capture.
-    if not task_only and client in {"codex", "claude", "cursor", "grok"}:
+    # Kimi's adapter reads only the known session's final completed wire step.
+    if not task_only:
         summary_command = local_hook_command([
             knowledge_owner_python(ROOT), knowledge_owner_path(ROOT, ROOT / ".agents/hooks/knowledge_summary.py"),
             "--client", client, "--project", knowledge_owner_path(ROOT, project),
@@ -764,12 +777,14 @@ def build_plan(client, project, *, kimi_config=None, task_only=False, kimi_sessi
         ])
         if client == "cursor":
             groups["afterAgentResponse"] = [{"command": summary_command}]
+            groups.setdefault("sessionEnd", []).append({"command": summary_command})
         else:
             groups["Stop"] = [{"hooks": [{"type": "command", "command": summary_command, "timeout": 5}]}]
     servers = desired_mcp_servers(task_only=task_only)
     if client == "kimi":
         servers = shared_kimi_servers(servers, project)
         servers = {name: {**{key: value for key, value in entry.items() if key not in {"type", "timeout"}},
+                          "env": {**entry.get("env", {}), "VAWS_MCP_CLIENT": "kimi"},
                           "toolTimeoutMs": 600000}
                    for name, entry in servers.items()}
     files = {}
@@ -845,11 +860,13 @@ def build_plan(client, project, *, kimi_config=None, task_only=False, kimi_sessi
                                       "--project", str(project)]) if extended else groups["SessionStart"][0]["hooks"][0]["command"]
         events = [*( ["SessionSetup"] if extended else []), *groups]
         body = "\n".join(
-            "[[hooks]]\nevent = " + json.dumps(event) + "\ncommand = " + json.dumps(command)
+            "[[hooks]]\nevent = " + json.dumps(event) + "\ncommand = " + json.dumps(
+                groups[event][0]["hooks"][0]["command"] if event == "Stop" else command)
             + "\ntimeout = " + str(600 if event == "SessionSetup" else HOOK_TIMEOUT_SECONDS) + "\n"
             for event in events
         )
-        original = remove_owned_kimi_hooks(original, project, ROOT, parse_command=hook_argv)
+        original = remove_owned_kimi_hooks(original, project, ROOT, parse_command=hook_argv,
+                                           include_summary=not task_only)
         files[path] = managed_toml_text(original, "session-" + project_key, body)
         add_kimi_user_mcp(files, notes, project, ROOT, path.parent,
                           owned_server=owned_environment_server)

--- a/.agents/scripts/vaws_native_mcp.py
+++ b/.agents/scripts/vaws_native_mcp.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Exec one user-level MCP provider in the native client's selected workspace.
+"""Serve one MCP provider from each task's selected immutable environment.
 
 Kimi supplies the stdio cwd. Cursor supplies VAWS_MCP_WORKSPACE through its
 native workspace variable. This selects only a saved package environment;
@@ -8,6 +8,7 @@ task identity remains the native attachment and is never inferred here.
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 import os
 from pathlib import Path
@@ -48,15 +49,16 @@ def main(argv=None) -> int:
     parser.add_argument("kind", choices=PROVIDERS)
     args = parser.parse_args(argv)
     try:
-        cwd, command, environment = provider_plan(args.kind, Path.cwd(), dict(os.environ))
-        print(json.dumps({"vaws_native_provider": args.kind, "cwd": str(cwd),
-                          "python": command[0], "receipt": environment[PIN_ENV]}),
-              file=sys.stderr, flush=True)
-        os.chdir(cwd)
-        if os.name == "nt":
-            from vaws_windows import run_owned
-            return run_owned(command, env=environment)
-        os.execve(command[0], command, environment)
+        from vaws_venv import ensure_workspace_interpreter
+        ensure_workspace_interpreter(repo_root=ROOT)
+        from vaws_mcp_runtime import serve
+        native = Path(os.environ.get("VAWS_MCP_WORKSPACE") or Path.cwd()).resolve()
+        try:
+            target = workspace(native, source=ROOT)
+        except ValueError:
+            target = ROOT
+        asyncio.run(serve(args.kind, target))
+        return 0
     except (OSError, ValueError, RuntimeError) as exc:
         print(f"VAWS {args.kind} provider unavailable: {exc}", file=sys.stderr)
         return 1

--- a/.agents/scripts/vaws_start.py
+++ b/.agents/scripts/vaws_start.py
@@ -18,7 +18,7 @@ from vaws_native_workspace import create_workspace
 from vaws_session_state import task_dir, write_json
 from vaws_task_target import resolve_context_file
 from vaws_venv import configure_windows_stdio, ensure_workspace_interpreter
-from vaws_workspace_entry import copy_workspace_identity
+from vaws_workspace_entry import copy_workspace_identity, workspace_entry
 from vaws_workspace_update import WorkspaceUpdater, common_dir, git, redact, update_lock
 from vaws_worktree_setup import configure_target, prepare_selected_knowledge, unpinned_environment
 
@@ -80,10 +80,11 @@ def start(client: str, project: Path = ROOT, context_file: str | None = None) ->
             raise ValueError("--client differs from the existing native attachment")
         project = shared_workspace_root(project.resolve())
         record = task_dir(context["session"]["id"], project) / "start.json"
-        phase = "reuse"
+        phase = "preparation_lock"
         # The repository lock also serializes two callers preparing one task.
         # Nothing in the completed path checks upstream or changes task sources.
-        with update_lock(project):
+        with update_lock(project, wait_seconds=180):
+            phase = "reuse"
             if record.is_file():
                 previous = json.loads(record.read_text(encoding="utf-8"))
                 workspace = Path(previous["workspace"])
@@ -146,6 +147,16 @@ def main(argv=None) -> int:
     parser.add_argument("--client", choices=CLIENTS, required=True)
     parser.add_argument("--context-file", help="existing native context, when the shell cannot provide it")
     args = parser.parse_args(argv)
+    setup = workspace_entry(shared_workspace_root(ROOT), announce=False)
+    if setup["state"] != "configured":
+        first_use = setup["state"] in {"identity_pending", "needs_github_user"}
+        next_step = ("Follow AGENTS.md First use, forks and updates. Reuse an already supplied personal "
+                     "GitHub username, or ask once; workspace_forks.py prepares the personal forks. "
+                     "Then prepare dependencies and client wiring as described there." if first_use else
+                     "Inspect the reported local initialization state; no identity, update preference or task was changed.")
+        print(json.dumps({"status": "needs_setup" if first_use else "failed", "phase": "initialization",
+                          "setup": setup, "next": next_step}, ensure_ascii=False))
+        return 1
     ensure_workspace_interpreter(repo_root=ROOT)
     result = start(args.client, ROOT, args.context_file)
     print(json.dumps(result, ensure_ascii=False), flush=True)

--- a/.agents/scripts/vaws_start.py
+++ b/.agents/scripts/vaws_start.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Prepare one new native task's workspace; repeat calls reuse its selection."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / ".agents/lib"))
+
+from vaws_environment import read_receipt, saved_ready, select_environment
+from vaws_knowledge_service import knowledge_config_path
+from vaws_local_state import shared_workspace_root
+from vaws_native_workspace import create_workspace
+from vaws_session_state import task_dir, write_json
+from vaws_task_target import resolve_context_file
+from vaws_venv import configure_windows_stdio, ensure_workspace_interpreter
+from vaws_workspace_entry import copy_workspace_identity
+from vaws_workspace_update import WorkspaceUpdater, common_dir, git, redact, update_lock
+from vaws_worktree_setup import configure_target, prepare_selected_knowledge, unpinned_environment
+
+CLIENTS = ("codex", "cursor", "claude", "grok", "kimi")
+
+
+def native_prepared(context: dict, project: Path) -> tuple[Path, dict] | None:
+    """Reuse a prepared native linked worktree, including an explicitly old ref."""
+    cwd = Path(context["attachment"]["cwd"])
+    try:
+        workspace = Path(git(cwd, "rev-parse", "--show-toplevel")).resolve()
+        shared = common_dir(project)
+        if common_dir(workspace) != shared:
+            return None
+        if Path(git(workspace, "rev-parse", "--absolute-git-dir")).resolve() == shared:
+            return None
+    except (OSError, ValueError, RuntimeError, subprocess.SubprocessError):
+        return None
+    selection = workspace / ".vaws-local/environment-selection" / f"{sys.platform}.json"
+    return (workspace, saved_ready(workspace)) if selection.is_file() else None
+
+
+def prepare_latest(project: Path) -> tuple[Path, dict, dict]:
+    """Prepare canonical HEAD without activating or inspecting the editing branch."""
+    updater = WorkspaceUpdater(project)
+    update = updater.step(apply=True, activate=False)
+    if update.get("status") not in {"ready", "current"}:
+        error = RuntimeError(update.get("detail") or update.get("reason") or "upstream preparation failed")
+        error.evidence = update
+        raise error
+    prepared = updater.state.get("prepared")
+    if not prepared:
+        # An already-current main checkout can lack a preparation cache. Use
+        # the updater's clean committed stage, never copy its working edits.
+        prepared = updater.prepare(update, updater.preparation_inputs(update))
+        updater.save(**{key: value for key, value in update.items() if key != "status"},
+                     prepared=prepared, phase="ready", status="ready")
+    stage = updater.validate_prepared(update, prepared)
+    return stage, prepared, update
+
+
+def selected_result(workspace: Path, receipt: dict, context: dict, *, status: str, evidence: Path,
+                    **facts) -> dict:
+    config = knowledge_config_path(workspace)
+    return {"status": status, "workspace": str(workspace), "head": git(workspace, "rev-parse", "HEAD"),
+            "environment": {key: receipt[key] for key in ("key", "python", "receipt")},
+            "context_file": context["context_file"], "native_cwd": context["attachment"]["cwd"],
+            "knowledge_config": str(config) if config.is_file() else None,
+            "evidence": str(evidence), **facts}
+
+
+def start(client: str, project: Path = ROOT, context_file: str | None = None) -> dict:
+    from vaws_coordinator.agent_session import AgentSessions, load_context
+
+    phase, context, record, workspace = "context", None, None, None
+    try:
+        context = load_context(resolve_context_file(context_file))
+        if context["attachment"]["client"] != client:
+            raise ValueError("--client differs from the existing native attachment")
+        project = shared_workspace_root(project.resolve())
+        record = task_dir(context["session"]["id"], project) / "start.json"
+        phase = "reuse"
+        # The repository lock also serializes two callers preparing one task.
+        # Nothing in the completed path checks upstream or changes task sources.
+        with update_lock(project):
+            if record.is_file():
+                previous = json.loads(record.read_text(encoding="utf-8"))
+                workspace = Path(previous["workspace"])
+                receipt = read_receipt(previous["environment"]["receipt"])
+                return selected_result(workspace, receipt, context, status="reused", evidence=record,
+                                       preparation=previous["preparation"], knowledge=previous.get("knowledge", {}))
+            prepared_native = native_prepared(context, project)
+            update, knowledge = {}, {}
+            if prepared_native:
+                workspace, receipt = prepared_native
+                preparation = "native"
+            else:
+                phase = "upstream"
+                print("VAWS: preparing the canonical workspace and its locked components", file=sys.stderr, flush=True)
+                stage, prepared, update = prepare_latest(project)
+                knowledge = prepared.get("knowledge", {})
+                workspace = project.parent / (project.name + "-" + context["session"]["id"])
+                phase = "worktree"
+                print(f"VAWS: creating {workspace}", file=sys.stderr, flush=True)
+                create_workspace(stage, workspace, linked=True)
+                copy_workspace_identity(project, workspace)
+                phase = "environment"
+                environment = unpinned_environment()
+                # The updater prepared this exact committed stage. Do not let
+                # the caller's old VAWS_ENV_RECEIPT select the new task runtime.
+                receipt = prepared["receipt"]
+                configure_target(client, workspace, receipt, environment)
+                select_environment(workspace, receipt)
+                preparation = "created"
+            phase = "knowledge"
+            knowledge = prepare_selected_knowledge(workspace, receipt)
+            phase = "sources"
+            store = AgentSessions(Path(context["state_dir"]))
+            # This is a task source selection, not a native cwd handoff.
+            context = store.bind_sources(context, {project.name: str(workspace)})
+            result = selected_result(workspace, receipt, context, status="ready", evidence=record,
+                                     preparation=preparation, update=update, knowledge=knowledge)
+            write_json(record, result)
+            if preparation == "created":
+                write_json(project / ".vaws-local/latest-runtime.json",
+                           {key: result[key] for key in ("workspace", "environment", "head")})
+            return result
+    except (OSError, ValueError, RuntimeError, KeyError, subprocess.SubprocessError) as exc:
+        result = {"status": "failed", "phase": phase, "error": redact(str(exc)),
+                  "error_type": type(exc).__name__}
+        if context:
+            result["context_file"] = context["context_file"]
+        if workspace:
+            result["workspace"] = str(workspace)
+        if record:
+            path = record.with_name("start-error.json")
+            write_json(path, {**result, "details": getattr(exc, "evidence", {})})
+            result["evidence"] = str(path)
+        return result
+
+
+def main(argv=None) -> int:
+    configure_windows_stdio()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--client", choices=CLIENTS, required=True)
+    parser.add_argument("--context-file", help="existing native context, when the shell cannot provide it")
+    args = parser.parse_args(argv)
+    ensure_workspace_interpreter(repo_root=ROOT)
+    result = start(args.client, ROOT, args.context_file)
+    print(json.dumps(result, ensure_ascii=False), flush=True)
+    return 1 if result["status"] == "failed" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/vaws_worktree_setup.py
+++ b/.agents/scripts/vaws_worktree_setup.py
@@ -159,7 +159,7 @@ def prepare_canonical(source: Path, baseline: dict | None = None) -> tuple[dict,
     result = workspace_entry(source)
     if result["state"] != "configured":
         return result, None
-    with update_lock(source):
+    with update_lock(source, wait_seconds=180):
         updater = WorkspaceUpdater(source)
         result = updater.step(apply=True, activate=False)
         if result.get("status") not in {"ready", "current"}:

--- a/.agents/scripts/vaws_worktree_setup.py
+++ b/.agents/scripts/vaws_worktree_setup.py
@@ -18,9 +18,11 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / ".agents/lib"))
 
 from vaws_environment import EnvironmentError, PIN_ENV, MANAGED_PIN_ENV, native_ready, saved_ready, select_environment, _inputs
-from vaws_workspace_entry import copy_workspace_identity, prepare_session, workspace_entry
+from vaws_knowledge_service import prepare_knowledge
+from vaws_session_state import write_json
+from vaws_workspace_entry import copy_workspace_identity, workspace_entry
 from vaws_workspace_update import (Deferred, SUBMODULES, WorkspaceUpdater, clean_checkout, common_dir,
-                                   git, gitlinks, initialized, prepared_source, run, update_lock)
+                                   git, gitlinks, initialized, run, update_lock)
 
 
 def native_paths(client: str, environment: dict, cwd: Path) -> tuple[Path, Path]:
@@ -75,8 +77,19 @@ def configure_target(client: str, target: Path, receipt: dict, environment: dict
     if client == "kimi":
         # One installed Kimi lifecycle adapter routes each native event to its
         # selected environment; a new worktree must not append global hooks.
-        arguments += ["--kimi-config", str(target / ".vaws-local/kimi-hooks.toml"), "--kimi-session-setup"]
+        arguments += ["--kimi-config", str(target / ".vaws-local/kimi-hooks.toml")]
     run(arguments, cwd=target, env={**environment, PIN_ENV: receipt["receipt"]}, timeout=120)
+
+
+def prepare_selected_knowledge(target: Path, receipt: dict) -> dict:
+    """Remember one preparation attempt alongside the existing environment choice."""
+    selection = target / ".vaws-local/environment-selection" / f"{sys.platform}.json"
+    selected = json.loads(selection.read_text(encoding="utf-8"))
+    if isinstance(selected.get("knowledge"), dict):
+        return selected["knowledge"]
+    knowledge = prepare_knowledge(target, receipt=receipt)
+    write_json(selection, {**selected, "knowledge": knowledge})
+    return knowledge
 
 
 def active_submodules(target: Path, revision: str) -> dict[str, str]:
@@ -91,8 +104,8 @@ def active_submodules(target: Path, revision: str) -> dict[str, str]:
 
 
 def advance_worktree(target: Path, prepared: Path, original: str,
-                     branch: str | None, active: dict[str, str]) -> dict[str, str]:
-    """Fast-forward one new checkout and its already-initialized components."""
+                     branch: str | None, active: dict[str, str], *, canonical: bool = False) -> dict[str, str]:
+    """Select prepared inputs in one clean new checkout and its active components."""
     clean_checkout(target, branch=branch, expected={original})
     if active_submodules(target, original) != active:
         raise Deferred("submodule_state_changed")
@@ -108,7 +121,12 @@ def advance_worktree(target: Path, prepared: Path, original: str,
             if not initialized(prepared, path):
                 raise Deferred("submodule_object_unavailable", path)
             git(module, "fetch", "--no-tags", str(prepared / path), sha)
-    git(target, "merge", "--ff-only", revision)
+    if canonical:
+        # This new checkout copied the editing source's HEAD. Its business
+        # history remains in that source; a new task starts at canonical HEAD.
+        git(target, "reset", "--hard", revision)
+    else:
+        git(target, "merge", "--ff-only", revision)
     for path in active:
         git(target / path, "checkout", "--detach", links[path])
     return {path: links[path] for path in active}
@@ -136,7 +154,7 @@ def default_branch_snapshot(source: Path, original: str) -> dict | None:
             "native_ref_selection": "unavailable"}
 
 
-def prepare_default_snapshot(source: Path, baseline: dict) -> tuple[dict, Path | None]:
+def prepare_canonical(source: Path, baseline: dict | None = None) -> tuple[dict, Path | None]:
     """Use existing preparation without requiring the editing source on main."""
     result = workspace_entry(source)
     if result["state"] != "configured":
@@ -146,7 +164,7 @@ def prepare_default_snapshot(source: Path, baseline: dict) -> tuple[dict, Path |
         result = updater.step(apply=True, activate=False)
         if result.get("status") not in {"ready", "current"}:
             return result, None
-        if "refs/heads/" + result["branch"] != baseline["ref"]:
+        if baseline is not None and "refs/heads/" + result["branch"] != baseline["ref"]:
             return {"status": "kept", "reason": "default_branch_changed"}, None
         if updater.state.get("phase") not in {"ready", "active"}:
             return result, None
@@ -182,6 +200,7 @@ def prepare_worktree(client: str, source: Path, target: Path, *, preserve_source
         # that bounded step without changing the saved version or its inputs.
         configure_target(client, target, receipt, environment)
         return {"status": "reused", "workspace": str(target), "environment": receipt["key"],
+                "knowledge": prepare_selected_knowledge(target, receipt),
                 **({"update": {"status": "kept", "reason": "fork_source"}} if preserve_source else {}),
                 **({"identity": identity} if identity else {})}
 
@@ -190,6 +209,7 @@ def prepare_worktree(client: str, source: Path, target: Path, *, preserve_source
     result = {"status": "kept", "reason": "explicit_source"}
     baseline = None
     prepared = None
+    from_current_source = False
     submodules = {}
     # Native clients may create a task from an explicitly selected older or
     # business commit. Preserve that choice, as well as copied local edits.
@@ -201,14 +221,15 @@ def prepare_worktree(client: str, source: Path, target: Path, *, preserve_source
         if client == "codex" and branch is None:
             baseline = default_branch_snapshot(source, original)
         if baseline is not None:
-            result, prepared = prepare_default_snapshot(source, baseline)
+            result, prepared = prepare_canonical(source, baseline)
         elif original == git(source, "rev-parse", "HEAD"):
-            result = prepare_session(source)
-            prepared = prepared_source(source)
+            from_current_source = True
+            baseline = {"kind": "source_head_snapshot", "head": original, "native_ref_selection": "unavailable"}
+            result, prepared = prepare_canonical(source)
         if prepared is not None:
             # Only this newly supplied worktree moves. Recheck after potentially
             # slow preparation so an intervening edit stays with its author.
-            submodules = advance_worktree(target, prepared, original, branch, active)
+            submodules = advance_worktree(target, prepared, original, branch, active, canonical=from_current_source)
     except Deferred as exc:
         result = {"status": "kept", "reason": exc.reason}
         prepared = None
@@ -224,6 +245,7 @@ def prepare_worktree(client: str, source: Path, target: Path, *, preserve_source
     select_environment(target, receipt)
     return {"status": "ready", "workspace": str(target), "head": git(target, "rev-parse", "HEAD"),
             "environment": receipt["key"], "update": result, "submodules": submodules,
+            "knowledge": prepare_selected_knowledge(target, receipt),
             **({"identity": identity} if identity else {})}
 
 

--- a/.agents/skills/repo-init/SKILL.md
+++ b/.agents/skills/repo-init/SKILL.md
@@ -6,89 +6,69 @@ description: Initialize this workspace or repair its dependency, fork and native
 # Initialize the workspace
 
 Complete the requested setup using existing configuration. Broad initialization
-usually needs submodules, dependency installation and a selected native client;
-a narrow repair uses only the relevant operation.
+usually needs submodules, dependencies and installed clients; a narrow repair
+uses only the relevant operation. Ordinary new sessions receive project startup
+guidance without invoking this skill.
 
 Use `uv run --no-project python` before local script paths on Windows, macOS,
-Linux and WSL. The bootstrap prepares or reuses an immutable environment without
-shell activation. Existing dependency receipts and probe results can be reused.
+Linux and WSL. Reuse ready dependency environments and conclusive probe results.
 
-## Inspect what is missing
+## Inspect only what is missing
 
 `scripts/repo_init_probe.py --compact` reports platform, GitHub authentication,
-submodules and remotes without creating an identity or setup choices. Add
-`--include-forks` only when personal fork discovery helps the requested topology.
+submodules and remotes without creating identity or setup choices. Add
+`--include-forks` when personal fork discovery helps the requested topology.
 Known state does not require another complete probe.
 
 Preserve extra remotes, dirty sources and user choices. Keep `.gitmodules` on
-community upstream URLs. All development forks belong to personal GitHub User
-accounts, with personal `origin` and official `upstream`. Task identity and remote resources belong to the
-native attachment and coordinator, so workspace setup needs no machine username
-or alias questionnaire.
+community URLs. Task identity and resources belong to native attachments and
+coordinator; do not ask for machine usernames or task aliases.
 
 ## Complete the relevant setup
 
-- Establish GitHub authentication when the requested GitHub operation needs it.
-  Initialize submodules recursively before configuring their remotes; Git in an
-  empty submodule directory can otherwise resolve to its parent repository.
-- For requested CI-pinned alignment, use `resolve_vllm_ci_pin.py` and report the
-  source of the ref. Preserve dirty submodules and existing intentional pins.
-- Configure development forks with the general entry
-  `.agents/scripts/workspace_forks.py --github-user USER --apply`. This command
-  works without the skill or installed runtime packages; omitting `--apply`
-  returns a read-only plan. On first setup ask only for the personal GitHub ID,
-  using the authenticated login as a suggestion. Reuse a saved confirmation on
-  subsequent runs. The command verifies the authenticated account, personal
-  ownership and official fork network before rewiring remotes. It preserves
-  correctly configured fetch/push protocol splits and extra remotes; conflicting
-  or multiple primary URLs require an explicit replacement with a local backup.
-  Existing business branches, commits and dirty files stay in place.
-- For missing package dependencies, run
-  `uv run --no-project python .agents/scripts/vaws_deps.py sync`. Reuse a ready
-  environment. `doctor` is available for unresolved capability or pin questions;
-  it is not an extra step after an already conclusive result.
-- For first initialization, run
-  `.agents/scripts/vaws_client_setup.py --client all --apply` once. It detects
-  installed clients, prepares hooks/providers and supported native defaults,
-  and records completed changes and remaining native actions in the primary
-  worktree's `.vaws-local/client-initialization.json`. Complete those native
-  actions during initialization using available client tools or computer use;
-  do not defer discovery to the first business task or silently call wiring a
-  mode selection. The record is not a recurring task gate. Explicit single-client
-  repair still uses `--client CLIENT --apply`. For Codex/Cursor, the native
-  Worktree mode/environment choice is separate from writing setup files.
-  New worktree setup and session attachment then run through the client without
-  an Agent launcher call. See the [client boundaries](../../../docs/native-workspace-isolation.md).
-  Codex's `--codex-global-hooks` option installs a fixed user hook scoped to
-  this Git worktree family. Review its native hook definitions once during
-  initialization; configuration generation does not grant trust. The same
-  definitions serve later worktrees and read each directory's saved environment.
-  Cursor's `--cursor-global-mcp` option installs the fixed VAWS providers once
-  in the user configuration, avoiding separate project MCP setup for every new
-  directory. Select New Worktree as its default environment. Claude uses WorktreeCreate in native worktree mode. Grok uses
-  its native Git worktree preference and the project Git creation callback. Kimi
-  requires an explicitly installed SessionSetup extension for automatic directories.
-  Configuration files alone do not prove environment selection or enabled MCPs;
-  one small real task can verify the requested setup. Preserve unrelated client
-  configuration and native hook trust.
+- Establish GitHub authentication when the requested operation needs it.
+  Initialize submodules before configuring their remotes: Git in an empty
+  submodule directory can otherwise resolve to its parent repository.
+- For requested CI-pinned vLLM alignment, use `resolve_vllm_ci_pin.py` and report
+  the source of the ref. Preserve dirty submodules and intentional pins.
+- On first setup ask once for the personal GitHub ID; the authenticated login
+  is a suggestion, not consent. Reuse a saved confirmation. Run
+  `.agents/scripts/workspace_forks.py --github-user USER --apply` to create or
+  reuse verified personal forks with personal `origin` and official `upstream`.
+  Omitting `--apply` returns a plan. Conflicting primary URLs require an explicit
+  replacement with a backup; existing branches, commits and dirty files remain.
+- Prepare missing dependencies with `.agents/scripts/vaws_deps.py sync`.
+  `doctor` helps unresolved capability or pin questions; it is not an extra step
+  after an already conclusive result.
+- Run `.agents/scripts/vaws_client_setup.py --client all --apply` once to detect
+  installed Codex, Cursor, Claude, Grok and Kimi clients and configure providers,
+  hooks and short project guidance. It preserves unrelated configuration and
+  records changes under `.vaws-local/client-initialization.json`. A targeted
+  repair uses `--client CLIENT --apply`. Native trust stays with each client.
+  Configuration alone is not live acceptance; use one small real task when
+  verifying the requested integration.
 
-Successful dependency setup also prepares knowledge. Pending model/index work
-leaves ordinary tools usable. Knowledge MCP maintains itself while alive;
-`.agents/scripts/knowledge_setup.py` is for an explicit preparation retry or
-configuration change. Default setup uses local knowledge and shared downloads;
-`--contribute` enables explicitly requested public contribution. Existing
-publishing choices are preserved. Ordinary development requires no knowledge
-maintenance sequence or additional summary.
+The shared guidance makes a new task prepare its workspace once through
+`vaws_start.py`; an independent native worktree whose setup already selected an
+environment is reused directly. The returned directory becomes the editing root,
+with shell cwd and absolute file paths. Native UI Worktree modes are optional
+optimizations, and official Grok/Kimi need no personal binary. Resume keeps the
+original task, directory and environment with no preparation or update. See
+[client boundaries](../../../docs/native-workspace-isolation.md).
 
-Windows and WSL clients of the same Windows-mounted workspace share its Windows
-knowledge process. A missing interpreter leaves knowledge preparation pending;
-an independent Linux workspace uses its native environment.
+New tasks use the mainline workspace's locked component combination. The stable
+MCP gateway selects each task's fixed environment without a manual reconnect.
+Official Kimi uses the hook's `context_file` for startup and all three VAWS MCP
+providers; other clients inject it through their supported hooks.
 
-Report the requested configuration changes, relevant verification and unresolved
-limitations. Reuse existing authorization; ask only for missing information that
-affects the requested result.
+Dependency preparation also prepares knowledge. Linked worktrees share its
+configuration, project snapshot, candidate store and reusable model/index state.
+Pending knowledge work leaves ordinary tools usable. `knowledge_setup.py` is for
+an explicit preparation retry or configuration change; existing custom roots and
+publishing choices are preserved, and new setup disables public contribution.
+Ordinary development needs no maintenance sequence or additional summary.
 
-Read [command recipes](references/command-recipes.md) for individual operations.
-
-The saved `.vaws-local/github.json` is only client configuration. Server identity,
-resource ownership and authorization remain the coordinator's responsibility.
+Report actual changes, relevant verification and unresolved limitations. Reuse
+existing authorization and ask only for missing information affecting the result.
+Read [command recipes](references/command-recipes.md) for individual operations
+and [the platform contract](../../../docs/platform-contract.md) for Windows/WSL owners.

--- a/.agents/skills/repo-init/references/command-recipes.md
+++ b/.agents/skills/repo-init/references/command-recipes.md
@@ -9,24 +9,40 @@ uv run --no-project python .agents/scripts/vaws_deps.py sync
 uv run --no-project python .agents/scripts/vaws_client_setup.py --client all --apply
 ```
 
-The second command detects installed clients, configures their providers/hooks
-and supported native defaults, and returns each client's remaining native
-initialization actions. Resolve them during this first setup using the client's
-own tools or computer use. Unavailable interfaces remain explicit; a configured
-MCP entry does not prove that new sessions default to a worktree. The primary
-worktree keeps `.vaws-local/client-initialization.json` for inspection. Ordinary
-tasks do not rerun this initialization or read its record as a prerequisite.
+The second command detects installed clients and configures providers, hooks and
+short project guidance. Native Worktree preferences are optional optimizations;
+o personal Grok/Kimi build is required. The primary worktree keeps
+`.vaws-local/client-initialization.json` for inspection. Trust remains native,
+and live acceptance requires an actual client task. Ordinary tasks do not rerun
+initialization or inspect its record as a prerequisite.
 
-## Codex native initialization
+## New native task
+
+Project guidance supplies this entry when native setup has not already prepared
+an independent worktree and selected environment:
+
+```text
+uv run --no-project python .agents/scripts/vaws_start.py --client CLIENT
+```
+
+Use the actual client name: `codex`, `cursor`, `claude`, `grok` or `kimi`.
+Official Kimi adds `--context-file PATH` from its existing hook. The returned
+workspace is the shell cwd and root for absolute file/search/patch paths;
+sources and environment are already bound. Kimi also passes that context to all
+three VAWS MCP providers. Resume uses the earlier directory and environment
+without running preparation. See [client boundaries](../../../../docs/native-workspace-isolation.md).
+
+## Optional Codex native hooks
 
 ```text
 uv run --no-project python .agents/scripts/vaws_client_setup.py --client codex --codex-global-hooks --apply
 ```
 
 This installs stable user hooks scoped to the current Git worktree family and
-migrates its generated project hooks. Review the native hook definitions once,
-then select Worktree mode and the VAWS local environment. Later directory setup
-reuses the installed hooks without this option; it does not grant trust.
+migrates its generated project hooks. Review native hook definitions once;
+setup does not grant trust. If native Worktree mode and the VAWS local environment
+are selected, the client can perform preparation before the first Agent action.
+The shared new-task entry also supports ordinary project sessions.
 
 ## Probe
 
@@ -139,17 +155,17 @@ while keeping shared downloads. `--repository OWNER/REPO` changes the shared
 corpus without enabling contribution. Only contribution setup needs a GitHub
 login and fork; no token belongs in tracked files.
 Refresh the selected clients with `vaws_client_setup.py --apply` afterward.
-The package MCP service maintains the model, index and shared releases while
-alive. Windows and WSL use the Windows knowledge owner for the same mounted
+Related worktrees reuse the shared configuration, project snapshot, candidate
+store and model/index state. Task-specific MCP backends maintain knowledge while
+alive; they do not require one new corpus or model download per task. Windows and WSL use the Windows knowledge owner for the same mounted
 workspace; a missing Windows interpreter is reported as pending. Independent
 Linux workspaces use their own environment. Knowledge PR review and merge remain
 manual. Ordinary development requires no maintenance commands.
 
 ## Optional isolated CLI entry
 
-Prefer the native client's Worktree mode and setup callback for normal new
-sessions. The following launcher is an optional terminal convenience; neither
-users nor Agents need it for configured native session attachment.
+This launcher remains an optional terminal convenience. Ordinary native sessions
+use the project startup guidance and do not require it.
 
 ```text
 uv run --no-project python .agents/scripts/vaws_client.py codex

--- a/.agents/tests/client_setup_fixtures.py
+++ b/.agents/tests/client_setup_fixtures.py
@@ -8,6 +8,7 @@ import shutil
 import sys
 
 import vaws_knowledge_service
+import vaws_kimi_config
 
 
 def selected_runtime(monkeypatch, setup, tmp_path):
@@ -22,6 +23,7 @@ def selected_runtime(monkeypatch, setup, tmp_path):
     monkeypatch.setattr(vaws_knowledge_service, "managed_receipt", lambda root: receipt)
     monkeypatch.setattr(vaws_knowledge_service, "managed_python", lambda root: sys.executable)
     monkeypatch.setattr(vaws_knowledge_service, "windows_mounted_workspace", lambda root: False)
+    monkeypatch.setattr(vaws_kimi_config, "managed_receipt", lambda root: receipt)
     return receipt
 
 

--- a/.agents/tests/test_agent_sessions.py
+++ b/.agents/tests/test_agent_sessions.py
@@ -283,14 +283,15 @@ class ScaffoldSetupTests(unittest.TestCase):
         result = tomllib.loads(setup.configuration("kimi", self.root, kimi_config=kimi)[kimi])
         self.assertTrue(all(item["timeout"] >= 12 for item in result["hooks"]))
 
-    def test_cursor_native_setup_supplies_context_only_to_task_tools(self):
+    def test_cursor_native_setup_supplies_context_to_task_and_companion_tools(self):
         import re
         files = setup.configuration("cursor", self.root)
         hooks = json.loads(files[self.root / ".cursor/hooks.json"])["hooks"]
         hook = hooks["preToolUse"][0]
-        for name in ("vaws_run", "MCP:vaws_execution", "mcp__vaws_task__vaws_message"):
+        for name in ("vaws_run", "MCP:vaws_execution", "mcp__vaws_task__vaws_message",
+                     "MCP:knowledge_query", "MCP:remote_read"):
             self.assertIsNotNone(re.search(hook["matcher"], name))
-        for name in ("read_file", "MCP:knowledge_query", "vaws_run_unrelated"):
+        for name in ("read_file", "MCP:user_query", "vaws_run_unrelated"):
             self.assertIsNone(re.search(hook["matcher"], name))
         self.assertGreaterEqual(hook["timeout"], 12)
         native = json.loads(files[self.root / ".cursor/worktrees.json"])
@@ -307,8 +308,9 @@ class ScaffoldSetupTests(unittest.TestCase):
                 wanted = setup.hook_groups(client, self.root)[event]
                 for name in ("vaws_session", "MCP:vaws_run", "vaws_task__vaws_message"):
                     self.assertIsNotNone(re.search(wanted[0]["matcher"], name))
-                for name in ("Bash", "read_file", "MCP:knowledge_query", "vaws_run_other"):
+                for name in ("Bash", "read_file", "MCP:user_query", "vaws_run_other"):
                     self.assertIsNone(re.search(wanted[0]["matcher"], name))
+                self.assertEqual(bool(re.search(wanted[0]["matcher"], "MCP:knowledge_query")), client == "cursor")
                 old = {key: value for key, value in wanted[0].items() if key != "matcher"}
                 settings = self.root / relative
                 settings.parent.mkdir(parents=True, exist_ok=True)

--- a/.agents/tests/test_client_setup_all.py
+++ b/.agents/tests/test_client_setup_all.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import plistlib
 import sys
 import tomllib
+from unittest.mock import patch
 
 import pytest
 
@@ -17,7 +18,8 @@ import vaws_native_mode_config as modes
 
 spec = importlib.util.spec_from_file_location("all_client_setup", ROOT / ".agents/scripts/vaws_client_setup.py")
 setup = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(setup)
+with patch("vaws_venv.ensure_workspace_interpreter"):
+    spec.loader.exec_module(setup)
 
 
 def installations(*names):
@@ -95,96 +97,74 @@ def test_grok_follows_path_while_kimi_follows_its_configured_home(tmp_path, monk
     assert found["kimi"]["executable"] == str(known["kimi"])
 
 
-@pytest.mark.parametrize("supported", [False, True])
-def test_all_preview_selects_native_options_by_installed_capability(local_setup, monkeypatch, capsys, supported):
+def test_all_preview_configures_stock_clients_without_native_patch(local_setup, monkeypatch, capsys):
     project, calls = local_setup
     monkeypatch.setattr(inventory, "installed_clients", lambda: installations("codex", "cursor", "kimi", "grok", "claude"))
-    probes = []
-    monkeypatch.setattr(modes, "kimi_session_setup_capability",
-                        lambda exe: probes.append(exe) or {"supported": supported, "checks": []})
     assert setup.main(["--client", "all", "--project", str(project)]) == 0
     result = json.loads(capsys.readouterr().out)
     options = dict(calls)
     assert options["codex"]["codex_global_hooks"]
     assert options["cursor"]["cursor_global_mcp"]
-    assert options["kimi"]["kimi_session_setup"] is supported
-    assert probes == ["/tools/kimi"]
-    assert result["clients"]["codex"]["native_worktree"]["default_mode"] == "not_verified"
-    assert result["clients"]["grok"]["native_worktree"]["initial_cli_start"] == "not_verified"
-    assert result["clients"]["claude"]["native_worktree"]["default_mode"] == "unsupported"
+    assert options["kimi"]["kimi_session_setup"] is False
+    for row in result["clients"].values():
+        assert row["workspace_start"]["trigger"] == "new-session-project-guidance"
+        assert row["workspace_start"]["native_patch_required"] is False
+        assert row["native_worktree"]["missing_action"] is None
     assert not list(project.iterdir())
     assert not (project.parent / ".grok/config.toml").exists()
 
 
-def test_all_skips_missing_clients_and_preserves_unsupported_existing_kimi(local_setup, monkeypatch, capsys):
+def test_all_skips_missing_clients_and_does_not_require_kimi_extension(local_setup, monkeypatch, capsys):
     project, calls = local_setup
     monkeypatch.setattr(inventory, "installed_clients", lambda: installations("kimi", "cursor"))
-    monkeypatch.setattr(modes, "kimi_session_setup_capability", lambda exe: {"supported": False})
     config = project.parent / ".kimi-code/config.toml"
     config.parent.mkdir()
-    original = '[[hooks]]\nevent="SessionSetup"\ncommand="custom-setup"\n'
+    original = '[[hooks]]\nevent="SessionStart"\ncommand="custom-setup"\n'
     config.write_text(original)
-    assert setup.main(["--client", "all", "--project", str(project), "--apply"]) == 1
+    assert setup.main(["--client", "all", "--project", str(project), "--apply"]) == 0
     result = json.loads(capsys.readouterr().out)
-    assert [name for name, _ in calls] == ["cursor"]
-    assert result["clients"]["kimi"]["state"] == "blocked"
+    assert {name for name, _ in calls} == {"cursor", "kimi"}
+    assert result["clients"]["kimi"]["state"] == "configured"
     assert result["clients"]["codex"]["state"] == "skipped"
     assert result["clients"]["cursor"]["state"] == "configured"
     assert config.read_text() == original
     record = json.loads(Path(result["record"]).read_text())
-    assert record["state"] == "partial"
-    assert record["clients"]["kimi"]["native_worktree"]["status"] == "unavailable"
+    assert record["state"] == "wiring_configured"
+    assert record["clients"]["kimi"]["workspace_start"]["resume"] == "reuse-existing-workspace"
 
 
-@pytest.mark.parametrize("supported", [False, True])
-def test_all_preserves_verified_extensions_before_applying(local_setup, monkeypatch, capsys, supported):
-    project, _ = local_setup
+@pytest.mark.parametrize("extended", [False, True])
+def test_all_preserves_native_update_preferences_and_requires_explicit_extension(local_setup, monkeypatch, capsys, extended):
+    project, calls = local_setup
     monkeypatch.setattr(inventory, "installed_clients", lambda: installations("grok", "kimi"))
     grok = project.parent / ".grok/config.toml"
     kimi_home = project.parent / "native-kimi-home"
     monkeypatch.setenv("KIMI_CODE_HOME", str(kimi_home))
     kimi = kimi_home / "tui.toml"
-    runtime_config = project.parent / "custom-kimi/config.toml"
-    runtime_config.parent.mkdir()
-    runtime_text = 'default_model = "keep-my-model"\n'
-    runtime_config.write_text(runtime_text)
     for path, text in ((grok, "[cli]\nauto_update = true\n"), (kimi, "[upgrade]\nauto_install = true\n")):
         path.parent.mkdir(parents=True)
         path.write_text(text)
-    probes = []
-
-    def grok_capability(executable, directory):
-        assert tomllib.loads(grok.read_text())["cli"]["auto_update"] is True
-        probes.append((executable, directory))
-        return {"supported": supported}
-
-    monkeypatch.setattr(modes, "grok_native_defaults", grok_capability)
-    monkeypatch.setattr(modes, "kimi_session_setup_capability", lambda exe: {"supported": supported})
-    assert setup.main(["--client", "all", "--project", str(project), "--kimi-config", str(runtime_config), "--apply"]) == 0
+    args = ["--client", "all", "--project", str(project), "--apply"]
+    if extended:
+        args.append("--kimi-session-setup")
+    assert setup.main(args) == 0
     result = json.loads(capsys.readouterr().out)
-    assert probes == [("/tools/grok", project)]
-    assert result["clients"]["grok"]["capability"]["supported"] is supported
-    assert tomllib.loads(grok.read_text())["cli"]["auto_update"] is not supported
-    assert tomllib.loads(kimi.read_text())["upgrade"]["auto_install"] is not supported
-    assert runtime_config.read_text() == runtime_text
-    assert not (runtime_config.parent / "tui.toml").exists()
-    assert not (kimi_home / "config.toml").exists()
-    assert not (project.parent / ".kimi-code/config.toml").exists()
+    assert dict(calls)["kimi"]["kimi_session_setup"] is extended
+    assert tomllib.loads(grok.read_text())["cli"]["auto_update"] is True
+    assert tomllib.loads(kimi.read_text())["upgrade"]["auto_install"] is True
+    assert result["clients"]["kimi"]["workspace_start"]["native_patch_required"] is False
 
 
-def test_native_setting_pending_is_reported_without_failing_initialization(local_setup, monkeypatch, capsys):
+def test_native_gui_choice_is_optional_for_project_startup(local_setup, monkeypatch, capsys):
     project, _ = local_setup
     monkeypatch.setattr(inventory, "installed_clients", lambda: installations("codex", "cursor"))
     assert setup.main(["--client", "all", "--project", str(project), "--apply"]) == 0
     result = json.loads(capsys.readouterr().out)
     assert result["state"] == "wiring_configured"
-    assert json.loads(Path(result["record"]).read_text())["state"] == "wiring_configured"
     for client in ("codex", "cursor"):
-        pending = result["clients"][client]["native_worktree"]
-        assert pending["default_mode"] == "not_verified"
-        assert "native tool once" in pending["missing_action"]
-        assert "Computer Use only if no public setter" in pending["missing_action"]
-        assert "not a recurring session check" in pending["missing_action"]
+        native = result["clients"][client]["native_worktree"]
+        assert native["default_mode"] == "client_choice"
+        assert native["missing_action"] is None
 
 
 def test_all_keeps_completed_files_backups_and_continues_after_a_write_failure(local_setup, monkeypatch, capsys):
@@ -220,7 +200,6 @@ def test_single_client_entry_does_not_discover_or_set_global_native_preferences(
     project, calls = local_setup
     monkeypatch.setattr(inventory, "installed_clients", lambda: pytest.fail("per-worktree setup scanned clients"))
     monkeypatch.setattr(modes, "add_native_mode", lambda *args, **kwargs: pytest.fail("per-worktree setup changed user preferences"))
-    monkeypatch.setattr(modes, "grok_native_defaults", lambda *args: pytest.fail("per-worktree setup probed a personal binary"))
     assert setup.main(["--client", "codex", "--project", str(project), "--apply"]) == 0
     capsys.readouterr()
     assert not calls[0][1]["codex_global_hooks"]

--- a/.agents/tests/test_coordinator_consumer.py
+++ b/.agents/tests/test_coordinator_consumer.py
@@ -728,7 +728,7 @@ class HookAdapterTests(unittest.TestCase):
             contexts = list((registry / "contexts").glob("*.json"))
             self.assertEqual(len(contexts), 1, proc.stderr)
             hint = json.loads(proc.stdout)["hookSpecificOutput"]["additionalContext"]
-            context_file = contexts[0]
+            context_file = contexts[0].resolve()
             self.assertIn(str(context_file), hint)
             self.assertTrue(context_file.is_file())
             self.assertEqual(context_file.parent.parent.resolve(), registry.resolve())

--- a/.agents/tests/test_coordinator_consumer.py
+++ b/.agents/tests/test_coordinator_consumer.py
@@ -725,9 +725,11 @@ class HookAdapterTests(unittest.TestCase):
                 check=False,
             )
             self.assertEqual(proc.returncode, 0, proc.stderr)
-            self.assertEqual(len(list((registry / "contexts").glob("*.json"))), 1, proc.stderr)
+            contexts = list((registry / "contexts").glob("*.json"))
+            self.assertEqual(len(contexts), 1, proc.stderr)
             hint = json.loads(proc.stdout)["hookSpecificOutput"]["additionalContext"]
-            context_file = Path(hint.splitlines()[1])
+            context_file = contexts[0]
+            self.assertIn(str(context_file), hint)
             self.assertTrue(context_file.is_file())
             self.assertEqual(context_file.parent.parent.resolve(), registry.resolve())
 

--- a/.agents/tests/test_coordinator_consumer.py
+++ b/.agents/tests/test_coordinator_consumer.py
@@ -473,7 +473,8 @@ class ClientSetupTests(unittest.TestCase):
         self.assertEqual(data["mcp_servers"]["remote_dev"]["command"], "user-command")
         self.assertEqual(data["mcp_servers"]["remote_dev"]["args"], ["user-argument"])
         self.assertEqual(data["mcp_servers"]["other"], {"command": "other-command"})
-        self.assertEqual(data["mcp_servers"]["vaws_task"]["args"], ["-m", "vaws_coordinator", "task-server"])
+        self.assertEqual(data["mcp_servers"]["vaws_task"]["args"],
+                         [str(self.setup.ROOT / ".agents/scripts/vaws_native_mcp.py"), "task"])
         config.write_text(files[config])
         self.assertNotIn(config, self.setup.configuration("codex", self.project))
 

--- a/.agents/tests/test_dependency.py
+++ b/.agents/tests/test_dependency.py
@@ -22,7 +22,7 @@ import vaws_dependency as deps  # noqa: E402
 class SpecLockTests(unittest.TestCase):
     def test_pyproject_requires_the_three_packages(self) -> None:
         versions = deps.required_versions()
-        self.assertEqual(set(versions), {"vaws-remote-dev", "vaws-coordinator", "vaws-knowledge", "pillow"})
+        self.assertEqual(set(versions), {"vaws-remote-dev", "vaws-coordinator", "vaws-knowledge", "pillow", "mcp"})
         self.assertNotIn(deps.VAWS_TOP_NAME, versions)
 
     def test_status_tracks_only_the_three_packages(self) -> None:

--- a/.agents/tests/test_gateway_client_setup.py
+++ b/.agents/tests/test_gateway_client_setup.py
@@ -104,3 +104,70 @@ def test_context_hook_covers_each_native_companion_name(client, name, configured
     assert not re.search(matcher, "user_provider__query")
     if client != "cursor":
         assert not re.search(matcher, "MCP:knowledge_query")
+
+
+LEGACY_TASK_MATCHER = r"(?:^|:|__)vaws_(session|run|execution|finish|message)$"
+
+
+def old_context_hook(client, project, *, wrapped=False):
+    event = "preToolUse" if client == "cursor" else "PreToolUse"
+    group = setup.hook_groups(client, project)[event][0]
+    group["matcher"] = LEGACY_TASK_MATCHER
+    if wrapped:
+        group["hooks"][0]["command"] = setup.local_hook_command([
+            sys.executable, str(project / ".agents/scripts/vaws_claude_entry.py"),
+            "session", "--agent-sessions-dir", str(project / ".vaws-local/agent-sessions")])
+    return event, group
+
+
+@pytest.mark.parametrize("client", ["claude", "cursor", "grok", "codex"])
+def test_existing_generated_task_only_matcher_upgrades_companion_context(client, configured_project):
+    project, _, _ = configured_project
+    event, old = old_context_hook(client, project, wrapped=client == "claude")
+    relative = {"claude": ".claude/settings.local.json", "cursor": ".cursor/hooks.json",
+                "grok": ".grok/hooks/vaws-session.json", "codex": ".codex/hooks.json"}[client]
+    path = project / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"hooks": {event: [old]}}))
+    plan = setup.build_plan(client, project)
+    groups = json.loads(plan["files"][path])["hooks"][event]
+    assert len(groups) == 1
+    assert re.search(groups[0]["matcher"], "mcp__vaws-knowledge__knowledge_query")
+    assert re.search(groups[0]["matcher"], "remote_dev__remote_read")
+    if client == "cursor":
+        assert re.search(groups[0]["matcher"], "MCP:knowledge_query")
+    for output, content in plan["files"].items():
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_bytes(content.encode())
+    assert setup.build_plan(client, project)["files"][path] == plan["files"][path]
+
+
+def test_claude_mixed_legacy_group_keeps_user_scope_when_owned_context_expands(configured_project):
+    project, _, _ = configured_project
+    event, old = old_context_hook("claude", project, wrapped=True)
+    user = {"type": "command", "command": "user-audit-hook", "timeout": 37}
+    old["hooks"].append(user)
+    old["custom_metadata"] = "retained"
+    path = project / ".claude/settings.local.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"hooks": {event: [old]}}))
+    plan = setup.build_plan("claude", project)
+    groups = json.loads(plan["files"][path])["hooks"][event]
+    assert groups[0] == {**old, "hooks": [user]}
+    assert len(groups) == 2
+    assert re.search(groups[1]["matcher"], "mcp__vaws-knowledge__knowledge_capture")
+    assert len(groups[1]["hooks"]) == 1
+    path.write_text(plan["files"][path])
+    assert setup.build_plan("claude", project)["files"][path] == plan["files"][path]
+
+
+def test_claude_custom_wrapper_scope_is_preserved(configured_project):
+    project, _, _ = configured_project
+    event, old = old_context_hook("claude", project, wrapped=True)
+    old["matcher"] = "Bash"
+    path = project / ".claude/settings.local.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"hooks": {event: [old]}}))
+    groups = json.loads(setup.build_plan("claude", project)["files"][path])["hooks"][event]
+    assert len(groups) == 1
+    assert groups[0]["matcher"] == "Bash"

--- a/.agents/tests/test_gateway_client_setup.py
+++ b/.agents/tests/test_gateway_client_setup.py
@@ -1,0 +1,106 @@
+"""Stable provider launchers and their project guidance across stock clients."""
+import json
+import re
+from pathlib import Path
+import sys
+import tomllib
+
+import pytest
+
+from test_knowledge_client_setup import setup
+from client_setup_fixtures import selected_runtime
+
+
+@pytest.fixture
+def configured_project(tmp_path, monkeypatch):
+    project = tmp_path / "project 用户"
+    project.mkdir()
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: user_dir))
+    monkeypatch.setenv("KIMI_CODE_HOME", str(user_dir / ".kimi-code"))
+    monkeypatch.setattr(setup, "ROOT", project)
+    monkeypatch.setattr(setup, "OWNED_HOOK_SCRIPT", project / ".agents/hooks/vaws_session.py")
+    receipt = selected_runtime(monkeypatch, setup, tmp_path)
+    monkeypatch.setattr(setup, "read_receipt", lambda _: receipt)
+    return project, user_dir, receipt
+
+
+@pytest.mark.parametrize("client", ["codex", "cursor", "claude", "grok", "kimi"])
+def test_every_provider_uses_stable_gateway_and_stock_startup(client, configured_project):
+    project, user_dir, _ = configured_project
+    plan = setup.build_plan(client, project, cursor_global_mcp=client == "cursor")
+    if client in {"grok", "codex"}:
+        providers = tomllib.loads(plan["files"][project / ("." + client) / "config.toml"])["mcp_servers"]
+    else:
+        path = {"claude": project / ".mcp.json", "cursor": user_dir / ".cursor/mcp.json",
+                "kimi": user_dir / ".kimi-code/mcp.json"}[client]
+        providers = json.loads(plan["files"][path])["mcpServers"]
+    assert len(providers) == 3
+    for server in providers.values():
+        assert Path(server["args"][0]).name in {"vaws_native_mcp.py", "vaws_claude_entry.py"}
+        assert server["args"][1] in {"task", "remote", "knowledge"}
+    assert "vaws_start.py --client CLIENT" in plan["files"][project / "AGENTS.md"]
+    assert "Resume keeps" in plan["files"][project / "AGENTS.md"]
+    if client == "kimi":
+        hooks = tomllib.loads(plan["files"][user_dir / ".kimi-code/config.toml"])["hooks"]
+        assert all(hook["event"] != "SessionSetup" for hook in hooks)
+
+
+@pytest.mark.parametrize("client", ["codex", "grok", "cursor"])
+def test_owned_old_provider_moves_to_gateway_but_keeps_custom_fields(client, configured_project):
+    project, _, receipt = configured_project
+    old = {"command": sys.executable, "args": setup.task_server_args(),
+           "env": {setup.PIN_ENV: receipt["receipt"], "CUSTOM": "retained"}}
+    if client == "cursor":
+        path = project / ".cursor/mcp.json"
+        path.parent.mkdir()
+        path.write_text(json.dumps({"mcpServers": {"vaws-task": {**old, "custom": 7},
+                                                   "other": {"command": "user-provider"}}}))
+    else:
+        path = project / ("." + client) / "config.toml"
+        path.parent.mkdir()
+        text = setup.toml_server_body("vaws_task", old).replace("\n[mcp_servers.vaws_task.env]",
+                    '\nenabled_tools = ["vaws_run"]\n[mcp_servers.vaws_task.env]')
+        path.write_text("# user comment\n" + text + '\n[mcp_servers.other]\ncommand = "user-provider"\n')
+    plan = setup.build_plan(client, project, task_only=True)
+    text = plan["files"][path]
+    providers = json.loads(text)["mcpServers"] if client == "cursor" else tomllib.loads(text)["mcp_servers"]
+    server = providers["vaws-task" if client == "cursor" else "vaws_task"]
+    assert server["args"] == [str(project / ".agents/scripts/vaws_native_mcp.py"), "task"]
+    assert server["env"]["CUSTOM"] == "retained"
+    assert providers["other"] == {"command": "user-provider"}
+    if client == "cursor":
+        assert server["custom"] == 7
+    else:
+        assert server["enabled_tools"] == ["vaws_run"]
+        assert text.startswith("# user comment\n")
+    for output, content in plan["files"].items():
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_bytes(content.encode())
+    repeated = setup.build_plan(client, project, task_only=True)
+    assert repeated["files"].get(path, text) == text
+
+
+def test_custom_same_named_launcher_is_not_replaced(configured_project):
+    project, _, _ = configured_project
+    custom = {"command": "user-python", "args": setup.task_server_args(), "custom": True}
+    desired = setup.desired_mcp_servers(task_only=True)["vaws-task"]
+    assert setup.merge_server_entry(custom, desired, checkout=project) == (custom, "preserved")
+
+
+@pytest.mark.parametrize("client,name", [
+    ("codex", "mcp__vaws_knowledge__knowledge_query"),
+    ("grok", "remote_dev__remote_read"),
+    ("claude", "mcp__vaws-knowledge__knowledge_capture"),
+    ("cursor", "MCP:knowledge_explain"),
+    ("cursor", "MCP:remote_read"),
+])
+def test_context_hook_covers_each_native_companion_name(client, name, configured_project):
+    project, _, _ = configured_project
+    groups = setup.hook_groups(client, project)
+    matcher = groups["preToolUse" if client == "cursor" else "PreToolUse"][0]["matcher"]
+    assert re.search(matcher, name)
+    assert not re.search(matcher, "user_provider__query")
+    if client != "cursor":
+        assert not re.search(matcher, "MCP:knowledge_query")

--- a/.agents/tests/test_grok_native_setup.py
+++ b/.agents/tests/test_grok_native_setup.py
@@ -149,7 +149,6 @@ def test_all_preview_reports_owned_crlf_hook_repair(repository, monkeypatch, cap
                         lambda: {"grok": {"installed": True, "executable": None, "evidence": []}})
     monkeypatch.setattr(vaws_native_mode_config, "add_native_mode", lambda *args, **kwargs: None)
     monkeypatch.setattr(vaws_native_mode_config, "add_grok_import_dedup", lambda *args, **kwargs: None)
-    monkeypatch.setattr(vaws_native_mode_config, "grok_native_defaults", lambda *args: {"supported": False})
     assert client_setup.main(["--client", "all", "--project", str(source)]) == 0
     result = json.loads(capsys.readouterr().out)
     assert result["clients"]["grok"]["files"] == [

--- a/.agents/tests/test_kimi_hook_migration.py
+++ b/.agents/tests/test_kimi_hook_migration.py
@@ -7,7 +7,7 @@ import tomllib
 from test_kimi_native_setup import client_setup, git, repo
 from client_setup_fixtures import selected_runtime
 import vaws_kimi_config
-from vaws_kimi_config import migrate_kimi_hooks
+from vaws_kimi_config import remove_owned_kimi_hooks
 
 
 def hook(command, event="SessionStart"):
@@ -19,7 +19,7 @@ def block(project, body):
     return f"# BEGIN VAWS session-{key}\n{body}# END VAWS session-{key}\n"
 
 
-def test_removes_only_same_family_generated_hooks_and_preserves_custom_blocks(tmp_path):
+def test_removes_all_same_family_generated_hooks_and_preserves_custom_text(tmp_path):
     project = repo(tmp_path / "project 用户")
     linked = tmp_path / "old tree"
     git(project, "worktree", "add", "--detach", str(linked), "HEAD")
@@ -36,14 +36,16 @@ def test_removes_only_same_family_generated_hooks_and_preserves_custom_blocks(tm
     original = ("# keep native settings\n[thinking]\nenabled = true\n\n"
                 + hook(direct(nested)) + block(linked, hook(adapter(linked)))
                 + unrelated + custom + hook("another-custom-hook") + current)
-    migrated = migrate_kimi_hooks(original, project, project, parse_command=shlex.split)
+    migrated = remove_owned_kimi_hooks(original, project, project, parse_command=shlex.split)
     assert block(linked, hook(adapter(linked))) not in migrated
-    assert unrelated in migrated and custom in migrated and current in migrated
+    assert current not in migrated
+    assert unrelated in migrated
+    assert hook("my-custom-hook") in migrated
+    assert hook("another-custom-hook") in migrated
     commands = [entry["command"] for entry in tomllib.loads(migrated)["hooks"]]
-    assert commands.count(direct(nested)) == 1
-    assert "another-custom-hook" in commands
+    assert commands == [direct(other), "my-custom-hook", "another-custom-hook"]
     assert tomllib.loads(migrated)["thinking"] == {"enabled": True}
-    assert migrate_kimi_hooks(migrated, project, project, parse_command=shlex.split) == migrated
+    assert remove_owned_kimi_hooks(migrated, project, project, parse_command=shlex.split) == migrated
 
 
 def test_preserves_custom_legacy_arguments_or_matcher(tmp_path):
@@ -51,7 +53,7 @@ def test_preserves_custom_legacy_arguments_or_matcher(tmp_path):
     command = shlex.join(["python", str(project / ".agents/hooks/vaws_session.py"),
                           "--client", "kimi", "--project", str(project)])
     original = hook(command + " --custom preserved") + hook(command) + 'matcher = "Bash"\n'
-    assert migrate_kimi_hooks(original, project, project, parse_command=shlex.split) == original
+    assert remove_owned_kimi_hooks(original, project, project, parse_command=shlex.split) == original
 
 
 def test_repair_after_native_writer_removed_markers_keeps_one_callback(tmp_path, monkeypatch):
@@ -68,10 +70,62 @@ def test_repair_after_native_writer_removed_markers_keeps_one_callback(tmp_path,
     repaired = client_setup.build_plan("kimi", project, kimi_config=config, task_only=True)["files"][config]
     hooks = tomllib.loads(repaired)["hooks"]
     events = [entry["event"] for entry in hooks]
-    assert events.count("SessionSetup") == 1
-    assert len(events) == len(set(events)) == len(tomllib.loads(original)["hooks"])
-    expected = ["uv", "run", "--no-project", "python",
-                str(client_setup.ROOT / ".agents/scripts/vaws_kimi_session_setup.py"), "--project", str(project)]
-    assert all(client_setup.hook_argv(entry["command"]) == expected for entry in hooks)
+    assert "SessionSetup" not in events
+    assert len(events) == len(set(events))
+    assert set(events) == set(client_setup.EVENTS) - {"PreToolUse"}
+    for entry in hooks:
+        argv = client_setup.hook_argv(entry["command"])
+        assert argv[1] == str(client_setup.ROOT / ".agents/hooks/vaws_session.py")
+        assert argv[argv.index("--client") + 1] == "kimi"
+        assert argv[argv.index("--project") + 1] == str(project)
     config.write_text(repaired)
     assert client_setup.build_plan("kimi", project, kimi_config=config, task_only=True)["files"][config] == repaired
+
+
+def test_official_switch_preserves_custom_and_stop_hooks_inside_managed_block(tmp_path, monkeypatch):
+    receipt = selected_runtime(monkeypatch, client_setup, tmp_path)
+    monkeypatch.setattr(vaws_kimi_config, "managed_receipt", lambda _: receipt)
+    project = repo(tmp_path / "project 用户")
+    config = tmp_path / "config.toml"
+    adapter = shlex.join(["uv", "run", "--no-project", "python",
+                          str(client_setup.ROOT / ".agents/scripts/vaws_kimi_session_setup.py"),
+                          "--project", str(project)])
+    knowledge = shlex.join(["python", str(client_setup.ROOT / ".agents/hooks/knowledge_summary.py"),
+                            "--client", "kimi", "--project", str(project)])
+    custom_start = hook("user-start-hook", "SessionStart")
+    custom_stop = hook("user-stop-hook", "Stop")
+    knowledge_stop = hook(knowledge, "Stop")
+    custom_adapter = hook(adapter + " --user-option preserved", "UserPromptSubmit")
+    config.write_text('[provider]\nname = "kept"\n\n' + block(project,
+        hook(adapter, "SessionSetup") + hook(adapter, "UserPromptSubmit")
+        + custom_start + custom_stop + knowledge_stop + custom_adapter))
+
+    repaired = client_setup.build_plan("kimi", project, kimi_config=config, task_only=True)["files"][config]
+    hooks = tomllib.loads(repaired)["hooks"]
+    assert all(entry["event"] != "SessionSetup" for entry in hooks)
+    assert all(entry["command"] != adapter for entry in hooks)
+    for preserved in (custom_start, custom_stop, knowledge_stop, custom_adapter):
+        assert preserved in repaired
+    assert tomllib.loads(repaired)["provider"] == {"name": "kept"}
+    assert [entry["command"] for entry in hooks].count("user-start-hook") == 1
+    assert [entry["command"] for entry in hooks].count("user-stop-hook") == 1
+    config.write_text(repaired)
+    repeated = client_setup.build_plan("kimi", project, kimi_config=config, task_only=True)["files"][config]
+    assert repeated == repaired
+
+
+def test_removal_requires_exact_owned_command_and_keeps_unrelated_projects(tmp_path):
+    project = repo(tmp_path / "project")
+    other = repo(tmp_path / "other")
+    adapter = lambda target: shlex.join(["uv", "run", "--no-project", "python",
+        str(project / ".agents/scripts/vaws_kimi_session_setup.py"), "--project", str(target)])
+    owned = hook(adapter(project), "SessionSetup")
+    unrelated = block(other, hook(adapter(other), "SessionSetup"))
+    customized = hook(adapter(project), "UserPromptSubmit") + 'matcher = "custom"\n'
+    original = block(project, owned + hook("keep-stop", "Stop")) + unrelated + customized
+    cleaned = remove_owned_kimi_hooks(original, project, project, parse_command=shlex.split)
+    assert owned not in cleaned
+    assert hook("keep-stop", "Stop") in cleaned
+    assert unrelated in cleaned
+    assert customized in cleaned
+    assert remove_owned_kimi_hooks(cleaned, project, project, parse_command=shlex.split) == cleaned

--- a/.agents/tests/test_kimi_native_setup.py
+++ b/.agents/tests/test_kimi_native_setup.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 from unittest.mock import patch
 
+import pytest
+
 from client_setup_fixtures import selected_runtime
 import vaws_kimi_config
 
@@ -74,7 +76,7 @@ def test_resume_routes_existing_receipt_without_preparing(tmp_path, monkeypatch)
     assert "--environment-receipt" in calls[0][0]
 
 
-def test_native_extension_is_opt_in_and_repair_preserves_each_project_choice(tmp_path, monkeypatch):
+def test_native_extension_requires_explicit_opt_in_on_each_configuration_run(tmp_path, monkeypatch):
     receipt = selected_runtime(monkeypatch, client_setup, tmp_path)
     monkeypatch.setattr(vaws_kimi_config, "managed_receipt", lambda root: receipt)
     project = repo(tmp_path / "extended")
@@ -94,7 +96,17 @@ def test_native_extension_is_opt_in_and_repair_preserves_each_project_choice(tmp
     assert all(client_setup.hook_argv(hook["command"]) == expected for hook in hooks)
     config.write_text(text)
     repaired = client_setup.build_plan("kimi", project, kimi_config=config, task_only=True)
-    assert repaired["files"][config] == text
+    repaired_hooks = client_setup.tomllib.loads(repaired["files"][config])["hooks"]
+    assert all(hook["event"] != "SessionSetup" for hook in repaired_hooks)
+    assert {hook["event"] for hook in repaired_hooks} == set(client_setup.EVENTS) - {"PreToolUse"}
+    for hook in repaired_hooks:
+        argv = client_setup.hook_argv(hook["command"])
+        assert Path(argv[1]) == ROOT / ".agents/hooks/vaws_session.py"
+        assert argv[argv.index("--client") + 1] == "kimi"
+        assert argv[argv.index("--project") + 1] == str(project)
+    assert client_setup.tomllib.loads(repaired["files"][config])["provider"] == {"name": "kept"}
+    # Configuring another repository must preserve this project's explicitly
+    # installed extension; only the selected project's owned hooks are replaced.
     separate = client_setup.build_plan("kimi", other, kimi_config=config, task_only=True)
     separate_hooks = client_setup.tomllib.loads(separate["files"][config])["hooks"]
     assert sum(hook["event"] == "SessionSetup" for hook in separate_hooks) == 1
@@ -102,20 +114,28 @@ def test_native_extension_is_opt_in_and_repair_preserves_each_project_choice(tmp
     assert Path(separate_argv[1]) == ROOT / ".agents/hooks/vaws_session.py"
     assert separate_argv[separate_argv.index("--project") + 1] == str(other)
     assert client_setup.tomllib.loads(separate["files"][config])["provider"] == {"name": "kept"}
+    config.write_text(repaired["files"][config])
+    assert client_setup.build_plan("kimi", project, kimi_config=config, task_only=True)["files"][config] == repaired["files"][config]
+    explicit_again = client_setup.build_plan("kimi", project, kimi_config=config, task_only=True,
+                                              kimi_session_setup=True)
+    assert sum(hook["event"] == "SessionSetup"
+               for hook in client_setup.tomllib.loads(explicit_again["files"][config])["hooks"]) == 1
 
 
-def test_user_mcp_moves_only_managed_providers_and_keeps_user_configuration(tmp_path, monkeypatch):
+@pytest.mark.parametrize("extended", [False, True])
+def test_user_mcp_moves_only_managed_providers_and_keeps_user_configuration(tmp_path, monkeypatch, extended):
     receipt = selected_runtime(monkeypatch, client_setup, tmp_path)
     monkeypatch.setattr(vaws_kimi_config, "managed_receipt", lambda root: receipt)
+    managed_task = client_setup.desired_mcp_servers(task_only=True)["vaws-task"]
     monkeypatch.setattr(client_setup, "owned_environment_server",
-                        lambda entry, project: entry.get("args") == ["-m", "vaws_coordinator", "task-server"])
+                        lambda entry, project: entry.get("args") == managed_task["args"])
     project = repo(tmp_path / "project")
     home = tmp_path / "home"
     home.mkdir()
     config = home / "config.toml"
     original = {"custom": "keep", "mcpServers": {"another": {"command": "custom-provider"}}}
     (home / "mcp.json").write_text(json.dumps(original))
-    plan = client_setup.build_plan("kimi", project, kimi_config=config, task_only=True, kimi_session_setup=True)
+    plan = client_setup.build_plan("kimi", project, kimi_config=config, task_only=True, kimi_session_setup=extended)
     value = json.loads(plan["files"][home / "mcp.json"])
     assert value["custom"] == "keep"
     assert value["mcpServers"]["another"] == original["mcpServers"]["another"]
@@ -124,7 +144,7 @@ def test_user_mcp_moves_only_managed_providers_and_keeps_user_configuration(tmp_
     assert "vaws-task" not in json.loads(plan["files"][project / ".kimi-code/mcp.json"])["mcpServers"]
     custom = {"mcpServers": {"vaws-task": {"command": "my-own-server", "custom": True}}}
     (home / "mcp.json").write_text(json.dumps(custom))
-    plan = client_setup.build_plan("kimi", project, kimi_config=config, task_only=True, kimi_session_setup=True)
+    plan = client_setup.build_plan("kimi", project, kimi_config=config, task_only=True, kimi_session_setup=extended)
     assert json.loads(plan["files"][home / "mcp.json"])["mcpServers"]["vaws-task"] == custom["mcpServers"]["vaws-task"]
 
 

--- a/.agents/tests/test_kimi_summary.py
+++ b/.agents/tests/test_kimi_summary.py
@@ -123,8 +123,9 @@ def test_setup_installs_stop_as_summary_command_and_is_idempotent(tmp_path, monk
     stops = [entry for entry in hooks if entry["event"] == "Stop"]
     assert len(stops) == 2
     assert stops[0]["command"] == "user-stop"
-    assert "knowledge_summary.py" in stops[1]["command"]
-    assert "vaws_session.py" not in stops[1]["command"]
+    arguments = client_setup.hook_argv(stops[1]["command"])
+    assert any(Path(argument).name == "knowledge_summary.py" for argument in arguments)
+    assert all(Path(argument).name != "vaws_session.py" for argument in arguments)
     assert all(entry["event"] != "SessionSetup" for entry in hooks)
     config.write_text(plan["files"][config])
     repeated = client_setup.build_plan("kimi", project, kimi_config=config)

--- a/.agents/tests/test_kimi_summary.py
+++ b/.agents/tests/test_kimi_summary.py
@@ -1,0 +1,131 @@
+"""Official Kimi final-step adaptation is bounded to the supplied session."""
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import vaws_kimi_summary as summary
+from test_knowledge_summary_hook import hook, invoke
+from test_kimi_native_setup import client_setup, git, repo
+from client_setup_fixtures import selected_runtime
+import vaws_kimi_config
+
+
+def event(kind, **values):
+    return {"type": "context.append_loop_event", "event": {"type": kind, **values}}
+
+
+def final_step(text="The ordinary completed reply is reused without another summary."):
+    return [event("step.begin", uuid="step", turnId="3"),
+            event("content.part", stepUuid="step", part={"type": "think", "text": "private thought"}),
+            event("content.part", stepUuid="step", part={"type": "text", "text": text}),
+            event("content.part", stepUuid="step", part={"type": "text", "text": " Done."}),
+            event("step.end", uuid="step", turnId="3", finishReason="end_turn")]
+
+
+def write_wire(home, payload, records, version="1.5"):
+    path = summary.journal_path(payload, home=home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(value) for value in [
+        {"type": "metadata", "protocol_version": version}, *records]) + "\n")
+    return path
+
+
+@pytest.fixture
+def payload(tmp_path):
+    return {"hook_event_name": "Stop", "cwd": str(tmp_path / "project 用户"), "session_id": "known-session"}
+
+
+def test_only_final_step_text_from_exact_session_is_captured(tmp_path, payload):
+    records = [{"type": "unrelated", "padding": "x" * (summary.TAIL_BYTES + 100)}, *final_step()]
+    path = write_wire(tmp_path, payload, records)
+    # Unrelated content is not opened, even if its session has a later mtime.
+    other = write_wire(tmp_path, {**payload, "session_id": "other"}, final_step("Unrelated response"))
+    with patch.object(Path, "glob", side_effect=AssertionError("session discovery")), \
+         patch.object(Path, "rglob", side_effect=AssertionError("session discovery")):
+        result = summary.summary_payload(payload, home=tmp_path)
+    assert result["last_assistant_message"] == final_step()[2]["event"]["part"]["text"] + " Done."
+    assert result["turn_id"] == "3"
+    assert "private thought" not in result["last_assistant_message"]
+    assert path != other
+
+
+@pytest.mark.parametrize("suffix", [
+    [event("step.begin", uuid="new")],
+    [{"type": "context.append_message", "message": {"role": "user", "content": []}}],
+    [event("step.end", uuid="new", finishReason="tool_use")],
+    [event("step.end", uuid="new", finishReason="error")],
+])
+def test_incomplete_tool_or_new_prompt_does_not_reuse_old_final(tmp_path, payload, suffix):
+    write_wire(tmp_path, payload, final_step() + suffix)
+    assert summary.summary_payload(payload, home=tmp_path) == payload
+
+
+def test_unknown_schema_and_oversized_final_are_skipped(tmp_path, payload):
+    write_wire(tmp_path, payload, final_step(), version="2.0")
+    assert summary.summary_result(payload, home=tmp_path) == (payload, {
+        "status": "no_summary", "reason": "unsupported-wire-version"})
+    write_wire(tmp_path, payload, final_step("x" * summary.TAIL_BYTES))
+    assert summary.summary_result(payload, home=tmp_path) == (payload, {
+        "status": "no_summary", "reason": "final-step-exceeds-tail-limit"})
+
+
+def test_flush_retry_is_short_and_bounded(tmp_path, payload):
+    path = write_wire(tmp_path, payload, final_step()[:-1])
+    sleeps = []
+    def flush(delay):
+        sleeps.append(delay)
+        with path.open("a") as stream:
+            stream.write(json.dumps(final_step()[-1]) + "\n")
+    with patch.object(summary.time, "sleep", side_effect=flush):
+        assert "last_assistant_message" in summary.summary_payload(payload, home=tmp_path)
+    assert sleeps == [0.025]
+
+
+def test_subagent_and_unknown_session_never_fall_back_to_another_file(tmp_path, payload):
+    write_wire(tmp_path, payload, final_step())
+    for changes in ({"agent_id": "child"}, {"session_id": "../known-session"},
+                    {"session_id": "missing"}, {"hook_event_name": "UserPromptSubmit"}):
+        value = {**payload, **changes}
+        assert summary.summary_payload(value, home=tmp_path) == value
+
+
+def test_hook_uses_adapter_and_same_family_shared_configuration(tmp_path, monkeypatch):
+    project = repo(tmp_path / "project")
+    linked = tmp_path / "linked"
+    git(project, "worktree", "add", "--detach", str(linked), "HEAD")
+    payload = {"hook_event_name": "Stop", "cwd": str(linked), "session_id": "known"}
+    write_wire(tmp_path, payload, final_step())
+    monkeypatch.setenv("KIMI_CODE_HOME", str(tmp_path))
+    with patch.object(hook, "ensure_workspace_interpreter"), \
+         patch("vaws_knowledge_service.service_config", return_value="shared") as config, \
+         patch("vaws_knowledge.summary_hook.capture_summary") as capture:
+        invoke(payload, client="kimi", project=project)
+    config.assert_called_once_with(project)
+    assert capture.call_args.kwargs == {"config": "shared", "client": "kimi"}
+    assert capture.call_args.args[0]["last_assistant_message"].endswith(" Done.")
+
+
+def test_setup_installs_stop_as_summary_command_and_is_idempotent(tmp_path, monkeypatch):
+    import tomllib
+    receipt = selected_runtime(monkeypatch, client_setup, tmp_path)
+    monkeypatch.setattr(vaws_kimi_config, "managed_receipt", lambda _: receipt)
+    project = repo(tmp_path / "project")
+    config = tmp_path / "config.toml"
+    config.write_text('[[hooks]]\nevent = "Stop"\ncommand = "user-stop"\n')
+    plan = client_setup.build_plan("kimi", project, kimi_config=config)
+    providers = json.loads(plan["files"][config.parent / "mcp.json"])["mcpServers"]
+    providers.update(json.loads(plan["files"][project / ".kimi-code/mcp.json"])["mcpServers"])
+    assert len(providers) == 3
+    assert all(server["env"]["VAWS_MCP_CLIENT"] == "kimi" for server in providers.values())
+    hooks = tomllib.loads(plan["files"][config])["hooks"]
+    stops = [entry for entry in hooks if entry["event"] == "Stop"]
+    assert len(stops) == 2
+    assert stops[0]["command"] == "user-stop"
+    assert "knowledge_summary.py" in stops[1]["command"]
+    assert "vaws_session.py" not in stops[1]["command"]
+    assert all(entry["event"] != "SessionSetup" for entry in hooks)
+    config.write_text(plan["files"][config])
+    repeated = client_setup.build_plan("kimi", project, kimi_config=config)
+    assert repeated["files"][config] == plan["files"][config]

--- a/.agents/tests/test_knowledge_client_setup.py
+++ b/.agents/tests/test_knowledge_client_setup.py
@@ -49,7 +49,8 @@ def test_all_clients_receive_knowledge_access_and_only_supported_summary_events(
     if client == "cursor":
         ended = payload["hooks"]["sessionEnd"]
         assert len(ended) == 2
-        assert any("vaws_session.py" in entry["command"] for entry in ended)
+        assert any(Path(argument).name == "vaws_session.py"
+                   for entry in ended for argument in setup.hook_argv(entry["command"]))
         assert sum(entry["command"] == command for entry in ended) == 1
     arguments = setup.hook_argv(command)
     if client == "claude":

--- a/.agents/tests/test_knowledge_client_setup.py
+++ b/.agents/tests/test_knowledge_client_setup.py
@@ -38,14 +38,19 @@ def test_all_clients_receive_knowledge_access_and_only_supported_summary_events(
     if client == "kimi":
         hooks = setup.tomllib.loads(plan["files"][tmp_path / "kimi-config.toml"])["hooks"]
         assert "SessionStart" in {entry["event"] for entry in hooks}
-        assert "Stop" not in {entry["event"] for entry in hooks}
-        assert all(Path(argument).name != "knowledge_summary.py"
-                   for entry in hooks for argument in setup.hook_argv(entry["command"]))
+        stop = next(entry for entry in hooks if entry["event"] == "Stop")
+        assert any(Path(argument).name == "knowledge_summary.py"
+                   for argument in setup.hook_argv(stop["command"]))
         return
     payload = json.loads(plan["files"][tmp_path / HOOK_FILES[client]])
     event = "afterAgentResponse" if client == "cursor" else "Stop"
     group = payload["hooks"][event][0]
     command = group["command"] if client == "cursor" else group["hooks"][0]["command"]
+    if client == "cursor":
+        ended = payload["hooks"]["sessionEnd"]
+        assert len(ended) == 2
+        assert any("vaws_session.py" in entry["command"] for entry in ended)
+        assert sum(entry["command"] == command for entry in ended) == 1
     arguments = setup.hook_argv(command)
     if client == "claude":
         assert arguments[1:3] == [str(tmp_path / ".agents/scripts/vaws_claude_entry.py"), "summary"]

--- a/.agents/tests/test_knowledge_client_setup.py
+++ b/.agents/tests/test_knowledge_client_setup.py
@@ -34,7 +34,7 @@ def test_all_clients_receive_knowledge_access_and_only_supported_summary_events(
     monkeypatch.setattr(setup, "managed_python", lambda: sys.executable)
     monkeypatch.setenv("KIMI_CODE_HOME", str(tmp_path / "kimi-home"))
     plan = setup.build_plan(client, tmp_path, kimi_config=tmp_path / "kimi-config.toml")
-    assert plan["mcp_servers"]["vaws-knowledge"] == ["-m", "vaws_knowledge.server.mcp_server"]
+    assert plan["mcp_servers"]["vaws-knowledge"] == [str(tmp_path / ".agents/scripts/vaws_native_mcp.py"), "knowledge"]
     if client == "kimi":
         hooks = setup.tomllib.loads(plan["files"][tmp_path / "kimi-config.toml"])["hooks"]
         assert "SessionStart" in {entry["event"] for entry in hooks}

--- a/.agents/tests/test_knowledge_prepare.py
+++ b/.agents/tests/test_knowledge_prepare.py
@@ -91,10 +91,11 @@ def test_prepare_uses_installed_cli_and_preserves_readiness(tmp_path, monkeypatc
     calls = []
     monkeypatch.setattr(knowledge, "knowledge_owner_python", lambda root: sys.executable)
     monkeypatch.setattr(knowledge, "knowledge_owner_env", lambda root: {"KNOWLEDGE_OWNER": "native"})
+    monkeypatch.setattr(knowledge, "shared_workspace_root", lambda root: root)
     monkeypatch.setattr(knowledge.subprocess, "run", lambda command, **kwargs: calls.append((command, kwargs)) or subprocess.CompletedProcess(command, code, json.dumps(payload)))
     result = knowledge.prepare_knowledge(tmp_path)
     command, kwargs = calls[0]
-    assert command == [sys.executable, "-m", "vaws_knowledge", "prepare", "--project", str(tmp_path)]
+    assert command == [sys.executable, "-c", knowledge.PREPARE_CODE]
     assert kwargs["env"]["KNOWLEDGE_OWNER"] == "native"
     assert kwargs["stdout"] == subprocess.PIPE and kwargs["stderr"] is sys.stderr
     assert result["ready"] is ready

--- a/.agents/tests/test_knowledge_summary_hook.py
+++ b/.agents/tests/test_knowledge_summary_hook.py
@@ -24,7 +24,15 @@ def invoke(payload, *, client="codex", project=ROOT):
         code = hook.main()
     assert code == 0
     assert output.getvalue() == "{}\n"
-    assert errors.getvalue() == ""
+    facts = [json.loads(line) for line in errors.getvalue().splitlines()]
+    if hook.in_project(payload, client=client, project=project):
+        assert len(facts) == 1
+        assert facts[0]["event"] == "knowledge_summary"
+        assert facts[0]["client"] == client
+        assert "status" in facts[0]
+    else:
+        assert facts == []
+    return facts
 
 
 def test_capture_receives_existing_summary_without_an_extra_format():
@@ -40,8 +48,11 @@ def test_capture_receives_existing_summary_without_an_extra_format():
 
 def test_capture_error_does_not_interrupt_client():
     with mock.patch.object(hook, "ensure_workspace_interpreter"), \
-         mock.patch("vaws_knowledge_service.service_config", side_effect=OSError("config unavailable")):
-        invoke({"hook_event_name": "Stop", "cwd": str(ROOT), "last_assistant_message": "Existing final response."})
+         mock.patch("vaws_knowledge_service.service_config", side_effect=OSError("config unavailable ghp_exampletoken")):
+        facts = invoke({"hook_event_name": "Stop", "cwd": str(ROOT), "last_assistant_message": "Existing final response."})
+    assert facts[0]["status"] == "failed"
+    assert facts[0]["error_type"] == "OSError"
+    assert facts[0]["error"] == "config unavailable [redacted]"
 
 
 def test_missing_environment_does_not_interrupt_client():
@@ -76,6 +87,22 @@ def test_cursor_workspace_roots_must_stay_in_scope(tmp_path):
     assert not hook.in_project({"workspace_roots": [str(tmp_path)]}, client="codex", project=tmp_path)
     assert not hook.in_project({"cwd": str(tmp_path.parent), "workspace_roots": [str(tmp_path)]},
                                client="cursor", project=tmp_path)
+
+
+def test_cursor_completed_session_end_captures_existing_final_response(tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    text = "The completed final response already contains useful task evidence."
+    transcript.write_text(json.dumps({"role": "assistant", "message": {
+        "content": [{"type": "text", "text": text}]}}) + "\n")
+    payload = {"hook_event_name": "sessionEnd", "final_status": "completed",
+               "conversation_id": "actual-session", "workspace_roots": [str(tmp_path)],
+               "transcript_path": str(transcript)}
+    with mock.patch.object(hook, "ensure_workspace_interpreter"), \
+         mock.patch("vaws_knowledge_service.service_config", return_value="shared"), \
+         mock.patch("vaws_knowledge.summary_hook.capture_summary") as capture:
+        invoke(payload, client="cursor", project=tmp_path)
+    assert capture.call_args.args[0] == {**payload, "hook_event_name": "afterAgentResponse", "text": text}
+    assert capture.call_args.kwargs == {"config": "shared", "client": "cursor"}
 
 
 @pytest.mark.skipif(os.name != "nt", reason="native Windows path interpretation")

--- a/.agents/tests/test_linked_workspace_fork.py
+++ b/.agents/tests/test_linked_workspace_fork.py
@@ -87,7 +87,9 @@ def test_kimi_fork_keeps_current_head_and_saved_pin_without_upstream_check(tmp_p
     assert not f.calls["prepare"]
     assert f.calls["configure"][-1]["receipt"] == f.receipt_old
     assert f.calls["configure"][-1]["head"] == f.old
-    assert json.loads((target / ".vaws-local/environment-selection" / f"{sys.platform}.json").read_text()) == f.receipt_old
+    selection = json.loads((target / ".vaws-local/environment-selection" / f"{sys.platform}.json").read_text())
+    assert selection.pop("knowledge") == {"status": "ready", "ready": True}
+    assert selection == f.receipt_old
     if dirty:
         assert (target / "README").read_text() == "working draft\n"
         assert (target / "new.txt").read_text() == "untracked draft\n"

--- a/.agents/tests/test_native_mode_config.py
+++ b/.agents/tests/test_native_mode_config.py
@@ -2,10 +2,8 @@
 from __future__ import annotations
 
 import os
-import hashlib
 import json
 from pathlib import Path
-import subprocess
 import sys
 import tempfile
 import tomllib
@@ -13,7 +11,7 @@ import unittest
 from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
-from vaws_native_mode_config import add_grok_import_dedup, add_native_mode, grok_native_defaults, kimi_session_setup_capability
+from vaws_native_mode_config import add_grok_import_dedup, add_native_mode
 
 
 class NativeModeConfigTests(unittest.TestCase):
@@ -101,42 +99,18 @@ class NativeModeConfigTests(unittest.TestCase):
         self.assertFalse(files)
         self.assertFalse(notes)
 
-    def test_verified_extensions_disable_auto_installation_idempotently(self):
-        for client, table, key in (("grok", "cli", "auto_update"), ("kimi", "upgrade", "auto_install")):
-            for initial in (True, None):
-                with self.subTest(client=client, initial=initial):
-                    path = self.user_dir / (".grok/config.toml" if client == "grok" else "custom-kimi/tui.toml")
-                    path.parent.mkdir(parents=True, exist_ok=True)
-                    before = "# keep user settings\n[" + table + "]\ncustom = 42\n"
-                    if initial is not None:
-                        before += key + " = true\n"
-                    path.write_text(before, encoding="utf-8")
-                    files, notes = {}, []
-                    options = {"user_home": self.user_dir, "capability": {"supported": True}, "kimi_tui_config": path}
-                    add_native_mode(files, notes, client, self.project, **options)
-                    after = tomllib.loads(files[path])
-                    self.assertIs(after[table][key], False)
-                    self.assertEqual(after[table]["custom"], 42)
-                    self.assertIs(notes[-1]["settings"][table][key], False)
-                    self.assertEqual(path.read_text(), before)
-                    path.write_text(files[path], encoding="utf-8")
-                    again = {}
-                    add_native_mode(again, notes, client, self.project, **options)
-                    self.assertEqual(again, {})
-                    self.assertEqual(notes[-1]["action"], "configured")
 
     def test_unverified_clients_preserve_automatic_update_settings(self):
         for client, table, key in (("grok", "cli", "auto_update"), ("kimi", "upgrade", "auto_install")):
-            for capability in (None, {"supported": False}):
-                with self.subTest(client=client, capability=capability):
+            for enabled in (False, True):
+                with self.subTest(client=client, enabled=enabled):
                     path = self.user_dir / (".grok/config.toml" if client == "grok" else "custom-kimi/tui.toml")
                     path.parent.mkdir(parents=True, exist_ok=True)
-                    before = "[" + table + "]\n" + key + " = true\n"
+                    before = "[" + table + "]\n" + key + " = " + str(enabled).lower() + "\n"
                     path.write_text(before, encoding="utf-8")
                     files, notes = {}, []
-                    add_native_mode(files, notes, client, self.project, user_home=self.user_dir,
-                                    capability=capability, kimi_tui_config=path)
-                    self.assertIs(tomllib.loads(files.get(path, before))[table][key], True)
+                    add_native_mode(files, notes, client, self.project, user_home=self.user_dir)
+                    self.assertIs(tomllib.loads(files.get(path, before))[table][key], enabled)
                     self.assertEqual(path.read_text(), before)
 
 
@@ -250,83 +224,6 @@ class GrokImportDedupTests(unittest.TestCase):
         files, notes = self.plan('disabled_mcp_servers = "custom"\n')
         self.assertNotIn(self.path, files)
         self.assertEqual(notes[-1]["reason"], "grok-compat-mcp-needs-integration")
-
-
-class KimiCapabilityTests(unittest.TestCase):
-    def test_installed_parser_contract_in_isolated_home(self):
-        paths = []
-
-        def doctor(argv, **kwargs):
-            path = Path(argv[-1])
-            paths.append(path)
-            self.assertEqual(argv[:3], ["/tools/kimi", "doctor", "config"])
-            self.assertEqual(kwargs["cwd"], path.parent)
-            self.assertEqual(kwargs["env"]["KIMI_CODE_HOME"], str(path.parent))
-            event = tomllib.loads(path.read_text())["hooks"][0]["event"]
-            return subprocess.CompletedProcess(argv, 0 if event == "SessionSetup" else 1,
-                                               "OK" if event == "SessionSetup" else "",
-                                               '' if event == "SessionSetup" else
-                                               'hooks[0].event: Invalid option: expected one of "SessionSetup"|"SessionStart"')
-
-        with patch("vaws_native_mode_config.subprocess.run", side_effect=doctor):
-            result = kimi_session_setup_capability("/tools/kimi")
-        self.assertTrue(result["supported"])
-        self.assertEqual(len(result["checks"]), 2)
-        self.assertTrue(all(not path.exists() for path in paths))
-
-    def test_official_or_permissive_parser_is_not_extension_evidence(self):
-        for responses in ((1, 1), (0, 0)):
-            with self.subTest(responses=responses), patch("vaws_native_mode_config.subprocess.run",
-                    side_effect=[subprocess.CompletedProcess([], code, "", 'hooks[0].event: expected one of "SessionStart"')
-                                 for code in responses]):
-                self.assertFalse(kimi_session_setup_capability("kimi")["supported"])
-
-    def test_unrelated_negative_failure_is_not_extension_evidence(self):
-        with patch("vaws_native_mode_config.subprocess.run", side_effect=[
-                subprocess.CompletedProcess([], 0, "OK", ""),
-                subprocess.CompletedProcess([], 1, "", "SessionSetup: network unavailable")]):
-            self.assertFalse(kimi_session_setup_capability("kimi")["supported"])
-
-    def test_missing_or_timed_out_cli_returns_evidence(self):
-        for error in (FileNotFoundError("kimi"), subprocess.TimeoutExpired(["kimi", "doctor"], 10)):
-            with self.subTest(error=error), patch("vaws_native_mode_config.subprocess.run", side_effect=error):
-                result = kimi_session_setup_capability("kimi")
-                self.assertFalse(result["supported"])
-                self.assertEqual(result["reason"], "native-session-setup-probe-failed")
-                self.assertTrue(result["error"])
-
-
-class GrokInstalledEvidenceTests(unittest.TestCase):
-    def test_acceptance_is_bound_to_the_installed_bytes(self):
-        with tempfile.TemporaryDirectory() as folder:
-            project = Path(folder)
-            binary = project / "grok"
-            binary.write_bytes(b"accepted native build")
-            receipt = project / ".vaws-local/client-installations/grok-native.json"
-            self.assertFalse(grok_native_defaults(binary, project)["supported"])
-            receipt.parent.mkdir(parents=True)
-            record = {"binary": str(binary), "sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
-                      "capabilities": {"bare_worktree_default": True}}
-            receipt.write_text(json.dumps(record))
-            self.assertTrue(grok_native_defaults(binary, project)["supported"])
-            binary.write_bytes(b"different build with the same version")
-            result = grok_native_defaults(binary, project)
-            self.assertFalse(result["supported"])
-            self.assertEqual(result["reason"], "native-default-build-changed")
-
-    def test_another_executable_or_incomplete_record_is_not_acceptance(self):
-        with tempfile.TemporaryDirectory() as folder:
-            project = Path(folder)
-            binary = project / "grok"
-            binary.write_bytes(b"a native build")
-            receipt = project / ".vaws-local/client-installations/grok-native.json"
-            receipt.parent.mkdir(parents=True)
-            for record in ({"binary": str(project / "other"), "capabilities": {"bare_worktree_default": True}},
-                           {"binary": str(binary), "capabilities": {}},
-                           {"binary": str(binary), "capabilities": []}, []):
-                with self.subTest(record=record):
-                    receipt.write_text(json.dumps(record))
-                    self.assertFalse(grok_native_defaults(binary, project)["supported"])
 
 
 if __name__ == "__main__":

--- a/.agents/tests/test_native_worktree_setup.py
+++ b/.agents/tests/test_native_worktree_setup.py
@@ -36,7 +36,7 @@ def snapshot(root):
             if path.is_file() and ".git" not in path.relative_to(root).parts}
 
 
-def make_repository(tmp_path, monkeypatch, *, submodule=False, detached=False):
+def make_repository(tmp_path, monkeypatch, *, submodule=False, detached=False, mock_update=True):
     source, target, stage = [tmp_path / name for name in ("source 用户", "native worktree", "prepared")]
     source.mkdir()
     git(source, "init", "-b", "main")
@@ -73,11 +73,11 @@ def make_repository(tmp_path, monkeypatch, *, submodule=False, detached=False):
                    "python": sys.executable, "receipt": str(tmp_path / "old-receipt.json")}
     receipt_new = {"key": "new-environment", "input_id": setup._inputs(stage)[3],
                    "python": sys.executable, "receipt": str(tmp_path / "new-receipt.json")}
-    calls = {"prepare": [], "configure": [], "select": []}
+    calls = {"prepare": [], "configure": [], "select": [], "knowledge": []}
 
-    def prepare(path):
+    def prepare(path, baseline=None):
         calls["prepare"].append(path)
-        return {"status": "ready", "target": new}
+        return {"status": "ready", "target": new}, stage
 
     def native(path):
         return receipt_new if setup._inputs(path)[3] == receipt_new["input_id"] else receipt_old
@@ -92,13 +92,15 @@ def make_repository(tmp_path, monkeypatch, *, submodule=False, detached=False):
         selection.parent.mkdir(parents=True, exist_ok=True)
         selection.write_text(json.dumps(receipt))
 
-    monkeypatch.setattr(setup, "prepare_session", prepare)
-    monkeypatch.setattr(setup, "prepared_source", lambda _: stage)
+    if mock_update:
+        monkeypatch.setattr(setup, "prepare_canonical", prepare)
     monkeypatch.setattr(setup, "native_ready", native)
     monkeypatch.setattr(setup, "saved_ready", lambda path: json.loads(
         (path / ".vaws-local/environment-selection" / f"{sys.platform}.json").read_text()))
     monkeypatch.setattr(setup, "configure_target", configure)
     monkeypatch.setattr(setup, "select_environment", select)
+    monkeypatch.setattr(setup, "prepare_knowledge", lambda path, **kwargs:
+                        calls["knowledge"].append((path, kwargs["receipt"])) or {"status": "ready", "ready": True})
     monkeypatch.setattr("vaws_local_owner.windows_mounted_workspace", lambda _: False)
     return SimpleNamespace(source=source, target=target, stage=stage, old=old, new=new,
                            module_old=module_old, module_new=module_new,
@@ -123,6 +125,8 @@ def test_native_new_worktree_updates_code_and_environment_only(tmp_path, monkeyp
     assert f.calls["configure"][0]["head"] == f.new
     assert f.calls["configure"][0]["receipt"] == f.receipt_new
     assert f.calls["select"] == [(f.target, f.receipt_new)]
+    assert f.calls["knowledge"] == [(f.target, f.receipt_new)]
+    assert result["knowledge"] == {"status": "ready", "ready": True}
 
 
 def test_explicit_old_revision_is_not_updated(fixture):
@@ -137,7 +141,7 @@ def test_explicit_old_revision_is_not_updated(fixture):
 
 
 def default_snapshot_fixture(tmp_path, monkeypatch):
-    f = make_repository(tmp_path, monkeypatch, detached=True)
+    f = make_repository(tmp_path, monkeypatch, detached=True, mock_update=False)
     git(f.source, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
     git(f.source, "checkout", "-b", "feature/current-task")
     (f.source / "README").write_text("current business work\n")
@@ -215,12 +219,12 @@ def test_default_snapshot_does_not_expand_existing_preservation_boundaries(tmp_p
 def test_default_snapshot_adoption_still_requires_clean_fast_forward(tmp_path, monkeypatch, change):
     f, calls = default_snapshot_fixture(tmp_path, monkeypatch)
     if change == "edit-during-prepare":
-        original_prepare = setup.prepare_default_snapshot
+        original_prepare = setup.prepare_canonical
         def intervening_edit(*args):
             result = original_prepare(*args)
             (f.target / "README").write_text("edit during native setup\n")
             return result
-        monkeypatch.setattr(setup, "prepare_default_snapshot", intervening_edit)
+        monkeypatch.setattr(setup, "prepare_canonical", intervening_edit)
     elif change == "diverged-upstream":
         # The local default tip has a commit absent from canonical history.
         (f.target / "README").write_text("local default commit\n")
@@ -240,13 +244,25 @@ def test_default_snapshot_adoption_still_requires_clean_fast_forward(tmp_path, m
         assert result["update"]["state"] == "disabled" and not calls
 
 
-def test_business_source_keeps_its_code(fixture, monkeypatch):
-    f = fixture
-    git(f.source, "branch", "-m", "feature/business")
-    monkeypatch.setattr(setup, "prepare_session", lambda _: {"status": "deferred", "reason": "working_branch"})
-    monkeypatch.setattr(setup, "prepared_source", lambda _: None)
-    result = setup.prepare_worktree("cursor", f.source, f.target)
-    assert result["head"] == f.old and result["environment"] == "old-environment"
+@pytest.mark.parametrize("client", ["codex", "cursor", "claude", "grok", "kimi"])
+def test_new_session_uses_canonical_when_mother_has_business_commits_and_edits(tmp_path, monkeypatch, client):
+    f, updates = default_snapshot_fixture(tmp_path, monkeypatch)
+    business = git(f.source, "rev-parse", "HEAD")
+    # The native client has just created its new directory from mother HEAD.
+    git(f.target, "reset", "--hard", business)
+    (f.source / "README").write_text("staged business work\n")
+    git(f.source, "add", "README")
+    (f.source / "README").write_text("unstaged business work\n")
+    (f.source / "untracked.txt").write_text("untracked business work\n")
+    before, index = snapshot(f.source), (f.source / ".git/index").read_bytes()
+    result = setup.prepare_worktree(client, f.source, f.target)
+    assert result["head"] == f.new and result["environment"] == "new-environment"
+    assert result["update"]["baseline"] == {
+        "kind": "source_head_snapshot", "head": business, "native_ref_selection": "unavailable"}
+    assert updates == [{"apply": True, "activate": False}]
+    assert git(f.source, "rev-parse", "HEAD") == business
+    assert git(f.source, "branch", "--show-current") == "feature/current-task"
+    assert snapshot(f.source) == before and (f.source / ".git/index").read_bytes() == index
 
 
 def test_dirty_native_worktree_keeps_edits_without_checking_updates(fixture):
@@ -262,8 +278,8 @@ def test_edit_during_preparation_stays_untouched(fixture, monkeypatch):
     f = fixture
     def intervening_edit(_):
         (f.target / "README").write_text("edit while preparing\n")
-        return {"status": "ready"}
-    monkeypatch.setattr(setup, "prepare_session", intervening_edit)
+        return {"status": "ready"}, f.stage
+    monkeypatch.setattr(setup, "prepare_canonical", intervening_edit)
     result = setup.prepare_worktree("cursor", f.source, f.target)
     assert result["head"] == f.old and result["update"]["reason"] == "dirty_checkout"
     assert result["environment"] == "old-environment"
@@ -274,12 +290,13 @@ def test_repeat_setup_uses_saved_environment_and_repairs_wiring(fixture, monkeyp
     setup.prepare_worktree("cursor", f.source, f.target)
     selected = (f.target / ".vaws-local/environment-selection" / f"{sys.platform}.json").read_bytes()
     (f.target / "uv.lock").write_text("a user draft that is not valid TOML\n")
-    monkeypatch.setattr(setup, "prepare_session", lambda _: pytest.fail("repeat must not check upstream"))
+    monkeypatch.setattr(setup, "prepare_canonical", lambda *_: pytest.fail("repeat must not check upstream"))
     monkeypatch.setattr(setup, "native_ready", lambda _: pytest.fail("repeat must not resolve changed dependency inputs"))
     result = setup.prepare_worktree("cursor", f.source, f.target)
     assert result["status"] == "reused" and result["environment"] == "new-environment"
     assert len(f.calls["configure"]) == 2
     assert len(f.calls["select"]) == 1
+    assert f.calls["knowledge"] == [(f.target, f.receipt_new)]
     assert (f.target / ".vaws-local/environment-selection" / f"{sys.platform}.json").read_bytes() == selected
 
 
@@ -300,6 +317,44 @@ def test_selection_written_by_sync_still_repairs_interrupted_wiring(fixture):
     assert result["status"] == "reused" and result["environment"] == "old-environment"
     assert not f.calls["prepare"] and not f.calls["select"]
     assert f.calls["configure"][0]["head"] == f.old
+    assert f.calls["knowledge"] == [(f.target, f.receipt_old)]
+
+
+def test_inherited_environment_prepares_knowledge_once_for_the_new_worktree(fixture):
+    f = fixture
+    source_selection = f.source / ".vaws-local/environment-selection" / f"{sys.platform}.json"
+    source_selection.parent.mkdir(parents=True)
+    source_selection.write_text(json.dumps(f.receipt_old))
+    first = setup.prepare_worktree("kimi", f.source, f.target, preserve_source=True)
+    assert first["update"]["reason"] == "fork_source"
+    assert first["knowledge"]["ready"] is True
+    second = setup.prepare_worktree("kimi", f.source, f.target, preserve_source=True)
+    assert second["knowledge"] == first["knowledge"]
+    assert f.calls["knowledge"] == [(f.target, f.receipt_old)]
+    assert not f.calls["prepare"]
+
+
+def test_pending_knowledge_is_reported_without_retrying_native_setup(fixture, monkeypatch):
+    f = fixture
+    pending = {"status": "pending", "ready": False, "reason": "offline corpus"}
+    calls = []
+    monkeypatch.setattr(setup, "prepare_knowledge", lambda *args, **kwargs: calls.append(args) or pending)
+    first = setup.prepare_worktree("codex", f.source, f.target)
+    assert first["status"] == "ready" and first["knowledge"] == pending
+    second = setup.prepare_worktree("codex", f.source, f.target)
+    assert second["status"] == "reused" and second["knowledge"] == pending
+    assert calls == [(f.target,)]
+
+
+def test_kimi_worktree_wiring_does_not_enable_an_unconfirmed_extension(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(setup, "run", lambda argv, **kwargs: calls.append((argv, kwargs)))
+    receipt = {"python": sys.executable, "receipt": "/selected/receipt.json"}
+    setup.configure_target("kimi", tmp_path, receipt, {})
+    argv, options = calls[0]
+    assert "--kimi-session-setup" not in argv
+    assert argv[-2:] == ["--kimi-config", str(tmp_path / ".vaws-local/kimi-hooks.toml")]
+    assert options["env"][setup.PIN_ENV] == receipt["receipt"]
 
 
 def test_malformed_optional_identity_does_not_block_local_setup(fixture):

--- a/.agents/tests/test_remote_dev_consumer.py
+++ b/.agents/tests/test_remote_dev_consumer.py
@@ -105,8 +105,9 @@ class ClientConfigurationTests(unittest.TestCase):
                         self.assertNotIn("VAWS_ENV_RECEIPT", entry["env"])
                         self.assertNotIn("VAWS_ENV_RECEIPT", task["env"])
                     else:
-                        self.assertEqual(entry["args"], self.SERVER_ARGS)
-                        self.assertEqual(task["args"], self.TASK_ARGS)
+                        gateway = str(ROOT / ".agents/scripts/vaws_native_mcp.py")
+                        self.assertEqual(entry["args"], [gateway, "remote"])
+                        self.assertEqual(task["args"], [gateway, "task"])
                         self.assertEqual(entry["env"]["VAWS_ENV_RECEIPT"], receipt["receipt"])
                     for key in self.REQUIRED_ENV:
                         self.assertIn(key, entry["env"])
@@ -141,8 +142,10 @@ class ClientConfigurationTests(unittest.TestCase):
             for key in self.REQUIRED_ENV:
                 self.assertIn(key, mcp["env"])
             codex = tomllib.loads(setup.configuration("codex", project)[project / ".codex/config.toml"])
-            self.assertEqual(codex["mcp_servers"]["remote_dev"]["args"], self.SERVER_ARGS)
-            self.assertEqual(codex["mcp_servers"]["vaws_task"]["args"], self.TASK_ARGS)
+            self.assertEqual(codex["mcp_servers"]["remote_dev"]["args"],
+                             [str(ROOT / ".agents/scripts/vaws_native_mcp.py"), "remote"])
+            self.assertEqual(codex["mcp_servers"]["vaws_task"]["args"],
+                             [str(ROOT / ".agents/scripts/vaws_native_mcp.py"), "task"])
             self.assertNotIn("REMOTE_DEV_RESOLVERS", codex["mcp_servers"]["remote_dev"]["env"])
         self.assertFalse(str(setup.BACKUP_DIR).startswith(str(ROOT / ".remote-dev")))
         self.assertTrue(str(setup.BACKUP_DIR).startswith(str(ROOT / ".vaws-local")))

--- a/.agents/tests/test_shared_knowledge_startup.py
+++ b/.agents/tests/test_shared_knowledge_startup.py
@@ -1,0 +1,131 @@
+"""Native and fallback worktrees use one knowledge owner and candidate store."""
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+import vaws_knowledge_service as knowledge
+from vaws_knowledge.local.instance import instance_for_config
+from vaws_knowledge.local.reconcile import reconcile_markdown
+from vaws_knowledge.server.capture import capture
+from vaws_knowledge.server.layers import load_config
+from vaws_knowledge.server.query import explain, query
+
+
+def git(root, *args):
+    return subprocess.run(["git", "-c", "core.hooksPath=/dev/null", "-C", str(root), *args],
+                          check=True, capture_output=True, text=True).stdout.strip()
+
+
+@pytest.fixture
+def family(tmp_path):
+    root = tmp_path / "母仓 with spaces"
+    root.mkdir()
+    git(root, "init", "-b", "main")
+    (root / ".gitignore").write_text(".vaws-local/\n")
+    notes = root / ".agents/knowledge"
+    notes.mkdir(parents=True)
+    (notes / "fact.md").write_text("# Recorded snapshot\n\nsharedsnapshot old text.\n")
+    git(root, "add", ".")
+    git(root, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "commit", "-m", "fixture")
+    a, b = tmp_path / "client A", tmp_path / "client B"
+    git(root, "worktree", "add", "--detach", str(a), "HEAD")
+    git(root, "worktree", "add", "--detach", str(b), "HEAD")
+    path = root / ".vaws-local/knowledge/service.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"backend": "memory", "layers": {"shared": {"enabled": False}},
+                               "shared_sync": {"enabled": False}, "publishing": {"enabled": False}}))
+    return root, a, b, path
+
+
+def test_capture_in_a_is_queryable_and_explainable_in_b(family):
+    root, a, b, path = family
+    knowledge.shared_project_config(a)
+    config_a = knowledge.service_config(a)
+    captured = capture(title="sharedcandidate canary", content="The reusable result stays across native clients.",
+                       config=config_a, index=False)
+    assert Path(captured["path"]).is_relative_to(root / knowledge.CANDIDATE_ROOT_RELATIVE)
+    knowledge.shared_project_config(b)
+    config_b = load_config(env=knowledge.knowledge_server_env(b))
+    assert config_b.config_path == path == knowledge.service_config(a).config_path
+    owner_a, owner_b = instance_for_config(config_a), instance_for_config(config_b)
+    assert owner_a.state_root == owner_b.state_root
+    assert owner_a.cache_dir == owner_b.cache_dir
+    # The package memory backend is deliberately process-local; reconstruct its
+    # index from the shared authoritative files, as package maintenance does.
+    assert not reconcile_markdown(config_b, verify=True).degraded
+    assert query(config_b, text="sharedcandidate").results[0]["title"] == "sharedcandidate canary"
+    assert explain(config_b, captured["ref"])["found"] is True
+    assert not (a / ".vaws-local/knowledge").exists()
+    assert not (b / ".vaws-local/knowledge").exists()
+
+
+def test_latest_snapshot_updates_in_place_without_mutating_other_checkout(family):
+    root, a, b, _ = family
+    knowledge.shared_project_config(a)
+    snapshot = root / ".vaws-local/knowledge/project"
+    original_time = (snapshot / "fact.md").stat().st_mtime_ns
+    knowledge.shared_project_config(a)
+    assert (snapshot / "fact.md").stat().st_mtime_ns == original_time
+    (b / ".agents/knowledge/fact.md").unlink()
+    (b / ".agents/knowledge/new.md").write_text("# New snapshot\n\nnew revision knowledge.\n")
+    knowledge.shared_project_config(b)
+    assert not (snapshot / "fact.md").exists()
+    assert (snapshot / "new.md").read_text() == (b / ".agents/knowledge/new.md").read_text()
+    assert (a / ".agents/knowledge/fact.md").is_file()
+    assert knowledge.service_config(a).mount("project").roots == (snapshot,)
+
+
+def test_custom_sources_and_publishing_choices_are_retained(family):
+    root, a, _, path = family
+    custom = {"backend": "memory", "state_root": "../custom-state", "layers": {
+        "project": {"roots": ["../custom-project"]}, "candidate": {"root": "../custom-candidate"},
+        "shared": {"enabled": False}}, "shared_sync": {"enabled": False, "repository": "chosen/corpus"},
+        "publishing": {"enabled": True, "repository": "chosen/corpus", "fork": "person/corpus"}}
+    path.write_text(json.dumps(custom))
+    knowledge.shared_project_config(a)
+    assert json.loads(path.read_text()) == custom
+    config = knowledge.service_config(a)
+    assert config.publishing == custom["publishing"]
+    mcp = load_config(env=knowledge.knowledge_server_env(a))
+    assert config.mount("candidate").roots == mcp.mount("candidate").roots
+    assert config.mount("candidate").roots[0].resolve() == (path.parent / "../custom-candidate").resolve()
+
+
+def test_cli_drops_inherited_location_and_uses_selected_runtime(family, monkeypatch):
+    _, a, _, path = family
+    for key in knowledge.LOCATION_ENV:
+        monkeypatch.setenv(key, "/obsolete-parent-location")
+    monkeypatch.setattr(knowledge, "knowledge_owner_python", lambda root: sys.executable)
+    monkeypatch.setattr(knowledge, "managed_receipt", lambda root: {"receipt": "/old-environment"})
+    calls = []
+    original_run = knowledge.subprocess.run
+    def run(command, **kwargs):
+        if command[0] == "git":
+            return original_run(command, **kwargs)
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, '{"ready": true, "status": "ready"}')
+    monkeypatch.setattr(knowledge.subprocess, "run", run)
+    receipt = {"python": sys.executable, "receipt": "/selected-environment"}
+    assert knowledge.prepare_knowledge(a, receipt=receipt)["ready"]
+    command, kwargs = calls[0]
+    assert command == [sys.executable, "-c", knowledge.PREPARE_CODE]
+    assert kwargs["env"]["VAWS_ENV_RECEIPT"] == "/selected-environment"
+    assert kwargs["env"]["VAWS_KNOWLEDGE_CONFIG"] == str(path)
+    assert all(key not in kwargs["env"] for key in knowledge.LOCATION_ENV if key != "VAWS_KNOWLEDGE_CONFIG")
+
+
+def test_startup_uses_package_incremental_maintenance_without_forced_model_audit(family, monkeypatch):
+    _, a, _, path = family
+    knowledge.shared_project_config(a)
+    calls = []
+    monkeypatch.setenv("VAWS_KNOWLEDGE_CONFIG", str(path))
+    monkeypatch.setattr("vaws_knowledge.publishing.run_once", lambda config, **kwargs:
+                        calls.append(("shared", kwargs)) or {"status": "disabled"})
+    monkeypatch.setattr("vaws_knowledge.maintenance.maintain", lambda config, **kwargs:
+                        calls.append(("maintain", kwargs)) or {"ready": True})
+    exec(knowledge.PREPARE_CODE, {})
+    assert calls == [("shared", {"force": True, "verify": False}),
+                     ("maintain", {"force": True, "verify": False})]

--- a/.agents/tests/test_start_guidance.py
+++ b/.agents/tests/test_start_guidance.py
@@ -29,7 +29,8 @@ def test_all_clients_share_one_agents_block_and_resume_contract(tmp_path):
         rendered.append(text)
         assert text.endswith(original)
         assert text.count(BEGIN) == text.count(END) == 1
-        assert text.index("On first use, complete AGENTS.md's First use, forks and updates setup") < text.index("For a new native session")
+        assert "command checks saved initialization itself" in text
+        assert "no configuration inspection is needed beforehand" in text
         assert ".agents/scripts/vaws_start.py --client CLIENT" in text
         assert "--context-file PATH" in text
         assert all(name in text for name in CLIENTS)
@@ -74,7 +75,7 @@ def test_cursor_generated_rule_is_always_applied_and_names_cursor(tmp_path):
     assert "\nalwaysApply: true\n" in rule.split("---", 2)[1]
     assert "vaws_start.py --client cursor" in rule
     assert "--client CLIENT" not in rule
-    assert rule.index("On first use, complete AGENTS.md's First use, forks and updates setup") < rule.index("For a new native session")
+    assert "command checks saved initialization itself" in rule
     assert rule.count(BEGIN) == rule.count(END) == 1
 
 

--- a/.agents/tests/test_start_guidance.py
+++ b/.agents/tests/test_start_guidance.py
@@ -29,6 +29,7 @@ def test_all_clients_share_one_agents_block_and_resume_contract(tmp_path):
         rendered.append(text)
         assert text.endswith(original)
         assert text.count(BEGIN) == text.count(END) == 1
+        assert text.index("On first use, complete AGENTS.md's First use, forks and updates setup") < text.index("For a new native session")
         assert ".agents/scripts/vaws_start.py --client CLIENT" in text
         assert "--context-file PATH" in text
         assert all(name in text for name in CLIENTS)
@@ -73,6 +74,7 @@ def test_cursor_generated_rule_is_always_applied_and_names_cursor(tmp_path):
     assert "\nalwaysApply: true\n" in rule.split("---", 2)[1]
     assert "vaws_start.py --client cursor" in rule
     assert "--client CLIENT" not in rule
+    assert rule.index("On first use, complete AGENTS.md's First use, forks and updates setup") < rule.index("For a new native session")
     assert rule.count(BEGIN) == rule.count(END) == 1
 
 

--- a/.agents/tests/test_start_guidance.py
+++ b/.agents/tests/test_start_guidance.py
@@ -1,0 +1,131 @@
+"""Native project instructions route new sessions once and preserve user text."""
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / ".agents/lib"))
+from vaws_start_guidance import BEGIN, END, add_start_guidance, guidance, managed_block
+
+
+CLIENTS = ("codex", "cursor", "claude", "grok", "kimi")
+
+
+def plan(project, client, files=None):
+    files = {} if files is None else files
+    notes = []
+    add_start_guidance(files, notes, client, project)
+    return files, notes
+
+
+def test_all_clients_share_one_agents_block_and_resume_contract(tmp_path):
+    original = "# Project rules\n\nKeep this user's instructions.\n"
+    (tmp_path / "AGENTS.md").write_text(original)
+    rendered = []
+    for client in CLIENTS:
+        files, notes = plan(tmp_path, client)
+        text = files[tmp_path / "AGENTS.md"]
+        rendered.append(text)
+        assert text.endswith(original)
+        assert text.count(BEGIN) == text.count(END) == 1
+        assert ".agents/scripts/vaws_start.py --client CLIENT" in text
+        assert "--context-file PATH" in text
+        assert all(name in text for name in CLIENTS)
+        assert "Skill" not in text
+        assert "Resume keeps the earlier W, task and environment" in text
+        assert "do not prepare, update or create another directory" in text
+        assert "absolute paths under W" in text
+        assert "do not repeat session setup" in text
+        assert notes[-1]["skill_required"] is False
+        assert notes[-1]["resume"] == "reuse-existing-workspace"
+        repeated, _ = plan(tmp_path, client, dict(files))
+        assert repeated == files
+    assert len(set(rendered)) == 1
+    assert (tmp_path / "AGENTS.md").read_text() == original
+
+
+def test_claude_imports_agents_without_replacing_custom_instructions(tmp_path):
+    claude = tmp_path / "CLAUDE.md"
+    custom = "# Claude preferences\n\nPreserve my review guidance.\n"
+    claude.write_text(custom)
+    files, _ = plan(tmp_path, "claude")
+    assert files[claude].count("@AGENTS.md") == 1
+    assert files[claude].endswith(custom)
+    assert files[claude].count(BEGIN) == files[claude].count(END) == 1
+    repeated, _ = plan(tmp_path, "claude", dict(files))
+    assert repeated == files
+
+
+def test_claude_existing_agents_import_does_not_get_another_block(tmp_path):
+    claude = tmp_path / "CLAUDE.md"
+    original = "# Custom\n@AGENTS.md\nKeep this text.\n"
+    claude.write_text(original)
+    files, _ = plan(tmp_path, "claude")
+    assert claude not in files
+    assert claude.read_text() == original
+
+
+def test_cursor_generated_rule_is_always_applied_and_names_cursor(tmp_path):
+    files, _ = plan(tmp_path, "cursor")
+    rule = files[tmp_path / ".cursor/rules/vaws-session-start.mdc"]
+    assert rule.startswith("---\n")
+    assert "\nalwaysApply: true\n" in rule.split("---", 2)[1]
+    assert "vaws_start.py --client cursor" in rule
+    assert "--client CLIENT" not in rule
+    assert rule.count(BEGIN) == rule.count(END) == 1
+
+
+def test_cursor_preserves_an_existing_custom_rule(tmp_path):
+    rule = tmp_path / ".cursor/rules/vaws-session-start.mdc"
+    rule.parent.mkdir(parents=True)
+    custom = "---\nalwaysApply: false\n---\n\nUser-owned startup rule.\n"
+    rule.write_text(custom)
+    files, notes = plan(tmp_path, "cursor")
+    assert rule not in files
+    assert rule.read_text() == custom
+    assert any(note.get("reason") == "custom-session-start-rule" for note in notes)
+
+
+def test_cursor_refresh_preserves_user_text_outside_its_generated_block(tmp_path):
+    files, _ = plan(tmp_path, "cursor")
+    rule = tmp_path / ".cursor/rules/vaws-session-start.mdc"
+    custom = "\n## Local Cursor instructions\nKeep this user-authored paragraph.\n"
+    files[rule] += custom
+    refreshed, _ = plan(tmp_path, "cursor", dict(files))
+    assert refreshed[rule].endswith(custom)
+    assert "\nalwaysApply: true\n" in refreshed[rule]
+    assert refreshed[rule].count(BEGIN) == refreshed[rule].count(END) == 1
+
+
+def test_managed_block_updates_only_owned_text():
+    original = "User introduction.\n" + BEGIN + "\nOld guidance.\n" + END + "\nUser conclusion.\n"
+    updated = managed_block(original, "New guidance.")
+    assert updated == "User introduction.\n" + BEGIN + "\nNew guidance.\n" + END + "\nUser conclusion.\n"
+    assert managed_block(updated, "New guidance.") == updated
+
+
+@pytest.mark.parametrize("original", [
+    BEGIN + "\nUnfinished block.\n",
+    "Orphan end marker.\n" + END,
+    END + "\nReversed markers.\n" + BEGIN,
+    BEGIN + "\n" + BEGIN + "\n" + END,
+    BEGIN + "\n" + END + "\n" + END,
+])
+def test_malformed_markers_are_rejected(original):
+    with pytest.raises(ValueError, match="markers"):
+        managed_block(original, guidance())
+
+
+@pytest.mark.parametrize("client,relative,body", [
+    ("kimi", "AGENTS.md", BEGIN + "\nUnfinished instructions.\n"),
+    ("claude", "CLAUDE.md", BEGIN + "\n@AGENTS.md\n"),
+    ("cursor", ".cursor/rules/vaws-session-start.mdc", BEGIN + "\nUnfinished rule.\n"),
+])
+def test_malformed_existing_projection_does_not_get_silently_replaced(tmp_path, client, relative, body):
+    path = tmp_path / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    with pytest.raises(ValueError, match="markers"):
+        plan(tmp_path, client)
+    assert path.read_text() == body

--- a/.agents/tests/test_start_guidance.py
+++ b/.agents/tests/test_start_guidance.py
@@ -59,7 +59,7 @@ def test_claude_imports_agents_without_replacing_custom_instructions(tmp_path):
 
 def test_claude_existing_agents_import_does_not_get_another_block(tmp_path):
     claude = tmp_path / "CLAUDE.md"
-    original = "# Custom\n@AGENTS.md\nKeep this text.\n"
+    original = "\n".join(("# Custom", "@AGENTS.md", "Keep this text.", ""))
     claude.write_text(original)
     files, _ = plan(tmp_path, "claude")
     assert claude not in files
@@ -119,7 +119,7 @@ def test_malformed_markers_are_rejected(original):
 
 @pytest.mark.parametrize("client,relative,body", [
     ("kimi", "AGENTS.md", BEGIN + "\nUnfinished instructions.\n"),
-    ("claude", "CLAUDE.md", BEGIN + "\n@AGENTS.md\n"),
+    ("claude", "CLAUDE.md", "\n".join((BEGIN, "@AGENTS.md", ""))),
     ("cursor", ".cursor/rules/vaws-session-start.mdc", BEGIN + "\nUnfinished rule.\n"),
 ])
 def test_malformed_existing_projection_does_not_get_silently_replaced(tmp_path, client, relative, body):

--- a/.agents/tests/test_vaws_cursor_summary.py
+++ b/.agents/tests/test_vaws_cursor_summary.py
@@ -1,0 +1,102 @@
+"""Cursor --print supplies a final transcript path when sessionEnd completes."""
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / ".agents/lib"))
+import vaws_cursor_summary as cursor
+
+
+def assistant(text, *more):
+    return {"role": "assistant", "message": {"content": [{"type": "text", "text": text}, *more]}}
+
+
+@pytest.fixture
+def native(tmp_path):
+    transcript = tmp_path / "native transcript.jsonl"
+    payload = {"hook_event_name": "sessionEnd", "conversation_id": "actual-native-id",
+               "generation_id": "actual-native-id", "session_id": "actual-native-id",
+               "cursor_version": "2026.09.08-6caf4ff", "workspace_roots": [str(tmp_path)],
+               "reason": "completed", "final_status": "completed",
+               "transcript_path": str(transcript)}
+    return transcript, payload
+
+
+def write_rows(path, *rows):
+    rows = (*rows, {"type": "turn_ended", "status": "success"})
+    path.write_text("\n".join(json.dumps(row, ensure_ascii=False) for row in rows) + "\n", encoding="utf-8")
+
+
+def test_official_completed_payload_keeps_native_identity_and_only_final_text(native):
+    transcript, payload = native
+    final = "任务完成：仅在选定 worktree 写入说明，知识查询成功，保留固定环境。"
+    write_rows(transcript, assistant("earlier commentary"),
+               {"role": "user", "message": {"content": [{"type": "tool_result", "content": "raw evidence"}]}},
+               assistant(final, {"type": "thinking", "thinking": "not a summary"}))
+    normalized = cursor.summary_payload(payload)
+    assert normalized == {**payload, "hook_event_name": "afterAgentResponse", "text": final}
+    assert payload["hook_event_name"] == "sessionEnd"
+
+
+def test_large_history_reads_only_complete_tail_row(native, monkeypatch):
+    transcript, payload = native
+    monkeypatch.setattr(cursor, "MAX_TAIL_BYTES", 256)
+    final = "Current task final response exceeds the minimum capture length."
+    write_rows(transcript, assistant("old history " * 1000), assistant(final))
+    assert cursor.summary_payload(payload)["text"] == final
+
+
+@pytest.mark.parametrize("last", [
+    {"role": "user", "message": {"content": [{"type": "text", "text": "new prompt"}]}},
+    assistant("still running", {"type": "tool_use", "name": "Shell", "input": {"command": "pwd"}}),
+    assistant("", {"type": "thinking", "thinking": "not final"}),
+])
+def test_no_final_response_does_not_capture_previous_turn(native, last):
+    transcript, payload = native
+    write_rows(transcript, assistant("old completed turn must never become this task's final summary"), last)
+    assert cursor.summary_payload(payload) is payload
+
+
+@pytest.mark.parametrize("changes", [
+    {"final_status": "aborted"}, {"final_status": "error"}, {"final_status": None},
+    {"hook_event_name": "afterAgentResponse"}, {"hookEventName": "stop"},
+    {"conversation_id": ""}, {"transcript_path": None},
+])
+def test_other_events_and_missing_native_facts_remain_untouched(native, changes):
+    transcript, payload = native
+    write_rows(transcript, assistant("valid final response that belongs to a different event"))
+    payload.update(changes)
+    assert cursor.summary_payload(payload) is payload
+
+
+def test_incomplete_tail_and_missing_file_are_noops(native):
+    transcript, payload = native
+    assert cursor.summary_payload(payload) is payload
+    _, facts = cursor.summary_result(payload)
+    assert facts["reason"] == "native-final-text-unavailable"
+    assert facts["transcript_path"] == str(transcript)
+    assert "FileNotFoundError" in facts["error"]
+    write_rows(transcript, assistant("previous completed answer should not mask the partial newest row"))
+    with transcript.open("a", encoding="utf-8") as stream:
+        stream.write('{"role":"assistant","message":')
+    assert cursor.summary_payload(payload) is payload
+
+
+def test_failed_terminal_marker_does_not_reuse_an_older_success(native):
+    transcript, payload = native
+    write_rows(transcript, assistant("previous complete answer is not evidence of a successful current turn"))
+    with transcript.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps({"type": "turn_ended", "status": "aborted"}) + "\n")
+    assert cursor.summary_payload(payload) is payload
+
+
+def test_observable_result_reports_source_without_logging_response(native):
+    transcript, payload = native
+    text = "Keep this full response in the capture owner, not in diagnostics."
+    write_rows(transcript, assistant(text))
+    normalized, facts = cursor.summary_result(payload)
+    assert normalized["text"] == text
+    assert facts == {"status": "ready", "reason": "native-final-text", "transcript_path": str(transcript)}

--- a/.agents/tests/test_vaws_mcp_runtime.py
+++ b/.agents/tests/test_vaws_mcp_runtime.py
@@ -1,0 +1,302 @@
+"""Exercise real stdio backends selected by two independent native tasks."""
+import asyncio
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / ".agents/lib"))
+import vaws_mcp_runtime as runtime
+
+
+FAKE_SERVER = '''import json,os,sys,threading,time
+from pathlib import Path
+key,evidence,init_gate=sys.argv[1:]
+lock=threading.Lock()
+waiting={}
+cancelled=set()
+def respond(message):
+ method=message.get("method")
+ params=message.get("params",{})
+ if method=="initialize":
+  while init_gate!="-" and not Path(init_gate).exists(): time.sleep(.01)
+  result={"protocolVersion":"2025-06-18","capabilities":{"tools":{}},"serverInfo":{"name":"fixture","version":key}}
+ elif method=="tools/list":
+  result={"tools":[{"name":"knowledge_query","description":"fixture","inputSchema":{"type":"object","properties":{"text":{"type":"string"}},"additionalProperties":False}}]}
+ elif method=="tools/call":
+  if params["name"]=="exit": os._exit(7)
+  if params["name"]=="fail":
+   with lock: print(json.dumps({"jsonrpc":"2.0","id":message["id"],"error":{"code":-32000,"message":"fixture remote failure"}}),flush=True)
+   return
+  if message["id"] in waiting:
+   waiting[message["id"]].wait()
+   if message["id"] in cancelled: return
+  payload={"runtime":key,"arguments":params["arguments"],"meta":params.get("_meta")}
+  result={"content":[{"type":"text","text":json.dumps(payload)}],"structuredContent":payload,"isError":False}
+ else: result={}
+ with lock: print(json.dumps({"jsonrpc":"2.0","id":message["id"],"result":result}),flush=True)
+for line in sys.stdin:
+ message=json.loads(line)
+ with open(evidence,"a",encoding="utf-8") as log: log.write(json.dumps(message)+"\\n")
+ if message.get("method")=="notifications/cancelled":
+  identifier=message["params"]["requestId"]
+  cancelled.add(identifier)
+  if identifier in waiting: waiting[identifier].set()
+  continue
+ if "id" not in message: continue
+ if message.get("params",{}).get("arguments",{}).get("wait"):
+  waiting[message["id"]]=threading.Event()
+ threading.Thread(target=respond,args=(message,),daemon=True).start()
+'''
+
+
+class RuntimeTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.script = self.root / "provider.py"
+        self.script.write_text(FAKE_SERVER)
+        self.workspaces = []
+        self.selections = {}
+        for key in ("old", "new"):
+            workspace = self.root / key
+            workspace.mkdir()
+            self.workspaces.append(workspace)
+            self.selections[key] = runtime.Selection(workspace, str(workspace / "ready.json"), sys.executable, key)
+        self.init_gate = None
+        self.command_patch = patch.object(runtime, "provider_command", side_effect=lambda kind, selected, env:
+                                          ([sys.executable, str(self.script), selected.key,
+                                            str(self.root / (selected.key + ".jsonl")), str(self.init_gate or "-")], dict(env)))
+        self.command_patch.start()
+        self.addCleanup(self.command_patch.stop)
+        from mcp.client import stdio
+        launch = stdio._create_platform_compatible_process
+        self.processes = []
+        async def observe_launch(*args, **kwargs):
+            process = await launch(*args, **kwargs)
+            self.processes.append(process)
+            return process
+        process_patch = patch.object(stdio, "_create_platform_compatible_process", side_effect=observe_launch)
+        process_patch.start()
+        self.addCleanup(process_patch.stop)
+
+    async def received(self, predicate, *, key="new"):
+        async def wait():
+            path = self.root / (key + ".jsonl")
+            while True:
+                for line in path.read_text(encoding="utf-8").splitlines() if path.is_file() else []:
+                    try:
+                        message = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue  # The child may still be appending this line.
+                    if predicate(message):
+                        return message
+                await asyncio.sleep(.01)
+        return await asyncio.wait_for(wait(), timeout=5)
+
+    async def test_persistent_provider_uses_each_tasks_fixed_runtime(self):
+        provider = runtime.Provider("knowledge", self.root)
+        contexts = {"first": {"id": "old"}, "second": {"id": "new"}}
+        def choose(root, context=None, *, catalog=False):
+            return self.selections[context["id"] if context else "new"]
+        try:
+            with patch.object(runtime, "caller_context", side_effect=lambda args, meta, **kw: contexts[args["context_file"]]), \
+                 patch.object(runtime, "selection", side_effect=choose):
+                tools = await provider.list_tools()
+                self.assertIn("context_file", tools[0].inputSchema["properties"])
+                old = await provider.call_tool("knowledge_query", {"text": "first", "context_file": "first"})
+                new = await provider.call_tool("knowledge_query", {"text": "second", "context_file": "second"})
+                again = await provider.call_tool("knowledge_query", {"text": "resume", "context_file": "first"})
+            self.assertEqual([old.structuredContent["runtime"], new.structuredContent["runtime"], again.structuredContent["runtime"]],
+                             ["old", "new", "old"])
+            self.assertNotIn("context_file", new.structuredContent["arguments"])
+            self.assertEqual(new.meta["vaws_provider"]["environment"], "new")
+            self.assertTrue(Path(new.meta["vaws_provider"]["stderr"]).is_file())
+            self.assertEqual(len(provider.backends), 2)
+        finally:
+            await provider.close()
+        self.assertTrue(all(item.worker.done() for item in provider.backends.values()))
+
+    async def test_task_context_and_native_metadata_survive_forwarding(self):
+        provider = runtime.Provider("task", self.root)
+        metadata = {"x-codex-turn-metadata": {"thread_id": "test-thread"}}
+        try:
+            with patch.object(runtime, "caller_context", return_value={"context_file": "known-context"}), \
+                 patch.object(runtime, "selection", return_value=self.selections["new"]):
+                result = await provider.call_tool("vaws_session", {}, metadata)
+            self.assertEqual(result.structuredContent["arguments"]["context_file"], "known-context")
+            self.assertEqual(result.structuredContent["meta"]["x-codex-turn-metadata"], metadata["x-codex-turn-metadata"])
+        finally:
+            await provider.close()
+
+    async def test_missing_backend_returns_failure_without_hidden_fallback(self):
+        provider = runtime.Provider("task", self.root)
+        try:
+            with patch.object(runtime, "provider_command", return_value=([sys.executable, str(self.root / "missing.py")], {})):
+                backend = provider.backend(self.selections["new"])
+                with self.assertRaises(Exception):
+                    await asyncio.wait_for(backend.request("list_tools"), timeout=10)
+                self.assertTrue(backend.stderr.is_file())
+                self.assertIn("missing.py", backend.stderr.read_text())
+        finally:
+            await provider.close()
+
+    async def test_companion_without_context_does_not_start_mother_runtime(self):
+        for kind in ("knowledge", "remote", "task"):
+            provider = runtime.Provider(kind, self.root)
+            with patch.object(runtime, "caller_context", return_value=None):
+                with self.assertRaisesRegex(ValueError, "No native task context"):
+                    await provider.call_tool("unused", {})
+            self.assertEqual(provider.backends, {})
+
+    async def test_long_call_keeps_status_and_stop_concurrent_and_cancellation_reaches_exact_request(self):
+        provider = runtime.Provider("remote", self.root)
+        backend = provider.backend(self.selections["new"])
+        try:
+            slow = asyncio.create_task(backend.request("call_tool", name="remote_bash", arguments={"wait": True}))
+            request = await self.received(lambda row: row.get("params", {}).get("name") == "remote_bash")
+            replies = await asyncio.wait_for(asyncio.gather(
+                backend.request("call_tool", name="remote_job_status", arguments={"job_id": "owned"}),
+                backend.request("call_tool", name="remote_job_stop", arguments={"job_id": "owned"}),
+            ), timeout=3)
+            self.assertFalse(slow.done())
+            self.assertEqual([row.structuredContent["arguments"] for row in replies], [{"job_id": "owned"}] * 2)
+            slow.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await slow
+            cancelled = await self.received(lambda row: row.get("method") == "notifications/cancelled")
+            self.assertEqual(cancelled["params"]["requestId"], request["id"])
+            self.assertEqual((await backend.request("list_tools")).tools[0].name, "knowledge_query")
+        finally:
+            await provider.close()
+        self.assertTrue(backend.worker.done())
+        self.assertTrue(self.processes)
+        self.assertTrue(all(process.returncode is not None for process in self.processes))
+
+    async def test_cancel_during_initialization_does_not_cancel_other_callers_startup(self):
+        self.init_gate = self.root / "initialize-release"
+        provider = runtime.Provider("remote", self.root)
+        backend = provider.backend(self.selections["new"])
+        try:
+            first = asyncio.create_task(backend.request("list_tools"))
+            await self.received(lambda row: row.get("method") == "initialize")
+            first.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await first
+            self.assertFalse(backend.ready.cancelled())
+            second = asyncio.create_task(backend.request("list_tools"))
+            self.init_gate.touch()
+            self.assertEqual((await asyncio.wait_for(second, timeout=3)).tools[0].name, "knowledge_query")
+            self.assertFalse(backend.worker.done())
+        finally:
+            await provider.close()
+        self.assertTrue(all(process.returncode is not None for process in self.processes))
+
+    async def test_remote_error_keeps_selected_runtime_and_raw_failure_visible(self):
+        provider = runtime.Provider("remote", self.root)
+        backend = provider.backend(self.selections["new"])
+        try:
+            with self.assertRaisesRegex(RuntimeError, "fixture remote failure") as error:
+                await backend.request("call_tool", name="fail", arguments={})
+            self.assertIn("remote provider call_tool failed in new", str(error.exception))
+            self.assertIn(str(backend.stderr), str(error.exception))
+            self.assertIsNotNone(error.exception.__cause__)
+            self.assertTrue(backend.stderr.is_file())
+            self.assertEqual((await backend.request("list_tools")).tools[0].name, "knowledge_query")
+        finally:
+            await provider.close()
+
+    async def test_child_exit_returns_evidence_and_close_reaps_the_process(self):
+        provider = runtime.Provider("remote", self.root)
+        backend = provider.backend(self.selections["new"])
+        try:
+            with self.assertRaisesRegex(RuntimeError, "evidence:") as error:
+                await asyncio.wait_for(backend.request("call_tool", name="exit", arguments={}), timeout=3)
+            self.assertIn(str(backend.stderr), str(error.exception))
+        finally:
+            await provider.close()
+        self.assertEqual([process.returncode for process in self.processes], [7])
+
+    async def test_evidence_directory_failure_finishes_startup_with_a_locatable_error(self):
+        provider = runtime.Provider("remote", self.root)
+        backend = provider.backend(self.selections["new"])
+        backend.stderr.parent.parent.mkdir(parents=True, exist_ok=True)
+        backend.stderr.parent.write_text("not a directory")
+        try:
+            with self.assertRaisesRegex(RuntimeError, "evidence:"):
+                await asyncio.wait_for(backend.request("list_tools"), timeout=3)
+        finally:
+            await provider.close()
+        self.assertEqual(self.processes, [])
+
+
+class SelectionTests(unittest.TestCase):
+    def test_metadata_cannot_override_an_explicit_different_native_context(self):
+        with patch("vaws_coordinator.agent_session.AgentSessions") as store:
+            store.return_value.native_context.return_value = {"context_file": "native-context"}
+            with self.assertRaisesRegex(ValueError, "differs"):
+                runtime.caller_context({"context_file": "another-task"},
+                                       {"x-codex-turn-metadata": {"thread_id": "native"}})
+
+    def test_persistent_process_environment_is_not_a_caller_identity(self):
+        with patch.dict("os.environ", {"VAWS_CONTEXT_FILE": "parent-task"}), \
+             patch("vaws_coordinator.agent_session.load_context") as load:
+            self.assertIsNone(runtime.caller_context({}, {}))
+            load.assert_not_called()
+
+    def test_task_receipt_wins_over_latest_catalog(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            old, new = root / "old", root / "new"
+            old.mkdir()
+            new.mkdir()
+            record = runtime.task_dir("vaws-" + "a" * 32, root) / "start.json"
+            record.parent.mkdir(parents=True)
+            record.write_text(json.dumps({"workspace": str(old), "environment": {"receipt": "old"}}))
+            latest = root / ".vaws-local/latest-runtime.json"
+            latest.write_text(json.dumps({"workspace": str(new), "environment": {"receipt": "new"}}))
+            context = {"session": {"id": "vaws-" + "a" * 32}, "context_file": "known", "attachment": {"cwd": str(root)}}
+            with patch.object(runtime, "read_receipt", side_effect=lambda key: {"key": key, "python": sys.executable, "receipt": key}):
+                self.assertEqual(runtime.selection(root, context).workspace, old.resolve())
+                self.assertEqual(runtime.selection(root, catalog=True).workspace, new.resolve())
+
+    def test_only_prepared_linked_worktree_can_supply_a_missing_task_receipt(self):
+        from vaws_workspace_update import git
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "mother"
+            root.mkdir()
+            git(root, "init")
+            git(root, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+                "-c", "commit.gpgsign=false", "commit", "--allow-empty", "-m", "fixture")
+            worktree = Path(tmp) / "prepared worktree"
+            git(root, "worktree", "add", "--detach", str(worktree), "HEAD")
+            context = {"session": {"id": "vaws-" + "a" * 32}, "context_file": "known", "attachment": {"cwd": str(root)}}
+            saved = {"key": "prepared", "python": sys.executable, "receipt": "fixed-receipt"}
+            mother_selection = root / ".vaws-local/environment-selection" / f"{sys.platform}.json"
+            mother_selection.parent.mkdir(parents=True)
+            mother_selection.write_text(json.dumps(saved))
+            with patch.object(runtime, "saved_ready", return_value=saved) as ready:
+                with self.assertRaisesRegex(ValueError, "no prepared workspace"):
+                    runtime.selection(root, context)
+                ready.assert_not_called()
+                context["attachment"]["cwd"] = str(worktree)
+                with self.assertRaisesRegex(ValueError, "no prepared workspace"):
+                    runtime.selection(root, context)
+                ready.assert_not_called()
+                native_selection = worktree / ".vaws-local/environment-selection" / f"{sys.platform}.json"
+                native_selection.parent.mkdir(parents=True)
+                native_selection.write_text(json.dumps(saved))
+                self.assertEqual(runtime.selection(root, context).workspace, worktree.resolve())
+                child = worktree / "src"
+                child.mkdir()
+                context["attachment"]["cwd"] = str(child)
+                self.assertEqual(runtime.selection(root, context).workspace, worktree.resolve())
+                self.assertEqual(ready.call_args.args, (worktree.resolve(),))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test_vaws_mcp_runtime.py
+++ b/.agents/tests/test_vaws_mcp_runtime.py
@@ -133,6 +133,17 @@ class RuntimeTests(unittest.IsolatedAsyncioTestCase):
         finally:
             await provider.close()
 
+    async def test_kimi_catalog_requires_the_existing_native_context(self):
+        for kind in ("task", "remote", "knowledge"):
+            provider = runtime.Provider(kind, self.root, {"VAWS_MCP_CLIENT": "kimi"})
+            try:
+                with patch.object(runtime, "selection", return_value=self.selections["new"]):
+                    tools = await provider.list_tools()
+                self.assertIn("context_file", tools[0].inputSchema["required"])
+                self.assertIn("native hook", tools[0].inputSchema["properties"]["context_file"]["description"])
+            finally:
+                await provider.close()
+
     async def test_missing_backend_returns_failure_without_hidden_fallback(self):
         provider = runtime.Provider("task", self.root)
         try:

--- a/.agents/tests/test_vaws_start.py
+++ b/.agents/tests/test_vaws_start.py
@@ -184,3 +184,15 @@ def test_failed_update_returns_evidence_without_binding_or_creating(workspace, m
     assert json.loads(Path(result["evidence"]).read_text())["details"]["log"] == "/raw/updater-log.json"
     assert store.context(context["attachment"]["id"])["source_defaults"]["origin"] != "explicit"
     assert not (project.parent / (project.name + "-" + context["session"]["id"])).exists()
+
+
+def test_first_use_returns_setup_before_dependency_or_native_context_checks(workspace, monkeypatch, capsys):
+    project = workspace[0]
+    monkeypatch.setattr(start, "ROOT", project)
+    monkeypatch.setattr(start, "ensure_workspace_interpreter", lambda **kwargs: pytest.fail("first use bootstrapped dependencies"))
+    monkeypatch.setattr(start, "resolve_context_file", lambda *_: pytest.fail("first use required a native attachment"))
+    assert start.main(["--client", "grok"]) == 1
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "needs_setup" and result["phase"] == "initialization"
+    assert "ask once" in result["next"]
+    assert not (project / ".vaws-local/updates/onboarding-notice.json").exists()

--- a/.agents/tests/test_vaws_start.py
+++ b/.agents/tests/test_vaws_start.py
@@ -1,0 +1,186 @@
+"""One native task adopts canonical inputs once without changing its attachment."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path[:0] = [str(ROOT / ".agents/lib"), str(ROOT / ".agents/scripts")]
+spec = importlib.util.spec_from_file_location("vaws_start_test", ROOT / ".agents/scripts/vaws_start.py")
+start = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(start)
+from vaws_coordinator.agent_session import AgentSessions
+
+
+def git(path, *args):
+    result = subprocess.run(["git", "-c", "core.hooksPath=/dev/null", "-C", str(path), *args],
+                            capture_output=True, text=True, encoding="utf-8", check=True)
+    return result.stdout.strip()
+
+
+def commit(path, message):
+    git(path, "add", ".")
+    git(path, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "commit", "-m", message)
+    return git(path, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    project, stage = tmp_path / "母仓 project", tmp_path / "canonical stage"
+    project.mkdir()
+    git(project, "init", "-b", "main")
+    (project / ".gitignore").write_text(".vaws-local/\n", encoding="utf-8")
+    (project / "README").write_text("old\n")
+    old = commit(project, "old")
+    git(project, "worktree", "add", "--detach", str(stage), old)
+    (stage / "README").write_text("canonical latest\n")
+    (stage / "uv.lock").write_text("new locked components\n")
+    latest = commit(stage, "latest")
+    git(project, "switch", "-c", "feature-work")
+    (project / "README").write_text("keep local work\n")
+    (project / "untracked.txt").write_text("keep untracked work\n")
+    receipt = {"key": "latest-environment", "python": sys.executable,
+               "receipt": str(tmp_path / "latest-ready.json")}
+    calls, selected = [], {}
+
+    class Updater:
+        def __init__(self, root):
+            assert root == project
+            self.state = {"prepared": {"stage": str(stage), "receipt": receipt, "knowledge": {"ready": True}}}
+
+        def step(self, **kwargs):
+            calls.append(("update", kwargs))
+            assert kwargs == {"apply": True, "activate": False}
+            return {"status": "ready", "target": latest, "branch": "main"}
+
+        def validate_prepared(self, result, prepared):
+            assert result["target"] == latest
+            return Path(prepared["stage"])
+
+    def select(path, chosen):
+        selected[path] = chosen
+        file = path / ".vaws-local/environment-selection" / f"{sys.platform}.json"
+        file.parent.mkdir(parents=True, exist_ok=True)
+        file.write_text(json.dumps(chosen))
+
+    monkeypatch.setattr(start, "WorkspaceUpdater", Updater)
+    monkeypatch.setattr(start, "select_environment", select)
+    monkeypatch.setattr(start, "saved_ready", lambda path: selected[path])
+    def read_fixed(path):
+        assert path == receipt["receipt"]
+        return receipt
+    monkeypatch.setattr(start, "read_receipt", read_fixed)
+    monkeypatch.setattr(start, "resolve_context_file", lambda explicit: explicit)
+    monkeypatch.setattr(start, "configure_target", lambda client, target, chosen, env:
+                        calls.append(("configure", client, target, chosen, env)))
+    monkeypatch.setattr(start, "prepare_selected_knowledge", lambda target, chosen: {"ready": True})
+    monkeypatch.setenv("VAWS_ENV_RECEIPT", "old-parent-environment")
+    store = AgentSessions(tmp_path / "native-registry")
+    return project, stage, latest, receipt, calls, selected, select, store
+
+
+@pytest.mark.parametrize("client", start.CLIENTS)
+def test_new_task_uses_canonical_worktree_and_preserves_native_cwd(workspace, client):
+    project, _, latest, receipt, calls, _, _, store = workspace
+    context = store.attach(client, "actual-native-session", str(project))
+    result = start.start(client, project, context["context_file"])
+    assert result["status"] == "ready", result
+    target = Path(result["workspace"])
+    assert target.parent == project.parent and target != project
+    assert result["head"] == latest
+    assert result["environment"] == receipt
+    assert result["knowledge"] == {"ready": True}
+    assert (target / "README").read_text() == "canonical latest\n"
+    assert not (target / "untracked.txt").exists()
+    assert (project / "README").read_text() == "keep local work\n"
+    assert (project / "untracked.txt").read_text() == "keep untracked work\n"
+    assert git(project, "branch", "--show-current") == "feature-work"
+    current = store.context(context["attachment"]["id"])
+    assert current["attachment"] == context["attachment"]
+    assert current["source_defaults"]["origin"] == "explicit"
+    assert current["source_defaults"]["sources"][project.name]["path"] == str(target)
+    configured = next(call for call in calls if call[0] == "configure")
+    assert configured[3] == receipt and "VAWS_ENV_RECEIPT" not in configured[4]
+    before = list(calls)
+    latest_runtime = project / ".vaws-local/latest-runtime.json"
+    assert json.loads(latest_runtime.read_text()) == {key: result[key] for key in ("workspace", "environment", "head")}
+    runtime_time = latest_runtime.stat().st_mtime_ns
+    (target / "README").write_text("ongoing task edits\n")
+    repeated = start.start(client, target, context["context_file"])
+    assert repeated["status"] == "reused" and repeated["workspace"] == str(target)
+    assert calls == before and (target / "README").read_text() == "ongoing task edits\n"
+    assert latest_runtime.stat().st_mtime_ns == runtime_time
+
+
+def test_prepared_native_old_ref_reuses_its_directory_and_receipt(workspace):
+    project, stage, _, _, calls, _, select, store = workspace
+    old_receipt = {"key": "native-old", "python": sys.executable, "receipt": "/old/selected.json"}
+    git(stage, "checkout", "--detach", git(project, "rev-parse", "HEAD"))
+    select(stage, old_receipt)
+    config = project / ".vaws-local/knowledge/service.json"
+    config.parent.mkdir(parents=True)
+    config.write_text("{}")
+    context = store.attach("codex", "native-prepared", str(stage))
+    result = start.start("codex", project, context["context_file"])
+    assert result["status"] == "ready" and result["preparation"] == "native"
+    assert result["workspace"] == str(stage)
+    assert result["environment"] == old_receipt
+    assert result["knowledge_config"] == str(config)
+    assert calls == []
+    assert not (project / ".vaws-local/latest-runtime.json").exists()
+    assert store.context(context["attachment"]["id"])["attachment"] == context["attachment"]
+
+
+def test_a_second_task_gets_a_separate_directory(workspace):
+    project, _, _, _, _, _, _, store = workspace
+    first = store.attach("grok", "native-first", str(project))
+    second = store.attach("grok", "native-second", str(project))
+    a = start.start("grok", project, first["context_file"])
+    b = start.start("grok", project, second["context_file"])
+    assert a["status"] == b["status"] == "ready"
+    assert a["workspace"] != b["workspace"]
+
+
+def test_repeat_keeps_task_receipt_after_explicit_workspace_maintenance(workspace):
+    project, _, _, receipt, calls, _, select, store = workspace
+    context = store.attach("codex", "native-fixed-runtime", str(project))
+    first = start.start("codex", project, context["context_file"])
+    target = Path(first["workspace"])
+    maintained = {"key": "maintenance-environment", "python": sys.executable, "receipt": "/new/ready.json"}
+    select(target, maintained)
+    before = list(calls)
+    repeated = start.start("codex", target, context["context_file"])
+    assert repeated["status"] == "reused" and repeated["environment"] == receipt
+    assert start.saved_ready(target) == maintained
+    assert calls == before
+
+
+def test_missing_or_wrong_native_identity_never_prepares(workspace, monkeypatch):
+    project, _, _, _, calls, _, _, store = workspace
+    context = store.attach("kimi", "native-kimi", str(project))
+    result = start.start("grok", project, context["context_file"])
+    assert result["status"] == "failed" and result["phase"] == "context"
+    monkeypatch.setattr(start, "resolve_context_file", lambda _: (_ for _ in ()).throw(ValueError("native context required")))
+    assert start.start("grok", project)["status"] == "failed"
+    assert calls == []
+
+
+def test_failed_update_returns_evidence_without_binding_or_creating(workspace, monkeypatch):
+    project, _, _, _, _, _, _, store = workspace
+    context = store.attach("cursor", "native-update-failed", str(project))
+
+    def failed(self, **kwargs):
+        return {"status": "deferred", "reason": "network_unavailable", "log": "/raw/updater-log.json"}
+
+    monkeypatch.setattr(start.WorkspaceUpdater, "step", failed)
+    result = start.start("cursor", project, context["context_file"])
+    assert result["status"] == "failed" and result["phase"] == "upstream"
+    assert json.loads(Path(result["evidence"]).read_text())["details"]["log"] == "/raw/updater-log.json"
+    assert store.context(context["attachment"]["id"])["source_defaults"]["origin"] != "explicit"
+    assert not (project.parent / (project.name + "-" + context["session"]["id"])).exists()

--- a/.agents/tests/test_vaws_start_context.py
+++ b/.agents/tests/test_vaws_start_context.py
@@ -131,7 +131,7 @@ def test_prepared_native_worktree_and_broken_selection(project):
     nested.mkdir()
     native = "native-worktree"
     result = run_hook(root, "claude", payload("claude", "SessionStart", native, nested))
-    assert "workspace is prepared: W=" + str(target) in result.stdout
+    assert "workspace is prepared: W=" + str(target) in hint("claude", "SessionStart", result.stdout)
     assert not (root / ".vaws-local/tasks").exists()
     selected = target / ".vaws-local/environment-selection" / f"{sys.platform}.json"
     selected.write_text("{broken")

--- a/.agents/tests/test_vaws_start_context.py
+++ b/.agents/tests/test_vaws_start_context.py
@@ -1,0 +1,208 @@
+"""Real package hooks project task selection without doing startup work."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / ".agents/lib"))
+import vaws_environment as environments
+import vaws_start_context as hints
+from vaws_coordinator.agent_session import AgentSessions
+
+
+def git(root, *args):
+    return subprocess.run(["git", "-c", "core.hooksPath=/dev/null", "-C", str(root), *args],
+                          capture_output=True, text=True, encoding="utf-8", check=True).stdout.strip()
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    root = tmp_path / "母仓 project"
+    root.mkdir()
+    git(root, "init", "-b", "main")
+    (root / "README").write_text("fixture\n")
+    git(root, "add", "README")
+    git(root, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "commit", "-m", "fixture")
+    target = tmp_path / "selected task W"
+    git(root, "worktree", "add", "--detach", str(target), "HEAD")
+    state = root / ".vaws-local/agent-sessions"
+    identity = root / ".vaws-local/github.json"
+    identity.parent.mkdir(parents=True)
+    identity.write_text(json.dumps({"schema": "vaws.github.v1", "login": "fixture-user", "github_user_id": 42}))
+    for key in ("VAWS_CONTEXT_FILE", "VAWS_PARENT_CONTEXT", "VAWS_ATTACH_CONTEXT", "CLAUDE_ENV_FILE"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("VAWS_SKIP_VENV_REEXEC", "1")
+    monkeypatch.setenv("VAWS_AGENT_SESSIONS_DIR", str(state))
+    monkeypatch.setenv("VAWS_GITHUB_IDENTITY_FILE", str(identity))
+
+    # A ready receipt exercises the actual selection reader. It need not run
+    # a provider: the selected Python is only a reported startup fact here.
+    python_identity = environments._identity()
+    selection = {"groups": [], "extras": [], "project": True}
+    key = environments._key(python_identity, "fixture-input", selection)
+    store = tmp_path / "environments"
+    directory = store / key
+    python = directory / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    python.parent.mkdir(parents=True)
+    python.write_bytes(b"fixture")
+    receipt = {"schema_version": 1, "recipe_version": environments.RECIPE_VERSION,
+               "key": key, "root": str(directory), "python": str(python),
+               "base_python": str(Path(getattr(sys, "_base_executable", sys.executable)).resolve()),
+               "python_identity": python_identity, "input_id": "fixture-input", "lock_sha256": "fixture-lock",
+               "selection": selection, "store": str(store), "receipt": str(directory / environments.READY_NAME),
+               **{name: python_identity[name] for name in ("platform", "arch", "abi", "python_version")}}
+    Path(receipt["receipt"]).write_text(json.dumps(receipt))
+    # A mother cached environment must never imply that a task is prepared.
+    environments.select_environment(root, receipt)
+    return root, target, AgentSessions(state), receipt
+
+
+def payload(client, event, native, cwd, **extra):
+    result = ({"hookEventName": event, "sessionId": native, "workspaceRoot": str(cwd)}
+              if client == "grok" else {"hook_event_name": event, "session_id": native, "cwd": str(cwd)})
+    if client == "cursor":
+        result.update(conversation_id=native, cursor_version="fixture", workspace_roots=[str(cwd)])
+    return {**result, **extra}
+
+
+def run_hook(root, client, event_payload, *, package=False):
+    entry = (["-m", "vaws_coordinator.hooks.vaws_session"] if package else
+             [str(ROOT / ".agents/hooks/vaws_session.py")])
+    return subprocess.run([sys.executable, *entry, "--client", client, "--project", str(root)],
+                          input=json.dumps(event_payload), capture_output=True, text=True,
+                          encoding="utf-8", cwd=root, timeout=15, check=True)
+
+
+def hint(client, event, raw):
+    if client == "kimi" and event == "UserPromptSubmit":
+        return raw
+    output = json.loads(raw)
+    return output["additional_context"] if client == "cursor" else output["hookSpecificOutput"]["additionalContext"]
+
+
+def task_record(root, context, target, receipt):
+    path = root / ".vaws-local/tasks" / context["session"]["id"] / "start.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"workspace": str(target), "environment": receipt}))
+    return path
+
+
+@pytest.mark.parametrize("client", ["claude", "codex", "cursor", "grok", "kimi"])
+def test_real_hook_unprepared_then_repeated_prepared_resume(project, client):
+    root, target, store, receipt = project
+    native = "native-exact-" + client
+    first = run_hook(root, client, payload(client, "SessionStart", native, root))
+    context = store.native_context(client, native)
+    message = hint(client, "SessionStart", first.stdout)
+    assert "NOT prepared" in message
+    assert "First repository action, before file reads" in message
+    assert "--client " + client in message and context["context_file"] in message
+    assert "Client startup owns" not in message
+    assert not (root / ".vaws-local/tasks").exists()
+
+    store.bind_sources(context, {root.name: str(target)})
+    record = task_record(root, context, target, receipt)
+    original = record.read_bytes()
+    for event in ("UserPromptSubmit", "SessionStart", "UserPromptSubmit"):
+        result = run_hook(root, client, payload(client, event, native, root, source="resume"))
+        message = hint(client, event, result.stdout)
+        assert "workspace is prepared: W=" + str(target) in message
+        assert receipt["key"] in message and receipt["python"] in message
+        assert "First repository action" not in message
+        assert record.read_bytes() == original
+        if client == "cursor":
+            assert "hookSpecificOutput" not in json.loads(result.stdout)
+    current = store.native_context(client, native)
+    assert current["session"]["id"] == context["session"]["id"]
+    assert current["attachment"]["cwd"] == str(root)
+    assert current["source_defaults"]["sources"][root.name]["path"] == str(target)
+
+
+def test_prepared_native_worktree_and_broken_selection(project):
+    root, target, store, receipt = project
+    environments.select_environment(target, receipt)
+    nested = target / "src"
+    nested.mkdir()
+    native = "native-worktree"
+    result = run_hook(root, "claude", payload("claude", "SessionStart", native, nested))
+    assert "workspace is prepared: W=" + str(target) in result.stdout
+    assert not (root / ".vaws-local/tasks").exists()
+    selected = target / ".vaws-local/environment-selection" / f"{sys.platform}.json"
+    selected.write_text("{broken")
+    result = run_hook(root, "claude", payload("claude", "UserPromptSubmit", native, nested))
+    assert "workspace selection could not be read" in result.stdout
+    assert "invalid environment selection" in result.stdout
+    assert "First repository action" not in result.stdout
+    assert selected.read_text() == "{broken"
+
+
+def test_broken_task_receipt_is_not_a_new_session(project):
+    root, target, store, receipt = project
+    native = "broken-task"
+    run_hook(root, "claude", payload("claude", "SessionStart", native, root))
+    context = store.native_context("claude", native)
+    record = task_record(root, context, target, receipt)
+    Path(receipt["receipt"]).write_text("{}")
+    result = run_hook(root, "claude", payload("claude", "UserPromptSubmit", native, root))
+    assert "workspace selection could not be read" in result.stdout
+    assert "incomplete ready receipt" in result.stdout
+    assert "First repository action" not in result.stdout
+    assert record.is_file()
+
+
+def test_missing_identity_does_not_claim_prepared(project, monkeypatch):
+    root, target, store, receipt = project
+    (root / ".vaws-local/github.json").unlink()
+    monkeypatch.delenv("VAWS_GITHUB_IDENTITY_FILE")
+    # Override the real wrapper's ROOT identity discovery with a missing
+    # package identity environment after the native package call below.
+    context = store.attach("claude", "first-use", str(root))
+    task_record(root, context, target, receipt)
+    result = hints.project_output("claude", payload("claude", "SessionStart", "first-use", root),
+                                  '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"native context"}}', root=root)
+    assert "first-use setup is incomplete" in result
+    assert "ask once" in result and "already supplied" in result
+    assert "workspace is prepared" not in result and "First repository action" not in result
+
+
+@pytest.mark.parametrize("case", ["foreign", "outside", "missing-id", "pretool", "kimi-extension"])
+def test_package_noop_error_and_tool_output_remain_exact(project, case):
+    root, _, _, _ = project
+    client = "kimi" if case == "kimi-extension" else "claude"
+    run_hook(root, client, payload(client, "SessionStart", "existing", root))
+    event_payload = payload(client, "UserPromptSubmit", "existing", root)
+    if case == "foreign":
+        event_payload = payload("grok", "SessionStart", "foreign-id", root)
+    elif case == "outside":
+        event_payload["cwd"] = str(root.parent)
+    elif case == "missing-id":
+        event_payload.pop("session_id")
+    elif case == "pretool":
+        event_payload = payload(client, "PreToolUse", "existing", root,
+                                tool_name="mcp__vaws-knowledge__knowledge_query", tool_input={"query": "principle"})
+    else:
+        event_payload["agent_id"] = "main"
+    expected = run_hook(root, client, event_payload, package=True)
+    actual = run_hook(root, client, event_payload)
+    assert actual.stdout == expected.stdout
+    assert actual.stderr == expected.stderr
+    if case == "pretool":
+        assert "context_file" in json.loads(actual.stdout)["hookSpecificOutput"]["updatedInput"]
+
+
+def test_projection_does_not_guess_context_from_cwd_or_environment(project, monkeypatch):
+    root, _, store, _ = project
+    context = store.attach("claude", "actual", str(root))
+    monkeypatch.setenv("VAWS_CONTEXT_FILE", context["context_file"])
+    output = '{"hookSpecificOutput":{"additionalContext":"native context"}}'
+    result = hints.project_output("claude", payload("claude", "SessionStart", "unknown", root), output, root=root)
+    assert "association is missing or ambiguous" in result
+    assert "First repository action" not in result
+    with pytest.raises(ValueError):
+        store.native_context("claude", "unknown")

--- a/.agents/tests/test_windows_client_setup.py
+++ b/.agents/tests/test_windows_client_setup.py
@@ -85,7 +85,7 @@ def test_kimi_code_uses_native_home_and_discovers_scoped_project_mcp(tmp_path, m
     assert setup.kimi_home() / "config.toml" in plan["files"]
     assert plan["launch_argv"] == ["kimi"]
     assert plan["launch_cwd"] == str(project)
-    assert setup.kimi_home() / "mcp.json" not in plan["files"]
+    assert json.loads(plan["files"][setup.kimi_home() / "mcp.json"])["mcpServers"]["existing"] == {}
     servers = json.loads(plan["files"][project / ".kimi-code/mcp.json"])["mcpServers"]
     assert servers["vaws-task"]["toolTimeoutMs"] == 600000
     assert "type" not in servers["vaws-task"]

--- a/.agents/tests/test_windows_client_setup.py
+++ b/.agents/tests/test_windows_client_setup.py
@@ -86,9 +86,14 @@ def test_kimi_code_uses_native_home_and_discovers_scoped_project_mcp(tmp_path, m
     assert plan["launch_argv"] == ["kimi"]
     assert plan["launch_cwd"] == str(project)
     assert json.loads(plan["files"][setup.kimi_home() / "mcp.json"])["mcpServers"]["existing"] == {}
-    servers = json.loads(plan["files"][project / ".kimi-code/mcp.json"])["mcpServers"]
-    assert servers["vaws-task"]["toolTimeoutMs"] == 600000
-    assert "type" not in servers["vaws-task"]
+    project_servers = json.loads(plan["files"][project / ".kimi-code/mcp.json"])["mcpServers"]
+    user_servers = json.loads(plan["files"][setup.kimi_home() / "mcp.json"])["mcpServers"]
+    # An owned native launch moves to the user provider; a custom interpreter
+    # stays project-scoped. Both native discoveries must expose exactly one.
+    entries = [servers["vaws-task"] for servers in (project_servers, user_servers) if "vaws-task" in servers]
+    assert len(entries) == 1
+    assert entries[0]["toolTimeoutMs"] == 600000
+    assert "type" not in entries[0]
 
 
 def test_generated_task_owner_migrates_without_rewriting_user_provider_or_policy(monkeypatch):

--- a/.agents/tests/test_workspace_forks.py
+++ b/.agents/tests/test_workspace_forks.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import copy
+import json
 import os
 from pathlib import Path
 import sys
@@ -76,6 +77,61 @@ class ForkValidationTests(unittest.TestCase):
             with self.assertRaises(forks.GitHubAPIError) as raised:
                 forks.GitHubClient().api("repos/alice/test")
         self.assertEqual(raised.exception.status, 401)
+        self.assertEqual(raised.exception.evidence["returncode"], 1)
+
+    def test_api_machine_output_overrides_terminal_color_without_changing_parent(self):
+        original = {"CLICOLOR_FORCE": "1", "FORCE_COLOR": "1", "GH_FORCE_TTY": "80", "GITHUB_TOKEN": "private-fixture"}
+        result = mock.Mock(returncode=0, stdout='{"ok": true}', stderr="")
+        with mock.patch.dict(os.environ, original), mock.patch.object(forks.subprocess, "run", return_value=result) as run:
+            self.assertEqual(forks.GitHubClient().api("user"), {"ok": True})
+            env = run.call_args.kwargs["env"]
+            self.assertEqual((env["CLICOLOR_FORCE"], env["FORCE_COLOR"], env["NO_COLOR"]), ("0", "0", "1"))
+            self.assertNotIn("GH_FORCE_TTY", env)
+            self.assertEqual(env["GITHUB_TOKEN"], original["GITHUB_TOKEN"])
+            self.assertEqual(os.environ["CLICOLOR_FORCE"], "1")
+            self.assertEqual(os.environ["GH_FORCE_TTY"], "80")
+            run.assert_called_once()
+
+    def test_invalid_json_keeps_redacted_raw_api_evidence_in_update_log(self):
+        from vaws_workspace_update import WorkspaceUpdater
+
+        token = "gh" + "p_" + "fixturecredential"
+        header = "> Authorization: " + "Bearer " + "private-fixture"
+        url = "https://" + "user:secret" + "@example.invalid/"
+        stderr = "\n".join((header, token, url, ""))
+        proc = mock.Mock(returncode=0, stdout="\x1b[32m{not-json}\x1b[0m", stderr=stderr)
+        with mock.patch.object(forks.subprocess, "run", return_value=proc) as run:
+            with self.assertRaises(forks.GitHubAPIError) as raised:
+                forks.GitHubClient().api("repos/alice/test")
+        facts = raised.exception.evidence
+        self.assertEqual(facts["endpoint"], "repos/alice/test")
+        self.assertEqual(facts["method"], "GET")
+        self.assertEqual(facts["command"], ["gh", "api", "--hostname", "github.com", "repos/alice/test", "--method", "GET"])
+        self.assertEqual(facts["stdout"], proc.stdout)
+        self.assertEqual(facts["returncode"], 0)
+        self.assertNotIn(token, facts["stderr"])
+        self.assertNotIn("private-fixture", facts["stderr"])
+        self.assertNotIn("user:secret", facts["stderr"])
+        run.assert_called_once()
+        with tempfile.TemporaryDirectory() as directory:
+            result = WorkspaceUpdater(Path(directory)).failure(raised.exception)
+            self.assertEqual(json.loads(Path(result["log"]).read_text()), facts)
+
+    def test_api_timeout_keeps_captured_bytes_without_retry(self):
+        timeout = forks.subprocess.TimeoutExpired(["gh"], 60, output=b"partial response", stderr=b"timeout detail")
+        with mock.patch.object(forks.subprocess, "run", side_effect=timeout) as run:
+            with self.assertRaises(forks.GitHubAPIError) as raised:
+                forks.GitHubClient().api("user")
+        self.assertEqual(raised.exception.evidence["stdout"], "partial response")
+        self.assertEqual(raised.exception.evidence["stderr"], "timeout detail")
+        self.assertIsNone(raised.exception.evidence["returncode"])
+        run.assert_called_once()
+
+    def test_api_non_object_keeps_original_response(self):
+        with mock.patch.object(forks.subprocess, "run", return_value=mock.Mock(returncode=0, stdout="[]", stderr="")):
+            with self.assertRaises(forks.GitHubAPIError) as raised:
+                forks.GitHubClient().api("user")
+        self.assertEqual(raised.exception.evidence["stdout"], "[]")
 
 
 class SetupTests(unittest.TestCase):

--- a/.agents/tests/test_workspace_update.py
+++ b/.agents/tests/test_workspace_update.py
@@ -7,6 +7,8 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import threading
+import time
 
 import pytest
 
@@ -387,6 +389,45 @@ def test_update_lock_is_shared_across_linked_worktrees(fixture):
         with pytest.raises(updates.Deferred, match="updater_running"):
             with updates.update_lock(linked):
                 pytest.fail("both publishers obtained the same repository lock")
+
+
+def test_new_session_waits_for_another_preparation_then_continues(fixture, monkeypatch, capsys):
+    waiting, acquired = threading.Event(), threading.Event()
+    errors = []
+    sleep = time.sleep
+
+    def observe_wait(seconds):
+        waiting.set()
+        sleep(seconds)
+
+    def next_session():
+        try:
+            with updates.update_lock(fixture["root"], wait_seconds=5):
+                acquired.set()
+        except Exception as exc:
+            errors.append(exc)
+
+    monkeypatch.setattr(updates.time, "sleep", observe_wait)
+    with updates.update_lock(fixture["root"]):
+        worker = threading.Thread(target=next_session)
+        worker.start()
+        assert waiting.wait(5), "the second session did not reach the shared preparation lock"
+        assert not acquired.is_set()
+    worker.join(5)
+    assert not worker.is_alive()
+    assert not errors
+    assert acquired.is_set()
+    assert capsys.readouterr().err.count("waiting for another session") == 1
+
+
+def test_preparation_wait_timeout_keeps_lock_and_elapsed_evidence(fixture):
+    with updates.update_lock(fixture["root"]):
+        with pytest.raises(updates.Deferred, match="preparation is still running") as failure:
+            with updates.update_lock(fixture["root"], wait_seconds=0.02):
+                pytest.fail("a timed-out waiter acquired another session's lock")
+    assert failure.value.reason == "updater_running"
+    assert Path(failure.value.evidence["lock"]).name == "vaws-update.lock"
+    assert failure.value.evidence["waited_seconds"] >= 0.02
 
 
 def test_git_failure_log_retains_stderr_without_token(fixture):

--- a/.cursor/rules/vaws-session-start.mdc
+++ b/.cursor/rules/vaws-session-start.mdc
@@ -1,0 +1,13 @@
+---
+description: Select this native session's editing workspace
+alwaysApply: true
+---
+
+<!-- BEGIN VAWS session-start -->
+For a new native session, use an independent native worktree when startup supplied its selected environment. Otherwise make the first repository action `uv run --no-project python .agents/scripts/vaws_start.py --client cursor`. Add `--context-file PATH` when the native hook supplied that context and the command cannot obtain it from the client environment (official Kimi needs it).
+
+Use the returned `workspace` as W: shell tools use W as cwd (or `cd W && ...`), and file, search and patch tools use absolute paths under W. Sources and the selected environment are already bound; do not repeat session setup. Official Kimi calls to the task, remote-dev and knowledge MCP providers also carry the returned `context_file`. Other clients receive context through hooks; if a tool reports missing context, pass the existing `context_file`. Use configured knowledge tools when useful.
+
+Resume keeps the earlier W, task and environment; do not prepare, update or create another directory. Client UI/default cwd can remain at the original project.
+<!-- END VAWS session-start -->
+

--- a/.cursor/rules/vaws-session-start.mdc
+++ b/.cursor/rules/vaws-session-start.mdc
@@ -4,6 +4,8 @@ alwaysApply: true
 ---
 
 <!-- BEGIN VAWS session-start -->
+On first use, complete AGENTS.md's First use, forks and updates setup before this new-session step.
+
 For a new native session, use an independent native worktree when startup supplied its selected environment. Otherwise make the first repository action `uv run --no-project python .agents/scripts/vaws_start.py --client cursor`. Add `--context-file PATH` when the native hook supplied that context and the command cannot obtain it from the client environment (official Kimi needs it).
 
 Use the returned `workspace` as W: shell tools use W as cwd (or `cd W && ...`), and file, search and patch tools use absolute paths under W. Sources and the selected environment are already bound; do not repeat session setup. Official Kimi calls to the task, remote-dev and knowledge MCP providers also carry the returned `context_file`. Other clients receive context through hooks; if a tool reports missing context, pass the existing `context_file`. Use configured knowledge tools when useful.

--- a/.cursor/rules/vaws-session-start.mdc
+++ b/.cursor/rules/vaws-session-start.mdc
@@ -4,9 +4,7 @@ alwaysApply: true
 ---
 
 <!-- BEGIN VAWS session-start -->
-On first use, complete AGENTS.md's First use, forks and updates setup before this new-session step.
-
-For a new native session, use an independent native worktree when startup supplied its selected environment. Otherwise make the first repository action `uv run --no-project python .agents/scripts/vaws_start.py --client cursor`. Add `--context-file PATH` when the native hook supplied that context and the command cannot obtain it from the client environment (official Kimi needs it).
+For a new native session, make the first repository action `uv run --no-project python .agents/scripts/vaws_start.py --client cursor`. Add `--context-file PATH` when the native hook supplied that context and the command cannot obtain it from the client environment (official Kimi needs it). The command checks saved initialization itself and reports missing first-use setup; no configuration inspection is needed beforehand. If the native hook explicitly reports a prepared workspace W and selected environment, use them directly.
 
 Use the returned `workspace` as W: shell tools use W as cwd (or `cd W && ...`), and file, search and patch tools use absolute paths under W. Sources and the selected environment are already bound; do not repeat session setup. Official Kimi calls to the task, remote-dev and knowledge MCP providers also carry the returned `context_file`. Other clients receive context through hooks; if a tool reports missing context, pass the existing `context_file`. Use configured knowledge tools when useful.
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ venv/
 *.out
 docs/superpowers/
 .claude/settings*.json
+.claude/worktrees/
 .codex/*
 .kimi-code/mcp.json
 .grok/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,11 @@
+<!-- BEGIN VAWS session-start -->
+For a new native session, use an independent native worktree when startup supplied its selected environment. Otherwise make the first repository action `uv run --no-project python .agents/scripts/vaws_start.py --client CLIENT`. Replace CLIENT with your native client: codex, cursor, claude, grok or kimi. Add `--context-file PATH` when the native hook supplied that context and the command cannot obtain it from the client environment (official Kimi needs it).
+
+Use the returned `workspace` as W: shell tools use W as cwd (or `cd W && ...`), and file, search and patch tools use absolute paths under W. Sources and the selected environment are already bound; do not repeat session setup. Official Kimi calls to the task, remote-dev and knowledge MCP providers also carry the returned `context_file`. Other clients receive context through hooks; if a tool reports missing context, pass the existing `context_file`. Use configured knowledge tools when useful.
+
+Resume keeps the earlier W, task and environment; do not prepare, update or create another directory. Client UI/default cwd can remain at the original project.
+<!-- END VAWS session-start -->
+
 # Repository instructions
 
 This is the vLLM-Ascend consumer workspace: project materials, client wiring
@@ -41,30 +49,22 @@ After identity setup, initialize the installed clients together with
 `uv run --no-project python .agents/scripts/vaws_deps.py sync`, then
 `uv run --no-project python .agents/scripts/vaws_client_setup.py --client all --apply`.
 The latter detects actual installed clients, prepares their hooks/providers and
-supported native defaults, and records the result in the primary worktree's
+shared startup instructions, and records the result in the primary worktree's
 `.vaws-local/client-initialization.json`. It does not require invoking a Skill.
-Complete any returned native UI choices once during this initialization, using
-available client tools or computer use; unsupported operations remain explicit
-in the result. Writing wiring files alone does not establish a default mode or
-native trust. An existing initialization attempt is not a per-task gate: do not
+Native worktree setup is an optional optimization; official clients also use
+the shared new-session entry. Client trust remains native. Do not
 rerun all-client setup, poll its record or repeat questions for ordinary work.
 Explicit initialization or repair can rerun the same idempotent entry.
 
-Codex
-local-environment setup and Cursor worktree setup then prepare the new directory
-created by the client, before the Agent starts: check the canonical default
-branch once, adopt an eligible revision and pin its components and client wiring.
-No Release or per-session Agent command is required. Normal SessionStart hooks
-automatically attach the native identity and actual cwd to VAWS; resume keeps
-the existing task, code and selected environment. There is no periodic watcher
-or update during work. A plain Local chat does not acquire a worktree from a hook.
-Native setup has contract tests and real-client acceptance evidence. Codex needs
-one native VAWS environment selection and `--codex-global-hooks` initialization
-with native review of the fixed user hooks; later worktrees reuse their definitions.
-Cursor uses New Worktree by default and
-the one-time `--cursor-global-mcp` setup. Claude uses WorktreeCreate; Grok uses native Git worktrees; Kimi needs the
-explicit native SessionSetup extension. Verified versions and remaining client
-boundaries are in [native client acceptance](docs/native-client-validation-2026-09-12.md).
+Each new native task selects its editing workspace, checks upstream once and
+fixes its component environment. Existing native worktree callbacks can perform
+this preparation; otherwise the generated startup instruction supplies the one
+command. The returned workspace is the editing root even when the client's UI
+still shows the original directory. Session hooks associate the native identity;
+the start operation binds the selected sources. Resume keeps that task, directory
+and environment. There is no periodic watcher or update during work, and no
+personal client binary is required. Current verification scope is recorded in
+[unified session acceptance](docs/unified-session-validation-2026-09-13.md).
 Explicit maintenance of an existing checkout can use
 `.agents/scripts/workspace_update.py apply`; this is not a per-task Agent step.
 Dirty sources and divergence stay for judgment when an update is needed.
@@ -90,12 +90,14 @@ adding personal/public categories, sharing permissions or publication steps.
 | Local files, shell, Git | Native client tools |
 | Explicit remote endpoint I/O | remote-dev companion tools with ordinary host/port/user/cwd |
 | Managed environments, NPU runs and services | `vaws_session`, `vaws_run`, `vaws_execution`, `vaws_finish` |
+| New native task without an already prepared worktree | Shared startup guidance and `.agents/scripts/vaws_start.py --client CLIENT` |
 | Workspace initialization or client wiring | `.agents/skills/repo-init/SKILL.md` |
 | Local fleet monitor lifecycle | `.agents/skills/npu-fleet-monitor/SKILL.md`; observation is not allocation |
 | Knowledge lookup and capture | `knowledge_query`, `knowledge_explain`, `knowledge_capture` |
 
-Native attachments automatically bind their actual working directory as the
-default source. `vaws_session` is optional for inspection or explicit source
+Startup binds the selected editing workspace as the task's default source;
+an already prepared native worktree uses its attached source. `vaws_session`
+is optional for inspection or explicit source
 overrides; a run can also pass `sources`, with an empty map using no project sources.
 Admission fixes source inputs for each execution. Coordinator
 prepares managed sources, environments, devices and ports through one `run`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,5 @@
 <!-- BEGIN VAWS session-start -->
-On first use, complete AGENTS.md's First use, forks and updates setup before this new-session step.
-
-For a new native session, use an independent native worktree when startup supplied its selected environment. Otherwise make the first repository action `uv run --no-project python .agents/scripts/vaws_start.py --client CLIENT`. Replace CLIENT with your native client: codex, cursor, claude, grok or kimi. Add `--context-file PATH` when the native hook supplied that context and the command cannot obtain it from the client environment (official Kimi needs it).
+For a new native session, make the first repository action `uv run --no-project python .agents/scripts/vaws_start.py --client CLIENT`. Replace CLIENT with your native client: codex, cursor, claude, grok or kimi. Add `--context-file PATH` when the native hook supplied that context and the command cannot obtain it from the client environment (official Kimi needs it). The command checks saved initialization itself and reports missing first-use setup; no configuration inspection is needed beforehand. If the native hook explicitly reports a prepared workspace W and selected environment, use them directly.
 
 Use the returned `workspace` as W: shell tools use W as cwd (or `cd W && ...`), and file, search and patch tools use absolute paths under W. Sources and the selected environment are already bound; do not repeat session setup. Official Kimi calls to the task, remote-dev and knowledge MCP providers also carry the returned `context_file`. Other clients receive context through hooks; if a tool reports missing context, pass the existing `context_file`. Use configured knowledge tools when useful.
 
@@ -28,9 +26,11 @@ remotes, not replacements for community upstreams.
 
 ## First use, forks and updates
 
-This applies without invoking a Skill. On first use, if no confirmed
-`.vaws-local/github.json` exists, inspect `.agents/scripts/workspace_forks.py`
-and ask once for the user's personal GitHub username, explaining that setup
+This applies without invoking a Skill. The new-session entry checks the saved
+initialization itself. A `vaws.github.v1` snapshot in `.vaws-local/github.json`
+is the confirmed setup result; there is no separate `confirmed` field and no
+per-session identity inspection. If the entry reports missing first-use setup,
+inspect `.agents/scripts/workspace_forks.py` and ask once for the user's personal GitHub username, explaining that setup
 creates personal development forks and configures the installed native clients
 once for upstream updates and worktree sessions. The current
 authenticated login is a suggestion, not consent. Reuse an explicit answer;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,6 @@
 <!-- BEGIN VAWS session-start -->
+On first use, complete AGENTS.md's First use, forks and updates setup before this new-session step.
+
 For a new native session, use an independent native worktree when startup supplied its selected environment. Otherwise make the first repository action `uv run --no-project python .agents/scripts/vaws_start.py --client CLIENT`. Replace CLIENT with your native client: codex, cursor, claude, grok or kimi. Add `--context-file PATH` when the native hook supplied that context and the command cannot obtain it from the client environment (official Kimi needs it).
 
 Use the returned `workspace` as W: shell tools use W as cwd (or `cd W && ...`), and file, search and patch tools use absolute paths under W. Sources and the selected environment are already bound; do not repeat session setup. Official Kimi calls to the task, remote-dev and knowledge MCP providers also carry the returned `context_file`. Other clients receive context through hooks; if a tool reports missing context, pass the existing `context_file`. Use configured knowledge tools when useful.
@@ -55,6 +57,10 @@ Native worktree setup is an optional optimization; official clients also use
 the shared new-session entry. Client trust remains native. Do not
 rerun all-client setup, poll its record or repeat questions for ordinary work.
 Explicit initialization or repair can rerun the same idempotent entry.
+Complete dependency and client setup before the first business session. If the
+running client does not load the new hooks/providers immediately, reopen the
+project or start a new native session once and complete its trust prompts.
+This is part of initialization, not a recurring session check.
 
 Each new native task selects its editing workspace, checks upstream once and
 fixes its component environment. Existing native worktree callbacks can perform

--- a/README.en.md
+++ b/README.en.md
@@ -10,7 +10,7 @@ Open this checkout in an Agent client and ask:
 
 > Initialize this workspace for vLLM Ascend development.
 
-Initialization reuses configuration, installs locked packages and runs `vaws_client_setup.py --client all --apply` to detect and configure installed Agent clients together. Invoking a Skill is optional. The result identifies supported native defaults and any remaining native choices, which can be completed once through client tools or computer use. Configured clients create worktrees and run setup before Agent work; ordinary sessions need no VAWS launcher command. Versions and real acceptance boundaries are in [native client acceptance](docs/native-client-validation-2026-09-12.md) and [native workspace isolation](docs/native-workspace-isolation.md). Installation and platform behavior are in [dependency-plane.md](docs/dependency-plane.md) and [platform-contract.md](docs/platform-contract.md).
+Initialization reuses configuration, installs locked packages and runs `vaws_client_setup.py --client all --apply` to configure installed Codex, Cursor, Claude, Grok and Kimi clients together. It requires neither invoking a Skill nor installing a personal client build. Short project guidance prepares one independent editing directory, upstream revision and component environment per new task; existing native worktree setup results are reused directly. Users keep working in their usual client, and resume retains the original directory and environment. See [workspace isolation](docs/native-workspace-isolation.md) for the contract and [this round's acceptance record](docs/unified-session-validation-2026-09-13.md) for verified scope. Installation and platform behavior are in [dependency-plane.md](docs/dependency-plane.md) and [platform-contract.md](docs/platform-contract.md).
 
 For daily work, describe the outcome and the inputs that matter:
 
@@ -63,6 +63,8 @@ Skill selection follows the task. Detailed inputs and procedures live beside the
 ## Repository and local state
 
 The canonical repository is `vllm-ascend-workspace/vllm-ascend-workspace`. Git submodules `vllm/` and `vllm-ascend/` remain on their community upstreams. Personal forks are development remotes; setup preserves established remote choices.
+
+A new task checks canonical main once and selects that revision's locked component combination; no Release is required. Startup binds the returned editing directory as task sources, and the MCP gateway routes calls to the task's fixed environment. The client's displayed cwd may stay at the original project. Work and resume do not switch versions. Related worktrees share knowledge configuration, content and reusable model/index state. See [forks and updates](docs/forks-and-updates.md).
 
 `.agents/skills/` contains business skills, `.agents/lib/` contains shared consumer code, and `.agents/scripts/` contains client wiring and maintenance tools. Client projections route to canonical skills. Runtime state and private configuration stay under untracked `.vaws-local/`; credentials are never committed. Public knowledge uses only package-prepared redacted copies.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 > 初始化这个工作区，配好 vLLM Ascend 的开发环境。
 
-初始化复用已有配置，安装锁定依赖，并通过 `vaws_client_setup.py --client all --apply` 一次检测和配置已安装的 Agent 客户端；不以调用 `repo-init` Skill 为前提。原生支持的默认模式由配置处理，仍需客户端界面完成的选择会在初始化时明确列出，由可用的客户端工具或 computer use 完成。配置后的新会话由客户端创建 worktree、运行 setup，再让 Agent 开始工作；日常无需 Agent 运行启动 CLI。已验证版本及实际边界见[原生客户端验收](docs/native-client-validation-2026-09-12.md)和[原生客户端与编辑隔离](docs/native-workspace-isolation.md)。安装与平台行为见 [dependency-plane.md](docs/dependency-plane.md) 和 [platform-contract.md](docs/platform-contract.md)。
+初始化复用已有配置，安装锁定依赖，并通过 `vaws_client_setup.py --client all --apply` 一次配置已安装的 Codex、Cursor、Claude、Grok 和 Kimi；不以调用 Skill 或安装个人修改版客户端为前提。项目短指引让新任务准备一次独立编辑目录、主仓版本及配套环境；已有原生 worktree setup 的结果直接复用。用户继续在原客户端表达目标，恢复会话沿用原目录和环境。实际边界见[编辑隔离合同](docs/native-workspace-isolation.md)，本轮实测进度见[验收记录](docs/unified-session-validation-2026-09-13.md)。安装与平台行为见 [dependency-plane.md](docs/dependency-plane.md) 和 [platform-contract.md](docs/platform-contract.md)。
 
 日常工作只需说明目标和影响结果的输入，例如：
 
@@ -64,7 +64,7 @@ Agent 按任务选择工具或技能；执行引用、状态推进和报告由�
 
 规范仓库是 `vllm-ascend-workspace/vllm-ascend-workspace`。`vllm/`、`vllm-ascend/` 是指向社区上游的 Git 子模块。首次使用由 `AGENTS.md` 和原生客户端入口提示 GitHub 身份，无需调用 `repo-init`；开发 Fork 必须属于个人账号，`origin` 指向个人 Fork，`upstream` 保留官方来源。
 
-配置后，原生客户端的新 worktree setup 检查一次 VAWS 主仓，为符合条件的新目录采用该提交、锁定依赖和客户端接线，并同步个人 Fork，无需等待 Release。新会话固定代码和环境；已有目录与恢复会话沿用原版本，工作中不检查或切换更新。普通 Local 会话不会被 hook 自动换成 worktree。见[个人 Fork 与自动更新](docs/forks-and-updates.md)。第一版已接通共享 root 下的用户容器命名、随正常调用投递的留言和算子产物缓存；权重沿用服务器现有路径，初始化后无需 Agent 填写身份、轮询或登记成果。见[身份与协调](docs/identity-and-agent-coordination.md)。
+新任务检查一次 VAWS 主仓，采用该提交的锁定组件组合并同步个人 Fork，无需等待 Release。启动入口绑定返回目录的 sources，MCP gateway 为该任务固定组件环境；客户端 UI 可以保持原目录，Agent 在返回目录中编辑。工作中和恢复会话不检查或切换版本，知识配置、内容和模型/index 缓存按工作区家族复用。见[个人 Fork 与自动更新](docs/forks-and-updates.md)。共享 root 下的用户容器命名、随正常调用投递的留言和算子产物缓存由组件处理；权重沿用服务器现有路径，初始化后无需 Agent 填写身份、轮询或登记成果。见[身份与协调](docs/identity-and-agent-coordination.md)。
 
 `.agents/skills/` 保存业务技能，`.agents/lib/` 保存共享消费代码，`.agents/scripts/` 保存客户端接线和维护工具。客户端投影统一指向规范技能。运行状态和私人配置放在未跟踪的 `.vaws-local/`，凭据不入库。公开知识只使用包生成的脱敏副本。
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,11 +8,11 @@ command recipe. Superseded designs and duplicate inventories are retained in Git
 
 ## Current contracts
 
-- [forks-and-updates.md](forks-and-updates.md) — Skill-independent first use, personal forks and upstream preparation in native new-worktree setup before the Agent starts.
+- [forks-and-updates.md](forks-and-updates.md) — Skill-independent first use, personal forks and one upstream preparation per new task.
 - [identity-and-agent-coordination.md](identity-and-agent-coordination.md) — shared-root user attribution, opportunistic message delivery and compiled-output reuse; first-version boundaries are explicit.
 
 - [platform-contract.md](platform-contract.md) — common Windows/macOS/Linux entry points, literal process arguments, native owners and immutable environments.
-- [native-workspace-isolation.md](native-workspace-isolation.md) — native worktree setup, per-client capability boundaries, automatic attachments and fixed local environments; CLI copying is optional.
+- [native-workspace-isolation.md](native-workspace-isolation.md) — official five-client startup guidance, editing paths, automatic attachments and exact task component selection; native setup is optional.
 
 - [design-principles.md](design-principles.md) — nine governing principles; total Agent task cost takes priority, tools stay bounded, knowledge is advisory, and valid work is reused.
 - [windows-installation.md](windows-installation.md) — PowerShell setup, same-filesystem uv cache and verified offline transfer.
@@ -31,6 +31,8 @@ command recipe. Superseded designs and duplicate inventories are retained in Git
 - [tracked-path-guard.md](tracked-path-guard.md) — anti-rot guard against dead in-tree paths in tracked docs.
 
 ## Dated design and validation evidence
+
+- [unified-session-validation-2026-09-13.md](unified-session-validation-2026-09-13.md) — unified official-client preparation and MCP routing; acceptance progress and pending native cases are explicit.
 
 - [native-client-validation-2026-09-12.md](native-client-validation-2026-09-12.md) — native worktree preparation, real client tasks and resume behavior, plus supported client extension boundaries.
 

--- a/docs/coordinator-consumption.md
+++ b/docs/coordinator-consumption.md
@@ -12,24 +12,28 @@ See [target-state.md](target-state.md) and [dependency-plane.md](dependency-plan
 
 ## 1. Public actions
 
-Configure clients with `uv run --no-project python .agents/scripts/vaws_client_setup.py --client CLIENT --apply`.
-Native hooks attach the session automatically. Codex, Claude, Cursor and Grok
-task-tool hooks inject `context_file`; an Agent does not need a preliminary
-session call. Kimi Code currently supplies context in its prompt hook but has
-no tool-input rewrite, so it is not equivalent to those adapters. Local Codex
-commands can resolve the actual `CODEX_THREAD_ID`, and Claude exports context
-through its session environment. Never guess the task from cwd or history.
-See [MCP and shell context](native-workspace-isolation.md#context-in-mcp-and-shell)
-for the remaining shell-entry limits.
+Configure installed clients once with
+`uv run --no-project python .agents/scripts/vaws_client_setup.py --client all --apply`.
+Native hooks attach the session. Shared project guidance prepares a new task's
+editing workspace and fixed component environment through `vaws_start.py`, unless
+native setup already supplied them. Preparation binds the selected source roots;
+`vaws_session` is not a prerequisite. Resume reuses the original selection.
 
-Kimi Code reads hooks from `~/.kimi-code/config.toml` (or `KIMI_CODE_HOME`)
-and discovers project `.kimi-code/mcp.json`. Setup returns its executable and
-working directory. The legacy Python `kimi-cli` has a different configuration
-contract and is not the Kimi Code client supported by this setup.
+The stable MCP gateway routes task tools to that task's selected coordinator
+package using explicit context or actual native metadata. Codex, Claude, Cursor
+and Grok hooks can supply `context_file`. Official Kimi exposes context through
+its prompt hook and carries it explicitly in startup and all three VAWS providers'
+calls. Never guess identity from cwd or history. See
+[MCP and shell context](native-workspace-isolation.md#context-in-mcp-and-shell).
+
+Kimi Code reads hooks from `~/.kimi-code/config.toml` (or `KIMI_CODE_HOME`).
+Setup configures project and user MCP providers using the supported official
+contract. A personal SessionSetup extension is optional; stock clients do not
+receive unknown hook events. The legacy Python `kimi-cli` is a different client.
 
 | Tool | Meaning |
 |---|---|
-| `vaws_session` | Optional inspection or explicit source-default override; native attachment already binds the actual worktree |
+| `vaws_session` | Optional inspection or explicit source-default override; startup already binds the selected editing roots |
 | `vaws_run` | Submit `command` plus optional `sources` / `env` / `environment` / `resources` / `topology` / `timeout_seconds` / `service` / `restart`. Skills do not pass `request_id` / `profile_key` / `runtime_id` / a Python path |
 | `vaws_execution` | Status, tail, stop, or read the ordinary endpoint of one owned execution |
 | `vaws_finish` | Close admission; stop owned executions; keep container, roots, evidence |
@@ -45,9 +49,10 @@ These observations do not grant resource access. Tail, target and stop keep
 their existing behavior.
 
 Package CLI: `python -m vaws_coordinator.vaws session|run|execution|finish`.
-MCP: `python -m vaws_coordinator task-server`.
+The gateway starts MCP backend `python -m vaws_coordinator task-server` in the
+task's selected environment.
 
-`sources` omitted uses the attachment's selected worktrees; `sources={}` runs
+`sources` omitted uses the effective task source defaults; `sources={}` runs
 without project sources. An explicit map selects sources for that execution.
 Names are not restricted to vLLM repositories. Admission captures fixed Git
 commits including dirty edits without modifying HEAD or the user's index.
@@ -98,19 +103,14 @@ not a per-model launch snippet.
 
 There is no workspace `leases.json` and no `session.json` resource authority.
 
-For a Windows checkout shared with WSL, generated WSL clients use the Windows
-workspace interpreter for task tools and session hooks. Source and context
-paths on mounted drives are normalized by the coordinator. Explicit remote
-tools normally use the client's native interpreter. Kimi Code is the shared
-project-config exception: when the project and Windows environment are on the
-same mounted drive, all three MCP entries use a project-relative Windows
-Python command. The same `.kimi-code/mcp.json` then runs from the project cwd
-in Windows and WSL without being rewritten between launches. Kimi session
-hooks remain in each platform's own Kimi home configuration. Existing custom
-server commands and environment values are preserved. Windows MCP entries
-include the `WSLENV` forwarding list so explicit state and custom environment
-values reach a Windows process launched from WSL. A Linux daemon refuses
-a state directory already owned through Windows IPC.
+For a Windows checkout shared with WSL, task tools and hooks retain the existing
+Windows owner and its selected interpreter. Mounted-drive source and context
+paths are normalized by coordinator. Native gateway generation preserves custom
+server fields and the required environment forwarding; Linux refuses a state
+directory already owned through Windows IPC. This does not imply support for
+native worktree setup from a WSL `/mnt` path. See the
+[platform contract](platform-contract.md) for interpreter and linked-worktree
+boundaries; configuration tests do not replace a real client launch.
 
 ## 3. User container
 

--- a/docs/dependency-plane.md
+++ b/docs/dependency-plane.md
@@ -38,12 +38,19 @@ combination from the official default branch. It invokes that revision's sync
 entry in an isolated checkout and prepares its pinned vaws-top wheel.
 Configured Codex/Cursor native worktree setup prepares once after the client
 creates a directory and before the Agent starts. It fixes the chosen environment
-and that directory's MCP/hook wiring. The callback does not create another editing
-copy or run from SessionStart/resume. Existing directories, resumed sessions and
-running services keep their selected environments; there is no periodic updater.
-Component releases do not trigger unrelated per-component upgrades. The optional
-CLI launcher uses the same updater, without becoming an Agent task prerequisite.
-Setup wiring has contract tests; real GUI new-session acceptance remains pending.
+and that directory's MCP/hook wiring. All five official clients also receive the
+same short `AGENTS.md` startup guidance. A prepared independent native worktree
+is reused; otherwise the first repository operation calls
+`uv run --no-project python .agents/scripts/vaws_start.py --client CLIENT`
+with the existing `--context-file PATH` when needed. This bounded entry prepares
+the canonical default branch with its latest locked components, creates an
+independent worktree, binds explicit sources and saves the task selection in
+`.vaws-local/tasks/<task-id>/start.json` under the shared primary worktree.
+It requires no Skill or client fork. Resume and repeated calls reuse that
+selection; running services keep their loaded environments. There is no periodic
+updater or unrelated per-component upgrade. The optional CLI launcher remains
+separate from this native-session entry. Dated native acceptance records do not
+establish acceptance of a subsequently changed startup or provider path.
 
 ## Loader
 
@@ -94,9 +101,10 @@ last. The selected base Python and store paths are resolved to physical paths so
 an interpreter alias change cannot replace a running client's dependencies.
 An ordinary command reads the ready receipt and never installs packages.
 
-After a successful install, `sync` runs the installed knowledge package's
-`prepare --project ROOT` command. This prepares the model and local index before
-normal use. The JSON retains the dependency install result and reports
+After a successful install, `sync` invokes the installed knowledge package's
+preparation APIs in the selected interpreter, using the shared service
+configuration to prepare the model and index. The JSON retains the dependency
+install result and reports
 `knowledge.status` and `knowledge.ready` separately. Pending knowledge does not
 change a successful dependency install's exit code or block ordinary tools.
 
@@ -109,14 +117,27 @@ sync still prepares knowledge, and real provider readiness is checked separately
 Entry scripts select a prepared platform environment. Interpreter flags and `-m`
 module calls survive re-execution; native Windows launches use UTF-8 and retain
 child-process ownership. A missing installation returns the bootstrap command
-as its remedy. Native client setup pins each MCP/hook process to its ready
-receipt, so later syncs do not change its imported dependencies.
+as its remedy. Hooks and the native MCP gateway start in a prepared environment.
+The gateway (`vaws_native_mcp.py` / `vaws_mcp_runtime.py`) resolves calls from an
+existing `context_file` or supported native metadata and reads the task's fixed
+workspace/receipt. It launches task, remote-dev and knowledge package backends
+with that receipt's Python and workspace cwd. A native worktree already prepared
+at startup can supply its saved selection directly. Missing task preparation or
+context produces an explicit error instead of selecting a recent task.
+
+Backends are retained by workspace and receipt. A long-lived gateway can serve
+tasks with different fixed environments; later syncs or a newer catalog selection
+do not replace their imported dependencies. Tool results expose the selected
+environment, workspace, Python and backend stderr path. Official Kimi passes the
+returned `context_file` to all three providers; clients without supported native
+metadata also need their existing context supplied by hooks or tool arguments.
 
 In a checkout shared by Windows and WSL, managed tasks and knowledge use the
 prepared Windows owner. A managed CLI switches owner before reading stdin or
-performing work; local analysis and explicit endpoint I/O stay native. Same-drive
-Kimi project MCP entries use a permanent per-environment junction with a relative
-Windows interpreter path. Run `uv run --no-project python
+performing work; local analysis and explicit endpoint I/O stay native. Existing
+per-environment Windows launch aliases remain immutable. The new gateway does
+not extend the supported mixed-OS worktree or owner boundaries.
+Run `uv run --no-project python
 .agents/scripts/vaws_client_setup.py --client CLIENT --project PATH --apply` to
 generate configuration; managed entries retain custom fields and foreign
 launchers. The [platform contract](platform-contract.md) describes the common
@@ -148,8 +169,18 @@ shared downloads; it does not create a fork or enable public contribution.
 Existing publishing configuration is preserved. `--contribute` explicitly enables
 authorized contribution; `--read-only` disables contribution while keeping shared
 downloads. A repository change alone preserves the existing contribution choice.
-Then refresh selected clients with `vaws_client_setup.py --apply` so MCP receives
-`.vaws-local/knowledge/service.json` and supported final-response hooks.
+Then refresh selected clients with `vaws_client_setup.py --apply` to install the
+MCP wiring and supported final-response hooks.
+
+Clients and linked worktrees use the shared primary worktree's
+`.vaws-local/knowledge/service.json`. Preparation refreshes its owned project
+Markdown snapshot from the selected workspace and retains custom mounts,
+candidate storage, backend settings and contribution choices. Default model and
+index state also live under this shared knowledge directory; they are not copied
+per editing worktree. Gateway routing fixes the package interpreter for each task,
+while the service configuration and reference content are shared. Package owners
+retain index maintenance, locking and model lifecycle; shared paths alone do not
+prove compatibility across concurrently running package versions.
 
 Knowledge MCP starts its internal model/index maintenance while alive, independent
 of public contribution. Shared synchronization is enabled by default and consumes
@@ -195,4 +226,9 @@ without starting OpenViking. `--install-dir <client-skill-directory>` installs
 that same packaged resource for native discovery. Workspace does not keep a
 second canonical copy or require curation for ordinary capture.
 
-Doctor also reads the running coordinator identity without launching a daemon. Its loaded version/commit can differ from the installed package after sync; use `vaws-coordinator daemon --action restart-if-idle` after owned executions and leases finish. Task MCP responses carry their own startup identity; refresh their native-client process separately when stale. Missing loaded identity remains unknown.
+Doctor also reads the running coordinator identity without launching a daemon.
+Its loaded version/commit can differ from the installed package after sync; use
+`vaws-coordinator daemon --action restart-if-idle` after owned executions and
+leases finish. Task MCP responses carry their backend's startup identity. A newer
+installed or catalog version does not hot-upgrade a task bound to an older
+receipt. Missing loaded identity remains unknown.

--- a/docs/forks-and-updates.md
+++ b/docs/forks-and-updates.md
@@ -2,36 +2,22 @@
 
 Status: current
 
-目标是首次真正使用仓库时即可建立个人开发配置，在原生客户端的新 worktree
-交给 Agent 前跟上主仓。
-不要求知道或调用某个 Skill。仅将身份校验、Git fast-forward、锁定依赖准备
-这些边界明确的操作工具化。常规更新由客户端生命周期回调消化；只有需要处理的
-特殊 remote、分叉历史或版本切换取舍才交给 Agent。遵循[九条设计原则](design-principles.md)。
+首次使用确认个人 GitHub 身份并配置客户端。之后，新任务在独立编辑目录中
+采用本轮主仓版本和配套组件，开始工作后保持固定。入口不依赖用户调用 Skill，
+也不要求安装个人修改版客户端。遵循[九条设计原则](design-principles.md)。
 
-## 首次使用入口
+## 首次使用
 
-| 使用方式 | 首次发现 | 更新方式 |
-|---|---|---|
-| 首次直接打开仓库使用 Agent | 根 AGENTS.md 说明一次身份确认 | 初始化接通所选客户端的 Worktree 模式和环境；已打开的目录保持原版本 |
-| 已配置的 Codex / Cursor 原生 Worktree 会话 | 客户端创建目录并调用 setup | Agent 开始前检查主仓、准备新目录及配套环境；SessionStart 自动关联 VAWS |
-| 已有目录、恢复会话或普通 Local 会话 | 客户端提供原生 ID 和实际 cwd | 保留代码和环境；不会由 session hook 另建目录或切换目录 |
-| 可选 CLI 入口 | 本地配置检查，缺身份时一次可见提示 | 新建编辑副本前检查和准备一次；已有目录复用原版本 |
-| 无 Agent / 无 hook | 直接调用通用脚本 | 显式 check、prepare 或 apply，无常驻进程 |
-
-Git clone 不会执行仓库代码；AGENTS.md 不是操作系统 hook，因此不声称仅 clone
-就会运行程序。初始化时一次选好原生 Worktree 模式和环境，后续新会话由客户端
-自动执行 setup，不要求 Agent 调用启动脚本。原生配置文件、客户端的环境选择与
-MCP 启用是不同的初始化状态，不能仅凭写文件宣称接通。实际验收记录见
-[原生客户端验收](native-client-validation-2026-09-12.md)，各客户端的能力边界见
-[原生客户端与编辑隔离](native-workspace-isolation.md)。
-身份待确认、离线或准备失败时，保留可用的本地版本；轻量 Review、目录查询
-和其他独立本地工作不需要先完成更新。
+根 `AGENTS.md` 提供首次身份提示和新任务入口；初始化通过
+`vaws_client_setup.py --client all --apply` 配置已安装的五种客户端。
+原生客户端负责项目与 hook 信任。Git clone 本身不执行代码，写出配置文件
+也不等于客户端已经加载配置；真实验收见[本轮验收](unified-session-validation-2026-09-13.md)。
 
 首次确认个人 GitHub 用户名。`gh` 登录是候选，不能静默代替用户选择。
 确认结果位于未跟踪的 `.vaws-local/github.json`，不包含凭据。
-coordinator 自动读取它并绑定 native session 的用户归属，SSH 仍使用 root；
-具体行为见[用户与协调](identity-and-agent-coordination.md)。GitHub 为新 Fork
-分配不同仓库名时，配置保存实际地址，新编辑副本和更新器沿用同一地址。
+coordinator 自动将它用于 native session 的用户归属，SSH 仍使用 root；见
+[用户与协调](identity-and-agent-coordination.md)。身份待确认时，独立本地查询
+和 Review 可继续，不重复追问或添加任务检查清单。
 
 ## 个人 Fork
 
@@ -40,41 +26,79 @@ uv run --no-project python .agents/scripts/workspace_forks.py
 uv run --no-project python .agents/scripts/workspace_forks.py --github-user USER --apply
 ```
 
-默认只读计划；用户接受后 apply。默认覆盖 workspace、vLLM、vLLM-Ascend；
+默认只读计划；用户接受后 apply。默认覆盖 workspace、vLLM、vLLM-Ascend，
 `--repo workspace` 可只配置主仓。入口为纯标准库，不依赖 Skill 或 VAWS runtime。
-
-校验当前认证 User、实际 full_name、owner.type、fork 标记和 canonical
-parent/source network，拒绝组织 Fork、指向其他所有者的 redirect、同名独立
-仓库和不相关 Fork。`origin` 是个人 Fork，`upstream` 是官方来源。
-`.gitmodules` 保留社区 URL；先初始化子模块再配置其 remotes，防止误改父仓库。
+工具核对认证 User、实际仓库名、个人所有者及 canonical fork network，拒绝组织
+Fork、其他所有者的 redirect 和无关同名仓库。`origin` 是个人 Fork，`upstream`
+是官方来源；GitHub 分配不同 Fork 名时保存并复用实际地址。
+`.gitmodules` 保留社区 URL；先初始化子模块再配置其 remotes。
 
 重复执行复用正确 Fork，保留额外 remote、脏内容和 Git HEAD。复杂 fetch/push
-配置报告具体差异，显式替换时保存备份。组件只在需要贡献时 fork；安装使用
-工作区锁定提交。本次 coordinator 测试版暂时锁定个人 Fork 的 `0.4.1.dev1`
-提交，正式组合再由维护者更新为官方版本。知识公开贡献由 knowledge package 管理，配置代码 Fork 不启用
-公开知识发布；它也必须遵循个人 Fork 约束。
+配置报告具体差异，显式替换时保存备份。组件只在需要贡献时 fork，安装使用
+工作区锁定的版本。公开知识贡献由 knowledge package 管理；配置代码 Fork
+不会启用知识发布。所有开发 Fork 都应属于个人 GitHub User。
 
-本轮自动校验覆盖上述三个开发仓库。外部组件包自己的 Fork/贡献入口还需要由
-各 owner 接入同样的校验；这里没有改其已发布代码，不能声称所有外部入口已强制执行。
+工作区入口校验上述三个开发仓库；外部组件的贡献入口由其 owner 负责。
+这不是拦截任意终端 Git 命令的权限系统。
 
-这是项目入口和工具的规则，不是劫持用户任意终端 Git 命令。
-组织级强制治理需要另配置 GitHub 权限和分支规则。
+## 每个新任务准备一次
 
-## 配套组件随工作区提交更新
+| 场景 | 行为 |
+|---|---|
+| 原生客户端已经创建独立 worktree，并由 setup 选定环境 | 直接使用已有目录和环境 |
+| 普通新会话尚未准备 | 项目短指引使 Agent 首个仓库动作运行 `vaws_start.py --client CLIENT` |
+| 同一任务重复准备 | 返回已完成的选择，不再 fetch、安装或创建目录 |
+| 恢复会话 | 沿用原任务、目录和环境，无准备或更新步骤 |
 
-主仓默认分支的每个提交通过 pyproject.toml、uv.lock、vaws-top wheel pin 和
-submodule gitlink 一起确定版本，不另复制一套 SHA 清单。组件更新后，维护者
-更新 workspace 锁定输入并验证；用户随主仓自动取得这套配套版本，不必等待
-workspace Release，也不各自追逐所有组件仓库的最新分支头。
-共享知识内容的 Release 继续由 knowledge package 自己同步。
+`vaws_start.py` 在母仓外的同级位置创建独立工作树，返回 `workspace`、`head`、
+`environment` 和 `context_file`，并绑定任务的默认 sources。用户继续使用原客户端，
+无需启动 VAWS launcher。客户端 UI/default cwd 可以保持原目录；后续 shell
+以返回目录为 cwd，文件、搜索和补丁使用该目录下的绝对路径。
+官方 Kimi 从已有 hook 取得 context，并将其传给启动命令及三个 VAWS MCP provider。
+各客户端短指引和边界见[编辑隔离合同](native-workspace-isolation.md)。
 
-正式 Release 仍可作为版本里程碑。`.github/workflows/release.yml`
-在官方仓库收到 `vMAJOR.MINOR.PATCH` tag 时，
-复用三平台消费者 CI，验证 monitor wheel 后才公开 Release。
-仅为审核过的官方主线提交打 tag，不移动已发布 tag；推荐启用 immutable releases。
-个人 Fork 不承担官方发布工作。
+准备检查 canonical 默认分支一次（当前为 main），不依赖 tag 或 Release。
+独立准备目录固定此次取得的精确 SHA；`vaws_deps.py sync --locked` 复用或创建
+该版本的不可变环境，并复用配套 monitor wheel。准备成功后，个人 Fork 默认分支
+仅 fast-forward 到该提交。同一提交已准备完成就复用，不重复下载。
+沿用 `.vaws-local/updates/releases/<SHA>` 缓存名不代表要求发布 Release。
 
-## 检测、准备和采用
+Codex 本地环境 setup、Cursor setup-worktree，以及客户端已有的原生创建回调
+仍可提前完成准备；它们只处理客户端刚创建的目录，不通过 hook 修改父进程 cwd。
+已有用户 setup 命令保留，VAWS 准备置于其前。已有环境选择的目录再次 setup
+只复用和修复接线。原生机制见
+[Codex 本地环境](https://learn.chatgpt.com/docs/environments/local-environment) 和
+[Cursor worktrees](https://cursor.com/docs/configuration/worktrees)。
+
+原生回调仅对可识别的默认分支基线采用主仓更新；显式业务分支、旧提交和带改动
+来源保留原选择。detached 新目录恰好匹配默认 tip 时，客户端没有提供用户选择 ref
+的标记，无法再区分显式选择；结果记录这个边界。原生回调不初始化尚未拉取的子模块，
+也不覆盖准备期间发生的编辑。普通 fallback 在另一个目录准备主仓，不改母仓的业务分支。
+
+更新不可用时可使用可用的本地版本，并返回未更新原因。若本地依赖或接线也无法
+准备，则返回实际失败及证据，不报告已就绪。不自动 stash、reset、rebase 或强推。
+
+## 组件和知识
+
+主仓提交通过 `pyproject.toml`、`uv.lock`、vaws-top wheel pin 和 submodule gitlink
+确定配套版本。维护者更新并验证这组输入；新任务取得主仓所选组合，不各自追逐
+所有组件仓库的分支头。Release 可作为里程碑，不是更新触发条件。
+
+稳定的 MCP gateway 根据明确的 native context 路由到该任务固定的环境，启动
+其中的 coordinator、remote-dev 和 knowledge 后端。已有客户端 MCP 连接也可为
+新任务选择新后端；旧任务继续使用原环境，不被新任务升级。目录和环境选择记录在
+任务的 `start.json`，原生已准备目录也可从其已保存环境选择中复用。
+Gateway 不从最近任务或 cwd 猜身份，亦不将“最新环境”当旧任务的默认值。
+
+同一工作区家族共享知识配置、项目知识快照、候选内容和包维护的模型/index 缓存。
+共享知识内容更新独立于任务代码版本；普通任务无需复制知识库、重建相同索引或
+单独维护模型。用户自定义知识根和发布选择保留，默认不开启公开贡献。
+准备 pending 不阻止独立工具。详见[依赖合同](dependency-plane.md)。
+
+coordinator daemon 的 idle 升级和 monitor 的实例管理仍由各包负责；忙碌实例的
+状态不由 workspace 强制改写。没有每五分钟轮询、常驻代码 watcher 或工作中换版本。
+
+## 显式维护与证据
 
 ```text
 uv run --no-project python .agents/scripts/workspace_update.py check
@@ -82,71 +106,16 @@ uv run --no-project python .agents/scripts/workspace_update.py prepare
 uv run --no-project python .agents/scripts/workspace_update.py apply
 ```
 
-配置个人身份和客户端后，原生客户端创建新 worktree，再在 Agent 首次操作前
-调用 `vaws_worktree_setup.py`。Codex 使用选定本地环境的 setup；Cursor 使用
-生成的 `<project>/.cursor/worktrees.json` 中的 setup-worktree。两者把实际源目录和新目录传给
-回调，由回调检测一次官方 default_branch 的最新提交（当前为 main），不依赖
-tag 或 Release。原生回调机制分别见
-[Codex 本地环境](https://learn.chatgpt.com/docs/environments/local-environment) 和
-[Cursor worktrees](https://cursor.com/docs/configuration/worktrees)。
+这些是主动维护入口。`check` 查版本，`prepare` 准备精确提交，`apply` 只更新
+干净、无 merge/rebase 的默认分支；已初始化子模块须无业务改动，且只采用记录的
+gitlink。普通任务无需运行它们。`vaws_client.py` 仍是可选终端便利入口，恢复已有
+目录需给原 `--workspace PATH`；日常新任务使用项目指引即可。
 
-回调只处理客户端刚创建的目录，不另建一份 worktree，也不通过 SessionStart
-切换父客户端 cwd。采用新版后，在该目录固定不可变环境和所选客户端的 MCP/hook
-接线，再交还客户端。已有 setup 命令继续保留，VAWS 准备置于其前，使安装和
-构建脚本读取本次选择的版本。SessionStart 负责自动建立或恢复 VAWS 关联；Cursor 的
-preToolUse 在内部补入 context，先后触发的关联操作保持幂等，无需 Agent 处理
-hook 顺序。已有环境选择的目录重复 setup 时只复用和修复接线，不再检查更新。
-恢复原会话使用原生客户端的恢复功能，保留原目录和版本。没有每五分钟轮询、
-常驻 watcher 或工作中的版本切换。
+`.vaws-local/updates/state.json` 保留检测提交、当前步骤、结果和未完成原因，
+失败命令证据保留在 logs 子目录。更新目录 `config.json` 的 `enabled: false`
+暂停新任务自动更新；显式命令仍可用于维护。同一 Git 公共目录使用 OS 锁串行更新。
+状态记录事实，不承担任务或设备权属。
 
-`check` 只检查版本；`prepare` 在独立目录准备本轮取得的精确提交 SHA，调用该版本的既有
-`vaws_deps.py sync --locked` 复用不可变环境，并缓存/验证 vaws-top wheel。
-准备成功后，个人 Fork 默认分支仅 fast-forward 到该提交。主仓继续前进时，
-下次新建会话再检查；同一提交已准备完成则直接复用，不重复下载依赖。
-沿用早期 `.vaws-local/updates/releases/<SHA>` 缓存目录名以复用已有准备结果，
-目录名不代表必须有 Release。
-
-准备过程不改源工作目录。若来源是干净、可快进的默认分支，新 worktree
-与来源 HEAD 一致且没有本地改动，setup 可将这个尚未交给 Agent 的目录快进到
-准备好的主仓提交。Codex 默认创建路径还有一个可识别基线：detached 新目录精确匹配本地默认分支
-tip，且 origin/upstream 的默认分支记录一致。此时即使母仓在开发分支或有未完成
-改动，也只在独立缓存准备主仓版本，再快进这个新目录。原生 setup 不提供用户
-选择的 ref 标记，因此显式选择恰好同一默认 tip 无法区分；结果会记录这一边界。
-其他显式旧提交、业务分支或带改动来源继续保留；
-未初始化的子模块不因启动会话而拉取。回调再次检查新目录，避免覆盖准备期间
-发生的编辑。更新不可用时保留本地代码；若连本地依赖或客户端接线也无法准备，
-setup 返回失败事实，由原生客户端显示，不报告为已就绪。
-已有目录的显式维护可用 apply：要求干净默认分支、没有 merge/rebase，
-已初始化子模块无业务改动；只采用工作区固定的 gitlink，未初始化子模块保持原样。
-不适合自动更新的来源跳过用不上的依赖准备，返回保留原因。正常任务无需检查
-更新状态或运行 apply；仅在主动维护该目录或任务需要新版本时处理。
-
-`vaws_client.py` 保留为可选 CLI 便利入口。它在创建独立编辑副本前使用同一
-更新器；恢复时必须带原来的 `--workspace PATH`，原生 resume ID 只透传给
-客户端，不用于猜测历史目录。这不是日常原生会话的前置步骤。
-
-不自动 stash/reset/rebase/强推。运行中的 MCP、hook、coordinator 和服务
-继续使用旧环境；新的原生 worktree 可以采用准备好的新版本，恢复会话沿用原环境。
-新 coordinator 客户端遇到较旧 daemon 时使用既有 restart-if-idle 自动切换；
-忙碌时保留旧实例，旧客户端不会将新版
-降级。monitor 继续使用其既有实例管理机制。知识准备 pending 不阻止独立工具。
-
-## 可观察性
-
-`.vaws-local/updates/state.json` 保留检测到的默认分支、精确提交、当前步骤、准备结果和
-未完成原因；命令返回本轮结果，失败命令证据保留在 logs 子目录。
-配置该目录 config.json 为 `{"enabled": false}` 暂停新建会话时的自动更新。
-显式命令仍可用于检查和修复。状态只记录安装结果，不接管任务和设备权属。
-
-同一 Git 公共目录通过 OS 锁串行执行更新。共享 Windows 挂载目录的原生 setup
-需要由 Windows owner 执行；本轮不支持从 WSL 的 /mnt 路径运行这项回调，
-也不扩展混合系统 linked-worktree 承诺。已有更新器的 Windows owner 转发
-不等于原生 GUI 回调已通过跨系统验收。
-
-## 参考与取舍
-
-新会话需要选择代码和环境，因此更新放在客户端创建目录之后、交给 Agent 之前；
-会话开始工作后版本固定。
-这个边界无需定时进程、通知接收层或 Agent 轮询，也不增加每任务维护命令。
-依赖组合和安装复用遵循 [uv locking/syncing](https://docs.astral.sh/uv/concepts/projects/sync/)，
-运行进程由 workspace 已有不可变环境机制保护。
+Windows 挂载工作区的原生 setup 使用 Windows owner，不从 WSL 的 `/mnt` 路径
+运行该回调，也不承诺混合系统 linked-worktree 行为。原生 owner、回调和安装边界
+见[平台合同](platform-contract.md)。

--- a/docs/forks-and-updates.md
+++ b/docs/forks-and-updates.md
@@ -70,10 +70,13 @@ Codex 本地环境 setup、Cursor setup-worktree，以及客户端已有的原�
 [Codex 本地环境](https://learn.chatgpt.com/docs/environments/local-environment) 和
 [Cursor worktrees](https://cursor.com/docs/configuration/worktrees)。
 
-原生回调仅对可识别的默认分支基线采用主仓更新；显式业务分支、旧提交和带改动
-来源保留原选择。detached 新目录恰好匹配默认 tip 时，客户端没有提供用户选择 ref
-的标记，无法再区分显式选择；结果记录这个边界。原生回调不初始化尚未拉取的子模块，
-也不覆盖准备期间发生的编辑。普通 fallback 在另一个目录准备主仓，不改母仓的业务分支。
+原生回调可采用主仓更新的基线包括：新目录精确复制母仓当前 HEAD，或 Codex 的
+detached 新目录精确匹配可识别的本地默认 tip。母仓处于 feature 分支或有未完成
+改动，本身不阻止这个干净的新目录采用主仓。不同于这两类基线的显式 HEAD、
+fork 来源、已选环境及新目录中的编辑继续保留。客户端没有提供用户选择 ref
+的完整标记，显式选择恰好同一基线时无法再区分；结果记录这个边界。回调不初始化
+尚未拉取的子模块，也不覆盖准备期间发生的编辑。普通 fallback 在另一个目录
+准备主仓，不改母仓的业务分支。
 
 更新不可用时可使用可用的本地版本，并返回未更新原因。若本地依赖或接线也无法
 准备，则返回实际失败及证据，不报告已就绪。不自动 stash、reset、rebase 或强推。

--- a/docs/native-workspace-isolation.md
+++ b/docs/native-workspace-isolation.md
@@ -20,6 +20,9 @@ setup 是可复用的优化，不是所有客户端都必须具备的前置能�
 在母仓外的同级位置准备独立编辑目录，选择 canonical main 的精确提交及其锁定
 组件环境，显式绑定 sources，并返回 `workspace`、`head`、`environment` 和
 `context_file`。同一 task 重复调用复用已保存结果，不再次 fetch、安装或换目录。
+初始化状态由命令在本地读取；只有缺少首次配置时才返回 setup 提示，不让 Agent
+每次检查身份文件。多个会话同时准备时，命令显示并等待仓库更新锁，超时才返回
+等待时长和锁文件证据。
 它不是通用客户端 launcher，也不解析客户端的 resume 参数。
 
 后续 shell 使用返回目录作为 cwd，或者在命令中使用 `cd W && ...`；文件、搜索
@@ -78,6 +81,7 @@ context。Cursor 的已观测 MCP:toolName 形式也用于固定的 knowledge �
 remote 工具。官方 Kimi 没有同等的透明 native metadata，调用三个 VAWS provider
 时带已有 `context_file`。其他客户端若工具报告缺少 context，复用已有值即可，
 不用事先检查每次是否注入。gateway 会在转发非 task 工具前去掉这个路由字段。
+Kimi 的工具 schema 将此字段声明为必填，避免先失败一次才补入上下文。
 
 shell 与 MCP 的身份传递各自独立。shell 优先读取 VAWS_CONTEXT_FILE 或客户端
 提供的原生 ID；官方 Kimi 使用 hook 返回的显式 context。Bash 的一次 cd 不被
@@ -95,6 +99,9 @@ shell 与 MCP 的身份传递各自独立。shell 优先读取 VAWS_CONTEXT_FILE
 索引；模型下载复用知识包缓存。新工作树不另建一套知识库。共享知识内容可由
 知识包维护更新，但 task 使用的组件版本保持固定。查询和捕获按需使用，不要求
 额外维护命令、轮询或重复总结。用户选择的知识挂载和发布设置保留。
+原生回复事件自动保存已有最终文本。Kimi Stop 和 Cursor 命令行 SessionEnd
+不直接携带这段文本时，适配器只读取该事件明确对应的会话记录尾部，提取已完成
+的最终回复；不扫描其它会话，也不要求 Agent 再总结。
 
 来源优先级为本次 run 显式 sources、task 显式默认值、attachment 自动来源。
 更新 attachment 的实际 cwd 不覆盖 task 的显式工作树，也不改变已接纳的执行。

--- a/docs/native-workspace-isolation.md
+++ b/docs/native-workspace-isolation.md
@@ -2,171 +2,114 @@
 
 Status: current
 
-默认接入客户端自己的会话生命周期。初始化时一次选好原生 Worktree 模式和
-环境；之后用户正常创建会话，客户端创建目录并运行 setup，再让 Agent 开始
-操作。setup 为符合条件的新目录检查主仓、采用准备好的代码，并固定配套依赖
-和客户端接线。SessionStart 自动关联实际会话与 cwd，Agent 不需要先调用
-VAWS 启动 CLI 或填写会话记录。已有目录和恢复会话保留代码、任务身份和环境。
+官方 Codex、Cursor、Claude Code、Grok 和 Kimi Code 共用项目启动指引。
+首次初始化配置客户端 hooks、MCP providers 和项目指引；用户照常创建会话，
+无需调用 Skill、选择额外 VAWS 启动器或安装个人客户端补丁。原生 worktree
+setup 是可复用的优化，不是所有客户端都必须具备的前置能力。
 
-普通 Local 会话仍在客户端选定的目录中，不会由 hook 强制变成 worktree。
-客户端选目录，setup 准备这个尚未开始工作的目录，session hook 记录原生身份；
-三个时点各自承担明确职责。
+## 新建与恢复
 
-首次初始化统一运行 `vaws_client_setup.py --client all --apply`。它按已安装的客户端
-配置接线和原生支持的默认偏好，保存逐客户端结果，并在同一次初始化中列出仍需
-原生界面完成的操作。Agent 可用客户端工具或 computer use 完成这些操作；没有
-接口的项目明确报告，不把生成配置文件算作启用。普通业务会话不运行此命令，
-不会逐次扫描客户端、核对状态或补登记。原生信任仍由客户端处理。
+新任务有两条准备路径：
 
-## 原生接入范围
+- 客户端已创建独立 worktree，且 setup 已提供选定环境：直接使用这个目录。
+- 普通项目目录中的新会话：项目指引让 Agent 的第一个仓库操作运行一次
+  `uv run --no-project python .agents/scripts/vaws_start.py --client CLIENT`。
+  官方 Kimi 加上原生 hook 已提供的 `--context-file PATH`。
 
-| 客户端 | 已接入的生命周期 | 当前边界 |
+`CLIENT` 是 codex、cursor、claude、grok 或 kimi。命令复用当前原生 task，
+在母仓外的同级位置准备独立编辑目录，选择 canonical main 的精确提交及其锁定
+组件环境，显式绑定 sources，并返回 `workspace`、`head`、`environment` 和
+`context_file`。同一 task 重复调用复用已保存结果，不再次 fetch、安装或换目录。
+它不是通用客户端 launcher，也不解析客户端的 resume 参数。
+
+后续 shell 使用返回目录作为 cwd，或者在命令中使用 `cd W && ...`；文件、搜索
+和 patch 使用该目录中的绝对路径。客户端 UI 和默认 cwd 可以保留原项目。
+这能完成隔离编辑，不声称子进程 `cd` 可以改变父客户端或所有工具的默认根目录。
+Grok 默认会过滤主仓内被忽略的目录，因此新编辑目录放在母仓外，不要求关闭
+Git ignore 或放宽全局权限。
+
+resume 沿用既有 task、编辑目录、sources 和环境，不调用新的准备流程。
+已经接纳的执行继续使用自己的固定输入。新建时失败返回阶段、原因和证据；
+不能把未准备成功的目录标为 ready，也不自动 stash、reset 或 rebase 用户工作。
+
+## 客户端接线
+
+`vaws_client_setup.py --client all --apply` 一次配置实际已安装的客户端，保留
+用户自定义 provider、hook 和指引。结果保存在主工作树的
+`.vaws-local/client-initialization.json`；它不是每个任务的检查清单。
+原生信任和审批仍由客户端处理，配置生成不等于真实会话验收。
+
+| 客户端 | 普通新会话指引与 context | 可复用的原生能力 |
 |---|---|---|
-| Codex App | 选定 local environment 的 setup 准备客户端新建 worktree；用户级 SessionStart 关联 VAWS | 一次选择 Worktree 和 VAWS 环境；客户端按主机和项目目录记住模式，后续同项目会话沿用。使用 --codex-global-hooks 并原生审阅固定 hook。创建任务 API 使用原生保存的环境选择；仅写配置文件或 Git key 不等于选定。 |
-| Cursor | worktrees.json 的 setup-worktree 准备新目录；sessionStart / preToolUse 自动关联 | 一次将 Default Environment 选为 New Worktree，并使用 --cursor-global-mcp 安装用户级 VAWS providers；新目录无需重复启用项目 MCP。 |
-| Claude Code | WorktreeCreate 创建并准备目录；SessionStart 关联；MCP/Hook 启动时读取实际目录的固定环境 | 使用原生 worktree 模式。2.1.269 已验证新建与从母仓恢复；旧 2.1.143 跨目录恢复存在客户端问题。 |
-| Grok | 原生 Git worktree 创建触发项目 post-checkout；SessionStart / PreToolUse 自动关联 | 全客户端初始化一次将 cli.worktree_type 设为 git，new_session_worktree_mode / fork_worktree_mode 设为 always。普通启动还需要已验收的原生补丁；单客户端接线保留全局偏好。已有 Git hook 保留给其 owner 集成。 |
-| Kimi Code | 官方 0.42.0 的 SessionStart 只关联；带 SessionSetup 扩展的个人 fork 能在创建 workspace/MCP 前准备目录 | 扩展需单独安装并显式启用，不能将官方版本描述为已支持。新建、恢复、Bash/MCP 与子 Agent 使用原生身份。 |
+| Codex | AGENTS.md；MCP 的真实 thread metadata 或 hook 关联当前 task | App local environment setup 准备客户端创建的 worktree；固定用户 hooks 避免每个目录重复安装 |
+| Cursor | AGENTS.md 和 alwaysApply 项目规则；sessionStart / preToolUse 自动关联与注入 context | worktrees.json setup 准备新目录；用户级 providers 接收原生 workspaceFolder |
+| Claude Code | CLAUDE.md 导入 AGENTS.md；SessionStart 导出 context，PreToolUse 注入 | WorktreeCreate 可准备客户端选用的原生 worktree；薄入口保留真实调用者 |
+| Grok | 原生读取 AGENTS.md；Bash 提供 GROK_SESSION_ID，PreToolUse 注入 context | Git worktree 创建回调及原生 /new、/fork 偏好；普通入口不依赖个人修复版 |
+| Kimi Code | 原生读取 AGENTS.md；UserPromptSubmit 提供 context_file；准备命令和三个 VAWS provider 的调用显式携带它 | 显式启用的 SessionSetup 扩展可提前选目录，官方配置只使用受支持事件 |
 
-Codex 的[本地环境 setup](https://learn.chatgpt.com/docs/environments/local-environment)
-和 Cursor 的[worktree setup](https://cursor.com/docs/configuration/worktrees)在工作开始前
-准备目录。Claude 的[WorktreeCreate](https://code.claude.com/docs/en/hooks#worktreecreate)
-返回客户端采用的路径；部分版本提前读取 MCP 配置，因此生成的薄启动入口只按
-实际 cwd 读取已经选好的 receipt，再执行对应组件，不在启动时更新代码。
+Grok 的 SessionStart stdout 不会成为模型提示，因此启动入口放在客户端真实
+读取的项目指引中。Kimi 官方 Bash 有 cwd 参数，Read/Write/Edit 支持绝对路径；
+无需假定存在会话中途改根 API。客户端仍按自己的审批机制处理文件访问。
 
-Codex 按配置来源和定义内容记录 hook 信任。初始化将本仓生成的 hook 迁移到
-用户级固定入口，保留自定义 hook；新 worktree 的 setup 自动去掉重复的项目入口。
-固定入口只处理同一 Git 公共目录的原生 cwd，读取该目录已经选好的环境和任务
-设置，再运行组件 hook。新目录和依赖版本不会改变这条入口定义，正常会话无需
-重复信任。配置生成本身不授予信任；新定义仍需按原生机制审阅。
+原生机制分别见 [Codex local environment](https://learn.chatgpt.com/docs/environments/local-environment)、
+[Cursor worktrees](https://cursor.com/docs/configuration/worktrees)、
+[Claude WorktreeCreate](https://code.claude.com/docs/en/hooks#worktreecreate)
+和 [Kimi hooks](https://moonshotai.github.io/kimi-code/en/customization/hooks)。
+具体已测版本记录在 dated 验收文档，不能从配置规划测试推断所有新客户端均已通过。
 
-Grok 的原生补丁让普通新会话也消费自动 worktree 偏好，恢复沿用原目录；
-官方版本的相同偏好只覆盖 /new 和 /fork。Git 创建回调只处理 Grok
-目录下刚创建的 linked worktree，普通 checkout 和其他客户端目录不受影响。
-默认的复制模式不触发这个回调。正式版 1.0.30 在 worktree 内连续 /new 或
-/fork 的目录判断仍有客户端缺陷；已安装的个人修复版基于公开源码 1.0.24，
-保留官方二进制供回退。补丁来源与实测范围见验收记录。
-
-全客户端初始化保护已确认的个人客户端扩展：Grok 的安装记录与实际二进制
-匹配且已有启动/恢复验收时，设置原生 `[cli] auto_update = false`；Kimi 的实际
-parser 确认支持 SessionSetup 时，在原生 `$KIMI_CODE_HOME/tui.toml`（默认
-`~/.kimi-code/tui.toml`）设置 `[upgrade] auto_install = false`；这与运行配置
-`config.toml` 和 `--kimi-config` 无关。
-这避免官方自动安装覆盖已验收补丁。官方版或未确认构建保留原有更新设置；
-单客户端和每会话接线不调整这些偏好。
-
-Grok 还会兼容导入 Cursor MCP，但不能消费 Cursor 的 workspaceFolder 替换。
-全客户端初始化在确认三个 VAWS Cursor 入口由本仓生成、且已有有效 Grok
-入口时，将这些重复名称加入 Grok 用户级 disabled_mcp_servers。Cursor
-配置和其他兼容导入保留；自定义同名入口交给 Agent 判断。
-
-Kimi 官方[会话 hook](https://moonshotai.github.io/kimi-code/en/customization/hooks)
-执行时 cwd 已经确定，现有插件不能替换它。个人客户端扩展增加一个有界的
-SessionSetup：在原生 workspace/MCP 创建前消费返回 cwd；恢复沿用原目录。
-原生分叉使用新目录和新身份，保留当前暂存、未暂存、普通未跟踪内容、已初始化
-子模块和会话历史。分叉沿用原 HEAD 与已选环境，不检查上游；普通新会话继续
-执行启动时更新。历史位置分叉保持客户端原有的对话截断语义，不回滚当前文件。
-消费端通过 `vaws_client_setup.py --client kimi --kimi-session-setup --apply`
-显式接入，普通官方客户端配置不会包含未知事件。现有信任策略仍由客户端处理。
-扩展模式同时配置用户级 VAWS providers，避免每个新目录重复进行项目 MCP
-初始化。Cursor 的用户级入口通过原生 `${workspaceFolder}` 获得目录，Kimi
-通过原生进程 cwd 获得目录；两者只读取该目录已准备的环境 receipt，再启动
-固定的三个组件。自定义服务器保留，工作目录不会被用于推断任务身份。
-实际通过的任务、所用版本和剩余边界见
-[原生客户端验收](native-client-validation-2026-09-12.md)。
+初始化不再因个人二进制缺失而阻塞，也不为保护补丁关闭客户端自动升级。
+Kimi 普通配置会替换本仓精确拥有的旧 SessionSetup 回调，保留用户项；
+`--kimi-session-setup` 仅用于明确选用的扩展。Grok 的兼容导入去重只处理已确认由
+本仓生成、且存在有效替代的三个 Cursor provider 名称，不影响其他用户配置。
 
 ## Context in MCP and shell
 
-MCP 工具参数和 shell 子进程环境是不同的入口。Claude、Cursor、Grok
-的 task-tool hook 可在内部注入 context。Codex 的原生 MCP 调用通过
-`_meta.x-codex-turn-metadata.thread_id` 传递真实调用者，coordinator 查找
-SessionStart 已建立的关联；`functions.exec` 内的调用也无需手动传 context。
-直接工具调用仍可使用已有的 task-tool hook。Kimi 扩展直接在 MCP tools/call 的
-_meta 携带原生 session/agent ID，coordinator 查找已有的对应 attachment；
-不使用共享 MCP 进程自己的 session，也不从目录猜测用户或任务。
+原生会话身份、编辑目录和组件进程是三个不同对象。目录或最近会话不能证明
+任务身份。原生 hooks 建立 attachment；显式 context 或客户端提供的 native
+metadata 选择这个 attachment。工具收到的 context 与原生调用者冲突时返回事实。
 
-普通 skill CLI 复用 VAWS_CONTEXT_FILE。Codex、Cursor、Grok、Kimi 扩展还能按
-客户端提供的真实原生 ID 解析同一关联；Claude 通过 CLAUDE_ENV_FILE 导出
-context 和固定 receipt。Kimi 字面 main 表示根 Agent，其余 child ID 必须精确
-对应已存在的 attachment。Cursor shell 提供的 CURSOR_CONVERSATION_ID
-支持原生 UUID 会话自动关联；被编码或截断的非 UUID 值直接返回事实，不猜测
-原始身份。MCP 与 shell 的无参调用已分别验证，Agent 无需搬运 context 参数。
+MCP 使用稳定的 `vaws_native_mcp.py` gateway。它按当前 task 的固定选择启动或
+复用 task、remote-dev 和 knowledge 后端，不实现这些包的业务功能。已有长活
+MCP 连接可以服务另一个新 task 的新环境；恢复旧 task 仍调用它原来的环境。
+因此更新不要求 Agent 每次手工重连，也不在旧任务工作中热换包版本。
 
-MCP 同时在 text 和 structuredContent 返回相同的紧凑事实；full=true 才展开
-完整记录。只读取 text 的客户端也能看到任务、来源、失败原因和原始记录引用。
+Codex 使用真实 thread metadata；Claude、Cursor、Grok 的 PreToolUse 可以补入
+context。Cursor 的已观测 MCP:toolName 形式也用于固定的 knowledge 工具和
+remote 工具。官方 Kimi 没有同等的透明 native metadata，调用三个 VAWS provider
+时带已有 `context_file`。其他客户端若工具报告缺少 context，复用已有值即可，
+不用事先检查每次是否注入。gateway 会在转发非 task 工具前去掉这个路由字段。
 
-## 目录、身份与固定输入
+shell 与 MCP 的身份传递各自独立。shell 优先读取 VAWS_CONTEXT_FILE 或客户端
+提供的原生 ID；官方 Kimi 使用 hook 返回的显式 context。Bash 的一次 cd 不被
+当作身份、sources 或 MCP 版本变更。
 
-| 对象 | 所有者与边界 |
-|---|---|
-| 本地文件、HEAD、index | 原生客户端选择的 Git 工作目录 |
-| 原生会话与 task attachment | coordinator 的原生身份记录；目录名称不授予关联或资源权限 |
-| 已接纳执行的源码、环境、资源 | coordinator；后续本地编辑不会改变固定输入 |
-| 本地 Python 与客户端配置 | 消费者环境准备和 wiring |
+## 固定环境与共享知识
 
-SessionStart hook 可以记录实际 cwd 和关联来源，其子进程不能通过切换目录
-移动父客户端。原生 setup 只准备客户端传入的新目录，不另建第二份编辑副本。
-Cursor 的 preToolUse 可在 SessionStart 尚未完成时幂等建立同一个关联，并为
-托管调用注入 context；先后顺序无需 Agent 排错。恢复使用明确的原生会话 ID。
-缺失的旧目录、冲突的身份和不支持的来源直接返回事实，不按最近会话猜测。
+工作区提交及锁文件决定组件组合，准备完成后环境不可变。新任务的
+`.vaws-local/tasks/<task-id>/start.json` 保存选定结果；原生已准备的 worktree
+也可通过自己的环境选择被复用。gateway 按这个 task 选择后端，不从“最新环境”
+推断旧 task 的版本。后端 stderr 保留在主工作树的 `.vaws-local/mcp/providers/`，
+并记录实际解释器、环境键、目录和 receipt。
 
-客户端拥有 worktree 的 Git/index 与创建方式。setup 只采用能快进的准备版本，
-保留显式旧提交、业务来源和脏内容；未初始化的空子模块保持未初始化，不拉取
-轻量任务不需要的源码。当前回调要求来源和目标是同一 Git 公共目录下的不同
-工作目录，并且目标是新 worktree 根目录。条件不满足时返回具体原因。
+同一 Git 工作区的各会话共享知识 service 配置、项目知识快照、candidate 和
+索引；模型下载复用知识包缓存。新工作树不另建一套知识库。共享知识内容可由
+知识包维护更新，但 task 使用的组件版本保持固定。查询和捕获按需使用，不要求
+额外维护命令、轮询或重复总结。用户选择的知识挂载和发布设置保留。
 
-Hook 通过 Git common directory 识别关联仓库，不能用字符串父目录关系把
-嵌套的另一仓库当作同一项目。执行来源优先级为：本次 run 指定的 sources、
-显式 task 默认值、该 attachment 的自动来源。更新 attachment 的 cwd 不覆盖
-其他 attachment，也不改变已接纳执行。SessionStart 创建本地 VAWS task，
-不因此占用远端容器、设备或端口；这些能力在实际执行需要时参与。
+来源优先级为本次 run 显式 sources、task 显式默认值、attachment 自动来源。
+更新 attachment 的实际 cwd 不覆盖 task 的显式工作树，也不改变已接纳的执行。
+SessionStart 只建立本地关联，不因此分配容器、NPU 或端口。
 
-## 固定的本地环境
+## 平台与验收
 
-依赖环境由平台、架构、实际 Python/ABI、lock 和有效依赖选择决定内容键。
-相同输入复用已经完成的环境；显式 sync 构建缺失环境。原生新 worktree 的
-setup 可在 Agent 开始前准备新环境；已有目录和恢复会话读取原环境的 ready
-receipt，不安装依赖或运行全量 doctor。已发布环境不原地升级或搬迁。
-
-新目录中的 Hook/MCP 配置固定解释器和 receipt；业务入口从该目录的环境选择
-读取依赖，无需 Agent 执行 shell 激活。不将 setup 子进程的环境变量当成已经
-传回父 GUI 客户端的事实。依赖变更通过更新项目声明并 sync 准备另一环境，
-不能用 pip 原地修改共享已发布环境。
-
-WSL 原生 Python 与 Windows 托管 owner 分别固定，避免运行中修改 lock 后
-切换另一方版本。共用配置所需的相对 Windows Python 链接按内容键生成且不改向。
-新编辑目录继承依赖选择，不复制任务执行状态或资源记录。客户端信任和审批
-遵循用户授权，由客户端自身配置；setup 不默默更改这些策略。
-
-## Windows 与 WSL
-
-共享 Windows owner 使用它能访问的 mounted-drive 来源。原生新 worktree
-setup 需要由 Windows owner 执行；当前从 WSL 的 /mnt 目录调用会返回该边界，
-不自动混用两端的 Git linked-worktree 指针。Linux home 中的原生目录不自动
-获得 Windows owner 可访问性。本轮不扩大混合系统原生 worktree 的支持承诺。
-Kimi 用户级 provider 使用 Windows owner 的绝对解释器和入口路径，避免换
-worktree 后解析母目录的相对链接；该配置供原生 Windows 客户端执行，不能
-同时当作 WSL Linux 客户端的启动命令。路径生成测试不替代 Windows 实机验收。
-独立 Linux、macOS 和 Windows 的行为以相应测试与实机证据为准。完整合同见
+Windows 和 WSL 沿用已有 owner 边界。共享 Windows 挂载目录的原生 worktree
+setup 由 Windows owner 执行；从 WSL 的 /mnt 路径调用不代表已支持跨系统
+linked-worktree。路径与配置测试不替代 Windows 实机验收。完整边界见
 [platform-contract.md](platform-contract.md)。
 
-## 可选 CLI 便利入口
+[2026-09-12 原生验收](native-client-validation-2026-09-12.md)记录旧方案的已测范围；
+[本轮统一启动验收](unified-session-validation-2026-09-13.md)单独记录新入口、
+组件路由、知识共享和 resume 的完成情况。
 
-`vaws_client.py` 适用于希望从终端启动已安装 CLI 的用户，不是原生客户端或
-Agent 日常创建会话的前置步骤：
-
-```text
-uv run --no-project python .agents/scripts/vaws_client.py codex
-uv run --no-project python .agents/scripts/vaws_client.py kimi --workspace PATH
-```
-
-此入口创建独立 Git 副本，在创建前使用同一更新器；已有显式目录直接复用。
-原生参数和恢复 ID 放在 `--` 之后；恢复须带原 `--workspace PATH`，入口不按
-ID 猜测历史目录。复制保留 HEAD、暂存与工作区变更、普通未跟踪文件、有效
-换行/文件模式及已初始化子模块的独立 Git 状态；不复制私有运行状态和被忽略
-内容。含非 Git 内容的未初始化 gitlink、冲突或稀疏 index 等状态明确失败。
-
-这些副本有独立 `.git`，区别于客户端自己的 linked worktree。挂载盘复制由
-已有 Windows owner 完成，避免两端解释绝对 Git 指针。入口在启动子 CLI 前
-设置 cwd、PATH 和 VIRTUAL_ENV，并清除父任务身份；这是该便利入口的能力，
-不代表任意 GUI setup 子进程可以改动父应用的环境。
+`vaws_client.py` 仍是可选终端便利入口，用于在启动一个新的客户端进程前选目录；
+正常新会话使用上述项目指引。其存在不改变客户端内部 /new 或 resume 的原生语义。

--- a/docs/platform-contract.md
+++ b/docs/platform-contract.md
@@ -20,10 +20,12 @@ uv run --no-project python .agents/scripts/vaws_deps.py status
 
 Ordinary use starts in the native client. One-time initialization uses
 `vaws_client_setup.py --client all --apply` to detect installed clients and
-prepare supported native defaults and wiring together. It reports remaining
-native choices at that time, so they can be completed through client tools or
-computer use before business work. Writing files alone does not establish a
-worktree mode or trust, and an unsupported native interface remains explicit.
+configure providers, hooks and project guidance together. Supported native
+worktree preferences are optional optimizations. Writing configuration does not
+grant native trust or prove a real client task passed.
+Official Codex, Cursor, Claude, Grok and Kimi receive the same short startup
+guidance in `AGENTS.md`, with a Claude reference and an always-applied Cursor rule.
+No Skill or personal client extension is required for this entry.
 Codex local-environment setup and Cursor worktree setup run after
 the client creates the new directory and before the Agent operates in it. The
 callback checks upstream once, advances an eligible new checkout and fixes its
@@ -35,11 +37,24 @@ user definitions. These hooks only handle the configured Git worktree family,
 read the actual directory's saved environment and retain their source and command
 across new worktrees. Setup preserves native trust and unrelated custom hooks.
 
-Native Local chats retain their selected directory. Session hooks cannot move
-the parent application. Resume retains the original task, code and environment;
-there is no periodic watcher or update during work. Setup contract tests and
-real-client evidence are recorded in [native client acceptance](native-client-validation-2026-09-12.md);
-client environment selection and MCP enablement are one-time initialization choices.
+A new session reuses an independent native worktree with a selected environment.
+Otherwise its first repository operation is
+`uv run --no-project python .agents/scripts/vaws_start.py --client CLIENT`
+(`codex`, `cursor`, `claude`, `grok` or `kimi`), adding `--context-file PATH` when
+the native context is unavailable to the shell. This entry prepares the canonical
+default branch and its locked components, creates an independent worktree, binds
+explicit sources and saves the task's selection in the shared primary worktree's
+`.vaws-local/tasks/<task-id>/start.json`.
+
+Native Local chats can retain their UI/default directory; session hooks cannot
+move the parent application. Agent shell operations use the returned workspace
+as cwd, or an explicit `cd` prefix, and file/search/patch tools use absolute paths
+under it. Resume and repeat calls reuse the original task, workspace and selected
+environment without another preparation or update. There is no periodic watcher.
+Historical setup tests and real-client evidence are recorded in
+[native client acceptance](native-client-validation-2026-09-12.md);
+they do not certify later startup or gateway changes. Native client environment
+selection and MCP enablement are one-time initialization choices.
 Other client capabilities and sources are listed in
 [native client boundaries](native-workspace-isolation.md). Explicit maintenance
 can use apply; see [forks and updates](forks-and-updates.md).
@@ -56,8 +71,10 @@ its parent's environment. Ordinary native sessions need no Agent launcher call.
 
 Internal commands pass an argument vector, explicit cwd and environment to the
 process API. Spaces, Unicode, quotes and shell punctuation remain data. File
-copying, directory creation and local state use filesystem APIs. No user shell
-activation, `cd && ...`, or PowerShell-to-bash string translation is needed.
+copying, directory creation and local state use filesystem APIs. Internal process
+launches need no user shell activation, `cd && ...`, or PowerShell-to-bash string
+translation. An Agent whose native shell tool lacks a cwd argument may use the
+shell's own directory-change syntax for the returned editing workspace.
 
 An explicitly supplied shell script still has a declared interpreter. Remote
 Linux shell commands use the remote bash contract on every client platform,
@@ -88,17 +105,26 @@ Prepared dependency environments have content identities including lock inputs,
 effective dependency selection and the actual Python platform/ABI. Published
 environments are immutable. Updating dependencies prepares another environment;
 it does not upgrade the interpreter of an already running client or daemon.
-Generated hooks and MCP entries pin their selected environment. The native client
+Generated hooks and the native MCP gateway start in a prepared environment.
+The gateway selects each task, remote-dev or knowledge backend from the task's
+fixed workspace receipt, using an existing `context_file` or supported native
+request metadata. It never selects identity from cwd or a recent task. Official
+Kimi carries `context_file` explicitly in all three providers' calls. Different
+tasks can use different retained backend processes through one gateway; a newer
+catalog does not replace an existing task's loaded packages. The native client
 also pins its managed owner environment independently, so a later lock edit in a
 WSL shell cannot switch the owner used by an already running task. Project-relative
 launch aliases are also per identity and never redirected to another version.
 
 Setup and ordinary task work have different costs: explicit sync prepares missing
-dependencies. Native new-worktree setup may prepare an upstream update once before
-the Agent starts; reopening an existing directory resolves its selected completed
-environment. Knowledge
-preparation remains an optional capability after sync and does not invalidate a
-completed package environment when model/index preparation is unavailable.
+dependencies. Native new-worktree setup may prepare an upstream update before
+the Agent starts; the shared startup entry performs that bounded preparation
+when no prepared native worktree is available. Resume resolves the existing
+task selection. Knowledge preparation uses the shared primary worktree's service
+configuration and model/index state. It remains optional after sync and does not
+invalidate a completed package environment when unavailable. These gateway and
+storage rules do not add mixed-OS linked-worktree support or change the verified
+Windows owner requirement above.
 
 ## Verification boundaries
 

--- a/docs/remote-dev-consumption.md
+++ b/docs/remote-dev-consumption.md
@@ -15,8 +15,9 @@ uv run --no-project python .agents/scripts/vaws_deps.py sync
 uv run --no-project python .agents/scripts/vaws_deps.py status vaws-remote-dev
 ```
 
-Client setup selects the prepared interpreter and pins its ready receipt for
-`-m remote_dev.mcp.server`; no mutable workspace venv is required.
+Client setup installs a stable MCP gateway. A new task selects a prepared
+immutable environment; the gateway starts `-m remote_dev.mcp.server` there.
+A mutable workspace venv is not required.
 
 ## 2. What this workspace may inject
 
@@ -40,15 +41,20 @@ user. They do not resolve `session_id` / `machine` through a consumer plugin.
 
 ## 4. Client wiring
 
-`uv run --no-project python .agents/scripts/vaws_client_setup.py` writes the `remote-dev` MCP
-entry as `python -m remote_dev.mcp.server` with the env above. It must not
-point the server at a workspace resolver.
+`uv run --no-project python .agents/scripts/vaws_client_setup.py --client all --apply`
+configures the remote-dev provider through `vaws_native_mcp.py`. The gateway
+selects the task's fixed environment from explicit context or actual native
+metadata, then forwards ordinary remote calls to the package. It strips its
+routing-only `context_file` before calling the remote-dev backend. It does not
+resolve endpoints, allocate resources or implement a remote-dev resolver.
 
-Clients normally use their native platform interpreter. Kimi Code shares
-`.kimi-code/mcp.json` between Windows and WSL in a mounted Windows project, so
-setup uses the same project-relative, per-environment Windows Python link for remote-dev,
-coordinator and knowledge. Start Kimi in that project directory; WSL launches
-the Windows executable through its normal interoperability support. Generated
-state paths use Windows spelling, and custom server commands and environment
-values remain intact. A generated `WSLENV` list forwards these values to the
-Windows process. Grok in WSL continues to use native Linux remote-dev.
+Supported client hooks provide context; official Kimi passes the existing
+`context_file` explicitly. New tasks can use newly prepared components without
+manually reconnecting the client, while resumed tasks keep their earlier
+selection. The package remains independently usable with explicit endpoints.
+
+Generated configuration preserves user server fields and follows the existing
+native interpreter/Windows owner rules, including required WSL environment
+forwarding. This does not expand mixed Windows/WSL worktree support. See the
+[platform contract](platform-contract.md) and
+[native client contract](native-workspace-isolation.md) for those boundaries.

--- a/docs/target-state.md
+++ b/docs/target-state.md
@@ -100,22 +100,41 @@ This is a `package = false` uv project. Dependency preparation uses
 inspect it. Prepared environments have permanent content addresses; an update
 prepares a new environment without modifying one used by a running client or daemon.
 
-Native client lifecycle integration is the default. Initialization wires the
-selected client once; its Worktree mode and environment are selected in the native
-UI. Codex local-environment setup and Cursor worktree setup prepare the new
-directory created by that client before the Agent starts. The callback checks
-upstream once and fixes an eligible revision, dependencies and client wiring.
-SessionStart automatically creates or resumes the VAWS attachment; Cursor
-preToolUse injects context internally and handles hook ordering idempotently.
-Existing directories and resumed sessions retain their code and selected environment.
-Ordinary Local chats are not silently moved into worktrees. Codex/Cursor setup
-wiring has contract tests; real GUI new-session acceptance remains pending.
-Other clients' capabilities are recorded in the editing-isolation contract.
+Initialization wires the official Codex, Cursor, Claude, Grok and Kimi clients
+once. All five receive the same short startup guidance in `AGENTS.md`; Claude
+references it from `CLAUDE.md` and Cursor receives an always-applied rule.
+This entry does not require a Skill. Native hooks attach the session identity
+and actual cwd; Cursor preToolUse handles context injection and hook ordering.
 
-`vaws_client.py CLIENT` is an optional installed-CLI convenience, not a per-task
-Agent step. Client setup generates platform-correct MCP and hook entries, fixing
-the chosen environment. Shared Windows-mounted WSL
-workspaces retain one Windows coordinator/knowledge owner while explicit remote
+A new session reuses an independent native worktree when startup has already
+prepared its selected environment. Codex local-environment setup and Cursor
+worktree setup can prepare that directory before the Agent starts. Otherwise,
+the first repository operation is
+`uv run --no-project python .agents/scripts/vaws_start.py --client CLIENT`, with
+`--context-file PATH` when the native context is not available to the shell.
+It prepares the canonical default branch and its locked components, creates an
+independent worktree, binds explicit task sources and saves the selection in the
+shared primary worktree's `.vaws-local/tasks/<task-id>/start.json`. Later calls
+and resume reuse that selection without checking upstream or preparing again.
+
+The returned workspace is the editing directory: set shell cwd to it, or prefix
+commands with `cd`, and use absolute paths for file/search/patch tools. The
+client UI and its default cwd can remain at the original project. Official Kimi
+uses this path without a personal SessionSetup extension. Native UI selection,
+trust and real-client acceptance remain separate from generated wiring; dated
+evidence and client boundaries are recorded in the editing-isolation contract.
+
+`vaws_native_mcp.py` and `vaws_mcp_runtime.py` route task, remote-dev and knowledge
+MCP calls through the task's selected environment. They resolve an existing
+`context_file` or supported native request metadata, never infer identity from
+cwd or recent tasks. Official Kimi must carry the returned `context_file` in all
+three providers' calls. A long-lived gateway can retain separate backends for
+different workspace/environment selections; a newer tool catalog does not
+replace an existing task's runtime. These adapters own local connections, while
+package owners retain execution and knowledge behavior.
+
+`vaws_client.py CLIENT` is an optional installed-CLI convenience. Shared
+Windows-mounted WSL workspaces retain one Windows coordinator/knowledge owner while explicit remote
 I/O can use the native Linux provider. Native and managed environments are pinned
 independently. User arguments, cwd, stdin and exit codes survive these boundaries.
 Native new-worktree setup on a Windows mounted drive requires the Windows owner;
@@ -143,10 +162,13 @@ planning parent is not itself grounds for rejection.
 Workspace install/client wiring owns the bounded personal-fork and default-branch
 consumption operations in [forks and updates](forks-and-updates.md). GitHub
 configuration is distinct from native task identity and shared root login. A new
-directory created by the native client can adopt the prepared revision during
-setup, before its first Agent operation. Component pins are reused and existing
-editing directories/processes remain unchanged. There is no periodic updater;
-session hooks record the application's selected cwd rather than replacing it.
+native directory can adopt the prepared revision during setup; the shared
+startup entry prepares a new editing worktree when native setup has not already
+provided one with a selected environment. An explicitly selected, prepared
+native revision is reused. Component pins are reused and resumed tasks and
+running processes retain their selections. There is no periodic updater;
+session hooks record the application's actual cwd, while explicit task sources
+can point at the separate editing worktree.
 The [identity and coordination implementation](identity-and-agent-coordination.md)
 uses shared root access and fixed per-user container names. Packages consume the
 initialized user and handle container binding, notifications and routine reuse
@@ -189,8 +211,10 @@ responsible for the scope of a conclusion.
 
 Use `knowledge_query(text)`, `knowledge_explain(ref)` and `knowledge_capture(title, content)`
 when they help. A title and non-empty Markdown body suffice; no frontmatter,
-fixed headings, labels, evidence form or task association is required. Preserve
-known conditions, evidence and uncertainty. Neither lookup nor capture is a
+fixed headings, labels, evidence form or task association is required by the
+knowledge API. The workspace MCP gateway uses the existing native context only
+to select the task's package environment. Preserve known conditions, evidence
+and uncertainty. Neither lookup nor capture is a
 prerequisite or completion step. A search miss does not prove that relevant
 experience is absent.
 
@@ -198,15 +222,23 @@ Local and shared results are references, not instructions, approvals or current
 environment facts. Review or release does not confer authority. Agents assess
 relevance and reuse existing evidence with checks proportional to change.
 
-Shared releases are read-only. Project Markdown lives in `.agents/knowledge/`;
-local captures and package state stay under `.vaws-local/knowledge/`. The package
-indexes content. Hooks reuse the normal task summary, and manual capture can
-reuse useful existing text without an extra summary or publishing follow-up.
+Shared releases are read-only. Project Markdown lives in `.agents/knowledge/`.
+Clients and linked worktrees share the primary worktree's
+`.vaws-local/knowledge/service.json`, candidate content and configured model/index
+state. Preparation refreshes an owned project Markdown snapshot from the selected
+workspace; explicit custom mounts and storage choices are preserved. This shared
+reference content is not a task's pinned source snapshot. The package owns
+indexing and model lifecycle. Supported hooks reuse the normal task summary,
+and manual capture can reuse useful existing text without an extra summary or
+publishing follow-up.
 
-Dependency sync asks the package to prepare its model and index. MCP maintains
-readiness and configured shared updates while alive. Pending knowledge is
+Dependency sync and new-workspace preparation ask the selected package to prepare
+the shared model and index. MCP maintains readiness and configured shared updates
+while alive. Pending knowledge is
 reported separately and leaves ordinary tools usable. Windows/WSL clients of
-one mounted workspace share its Windows knowledge process.
+one mounted workspace retain its Windows knowledge owner. Sharing configuration
+and state does not imply that every task uses one backend process, or establish
+compatibility between concurrently running package versions.
 
 Public sharing follows existing authorization/configuration and uses only a
 package-prepared redacted copy. Public review and merge remain human; failed

--- a/docs/unified-session-validation-2026-09-13.md
+++ b/docs/unified-session-validation-2026-09-13.md
@@ -1,0 +1,46 @@
+# Unified native-session startup acceptance
+
+Status: dated validation evidence — 2026-09-13, acceptance in progress
+
+This record covers the unified project-guidance startup and task-selected MCP
+runtime. It does not promote the earlier personal Grok/Kimi builds or the
+2026-09-12 results into acceptance of this new path.
+
+## Evidence recorded so far
+
+Configuration/guidance regression tests exercised the five stock-client plans,
+stable gateway entries, exact generated-provider replacement, custom settings
+preservation, Kimi official-event migration, context matchers and resume guidance.
+The affected ten-file run passed 144 tests, with four platform-specific skips
+and 13 subtests. These are configuration tests, not real model sessions.
+
+The implementation is still being integrated. Final consumer/component commits,
+CI results and runtime evidence must be recorded before claiming completion.
+No live client result is inferred from a generated configuration or connected
+MCP panel.
+
+## Real-client acceptance
+
+| Client | Version / build | New session edits selected directory | Latest locked components and knowledge query/capture | Resume keeps directory/task/environment |
+|---|---|---|---|---|
+| Codex | Pending | Pending | Pending | Pending |
+| Cursor | Pending | Pending | Pending | Pending |
+| Claude Code | Pending | Pending | Pending | Pending |
+| Official Grok | Pending | Pending | Pending | Pending |
+| Official Kimi Code | Pending | Pending | Pending | Pending |
+
+For each executed row, retain the ordinary launch/new/resume action, native ID,
+selected workspace and HEAD, task/environment receipt, provider startup facts,
+knowledge result and unchanged resume selection. Local paths and native IDs stay
+in untracked evidence; this public record should summarize their relationships.
+A stock-client result must identify the stock executable, not merely a version
+number shared by a personal build.
+
+## Remaining checks
+
+A long-lived gateway must route a new task to its new selected component
+environment and a resumed task to its original one. Knowledge acceptance must
+show shared configuration/index/model reuse across different worktrees, without
+creating per-worktree knowledge stores. Update/preparation failures must expose
+their phase and preserve existing work. Platform-specific results and skips are
+reported separately; no remote NPU or Windows GUI acceptance is claimed here.

--- a/docs/unified-session-validation-2026-09-13.md
+++ b/docs/unified-session-validation-2026-09-13.md
@@ -14,32 +14,35 @@ preservation, Kimi official-event migration, context matchers and resume guidanc
 The affected ten-file run passed 144 tests, with four platform-specific skips
 and 13 subtests. These are configuration tests, not real model sessions.
 
-The implementation is still being integrated. Final consumer/component commits,
-CI results and runtime evidence must be recorded before claiming completion.
+The implementation is still being integrated. Coordinator PR #26 and knowledge
+PR #26 are merged; final consumer pins, CI results and runtime evidence will be
+recorded with acceptance.
 No live client result is inferred from a generated configuration or connected
 MCP panel.
 
 ## Real-client acceptance
 
-| Client | Version / build | New session edits selected directory | Latest locked components and knowledge query/capture | Resume keeps directory/task/environment |
-|---|---|---|---|---|
-| Codex | Pending | Pending | Pending | Pending |
-| Cursor | Pending | Pending | Pending | Pending |
-| Claude Code | Pending | Pending | Pending | Pending |
-| Official Grok | Pending | Pending | Pending | Pending |
-| Official Kimi Code | Pending | Pending | Pending | Pending |
+| Client | Version / build | New session edits selected directory | Latest locked components and knowledge query/capture |
+|---|---|---|---|
+| Codex | Pending | Pending | Pending |
+| Cursor | Pending | Pending | Pending |
+| Claude Code | Pending | Pending | Pending |
+| Official Grok | Pending | Pending | Pending |
+| Official Kimi Code | Pending | Pending | Pending |
 
-For each executed row, retain the ordinary launch/new/resume action, native ID,
-selected workspace and HEAD, task/environment receipt, provider startup facts,
-knowledge result and unchanged resume selection. Local paths and native IDs stay
-in untracked evidence; this public record should summarize their relationships.
+For each executed row, retain the ordinary launch/new action, native ID,
+selected workspace and HEAD, task/environment receipt, provider startup facts
+and knowledge result. Local paths and native IDs stay in untracked evidence;
+this public record should summarize their relationships.
 A stock-client result must identify the stock executable, not merely a version
 number shared by a personal build.
 
 ## Remaining checks
 
 A long-lived gateway must route a new task to its new selected component
-environment and a resumed task to its original one. Knowledge acceptance must
+environment while retaining an earlier task's fixed selection. Resume adds no
+preparation or update under the existing contract; this round's requested live
+acceptance scope is new sessions. Knowledge acceptance must
 show shared configuration/index/model reuse across different worktrees, without
 creating per-worktree knowledge stores. Update/preparation failures must expose
 their phase and preserve existing work. Platform-specific results and skips are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ package = false
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" }
 vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "831a0f568024e982b88bfba0d72f3debf542f723" }
-vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "48c71041136184c1c7a418079576cb8b655bc020" }
+vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "f928dc37c6f34688d0cfa9a9b4f6d3e882958959" }
 
 [tool.pytest.ini_options]
 pythonpath = [".agents/lib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0"
 requires-python = ">=3.11"
 dependencies = [
   "Pillow>=11",
+  "mcp==1.30.0",
   "vaws-remote-dev==0.7.0",
   "vaws-coordinator==0.4.1.dev1",
   "vaws-knowledge==0.5.0",
@@ -14,7 +15,6 @@ dev = [
   "pytest",
   "pyyaml",
   "jsonschema",
-  "mcp==1.30.0",
 ]
 
 [tool.uv]
@@ -22,8 +22,8 @@ package = false
 
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" }
-vaws-coordinator = { git = "https://github.com/maoxx241/vaws-coordinator", rev = "03b30474d38c61f9ea5b7b7a2415aaad40805de5" }
-vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "c95293836a3b595c13a80189197d44a2980c9fbd" }
+vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "831a0f568024e982b88bfba0d72f3debf542f723" }
+vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "48c71041136184c1c7a418079576cb8b655bc020" }
 
 [tool.pytest.ini_options]
 pythonpath = [".agents/lib"]

--- a/uv.lock
+++ b/uv.lock
@@ -4240,7 +4240,7 @@ wheels = [
 [[package]]
 name = "vaws-coordinator"
 version = "0.4.1.dev1"
-source = { git = "https://github.com/maoxx241/vaws-coordinator?rev=03b30474d38c61f9ea5b7b7a2415aaad40805de5#03b30474d38c61f9ea5b7b7a2415aaad40805de5" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=831a0f568024e982b88bfba0d72f3debf542f723#831a0f568024e982b88bfba0d72f3debf542f723" }
 dependencies = [
     { name = "setuptools-scm" },
     { name = "vaws-remote-dev" },
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "vaws-knowledge"
 version = "0.5.0"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=c95293836a3b595c13a80189197d44a2980c9fbd#c95293836a3b595c13a80189197d44a2980c9fbd" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=48c71041136184c1c7a418079576cb8b655bc020#48c71041136184c1c7a418079576cb8b655bc020" }
 dependencies = [
     { name = "fastembed" },
     { name = "openviking" },
@@ -4267,6 +4267,7 @@ name = "vaws-workspace"
 version = "0"
 source = { virtual = "." }
 dependencies = [
+    { name = "mcp" },
     { name = "pillow" },
     { name = "vaws-coordinator" },
     { name = "vaws-knowledge" },
@@ -4276,23 +4277,22 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "jsonschema" },
-    { name = "mcp" },
     { name = "pytest" },
     { name = "pyyaml" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "mcp", specifier = "==1.30.0" },
     { name = "pillow", specifier = ">=11" },
-    { name = "vaws-coordinator", git = "https://github.com/maoxx241/vaws-coordinator?rev=03b30474d38c61f9ea5b7b7a2415aaad40805de5" },
-    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=c95293836a3b595c13a80189197d44a2980c9fbd" },
+    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=831a0f568024e982b88bfba0d72f3debf542f723" },
+    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=48c71041136184c1c7a418079576cb8b655bc020" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "jsonschema" },
-    { name = "mcp", specifier = "==1.30.0" },
     { name = "pytest" },
     { name = "pyyaml" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "vaws-knowledge"
 version = "0.5.0"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=48c71041136184c1c7a418079576cb8b655bc020#48c71041136184c1c7a418079576cb8b655bc020" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=f928dc37c6f34688d0cfa9a9b4f6d3e882958959#f928dc37c6f34688d0cfa9a9b4f6d3e882958959" }
 dependencies = [
     { name = "fastembed" },
     { name = "openviking" },
@@ -4286,7 +4286,7 @@ requires-dist = [
     { name = "mcp", specifier = "==1.30.0" },
     { name = "pillow", specifier = ">=11" },
     { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=831a0f568024e982b88bfba0d72f3debf542f723" },
-    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=48c71041136184c1c7a418079576cb8b655bc020" },
+    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=f928dc37c6f34688d0cfa9a9b4f6d3e882958959" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" },
 ]
 


### PR DESCRIPTION
Ordinary new sessions could keep editing the mother checkout and using a previous component environment. A shared project instruction now calls one deterministic startup entry: check saved initialization, prepare canonical main and its locked environment, create an independent worktree, and bind it to the existing native task. Already-prepared native worktrees are reused. Existing tasks keep their selected workspace and environment.

The MCP gateway selects task, remote-dev and knowledge backends from each task's fixed receipt, with concurrent calls, cancellation and provider diagnostics. Five official clients share the same knowledge configuration, notes, index and model cache. Kimi Stop and Cursor CLI sessionEnd extract only their known session's final response for automatic capture; no second Agent summary or personal client build is needed. Concurrent startup waits inside the tool, and GitHub JSON calls remain machine-readable in terminals that force colors.

Validation includes 146 affected consumer tests and 14 subtests (one platform skip), 91 update/worktree tests, real stdio runtime routing, and ordinary logged-in sessions in Codex, Cursor, Claude Code, official Grok and official Kimi Code. The component changes passed Linux/macOS/Windows CI in coordinator #26 and knowledge #26/#27. Consumer CI is required before merge; the final merged-main acceptance is recorded separately in docs/unified-session-validation-2026-09-13.md.
