### PR TITLE
Repair existing Cursor summary hooks and record official client acceptance

### DIFF
--- a/.agents/scripts/vaws_client_setup.py
+++ b/.agents/scripts/vaws_client_setup.py
@@ -654,7 +654,11 @@ def merge_json(path, *, hooks=None, mcp=None, notes=None, client=None, project=N
     if hooks:
         target = value.setdefault("hooks", {})
         for event, groups in hooks.items():
-            target[event] = merge_hook_event(target.get(event) or [], groups, client, project)
+            merged = target.get(event) or []
+            # A native event can own both session and summary hook commands.
+            for group in groups:
+                merged = merge_hook_event(merged, [group], client, project)
+            target[event] = merged
         if path.parent.name == ".cursor":
             value.setdefault("version", 1)
     if mcp:

--- a/.agents/tests/test_knowledge_client_setup.py
+++ b/.agents/tests/test_knowledge_client_setup.py
@@ -82,6 +82,32 @@ def test_grok_summary_preserves_foreign_stop_and_existing_session_hook(tmp_path,
     assert len(commands) == 2
 
 
+@pytest.mark.parametrize("existing_summary", [False, True])
+def test_cursor_existing_session_end_adds_or_updates_summary(tmp_path, monkeypatch, existing_summary):
+    monkeypatch.setattr(setup, "ROOT", tmp_path)
+    monkeypatch.setattr(setup, "OWNED_HOOK_SCRIPT", tmp_path / ".agents/hooks/vaws_session.py")
+    path = tmp_path / HOOK_FILES["cursor"]
+    desired = json.loads(setup.configuration("cursor", tmp_path)[path])
+    session, summary = desired["hooks"]["sessionEnd"]
+    foreign = {"command": "foreign-session-end", "timeout": 23}
+    existing = [{**session, "timeout": 19}, foreign]
+    if existing_summary:
+        arguments = setup.hook_argv(summary["command"])
+        arguments[0] = str(tmp_path / ".vaws-local/env-links" / ("a" * 64) / "bin/python")
+        existing.append({"command": setup.local_hook_command(arguments), "timeout": 31})
+    desired["hooks"]["sessionEnd"] = existing
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(desired), encoding="utf-8")
+
+    updated = setup.configuration("cursor", tmp_path)[path]
+    ended = json.loads(updated)["hooks"]["sessionEnd"]
+    assert ended[:2] == [{**session, "timeout": 19}, foreign]
+    assert len(ended) == 3
+    assert ended[2] == ({**summary, "timeout": 31} if existing_summary else summary)
+    path.write_text(updated, encoding="utf-8")
+    assert setup.configuration("cursor", tmp_path)[path] == updated
+
+
 @pytest.mark.parametrize("client", ["claude", "cursor", "codex", "grok"])
 def test_generated_knowledge_owner_and_paths_migrate_without_changing_custom_values(client, tmp_path, monkeypatch):
     workspace = tmp_path / "workspace"

--- a/docs/unified-session-validation-2026-09-13.md
+++ b/docs/unified-session-validation-2026-09-13.md
@@ -1,49 +1,122 @@
 # Unified native-session startup acceptance
 
-Status: dated validation evidence — 2026-09-13, acceptance in progress
+Status: dated validation evidence — 2026-09-13, official CLI acceptance completed
 
-This record covers the unified project-guidance startup and task-selected MCP
-runtime. It does not promote the earlier personal Grok/Kimi builds or the
-2026-09-12 results into acceptance of this new path.
+## Tested implementation
 
-## Evidence recorded so far
+[Workspace PR #154](https://github.com/vllm-ascend-workspace/vllm-ascend-workspace/pull/154)
+merged as `16b6dc9907a5d6268a8e6adabc17d0783e2552b0`. Its final implementation
+head `767829ad13e956d7e68b693f9161f5d65cf2b583` passed complete consumer CI on
+Ubuntu/Python 3.11, Windows/Python 3.13 and macOS/Python 3.13
+([run](https://github.com/vllm-ascend-workspace/vllm-ascend-workspace/actions/runs/34713221298)).
 
-Configuration/guidance regression tests exercised the five stock-client plans,
-stable gateway entries, exact generated-provider replacement, custom settings
-preservation, Kimi official-event migration, context matchers and resume guidance.
-The affected ten-file run passed 144 tests, with four platform-specific skips
-and 13 subtests. These are configuration tests, not real model sessions.
+The selected immutable component environment was `794caf986c1d…`:
 
-The implementation is still being integrated. Coordinator PR #26 and knowledge
-PR #26 are merged; final consumer pins, CI results and runtime evidence will be
-recorded with acceptance.
-No live client result is inferred from a generated configuration or connected
-MCP panel.
+| Component | Selected revision |
+|---|---|
+| vaws-coordinator | `831a0f568024e982b88bfba0d72f3debf542f723` |
+| vaws-knowledge | `f928dc37c6f34688d0cfa9a9b4f6d3e882958959` |
+| remote-dev | `2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa` |
 
-## Real-client acceptance
+Coordinator PR #26 and knowledge PRs #26/#27 passed their own CI before the
+consumer pins were adopted. Earlier sessions selected workspace `4a1f28e…`
+and environment `91a33bf6008a…`; new sessions selected the merged canonical
+main and its new environment automatically.
 
-| Client | Version / build | New session edits selected directory | Latest locked components and knowledge query/capture |
+## Ordinary new-session tasks
+
+Each official CLI launched from the configured primary project with an ordinary
+business prompt: read the first design principle, write two sentences to one
+`notes-CLIENT.txt`, query project knowledge, and report directory/source/runtime.
+The prompt did not name the startup command, request a worktree, or supply a
+replacement system prompt. Existing authentication and model preferences were
+reused. The clients independently followed generated project guidance and
+executed the startup entry before repository work.
+
+| Client | Official version | Selected worktree and latest environment | Automatic final-summary capture |
 |---|---|---|---|
-| Codex | Pending | Pending | Pending |
-| Cursor | Pending | Pending | Pending |
-| Claude Code | Pending | Pending | Pending |
-| Official Grok | Pending | Pending | Pending |
-| Official Kimi Code | Pending | Pending | Pending |
+| Codex CLI | 0.153.4 | Passed | Passed |
+| Cursor CLI | 2026.09.08-6caf4ff | Passed | Passed after configuration repair |
+| Claude Code | 2.1.269 | Passed | Passed |
+| Grok | 1.0.30 (`04b7ffed98c6`) | Passed | Passed |
+| Kimi Code | 0.42.0 | Passed | Passed |
 
-For each executed row, retain the ordinary launch/new action, native ID,
-selected workspace and HEAD, task/environment receipt, provider startup facts
-and knowledge result. Local paths and native IDs stay in untracked evidence;
-this public record should summarize their relationships.
-A stock-client result must identify the stock executable, not merely a version
-number shared by a personal build.
+Grok and Kimi ran through their restored default official executables. SHA-256
+was checked against the downloaded official files; earlier personal builds were
+retained only as backups. The invocation records retain executable identities
+and hashes, rather than relying on a version string alone.
 
-## Remaining checks
+All test notes were written only inside their selected worktrees; the primary
+checkout retained its tracked contents and contained none of the test notes.
+Real MCP provider output identified the selected workspace, Python and component
+revision. Claude's raw `vaws_session {}` and knowledge calls with only business
+arguments received the correct native context through PreToolUse. Kimi's
+schema required its existing context, and its first knowledge call supplied it
+without a missing-argument retry. A separate ordinary Kimi inspection task called
+`vaws_session` successfully and observed the selected source and new coordinator
+runtime, without file changes or remote execution.
 
-A long-lived gateway must route a new task to its new selected component
-environment while retaining an earlier task's fixed selection. Resume adds no
-preparation or update under the existing contract; this round's requested live
-acceptance scope is new sessions. Knowledge acceptance must
-show shared configuration/index/model reuse across different worktrees, without
-creating per-worktree knowledge stores. Update/preparation failures must expose
-their phase and preserve existing work. Platform-specific results and skips are
-reported separately; no remote NPU or Windows GUI acceptance is claimed here.
+Cursor also succeeded with raw `vaws_session {}` and knowledge arguments limited
+to text and limit. After configuration repair, the real CLI's completed native
+answer was captured once, with matching session identity and identical body.
+
+The clients ran concurrently to exercise the shared preparation lock. Waiting
+remained inside the startup process rather than returning a lock conflict to the
+model. End-to-end times include model work and this deliberate contention;
+they are not isolated startup benchmarks.
+
+## Runtime and knowledge evidence
+
+A single live knowledge gateway handled old-task, new-task, then old-task calls
+through two real component processes. The old task retained environment
+`91a33bf6008a…` and its original package revision; the new task used
+`794caf986c1d…` and `f928dc3…`. Repeating the old call reused its original
+backend, and both workers closed cleanly. This tests selected-runtime routing
+without treating a connected MCP panel as execution evidence.
+
+The worktrees shared the primary knowledge configuration, index and compatible
+model services. Existing service processes remained alive throughout acceptance;
+there was no per-worktree model download or knowledge store. Grok's automatically
+captured final answer was retrieved through both `knowledge_query` and
+`knowledge_explain` from the separate Codex task, with the original Grok source
+identity preserved. No manual capture or index repair was used for this check.
+
+Kimi briefly reported pending background index maintenance while still returning
+eight results. Its next ordinary query was no longer degraded. The raw status
+was retained rather than interpreted as a complete first search.
+
+## Observed boundaries and repairs
+
+Cursor's first final run exposed an upgrade bug: a pre-existing `sessionEnd`
+identity hook caused configuration merging to omit the newly added summary hook.
+Fresh-configuration tests had not exercised that migration. The repair merges
+each desired hook separately and adds upgrade/idempotence coverage. The official
+CLI's `sessionEnd` transcript path supplies the completed final answer; the
+interactive `afterAgentResponse` path remains supported.
+The two migration cases failed before the repair and passed afterward; affected
+configuration/consumer coverage passed 83 tests and 14 subtests, with three
+existing interpreter/platform skips. Applying the repaired setup changed only
+the existing Cursor hook configuration, and repeating all-client setup changed
+no files. The subsequent ordinary Cursor session passed all checks in 81.5
+seconds. Its workspace remained canonical `16b6dc9…`; the repair changes setup
+merging rather than component pins or execution behavior. The earlier failed
+run is retained as failed evidence.
+
+The fallback prepares the editing workspace and binds VAWS sources; it does not
+change the native application's default cwd or force all native tools into that
+directory. Grok made two read-only shell calls without changing directory,
+including one failed relative file read, then corrected itself. Its writes were
+isolated throughout. This is a measured instruction-following cost, not enforced
+native shell isolation. No personal Grok or Kimi binary patch is required.
+
+Resume was outside this round's requested live scope. It retains its existing
+task, worktree and component selection by contract; there is no periodic code
+watcher or update during work. This round exercised official macOS CLIs, not
+Windows GUI or NPU execution. The Mac was already locked when continuous
+anti-sleep protection was established, so desktop UI acceptance was not repeated.
+
+Local raw evidence is retained under untracked
+`.vaws-local/implementation/20260913-unified-startup/acceptance/`: client
+invocations and transcripts, native identities, start receipts, provider logs,
+candidate metadata, runtime routing and cross-client knowledge results.
+Private paths, native IDs and server addresses are intentionally absent here.


### PR DESCRIPTION
Existing Cursor configurations already contain a `sessionEnd` task hook. Adding a summary hook to the same event silently skipped the second desired command, so ordinary Cursor CLI sessions prepared their worktree and runtime correctly but never captured their final answer. Merge each desired hook independently while retaining the existing ownership and metadata rules; repeated setup remains idempotent.

Update the dated acceptance record with official Codex, Cursor, Claude, Grok and Kimi sessions on the merged implementation, real task-selected component processes, automatic summary capture and cross-client knowledge reuse. Record observed cwd and desktop-UI limits explicitly.

Validation:
- Two migration regression cases reproduced the bug before the fix; affected configuration/consumer tests: 83 passed, 3 platform skips, 14 subtests.
- Applying the repair changed only the existing Cursor hook configuration; a second all-client setup changed no files.
- Real official-client transcripts, native identities, selected-runtime receipts and captured-summary comparisons are retained locally; the public dated record contains the results without private machine details.

Post-merge validation: all three platform checks passed for `8972bfb`. With the primary checkout deliberately left at `16b6dc9`, an ordinary official Claude new session independently prepared canonical `dd2fe85`, reused the existing locked component environment, and reported that new source through `vaws_session`. Both directories remained clean, and the primary checkout stayed on its old revision until explicit maintenance. This directly exercises remote-ahead update selection without changing an active checkout.
