### PR TITLE
Adopt verified native kernel recipes and record controlled timings

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,8 @@ command recipe. Superseded designs and duplicate inventories are retained in Git
 
 ## Dated design and validation evidence
 
+- [native-kernel-recipe-performance-2026-09-13.md](native-kernel-recipe-performance-2026-09-13.md) — controlled incremental recipe compilation timings, retained fallback and failed attempts, and actual operator validation.
+
 - [six-scenario-performance-2026-09-13.md](six-scenario-performance-2026-09-13.md) — fixed-component managed preparation, cross-container native reuse, incremental compilation and independent Agent timing comparisons.
 
 - [unified-session-validation-2026-09-13.md](unified-session-validation-2026-09-13.md) — unified official-client preparation and MCP routing; acceptance progress and pending native cases are explicit.

--- a/docs/native-kernel-recipe-performance-2026-09-13.md
+++ b/docs/native-kernel-recipe-performance-2026-09-13.md
@@ -1,0 +1,34 @@
+# Native kernel recipe performance evidence
+
+Status: dated historical evidence, 2026-09-13. This records a controlled experiment and the subsequently merged implementation. It is not a current execution contract or a guarantee of task latency.
+
+The successful recipe candidate reduced managed submission-to-release time from **98.836073 to 88.682851 seconds**, an observed **10.153222 seconds (10.3%)**. Its incremental-build stage fell from **48.918923 to 40.152517 seconds**. These are individual controlled task measurements, not fresh-Agent completion times or a statistical guarantee. The [six-scenario report](six-scenario-performance-2026-09-13.md), including the slower managed ultra Agent sample and the unmet universal six-case speed objective, remains unchanged.
+
+[Coordinator PR #29](https://github.com/vllm-ascend-workspace/vaws-coordinator/pull/29) merged at 2026-09-12 21:48:30 UTC as `3f9cdbdc631fdb3a710e08b37b29e04c3d25b85e`, after all four owner CI checks passed. Its Git tree is identical to the measured `d18a269b7c110bd32cd089257c58423ab8a5e896` candidate. The accompanying consumer pin adopts that canonical merge and retains remote-dev `4da7bbd` and all other dependency pins. The experiment itself ran the fixed candidate revision shown below.
+
+## Scope and retained attempts
+
+Each run made a distinct, semantically equivalent local-variable rename in the same `add_rms_norm_bias` AscendC kernel. The coordinator fixed each source snapshot, reused compatible native prerequisites, rebuilt the affected variants, and attempted the same operator validation. Source hashes therefore differ between runs. The business source baseline, image and dependencies were held fixed; remote-dev stayed at `4da7bbdd6b1a5d809d53522c9ee0b0b1d7d2e83c`.
+
+Times are seconds from TaskClient submission to observed terminal state and resource release. Local experiment preparation, evidence retrieval and report writing are outside this boundary. The build-stage interval runs from the incremental-install progress observation to the following marker-write observation, so it includes orchestration and transitions as well as compiler work.
+
+| Attempt | Coordinator | Submit to release | Build stage | Outcome |
+| --- | --- | ---: | ---: | --- |
+| Original incremental build | `91d28a9` | 98.836073 | 48.918923 | Succeeded; operator passed; resources released. |
+| First recipe candidate | `358ced4` | 97.958771 | 49.886969 | Fell back to the original build because installed tiling metadata was looked up in the wrong directory; succeeded and released. This did not demonstrate a recipe-path improvement. |
+| Tiling lookup corrected | `4989c2a` | 54.931356 | Not a completed stage | All three OPC variants completed, then configuration generation failed because the temporary directory omitted the expected compute-unit layout. Released; no business execution. This is not a successful latency result. |
+| Layout corrected | `d18a269` | 88.682851 | 40.152517 | Recipe path completed; operator passed; resources released. |
+
+The successful comparison saved 8.766406 seconds (17.9%) in the observed build stage. Business-process timers were 7.265429 seconds for the baseline and 7.451007 seconds for the final candidate. Those timers include imports, initialization and assertions; they are not isolated kernel latency or the complete submission-to-release interval. No repeated A/B series was run for this change.
+
+## Work removed and correctness retained
+
+The original incremental build still configured CMake, downloaded the third-party JSON headers and rebuilt unchanged host and tiling objects before running the three operator compiler commands. The qualified recipe path reused the verified installed prerequisites and generated the operator parameters directly. The final log contains three actual OPC completions and omits that CMake, download and host-rebuild work. The measured interval does not separately attribute the savings among those removed operations.
+
+Eligibility retains the existing single-CPP native-input and environment compatibility checks. The recorded recipe binds effective OPC arguments, parameter hashes, generator hashes and installed output hashes. The regenerated variants must match that record before compilation. Older builds without a usable recipe, or unsupported recipe options, use the existing build path; an empty current environment is not proof of historical compiler options. This is internal preparation behavior and adds no Agent parameter or publication step.
+
+The compiler receives the current fixed CPP through a private source copy. Guards check the actual source path and SHA256 at source lookup and compilation, and all three variants must produce complete outputs. Compilation failures propagate once compilation has started; they do not trigger a second build through fallback. The final correction preserves failed compiler evidence and keeps the upstream compute-unit directory structure.
+
+The successful case ran FP32 `add_rms_norm_bias` with shape 16 x 128, seed 20260913 and epsilon 1e-6 against an independent CPU reference. All outputs were finite and passed rtol/atol 0.000244140625. Maximum absolute errors were 9.5367431640625e-7 for `y`, 5.960464477539063e-8 for `rstd`, and zero for `x`. Runtime evidence recorded opening the rebuilt kernel object from the execution's own output tree and its SHA256. The candidate CPP hash differed from the baseline; the opened object hash was identical, which is consistent with the semantics-preserving rename and does not replace the recorded proof of actual recompilation.
+
+The final captured native manifest also retained the compiler recipe, allowing a subsequent eligible build to verify the same effective recipe. Local private evidence retains all four results, preparation logs, successful business results and captured manifests. This public summary omits endpoint identities and private filesystem locations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ package = false
 
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "4da7bbdd6b1a5d809d53522c9ee0b0b1d7d2e83c" }
-vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "70d3aab95a11a5c1f015d45d186817a004ec13b6" }
+vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "3f9cdbdc631fdb3a710e08b37b29e04c3d25b85e" }
 vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "f928dc37c6f34688d0cfa9a9b4f6d3e882958959" }
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -4240,7 +4240,7 @@ wheels = [
 [[package]]
 name = "vaws-coordinator"
 version = "0.4.1.dev1"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=70d3aab95a11a5c1f015d45d186817a004ec13b6#70d3aab95a11a5c1f015d45d186817a004ec13b6" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=3f9cdbdc631fdb3a710e08b37b29e04c3d25b85e#3f9cdbdc631fdb3a710e08b37b29e04c3d25b85e" }
 dependencies = [
     { name = "setuptools-scm" },
     { name = "vaws-remote-dev" },
@@ -4285,7 +4285,7 @@ dev = [
 requires-dist = [
     { name = "mcp", specifier = "==1.30.0" },
     { name = "pillow", specifier = ">=11" },
-    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=70d3aab95a11a5c1f015d45d186817a004ec13b6" },
+    { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=3f9cdbdc631fdb3a710e08b37b29e04c3d25b85e" },
     { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=f928dc37c6f34688d0cfa9a9b4f6d3e882958959" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=4da7bbdd6b1a5d809d53522c9ee0b0b1d7d2e83c" },
 ]


### PR DESCRIPTION
Qualified single-CPP rebuilds previously repeated CMake configuration, a third-party header download and unchanged host compilation. Adopt the canonical coordinator merge from [PR #29](https://github.com/vllm-ascend-workspace/vaws-coordinator/pull/29), which can reuse verified effective compiler recipes while still compiling every affected variant from the fixed candidate source. Remote-dev and every other dependency pin remain unchanged.

The new dated report records all four controlled attempts. The successful candidate reduced submission-to-release time from 98.836073 to 88.682851 seconds and the observed build stage from 48.918923 to 40.152517 seconds. The first candidate fell back; the next completed three OPC variants but failed configuration generation and never ran the business case. Both remain explicit. The successful trial passed the actual operator reference checks and released resources. These individual task timings do not establish fresh-Agent performance or a universal six-case improvement.

The canonical merge `3f9cdbdc631fdb3a710e08b37b29e04c3d25b85e` has the same Git tree as the measured `d18a269b7c110bd32cd089257c58423ab8a5e896` candidate, whose four owner CI checks passed.

Validation: locked immutable dependency preparation succeeded; installed package commits match the lock; 52 affected dependency/environment/CLI tests passed on Windows; lock consistency, tracked paths, staged leak scan and diff checks passed. Existing historical six-scenario evidence is unchanged. No remote benchmark was run for this consumer update.
